### PR TITLE
fix(ci): ignore RUSTSEC-2026-0097 (rand unsound) until agentmesh bump

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,22 @@
+# cargo-audit configuration
+# See: https://docs.rs/cargo-audit/latest/cargo_audit/#configuration
+
+[advisories]
+ignore = [
+    # RUSTSEC-2026-0097 — `rand` is unsound with a custom logger using `rand::rng()`
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097
+    #
+    # Severity: informational ("unsound"), NOT a vulnerability.
+    # Source: transitive dependency — `agentmesh 3.1.0` pins `rand = "=0.8.5"` exactly.
+    #   Our own direct deps are already on `rand = "0.9"` (patched).
+    # Exploitation requires ALL of:
+    #   1. A custom `log::Log` implementation is installed.
+    #   2. That logger calls `rand::rng()` (or `rand::thread_rng()`).
+    #   3. Trace-level logging is enabled AND a `TryRng`/`RngCore` method is invoked
+    #      from inside the logger during a `ThreadRng` reseed (every 64 KiB).
+    # Our inference-router uses `tracing-subscriber` (not `log::Log`) and no logger
+    # implementation accesses `rand`. The upstream `agentmesh` crate uses `rand` only
+    # for nonce/key generation, none of it from inside a logger.
+    # TODO: remove once `agentmesh` ships a release with `rand >= 0.8.6`.
+    "RUSTSEC-2026-0097",
+]


### PR DESCRIPTION
Unblocks the `Rust Dependency Audit (RustSec advisories)` CI check currently failing on `main`.

## Problem
`cargo audit --deny warnings` fails on:
- Advisory: **RUSTSEC-2026-0097** — "Rand is unsound with a custom logger using `rand::rng()`" (2026-04-09)
- Severity: `informational = "unsound"` (NOT a Vulnerability)
- Affected: `rand 0.8.5` (patched in 0.8.6 / 0.9.3 / 0.10.1)

## Source of the bad version
Transitive: `agentmesh 3.1.0` pins `rand = "=0.8.5"` exactly. Our own direct deps (`Cargo.toml`, `inference-router/Cargo.toml`) are already `rand = "0.9"`, which is patched.

`cargo update -p rand@0.8.5 --precise 0.8.6` is refused because `agentmesh` pins the exact version. No new `agentmesh` release exists yet.

## Why ignore is safe
Exploitation requires ALL of:
1. A custom `log::Log` implementation is installed.
2. That logger calls `rand::rng()` (or `rand::thread_rng()`).
3. The logger invokes a `TryRng`/`RngCore` method from inside itself during a `ThreadRng` reseed (every 64 KiB).

We use `tracing-subscriber`, not `log::Log`, and no logger in our tree touches `rand`. Upstream `agentmesh` uses `rand` only for nonce/key generation, never from inside a logger.

## Follow-up
`TODO` comment in `.cargo/audit.toml` — remove the ignore once `agentmesh` ships a release with `rand >= 0.8.6`. I'll file an upstream issue against `agentmesh` to loosen the pin.

## Verified locally
```
$ cargo audit --deny warnings
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1055 security advisories (from /Users/.../advisory-db)
    Scanning Cargo.lock for vulnerabilities (343 crate dependencies)
$ echo $?
0
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>