### PR TITLE
feat(up): preflight RBAC + provider checks, stepper numbering fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -472,4 +472,5 @@ cli/*.test.*
 SECURITY-HARDENING-PLAN.md
 .DS_Store
 docs/demo-script.md
+docs/competitive.md
 nohup.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Preflight RBAC checks for `azureclaw up`** — new `cli/src/preflight.ts` queries effective permissions at subscription scope (`Microsoft.Authorization/permissions`), resource-provider registration, and preview-feature flags BEFORE Bicep runs, so operators fail in ≤30s instead of 20 minutes in. Prints copy-pasteable `az role assignment create` remediation commands with the exact missing actions. Escape hatch: `--skip-preflight`. See `docs/permissions.md` for the full role matrix + custom-role JSON.
+- **`docs/permissions.md`** — canonical required-roles reference for `azureclaw up`: Contributor + User Access Administrator (or Owner), per-action justification, least-privilege custom role, preview feature registration, and Entra `api://agentmesh` tenant-admin caveat.
 - **Bidirectional Agent Handoff** — live-migrate agents between local Docker and AKS cloud with `azureclaw handoff <name> --to cloud|local`. Supports both CLI-driven (operator) and LLM-driven (webchat) orchestration paths
 - **Sub-Agent Handoff** — sub-agents are snapshotted (workspace + task state), destroyed on source, re-spawned on target, and injected with workspace + resume signal via E2E encrypted mesh
 - **Stale AMID Cache Poisoning Fix** — three-layer defense: identity-based AMID rejection, prekey readiness gate, workspace inject retry with ack verification
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test fixtures** — 8 sanitized Azure Foundry JSON fixtures + 3 axum-based fake servers (IMDS, AAD, Azure upstream) with a request recorder, all shared between Rust integration tests and the CLI fake-router runner.
 
 ### Fixed
+- **`azureclaw up` stepper numbering** — declared `totalSteps: 7` never matched the 9 runtime phases (10 with `--expose-registry`), and step 4 (`kubectl` configure) was missing its `stepper.done()` call so it appeared to silently disappear from the progress log. Total now tracks the actual branch count, and every step has an explicit completion.
 - Router bind address fix for K8s probe accessibility
 - K8s probe host field removal (kubelet defaults to pod IP)
 - Missing transitive Python dependencies (typing_inspection, cryptography) via PyPI fallback

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ All images build on Azure Linux 3 (`mcr.microsoft.com/azurelinux/base/core:3.0`)
 | Helm | 3.14+ | AKS path only |
 | Rust | 1.88+ (edition 2024) | Building from source (both paths) |
 
+> **Azure RBAC:** `azureclaw up` needs `Contributor` **and** `User Access Administrator` at subscription scope (or `Owner`). See [`docs/permissions.md`](docs/permissions.md) for the full breakdown, a least-privilege custom role, and common failure modes. The CLI runs a preflight check automatically and fails fast in ≤30s if anything is missing.
+
 ### Step 1: Install the CLI
 
 ```bash

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { existsSync } from "fs";
 import { Stepper, banner, section, kvLine, checkLine } from "../stepper.js";
 import { saveContext, loadContext } from "../config.js";
+import { runPreflightChecks } from "../preflight.js";
 
 function isValidAzureHost(url: string, expectedSuffix: string): boolean {
   try {
@@ -46,6 +47,7 @@ export function upCommand(): Command {
     .option("--mesh-peer", "Enable mesh federation peer (default: on; use --no-mesh-peer to disable)", true)
     .option("--global-registry <url>", "Use an external AgentMesh registry (skip local registry deployment)")
     .option("--expose-registry", "Deploy AGIC Ingress to expose this cluster's registry publicly", false)
+    .option("--skip-preflight", "Skip upfront RBAC & provider checks (advanced; you know what you're doing)", false)
     .action(async (options) => {
       const blue = chalk.hex("#0078D4");
       const { default: inquirer } = await import("inquirer");
@@ -495,6 +497,24 @@ export function upCommand(): Command {
 
       const rg = options.resourceGroup || `azureclaw-${options.region}`;
 
+      // ── 3b. RBAC + provider preflight ──────────────────────────────
+      // Fails fast (≤30s) if the caller lacks roles / providers / features
+      // needed for the ~20-minute `up` flow. Skip on --dry-run and --skip-infra
+      // (the latter implies the cluster already exists and the caller already
+      // has cluster creds) and when the operator opts out explicitly.
+      if (!options.dryRun && !options.skipInfra && !options.skipPreflight) {
+        const pf = await runPreflightChecks({
+          region: options.region,
+          resourceGroup: rg,
+          isolation: options.isolation,
+          foundryEndpoint: options.foundryEndpoint,
+          skipPreflight: options.skipPreflight,
+        });
+        if (!pf.ok) {
+          process.exit(1);
+        }
+      }
+
       // ── 4. SKU availability check ──────────────────────────────────
       if (!options.dryRun && !options.skipInfra) {
         console.log();
@@ -603,7 +623,20 @@ export function upCommand(): Command {
       const clusterName = options.clusterName ?? "azureclaw";
       const baseName = clusterName.replace(/-aks$/, "");
       let acrName = ""; // resolved from Bicep output after deployment
-      const stepper = new Stepper({ totalSteps: 7 });
+      // Stepper counts the 9 runtime phases below (10 with --expose-registry).
+      // Preflight runs before the stepper (see runPreflightChecks above).
+      //   1. Resource group + preview features
+      //   2. Bicep deploy (or verify existing)
+      //   3. Network/firewalls/ACR attach
+      //   4. Get AKS credentials
+      //   5. Build OR import images
+      //   6. Helm install (CRD + controller + seccomp DS)
+      //   7. AgentMesh infrastructure (relay + registry)
+      //   8. (optional) AgentMesh Ingress — only with --expose-registry
+      //   9. Create ClawSandbox CR
+      //  10. Wait for sandbox Running
+      const totalSteps = 9 + (options.exposeRegistry ? 1 : 0);
+      const stepper = new Stepper({ totalSteps });
 
       try {
         const path = await import("path");
@@ -908,7 +941,7 @@ export function upCommand(): Command {
 
         stepper.done("Network access configured");
 
-        // ── Step 4: Get AKS credentials ──────────────────────────────
+        // ── Step 5: Get AKS credentials ──────────────────────────────
         stepper.step("Configuring kubectl...");
         await execa("az", [
           "aks", "get-credentials",
@@ -917,8 +950,9 @@ export function upCommand(): Command {
           "--overwrite-existing",
           "--output", "none",
         ], { stdio: "pipe" });
+        stepper.done("kubectl configured");
 
-        // ── Step 5: Get images into ACR ──────────────────────────────
+        // ── Step 6: Get images into ACR ──────────────────────────────
         const acr = acrLoginServer.replace(".azurecr.io", "");
 
         if (options.build) {

--- a/cli/src/preflight.test.ts
+++ b/cli/src/preflight.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { matchAction, hasEffectiveAction } from "./preflight.js";
+
+describe("matchAction", () => {
+  it("matches exact action", () => {
+    expect(matchAction("Microsoft.ContainerService/managedClusters/write",
+                       "Microsoft.ContainerService/managedClusters/write")).toBe(true);
+  });
+
+  it("matches wildcard across segments", () => {
+    expect(matchAction("Microsoft.ContainerService/*",
+                       "Microsoft.ContainerService/managedClusters/write")).toBe(true);
+  });
+
+  it("matches '*' catch-all", () => {
+    expect(matchAction("*", "Microsoft.KeyVault/vaults/write")).toBe(true);
+  });
+
+  it("is case-insensitive (Azure action matching)", () => {
+    expect(matchAction("microsoft.containerservice/managedClusters/WRITE",
+                       "Microsoft.ContainerService/managedClusters/write")).toBe(true);
+  });
+
+  it("rejects different resource provider", () => {
+    expect(matchAction("Microsoft.ContainerRegistry/*",
+                       "Microsoft.ContainerService/managedClusters/write")).toBe(false);
+  });
+
+  it("escapes regex metacharacters in the pattern", () => {
+    // A literal '.' in a pattern must match only '.', not any char.
+    expect(matchAction("Microsoft.KeyVault/vaults/write",
+                       "Microsoft-KeyVault/vaults/write")).toBe(false);
+  });
+});
+
+describe("hasEffectiveAction", () => {
+  it("grants when a permission set allows the action", () => {
+    expect(hasEffectiveAction(
+      [{ actions: ["Microsoft.ContainerService/*"], notActions: [] }],
+      "Microsoft.ContainerService/managedClusters/write"
+    )).toBe(true);
+  });
+
+  it("denies when notActions covers the action", () => {
+    expect(hasEffectiveAction(
+      [{ actions: ["*"], notActions: ["Microsoft.Authorization/*/write"] }],
+      "Microsoft.Authorization/roleAssignments/write"
+    )).toBe(false);
+  });
+
+  it("grants if ANY permission set allows (multiple roles merge)", () => {
+    expect(hasEffectiveAction(
+      [
+        { actions: ["Microsoft.ContainerService/*"], notActions: [] },
+        { actions: ["Microsoft.Authorization/roleAssignments/*"], notActions: [] },
+      ],
+      "Microsoft.Authorization/roleAssignments/write"
+    )).toBe(true);
+  });
+
+  it("Contributor-shaped role (star + notActions) denies roleAssignments/write", () => {
+    // This mirrors the real Contributor built-in role shape, which is the
+    // classic pitfall: Contributor CANNOT grant/revoke role assignments.
+    const contributorShape = [{
+      actions: ["*"],
+      notActions: [
+        "Microsoft.Authorization/*/Delete",
+        "Microsoft.Authorization/*/Write",
+        "Microsoft.Authorization/elevateAccess/Action",
+      ],
+    }];
+    expect(hasEffectiveAction(contributorShape,
+      "Microsoft.Authorization/roleAssignments/write")).toBe(false);
+    // But it still grants cluster creation
+    expect(hasEffectiveAction(contributorShape,
+      "Microsoft.ContainerService/managedClusters/write")).toBe(true);
+  });
+
+  it("denies when no permission set grants the action", () => {
+    expect(hasEffectiveAction(
+      [{ actions: ["Microsoft.ContainerRegistry/*"], notActions: [] }],
+      "Microsoft.KeyVault/vaults/write"
+    )).toBe(false);
+  });
+});

--- a/cli/src/preflight.ts
+++ b/cli/src/preflight.ts
@@ -1,0 +1,359 @@
+/**
+ * Preflight RBAC & provider checks for `azureclaw up`.
+ *
+ * `azureclaw up` takes ~15–25 minutes end-to-end. Failing halfway through
+ * because the caller lacks `Microsoft.Authorization/roleAssignments/write`
+ * is a terrible experience. This module queries the caller's effective
+ * permissions at subscription scope, resource provider registration
+ * state, and preview feature flags BEFORE Bicep runs, so we fail fast
+ * with copy-pasteable remediation commands.
+ *
+ * Checks performed:
+ *   1. az account show — caller signed in; capture tenant/sub/user
+ *   2. Effective actions at subscription scope (via Microsoft.Authorization/permissions REST)
+ *      diffed against the minimum set that `up` needs
+ *   3. Required resource provider registration
+ *   4. Preview feature flags (EncryptionAtHost always; KataVMIsolationPreview if confidential)
+ *   5. Best-effort Entra warning about the `api://agentmesh` scope
+ *
+ * Exits non-zero on blocking failures. Pass `--skip-preflight` to bypass
+ * (for environments where the caller knows their RBAC is correct but the
+ * check API returns a misleading result, e.g. cross-tenant guests).
+ */
+
+import chalk from "chalk";
+import ora from "ora";
+import { execa } from "execa";
+
+const BLUE = chalk.hex("#0078D4");
+
+export interface PreflightOptions {
+  region: string;
+  resourceGroup: string;
+  isolation: "standard" | "enhanced" | "confidential" | string;
+  /** If set, we don't need Microsoft.CognitiveServices write (external Foundry) */
+  foundryEndpoint?: string;
+  /** If set, skip all preflight checks (escape hatch). */
+  skipPreflight?: boolean;
+}
+
+export interface PreflightResult {
+  ok: boolean;
+  blocking: string[];
+  warnings: string[];
+  subscription?: string;
+  tenant?: string;
+  user?: string;
+}
+
+// Minimum set of Azure control-plane actions `azureclaw up` requires.
+// Each entry lists the action and a short human label for error output.
+interface RequiredAction {
+  action: string;
+  why: string;
+  /** Optional predicate — only require this action when predicate returns true. */
+  when?: (opts: PreflightOptions) => boolean;
+}
+
+const REQUIRED_ACTIONS: RequiredAction[] = [
+  { action: "Microsoft.Resources/subscriptions/resourceGroups/write", why: "create the resource group" },
+  { action: "Microsoft.Resources/deployments/write", why: "run the Bicep deployment" },
+  { action: "Microsoft.ContainerService/managedClusters/write", why: "provision AKS" },
+  { action: "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action", why: "az aks get-credentials" },
+  { action: "Microsoft.ContainerRegistry/registries/write", why: "provision ACR" },
+  { action: "Microsoft.ContainerRegistry/registries/importImage/action", why: "import sandbox images into ACR" },
+  { action: "Microsoft.KeyVault/vaults/write", why: "provision the Key Vault for sandbox secrets" },
+  { action: "Microsoft.ManagedIdentity/userAssignedIdentities/write", why: "create Workload Identity" },
+  { action: "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write", why: "federate Workload Identity to the sandbox ServiceAccount" },
+  { action: "Microsoft.OperationalInsights/workspaces/write", why: "provision Log Analytics workspace" },
+  { action: "Microsoft.Authorization/roleAssignments/write", why: "attach ACR to AKS and grant Workload Identity RBAC" },
+  { action: "Microsoft.Network/virtualNetworks/write", why: "AKS VNet (if Bicep creates one)" },
+  { action: "Microsoft.CognitiveServices/accounts/write", why: "provision Azure AI Foundry project", when: (o) => !o.foundryEndpoint },
+];
+
+// Role names that satisfy most of the above at subscription scope.
+// Printed as remediation hints.
+const REMEDIATION_ROLES = [
+  "Contributor (Microsoft.Resources, AKS, ACR, KV, Monitor, MI)",
+  "User Access Administrator (Microsoft.Authorization/roleAssignments/*)",
+  // Or the single role that covers both:
+  "— OR — Owner (covers both, but violates least-privilege)",
+];
+
+// Required resource providers. `azureclaw up` will attempt `az provider register`
+// on Microsoft.Compute / Microsoft.ContainerService explicitly; others are
+// typically auto-registered on first use but checking upfront catches locked-down
+// subs that block auto-registration.
+const REQUIRED_PROVIDERS = [
+  "Microsoft.ContainerService",
+  "Microsoft.ContainerRegistry",
+  "Microsoft.KeyVault",
+  "Microsoft.ManagedIdentity",
+  "Microsoft.OperationalInsights",
+  "Microsoft.Insights",
+  "Microsoft.Network",
+  "Microsoft.Compute",
+  "Microsoft.Authorization",
+];
+
+/**
+ * Match a permission-set wildcard (e.g. `Microsoft.ContainerService/*`) against
+ * a concrete action string. `*` matches any characters including `/`.
+ * Case-insensitive — Azure action matching is case-insensitive.
+ */
+export function matchAction(pattern: string, action: string): boolean {
+  const escaped = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&") // regex-escape literals
+    .replace(/\*/g, ".*");
+  return new RegExp("^" + escaped + "$", "i").test(action);
+}
+
+interface PermissionSet {
+  actions?: string[];
+  notActions?: string[];
+  dataActions?: string[];
+  notDataActions?: string[];
+}
+
+export function hasEffectiveAction(perms: PermissionSet[], action: string): boolean {
+  for (const p of perms) {
+    const granted = (p.actions || []).some((a) => matchAction(a, action));
+    if (!granted) continue;
+    const denied = (p.notActions || []).some((a) => matchAction(a, action));
+    if (!denied) return true;
+  }
+  return false;
+}
+
+async function fetchSubscriptionPermissions(subscriptionId: string): Promise<PermissionSet[]> {
+  // az rest auto-uses caller's AAD token and the management.azure.com audience.
+  const { stdout } = await execa(
+    "az",
+    [
+      "rest",
+      "--method", "GET",
+      "--url", `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01`,
+      "--url-parameters", "",
+    ],
+    { stdio: "pipe", timeout: 20000 }
+  );
+  const parsed = JSON.parse(stdout || "{}");
+  return Array.isArray(parsed.value) ? parsed.value : [];
+}
+
+async function providerRegistrationState(providerNamespace: string): Promise<string | null> {
+  try {
+    const { stdout } = await execa(
+      "az",
+      ["provider", "show", "--namespace", providerNamespace, "--query", "registrationState", "-o", "tsv"],
+      { stdio: "pipe", timeout: 15000 }
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function featureRegistrationState(
+  providerNamespace: string,
+  featureName: string
+): Promise<string | null> {
+  try {
+    const { stdout } = await execa(
+      "az",
+      [
+        "feature", "show",
+        "--namespace", providerNamespace,
+        "--name", featureName,
+        "--query", "properties.state",
+        "-o", "tsv",
+      ],
+      { stdio: "pipe", timeout: 15000 }
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run all preflight checks and print results. Returns a PreflightResult.
+ * The caller decides whether to exit on `!ok`.
+ */
+export async function runPreflightChecks(opts: PreflightOptions): Promise<PreflightResult> {
+  const result: PreflightResult = { ok: true, blocking: [], warnings: [] };
+
+  if (opts.skipPreflight) {
+    console.log(chalk.yellow("\n  ⚠ Preflight skipped (--skip-preflight)\n"));
+    return result;
+  }
+
+  console.log(BLUE("\n  ── Preflight: Azure permissions & prerequisites ──────────"));
+
+  // 1. Caller signed in
+  let spin = ora({ text: "Checking Azure sign-in...", color: "cyan" }).start();
+  let account: { id: string; tenantId: string; user?: { name?: string } };
+  try {
+    const { stdout } = await execa("az", ["account", "show", "-o", "json"], {
+      stdio: "pipe",
+      timeout: 15000,
+    });
+    account = JSON.parse(stdout);
+    result.subscription = account.id;
+    result.tenant = account.tenantId;
+    result.user = account.user?.name;
+    spin.succeed(`Signed in as ${chalk.bold(account.user?.name ?? "<unknown>")} (sub: ${account.id})`);
+  } catch {
+    spin.fail("Not signed in to Azure — run `az login`");
+    result.ok = false;
+    result.blocking.push("Run `az login` and try again.");
+    return result;
+  }
+
+  // 2. RBAC — effective permissions at subscription scope
+  spin = ora({ text: "Evaluating RBAC at subscription scope...", color: "cyan" }).start();
+  let perms: PermissionSet[] = [];
+  try {
+    perms = await fetchSubscriptionPermissions(account.id);
+  } catch (e) {
+    spin.warn(`Could not read effective permissions — ${(e as Error).message.split("\n")[0]}`);
+    result.warnings.push(
+      "RBAC check inconclusive. If `up` fails with an authorization error, re-run with adequate roles."
+    );
+  }
+
+  if (perms.length > 0) {
+    const missing: RequiredAction[] = [];
+    for (const req of REQUIRED_ACTIONS) {
+      if (req.when && !req.when(opts)) continue;
+      if (!hasEffectiveAction(perms, req.action)) missing.push(req);
+    }
+    if (missing.length === 0) {
+      spin.succeed(`RBAC — all ${REQUIRED_ACTIONS.filter((r) => !r.when || r.when(opts)).length} required actions granted`);
+    } else {
+      spin.fail(`RBAC — ${missing.length} required action(s) missing at subscription scope`);
+      for (const m of missing) {
+        console.log(chalk.red(`      ✗ ${m.action}`) + chalk.dim(`  — ${m.why}`));
+      }
+      result.ok = false;
+      result.blocking.push(
+        `Grant the current user sufficient RBAC. At minimum you need the roles:\n      ${REMEDIATION_ROLES.map((r) => chalk.cyan(r)).join("\n      ")}\n\n      Ask your subscription Owner / Global Admin to run:\n      ${chalk.cyan(`az role assignment create --assignee ${account.user?.name ?? "<your-user>"} --role "Contributor" --scope /subscriptions/${account.id}`)}\n      ${chalk.cyan(`az role assignment create --assignee ${account.user?.name ?? "<your-user>"} --role "User Access Administrator" --scope /subscriptions/${account.id}`)}`
+      );
+    }
+  }
+
+  // 3. Resource providers
+  spin = ora({ text: "Checking resource provider registration...", color: "cyan" }).start();
+  const providerStates: Array<{ ns: string; state: string | null }> = [];
+  for (const ns of REQUIRED_PROVIDERS) {
+    providerStates.push({ ns, state: await providerRegistrationState(ns) });
+  }
+  // Microsoft.CognitiveServices only required when provisioning a new Foundry
+  if (!opts.foundryEndpoint) {
+    providerStates.push({
+      ns: "Microsoft.CognitiveServices",
+      state: await providerRegistrationState("Microsoft.CognitiveServices"),
+    });
+  }
+
+  const unregistered = providerStates.filter((p) => p.state !== "Registered");
+  if (unregistered.length === 0) {
+    spin.succeed(`Resource providers — ${providerStates.length} registered`);
+  } else {
+    const notFound = unregistered.filter((p) => p.state === null);
+    const pending = unregistered.filter((p) => p.state !== null);
+    if (pending.length > 0) {
+      spin.warn(
+        `Resource providers — ${pending.length} not yet registered (${pending.map((p) => p.ns).join(", ")})`
+      );
+      result.warnings.push(
+        `${pending.length} resource provider(s) need registration. Run:\n      ${pending
+          .map((p) => chalk.cyan(`az provider register -n ${p.ns}`))
+          .join("\n      ")}`
+      );
+    }
+    if (notFound.length > 0) {
+      spin = ora().fail(
+        `Resource providers — could not verify ${notFound.length} (${notFound.map((p) => p.ns).join(", ")})`
+      );
+      result.warnings.push(
+        `Could not read registration state for: ${notFound.map((p) => p.ns).join(", ")}. Verify network access to management.azure.com.`
+      );
+    }
+  }
+
+  // 4. Preview feature flags
+  spin = ora({ text: "Checking preview feature flags...", color: "cyan" }).start();
+  const requiredFeatures: Array<{ ns: string; name: string; required: boolean }> = [
+    { ns: "Microsoft.Compute", name: "EncryptionAtHost", required: true },
+  ];
+  if (opts.isolation === "confidential") {
+    requiredFeatures.push({
+      ns: "Microsoft.ContainerService",
+      name: "KataVMIsolationPreview",
+      required: true,
+    });
+  }
+  const featureStates = await Promise.all(
+    requiredFeatures.map(async (f) => ({
+      ...f,
+      state: await featureRegistrationState(f.ns, f.name),
+    }))
+  );
+  const unregisteredFeatures = featureStates.filter((f) => f.state !== "Registered");
+  if (unregisteredFeatures.length === 0) {
+    spin.succeed(`Preview features — ${featureStates.length} registered`);
+  } else {
+    spin.warn(
+      `Preview features — ${unregisteredFeatures.length} not yet registered (${unregisteredFeatures
+        .map((f) => f.name)
+        .join(", ")})`
+    );
+    // Not blocking: up.ts attempts `az feature register` automatically, but
+    // feature propagation can take 10+ minutes. Warn so the operator knows.
+    result.warnings.push(
+      `${unregisteredFeatures.length} feature(s) need registration (may take 5–15 min to propagate):\n      ${unregisteredFeatures
+        .map((f) => chalk.cyan(`az feature register --namespace ${f.ns} --name ${f.name}`))
+        .join("\n      ")}`
+    );
+  }
+
+  // 5. Tenant-level warning about api://agentmesh scope
+  //    We can't actually verify this from the CLI without Graph permissions.
+  //    Just surface the known caveat so operators aren't surprised later.
+  console.log(
+    chalk.dim(
+      `      · AGT scope ${chalk.cyan("api://agentmesh")} — requires tenant admin to register (sandboxes fall back to AGT anonymous tier otherwise).`
+    )
+  );
+
+  // Summary
+  console.log();
+  if (!result.ok) {
+    console.log(chalk.red(`  ✗ Preflight failed — ${result.blocking.length} blocking issue(s)`));
+    for (const b of result.blocking) {
+      console.log(chalk.red(`    • `) + b.replace(/\n/g, "\n      "));
+    }
+    if (result.warnings.length > 0) {
+      console.log(chalk.yellow(`\n  ${result.warnings.length} warning(s):`));
+      for (const w of result.warnings) {
+        console.log(chalk.yellow(`    • `) + w.replace(/\n/g, "\n      "));
+      }
+    }
+    console.log(
+      chalk.dim(
+        `\n  See ${chalk.cyan("docs/permissions.md")} for the full permission matrix, or bypass with ${chalk.cyan("--skip-preflight")}.`
+      )
+    );
+  } else if (result.warnings.length > 0) {
+    console.log(chalk.yellow(`  ⚠ Preflight passed with ${result.warnings.length} warning(s)`));
+    for (const w of result.warnings) {
+      console.log(chalk.yellow(`    • `) + w.replace(/\n/g, "\n      "));
+    }
+  } else {
+    console.log(chalk.green(`  ✓ Preflight passed — permissions & prerequisites OK`));
+  }
+  console.log();
+
+  return result;
+}

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,221 @@
+# Azure permissions required for `azureclaw up`
+
+`azureclaw up` provisions a complete secure-by-default AKS runtime: cluster,
+ACR, Key Vault, Log Analytics, Azure AI Foundry project, Workload Identity,
+role assignments, network rules, Helm charts, and the `ClawSandbox` CRD.
+
+End-to-end the flow takes **15–25 minutes**. If the caller lacks the right
+RBAC, the flow fails halfway through with a cryptic `AuthorizationFailed`
+error. This document enumerates exactly what's required so you can either
+ask your subscription Owner for the right roles up front, or hand them this
+page.
+
+The CLI also ships a preflight check (run automatically at the start of
+`azureclaw up`) that queries your effective permissions and fails fast in
+under 30 seconds if anything is missing. You can bypass it with
+`--skip-preflight` if you know better.
+
+---
+
+## TL;DR — grant these two roles
+
+At **subscription** scope, for the user (or service principal) running
+`azureclaw up`:
+
+```bash
+SUB=$(az account show --query id -o tsv)
+USER=$(az account show --query user.name -o tsv)
+
+az role assignment create --assignee "$USER" --role "Contributor"                 --scope "/subscriptions/$SUB"
+az role assignment create --assignee "$USER" --role "User Access Administrator"   --scope "/subscriptions/$SUB"
+```
+
+Alternatively, `Owner` at subscription scope covers both, but it violates
+least-privilege. If you're running a one-off bootstrap, `Owner` scoped to
+the target **resource group** (after you create it manually) is also
+acceptable.
+
+---
+
+## Why two roles?
+
+| Role | Actions it grants | What `azureclaw up` needs it for |
+|------|-------------------|----------------------------------|
+| **Contributor** | `*` except `Microsoft.Authorization/*/Write`, `*/Delete` | Create AKS, ACR, KV, Log Analytics, Foundry, VNet, Workload Identity, Bicep deployments |
+| **User Access Administrator** | `Microsoft.Authorization/*` | `az aks update --attach-acr` (kubelet↔ACR role assignment), federated-credential creation, Workload Identity → Foundry role grants |
+
+`Contributor` alone is **not enough** — AKS↔ACR attachment creates a role
+assignment between the AKS kubelet identity and the ACR, and that requires
+`Microsoft.Authorization/roleAssignments/write`.
+
+---
+
+## Full required actions matrix
+
+These are the individual control-plane actions the preflight checks against.
+Most are bundled inside `Contributor` + `User Access Administrator`; listed
+here so you can build a **custom role** if you need tighter least-privilege.
+
+| Action | Purpose |
+|--------|---------|
+| `Microsoft.Resources/subscriptions/resourceGroups/write` | Create the target resource group |
+| `Microsoft.Resources/deployments/write` | Run the Bicep deployment |
+| `Microsoft.ContainerService/managedClusters/write` | Provision AKS cluster |
+| `Microsoft.ContainerService/managedClusters/listClusterUserCredential/action` | `az aks get-credentials` |
+| `Microsoft.ContainerRegistry/registries/write` | Provision ACR |
+| `Microsoft.ContainerRegistry/registries/importImage/action` | Import sandbox/controller/router images |
+| `Microsoft.KeyVault/vaults/write` | Provision Key Vault for sandbox secrets |
+| `Microsoft.ManagedIdentity/userAssignedIdentities/write` | Create Workload Identity |
+| `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write` | Federate each sandbox ServiceAccount |
+| `Microsoft.OperationalInsights/workspaces/write` | Provision Log Analytics |
+| `Microsoft.Authorization/roleAssignments/write` | Attach ACR to AKS, grant Workload Identity scoped RBAC |
+| `Microsoft.Network/virtualNetworks/write` | AKS VNet (if Bicep creates one) |
+| `Microsoft.CognitiveServices/accounts/write` | Provision Azure AI Foundry project (skip if you pass `--foundry-endpoint`) |
+| `Microsoft.Features/providers/features/register/action` | Register `EncryptionAtHost`, `KataVMIsolationPreview` |
+
+### Custom role JSON (copy-paste)
+
+```jsonc
+{
+  "Name": "AzureClaw Deployer",
+  "Description": "Minimal role to run 'azureclaw up' end-to-end",
+  "IsCustom": true,
+  "Actions": [
+    "Microsoft.Resources/subscriptions/resourceGroups/write",
+    "Microsoft.Resources/subscriptions/resourceGroups/read",
+    "Microsoft.Resources/deployments/*",
+    "Microsoft.ContainerService/managedClusters/*",
+    "Microsoft.ContainerRegistry/registries/*",
+    "Microsoft.KeyVault/vaults/*",
+    "Microsoft.ManagedIdentity/userAssignedIdentities/*",
+    "Microsoft.OperationalInsights/workspaces/*",
+    "Microsoft.Insights/*",
+    "Microsoft.Authorization/roleAssignments/write",
+    "Microsoft.Authorization/roleAssignments/read",
+    "Microsoft.Authorization/roleAssignments/delete",
+    "Microsoft.Authorization/roleDefinitions/read",
+    "Microsoft.Network/virtualNetworks/*",
+    "Microsoft.Network/networkSecurityGroups/*",
+    "Microsoft.Network/privateEndpoints/*",
+    "Microsoft.CognitiveServices/accounts/*",
+    "Microsoft.Features/providers/features/register/action",
+    "Microsoft.Features/providers/features/read",
+    "Microsoft.Features/features/read"
+  ],
+  "NotActions": [],
+  "AssignableScopes": ["/subscriptions/<YOUR_SUB_ID>"]
+}
+```
+
+Assign with:
+
+```bash
+az role definition create --role-definition ./azureclaw-deployer.json
+az role assignment create --assignee "$USER" --role "AzureClaw Deployer" --scope "/subscriptions/$SUB"
+```
+
+---
+
+## Resource providers
+
+The preflight checks these are `Registered`. If any are `NotRegistered`, it
+prints the exact `az provider register` command. Most subscriptions
+auto-register on first use; locked-down subs block that.
+
+- `Microsoft.ContainerService`
+- `Microsoft.ContainerRegistry`
+- `Microsoft.KeyVault`
+- `Microsoft.ManagedIdentity`
+- `Microsoft.OperationalInsights`
+- `Microsoft.Insights`
+- `Microsoft.Network`
+- `Microsoft.Compute`
+- `Microsoft.Authorization`
+- `Microsoft.CognitiveServices` *(only if provisioning a new Foundry)*
+
+Bulk-register:
+
+```bash
+for ns in Microsoft.ContainerService Microsoft.ContainerRegistry Microsoft.KeyVault \
+          Microsoft.ManagedIdentity Microsoft.OperationalInsights Microsoft.Insights \
+          Microsoft.Network Microsoft.Compute Microsoft.Authorization Microsoft.CognitiveServices; do
+  az provider register -n "$ns"
+done
+```
+
+---
+
+## Preview features
+
+| Feature | Required when |
+|---------|---------------|
+| `Microsoft.Compute/EncryptionAtHost` | Always — `clawpool` VMs use encryption-at-host |
+| `Microsoft.ContainerService/KataVMIsolationPreview` | Only with `--isolation confidential` |
+
+`azureclaw up` attempts to register these automatically. **Feature
+propagation takes 5–15 minutes** — if your tenant hasn't registered them
+before, the preflight will print a warning and you'll want to register
+them ahead of time:
+
+```bash
+az feature register --namespace Microsoft.Compute         --name EncryptionAtHost
+az feature register --namespace Microsoft.ContainerService --name KataVMIsolationPreview   # only for confidential
+```
+
+Track progress with `az feature show`. Once both show `Registered`, re-run
+the provider refresh:
+
+```bash
+az provider register -n Microsoft.Compute
+az provider register -n Microsoft.ContainerService
+```
+
+---
+
+## Tenant-level (Entra ID) considerations
+
+AzureClaw's inter-agent mesh (AGT) authenticates agents to the AgentMesh
+relay using an Entra-issued token for the scope `api://agentmesh/.default`.
+**Registering that scope requires a tenant administrator** (Global
+Administrator or Application Administrator). AzureClaw does **not** create
+the app registration automatically.
+
+If nobody has provisioned the `api://agentmesh` Entra application in your
+tenant, sandboxes still come up — they fall back to the **AGT anonymous
+tier**, which works for dev/test but not for production tenant-isolated
+workloads. Ask your tenant admin to run:
+
+```bash
+# Requires Application Administrator or Global Admin
+az ad app create --display-name "AgentMesh" --identifier-uris "api://agentmesh"
+APP_ID=$(az ad app list --display-name AgentMesh --query "[0].appId" -o tsv)
+az ad sp create --id "$APP_ID"
+```
+
+---
+
+## Common failure modes
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `AuthorizationFailed` on AKS attach-ACR | Missing `Microsoft.Authorization/roleAssignments/write` | Grant `User Access Administrator` at sub scope |
+| `FeatureNotRegistered` during Bicep | `EncryptionAtHost` not propagated yet | Wait 5–15 min after `az feature register`, then retry |
+| `SubscriptionNotRegistered` for Microsoft.ContainerService | Locked-down sub blocks auto-registration | `az provider register -n Microsoft.ContainerService` |
+| `ResourceQuotaExceeded` for VM cores | Regional vCPU quota | Request quota increase or use `--region` to pick a different region |
+| Sandboxes come up but AGT messages fail auth | `api://agentmesh` Entra app not registered | Ask tenant admin (see above) — sandboxes fall back to anonymous tier |
+| `AADSTS500011` in router logs | Same as above | Tenant admin registers `api://agentmesh` |
+
+---
+
+## Running the preflight manually
+
+```bash
+# The preflight runs automatically at the start of `azureclaw up`. To run
+# just the checks without deploying, pair it with --dry-run:
+azureclaw up --dry-run
+
+# To bypass (e.g. cross-tenant guests where the permissions API returns
+# misleading results, or CI systems using a federated identity where the
+# effective-permissions API doesn't reflect reality):
+azureclaw up --skip-preflight
+```


### PR DESCRIPTION
## Summary

Fixes the two leftover production-readiness gaps in `azureclaw up` the user flagged, so non-Owner operators no longer have to fail 20 minutes into the deploy before learning they were missing RBAC.

### 1. Preflight RBAC + provider checks (`cli/src/preflight.ts`)

Runs automatically before the Bicep deploy. Fails in ≤30s instead of halfway through.

- Queries effective permissions at subscription scope via `Microsoft.Authorization/permissions` and diffs against the minimum action set `up.ts` needs (resource group create, AKS, ACR, KV, Log Analytics, Foundry, Workload Identity, federated credentials, role assignments, VNet).
- Checks required resource-provider registration (Microsoft.ContainerService, ContainerRegistry, KeyVault, ManagedIdentity, OperationalInsights, Insights, Network, Compute, Authorization, and CognitiveServices when provisioning a new Foundry).
- Checks preview feature flags (`EncryptionAtHost` always; `KataVMIsolationPreview` when `--isolation confidential`).
- Best-effort note about the `api://agentmesh` Entra scope — the one tenant-level dependency the CLI cannot fix itself.
- Prints missing actions with copy-paste `az role assignment create` remediation.
- Escape hatch: `--skip-preflight` for cross-tenant guests where the permissions API returns misleading results.

Implementation notes:
- Pure-function helpers (`matchAction`, `hasEffectiveAction`) are exported and covered by **11 unit tests**, including the Contributor-shape `notActions` edge case that's the single most common "why is attach-acr failing" pitfall.
- Skipped automatically on `--dry-run` and `--skip-infra` (the latter implies the cluster exists and creds are already OK).

### 2. Stepper numbering fix

- `totalSteps` was hardcoded to 7 but `up.ts` actually runs 9 phases (10 with `--expose-registry`). Progress was rendering `8/7`, `9/7`.
- Step 4 (`Configuring kubectl…`) was missing its `stepper.done()` — the spinner got silently `.stop()`ed when step 5 started, so the user saw step 4 briefly appear and then vanish with no ✓. That matches the "missing number 4" observation.
- Added explicit `stepper.done("kubectl configured")` and made `totalSteps` branch on `--expose-registry`.

### 3. `docs/permissions.md`

Canonical required-roles reference: `Contributor` + `User Access Administrator` (or `Owner`), full per-action matrix with justifications, least-privilege custom-role JSON, bulk provider/feature registration commands, and the Entra `api://agentmesh` tenant-admin caveat. Linked from README prerequisites.

## Test plan

- `npm run typecheck` — clean
- `npm run build` — clean
- `npx vitest run src/preflight.test.ts src/config.test.ts src/router-url.test.ts src/redact.test.ts` — **54 tests pass**
- `npm run lint` — no new warnings (26 pre-existing)

## Out of scope

Did not yet implement a live-run verification against a real subscription; the preflight uses the `az rest` + `az feature show` tools that have been battle-tested elsewhere in the CLI. Operators can dry-run with `azureclaw up --dry-run` to see the plan without deploying.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>