### PR TITLE
fix(build): use npm ci for reproducible builds, prevent lockfile churn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ router: ## Build the Rust inference router
 	cargo build --release --package azureclaw-inference-router
 
 cli: ## Build the TypeScript CLI
-	cd cli && npm install && npm run build
+	cd cli && npm ci && npm run build
 
 # ─── Test ─────────────────────────────────────────────────────────────────────
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -106,6 +106,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -167,6 +168,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
       "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -2587,6 +2589,7 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3979,6 +3982,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4571,6 +4575,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5021,6 +5026,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5041,6 +5047,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5180,6 +5187,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5499,6 +5507,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/sandbox-images/openclaw/Dockerfile
+++ b/sandbox-images/openclaw/Dockerfile
@@ -25,10 +25,10 @@ FROM ${INFERENCE_ROUTER_IMAGE} AS router-bin
 FROM ${SANDBOX_BASE_IMAGE} AS cli-builder
 
 WORKDIR /build
-COPY cli/package.json cli/tsconfig.json ./cli/
+COPY cli/package.json cli/package-lock.json cli/tsconfig.json ./cli/
 COPY cli/src/ ./cli/src/
 COPY policy-engine/profiles/ ./policy-engine/profiles/
-RUN cd cli && npm install --ignore-scripts 2>/dev/null || true && npm run build
+RUN cd cli && npm ci --ignore-scripts && npm run build
 
 # ─── Runtime Stage (overlay on base) ─────────────────────────────────────────
 
@@ -42,19 +42,18 @@ COPY --from=router-bin /usr/local/bin/azureclaw-inference-router /usr/local/bin/
 
 # Copy AzureClaw OpenClaw plugin (built from source in cli-builder stage)
 COPY --from=cli-builder /build/cli/dist/ /opt/azureclaw-plugin/
-COPY cli/package.json cli/openclaw.plugin.json /opt/azureclaw-plugin/
+COPY cli/package.json cli/package-lock.json cli/openclaw.plugin.json /opt/azureclaw-plugin/
 COPY cli/skills/ /opt/azureclaw-plugin/skills/
 COPY cli/policies/ /opt/azureclaw-plugin/policies/
 
 # Install plugin runtime dependencies
-RUN cd /opt/azureclaw-plugin && npm install --omit=dev --ignore-scripts 2>/dev/null || true
+RUN cd /opt/azureclaw-plugin && npm ci --omit=dev --ignore-scripts
 
 # Install vendored SDK with its dependencies (libsodium-wrappers etc.)
-COPY vendor/agentmesh-sdk/package.json vendor/agentmesh-sdk/tsup.config.ts /opt/azureclaw-vendored-sdk/
+COPY vendor/agentmesh-sdk/package.json vendor/agentmesh-sdk/package-lock.json vendor/agentmesh-sdk/tsup.config.ts /opt/azureclaw-vendored-sdk/
 COPY vendor/agentmesh-sdk/src/ /opt/azureclaw-vendored-sdk/src/
 COPY vendor/agentmesh-sdk/dist/ /opt/azureclaw-vendored-sdk/dist/
-RUN cd /opt/azureclaw-vendored-sdk && npm install --ignore-scripts 2>/dev/null || true && \
-    npm prune --omit=dev 2>/dev/null || true
+RUN cd /opt/azureclaw-vendored-sdk && npm ci --omit=dev --ignore-scripts
 
 # Overlay vendored SDK into plugin node_modules (patched dist + deps)
 RUN mkdir -p /opt/azureclaw-plugin/node_modules/@agentmesh/sdk && \

--- a/vendor/agentmesh-sdk/package-lock.json
+++ b/vendor/agentmesh-sdk/package-lock.json
@@ -901,6 +901,7 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1213,6 +1214,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1661,6 +1663,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1710,6 +1713,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2139,6 +2143,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Problem

`make build` modifies `cli/package-lock.json` on every run because:
- The Makefile uses `npm install` which regenerates the lockfile
- The committed lockfile was generated by npm 10 (Node 22), but npm 11 (Node 24) adds `"peer": true` annotations — causing a 9-line diff each time

Additionally, the sandbox Dockerfile didn't copy lockfiles into build stages, using `npm install` instead of `npm ci`, meaning Docker builds had non-deterministic dependency resolution.

## Fix

**Makefile**: Switch `npm install` → `npm ci` so builds install from the lockfile without modifying it.

**Dockerfile** (3 stages fixed):
- **cli-builder**: Copy `cli/package-lock.json`, use `npm ci --ignore-scripts`
- **plugin install**: Copy `cli/package-lock.json`, use `npm ci --omit=dev --ignore-scripts`
- **vendored SDK**: Copy `vendor/agentmesh-sdk/package-lock.json`, use `npm ci --omit=dev --ignore-scripts` (replaces `npm install` + `npm prune`)

**Lockfiles**: Regenerated with npm 11.6.2 for consistency with current toolchain.

## Testing

- Verified `npm ci` installs cleanly without modifying lockfile
- Verified `npm run build` succeeds after `npm ci`