### PR TITLE
fix(dev): prompt for credentials before image build + fix CLI execute bit

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,7 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "tsc && cp -r ../policy-engine/profiles dist/profiles",
+    "build": "tsc && chmod +x dist/index.js && cp -r ../policy-engine/profiles dist/profiles",
     "dev": "tsx watch src/index.ts",
     "lint": "oxlint .",
     "format": "oxfmt .",

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync } from "fs";
 import { Stepper, banner, section, kvLine, checkLine } from "../stepper.js";
-import { ensureCredentials, CREDENTIALS_FILE, resolveSecret, getSecret } from "../config.js";
+import { loadConfig, promptAndSaveCredentials, CREDENTIALS_FILE, resolveSecret, getSecret } from "../config.js";
 
 const DEFAULT_SANDBOX_IMAGE =
   "azureclaw-sandbox:dev";
@@ -75,6 +75,20 @@ export function devCommand(): Command {
         while (repoRoot !== "/" && !existsSync(path.join(repoRoot, "Cargo.toml"))) {
           repoRoot = path.dirname(repoRoot);
         }
+
+        // ── Credentials (first — prompt before potentially long build) ──
+        stepper.step("Checking credentials...");
+        let creds = loadConfig();
+        if (!creds) {
+          // Stop spinner so inquirer interactive prompts display correctly
+          stepper.stop();
+          console.log(chalk.yellow("\n  No Azure OpenAI credentials found. Let's set them up:\n"));
+          creds = await promptAndSaveCredentials();
+          stepper.done("Credentials configured");
+        } else {
+          stepper.done("Credentials loaded");
+        }
+        const model = options.model !== "gpt-4.1" ? options.model : creds.model;
 
         // ── Image resolution ─────────────────────────────────────────
         stepper.step("Resolving sandbox image...");
@@ -188,12 +202,6 @@ export function devCommand(): Command {
         } else {
           stepper.done("Sandbox image found");
         }
-
-        // ── Load or prompt for credentials ──────────────────────────
-        stepper.step("Loading credentials...");
-        const creds = await ensureCredentials();
-        stepper.done("Credentials ready");
-        const model = options.model !== "gpt-4.1" ? options.model : creds.model;
 
         // ── Discover deployed models from Azure endpoint ─────────────
         let discoveredDeployments = "";

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -19,10 +19,12 @@ export function devCommand(): Command {
 
   cmd
     .description(
-      "Run a sandbox locally via Docker for development. Same policies, same model routing, on your laptop."
+      "Run a sandbox locally via Docker for development. Same policies, same model routing, on your laptop.\n" +
+      "Requires an existing Azure OpenAI resource with at least one model deployment (e.g. gpt-4.1).\n" +
+      "On first run, you will be prompted for your endpoint, model deployment name, and resource-level API key."
     )
     .option("--name <name>", "Sandbox name", "dev-agent")
-    .option("--model <model>", "AI model", "gpt-4.1")
+    .option("--model <model>", "Existing model deployment name in your Azure OpenAI resource", "gpt-4.1")
     .option(
       "--policy <preset>",
       "Policy preset: minimal, developer, web, azure",
@@ -82,7 +84,8 @@ export function devCommand(): Command {
         if (!creds) {
           // Stop spinner so inquirer interactive prompts display correctly
           stepper.stop();
-          console.log(chalk.yellow("\n  No Azure OpenAI credentials found. Let's set them up:\n"));
+          console.log(chalk.yellow("\n  No Azure OpenAI credentials found. Let's set them up."));
+          console.log(chalk.yellow("  You need an existing Azure OpenAI resource with a deployed model (e.g. gpt-4.1).\n"));
           creds = await promptAndSaveCredentials();
           stepper.done("Credentials configured");
         } else {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -145,13 +145,13 @@ export async function promptAndSaveCredentials(options?: {
     {
       type: "input",
       name: "model",
-      message: "Model deployment name:",
+      message: "Model deployment name (must already exist in your Azure OpenAI resource):",
       default: existing?.model || "gpt-4.1",
     },
     {
       type: "password",
       name: "apiKey",
-      message: "API key:",
+      message: "Azure OpenAI resource API key (resource-level key, not a per-model key):",
       mask: "•",
       validate: (input: string) => {
         if (!input || input.length < 10) return "API key is required";


### PR DESCRIPTION
## Problem

When `azureclaw dev --build` is run for the first time (no `~/.azureclaw/config.json`), the credential prompt doesn't work properly. Additionally, `make install-cli` results in a permission denied error when running `azureclaw`.

### Root causes

1. **Wrong step order** — Credentials were prompted at step 2, *after* the Docker image build (step 1), which can take 10-20 minutes for Rust compilation. Users should be asked for credentials first.

2. **Spinner hides interactive prompt** — `stepper.step("Loading credentials...")` starts an `ora` spinner that's still animating when `inquirer.prompt()` tries to display the interactive endpoint/model/API-key inputs. The spinner overwrites the prompt text, making it invisible or unresponsive.

3. **Missing execute bit on dist/index.js** — `tsc` doesn't preserve the executable permission on output files, so after `npm link`, running `azureclaw` fails with `EACCES: permission denied`.

## Changes

### `cli/src/commands/dev.ts`
- Move credential check to **step 1** (before image resolution/build)
- Stop the stepper spinner before calling `promptAndSaveCredentials()` so `inquirer` prompts display correctly
- Import `loadConfig` + `promptAndSaveCredentials` directly instead of `ensureCredentials` for finer control

### `cli/package.json`
- Add `chmod +x dist/index.js` to the build script so the CLI entry point is always executable after `tsc`

## New first-run flow

```
1/3 ✓ Credentials configured       ← prompts immediately
2/3 ● Building sandbox image...     ← long build happens after creds are saved
3/3 ✓ Sandbox running
```

## Testing

- `tsc --noEmit` passes
- All 159 vitest tests pass
- `oxlint` — 0 errors
- `make install-cli` → `azureclaw --help` works (no permission denied)