### PR TITLE
Phase 0 (1/9): security-audit scaffolding, AGT boundary, vendored-patch audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -474,3 +474,4 @@ SECURITY-HARDENING-PLAN.md
 docs/demo-script.md
 docs/competitive.md
 nohup.out
+docs/implementation-plan.md

--- a/docs/agt-boundary.md
+++ b/docs/agt-boundary.md
@@ -1,0 +1,109 @@
+# AGT Boundary — what AzureClaw consumes vs. what AzureClaw builds
+
+**Status:** internal draft, shared with AGT team for confirmation.
+**Companion:** `docs/implementation-plan.md` §1 ("AGT boundary (operational,
+not rhetorical)") is the canonical version; this file is the standalone
+reference that non-plan readers need.
+
+AGT ships the governance engine. AzureClaw is the AKS operator and data plane
+that feeds AGT and surfaces AGT decisions as K8s primitives. Any overlap is a
+bug to resolve, not a feature to negotiate.
+
+---
+
+## 1. Responsibility split
+
+### AGT owns
+
+- **Policy evaluation** — `PolicyEngine.decide(request) -> verdict`. Policy
+  profile schema is AGT's. We emit profiles from CRDs; we do not redefine the
+  schema.
+- **Signal Protocol primitives** — X3DH key exchange, Double Ratchet, prekey
+  lifecycle, session state machine.
+- **Audit Merkle chain** — `AuditLogger.append(event) -> ReceiptId`. Storage,
+  retention SLA, signing of tree roots, queryability API.
+- **Trust scoring** — `TrustManager`. Per-peer trust scores, transitive
+  evaluation, decay functions, negative-signal ingestion.
+- **Behavior anomaly detection** — `BehaviorMonitor`. Baseline capture,
+  deviation detection, Shadow-MCP behavioral signals.
+- **Rate-limit token bucket** — per-identity, per-tool, per-mesh counters.
+  We configure caps; AGT enforces.
+- **Signing keys** — HSM / HW-backed key custody, key rotation, signing
+  primitives for A2A cards and AP2 transfers.
+- **A2A 1.2 Signed Agent Card signing** — when AGT ships this primitive. If
+  not, we implement via our `SigningProvider` and document the gap.
+- **AP2 policy grammar** — if AGT defines; otherwise we define an internal
+  schema designed to be portable to a future AGT definition.
+
+### AzureClaw owns
+
+- **K8s operator** — controller, CRDs, admission policies, reconcilers.
+- **Router data plane** — L7 proxy, IMDS/Workload-Identity auth, Foundry
+  calls, MCP transport (Streamable HTTP + SSE compat), A2A transport,
+  OpenAI-SDK sandbox-provider adapter, channel plugins.
+- **Sandbox image** — Dockerfile layout, seccomp profiles, Landlock policy,
+  egress-guard iptables, UID layout, init containers.
+- **CLI (`azureclaw`)** — including `operator` TUI, `up`, `add`, `push`,
+  `dev`, `handoff`, `offload`, `policy learn`, `migrate`, `convert`,
+  `claw attest`.
+- **Confidential compute integration** — Kata + SEV-SNP runtime class,
+  attestation document handling.
+- **K8s AI Conformance** — internal certification harness; public certification
+  deferred to post-OSS.
+- **`sigs/agent-sandbox` compat mode** — translator / overlay / vendored
+  reconciler for the upstream schema. Opt-in; default stays Native.
+
+---
+
+## 2. Provider contracts (Phase 0)
+
+Four provider traits, each with three impls (`Vendored*`, `Agt*`, `Null*`).
+`Null*` is test-only and blocked in prod by admission (see
+`docs/implementation-plan.md` §6 item 6).
+
+| Trait | Current impls | Role |
+|---|---|---|
+| `MeshProvider` | `VendoredAgentMesh` · `Agt` (pending AGT AgentMesh delivery) | E2E session establishment + message send/receive |
+| `PolicyDecisionProvider` | `Vendored` · `AgtRustSdk` · `Null` | Allow/Deny/Approval/RateLimit evaluation |
+| `AuditSink` | `Vendored` · `AgtRustSdk` · `Null` | Append-only audit events → receipt id |
+| `SigningProvider` | `Vendored` · `AgtRustSdk` · `Null` | Sign (key_ref, payload) and verify |
+
+Providers are selected **per tenant** via feature flag. The vendored path is
+permanent alternate architecture, not migration staging — it is never
+scheduled for deletion.
+
+## 3. Outage semantics
+
+Every provider call passes through an outage-mode layer:
+
+| Mode | Behaviour on provider outage | Default |
+|---|---|---|
+| `Strict` | Fail-closed. Refuse the operation. | **Prod (default)** |
+| `CachedRead` | Use last-known decision for read-only paths; fail-close on mutation. | opt-in, regulated tenants |
+| `DegradedDev` | Allow, mark event `degraded=true`, emit loud metric. | `azureclaw dev` |
+
+Per-tenant override via `ClawSandbox.spec.agt.outageMode`.
+
+## 4. What we never build
+
+- Signal/X3DH/Double-Ratchet primitives (principle §0.2 #8: no custom crypto).
+- A standalone audit chain (we emit into AGT's).
+- A trust-score computation engine.
+- A rate-limit enforcement bucket outside AGT.
+- Key custody or HSM integration outside AGT.
+
+## 5. What we always build
+
+- The K8s-primitive surface (CRDs) for anything AGT exposes.
+- The router data-plane enforcement point for every AGT decision.
+- The sandbox isolation substrate AGT assumes.
+
+## 6. Working mode with AGT
+
+- This file is shared with the AGT team for confirmation (Phase 0
+  deliverable).
+- Disagreements resolved by: (a) AGT's ownership wins if they commit to
+  shipping; (b) AzureClaw picks it up temporarily if they cannot commit;
+  (c) scope is documented here and in the relevant security-audit docs.
+- AGT Rust SDK releases trigger `ci/vendored-patch-audit.sh` re-runs (see
+  `docs/agt-vendored-patch-audit.md`).

--- a/docs/agt-vendored-patch-audit.md
+++ b/docs/agt-vendored-patch-audit.md
@@ -1,0 +1,83 @@
+# Vendored AgentMesh Patch Audit
+
+**Status:** tracked per AGT SDK / upstream AgentMesh release.
+**Enforcer:** `ci/vendored-patch-audit.sh` — fails CI if `vendor/**` or the
+AGT SDK version changed without a matching re-audit row below.
+
+This document tracks the patches applied to the vendored AgentMesh components
+(`vendor/agentmesh-sdk`, `vendor/agentmesh-relay`, `vendor/agentmesh-registry`).
+Per principle §0.2 #8 of `docs/implementation-plan.md`, every patch is
+re-audited on each AGT SDK / upstream bump: still required, upstream-absorbed,
+or superseded by the `AgtMeshProvider` (once AGT ships AgentMesh).
+
+## Current pins
+
+| Component | Vendored from upstream | Pinned version | Upstream URL |
+|---|---|---|---|
+| `vendor/agentmesh-sdk` | `amitayks/agentmesh/agentmesh-js` | v0.1.2 | <https://github.com/amitayks/agentmesh/tree/main/agentmesh-js> |
+| `vendor/agentmesh-relay` | `amitayks/agentmesh/relay` | v0.3.0 | <https://github.com/amitayks/agentmesh/tree/main/relay> |
+| `vendor/agentmesh-registry` | `amitayks/agentmesh/registry` | v0.3.0 | <https://github.com/amitayks/agentmesh/tree/main/registry> |
+| `vendor/sandbox-wheels` | (internal Python wheel cache) | N/A | N/A |
+
+`npm`-published equivalent (historical): `@agentmesh/sdk` v0.1.2.
+AGT Rust SDK (shipped, consumed by Phase 0): version TBD — roster row to be
+added once crate is pinned in Phase 0.
+
+## Patch status — `vendor/agentmesh-sdk`
+
+Source of truth: `vendor/agentmesh-sdk/README.md`. Numbering matches.
+
+| # | Title | Still required? | Notes |
+|---|---|---|---|
+| 1 | `PrekeyManager.buildBundle()` — empty signature + missing prekeys | **Yes** | Upstream still returns empty sig on v0.1.2. Revalidate on v0.2.x. |
+| 2 | `base64Decode` — `x25519:` / `ed25519:` key type prefix crash | **Yes** | Registry still returns prefixed keys; patch needed everywhere we consume keys from the registry. |
+| 3 | X3DH → Double Ratchet handoff — missing peer ratchet key | **Yes** | Core Signal-protocol correctness; cannot ship without. |
+| 4 | KNOCK protocol — not wired to relay transport | **Yes** | Sessions silently never establish without it. |
+| 5 | KNOCK race condition — message before KNOCK accepted | **Yes** | 1–33 ms race window; reproducible under load. |
+| 6 | `connect()` prekey/register order — registry requires registration first | **Yes** | Plus sender-side retry in `plugin.ts`. |
+| 7 | `submitReputation` — silent error swallowing | **Yes** | Logs only; safe to keep until AGT TrustManager replaces. |
+| 8 | `connect()` — stale connected state blocks reconnect | **Yes** | Reconnect-loop correctness; cannot ship without. |
+
+**Known remaining gap** (documented in SDK README): transport `receive`
+events are not wired to `AgentMeshClient.onMessage()`. Parent → sub-agent send
+works E2E; sub-agent → parent receive needs the sub-agent to drive its own
+relay listener in `entrypoint.sh`. Tracked as a `MeshProvider` behaviour to
+replicate faithfully under both `VendoredAgentMeshProvider` and the future
+`AgtMeshProvider`; the Phase 0 Signal conformance corpus must assert it.
+
+## Patch status — `vendor/agentmesh-relay`
+
+Source of truth: `vendor/agentmesh-relay/README.md`.
+
+| # | Title | Still required? | Notes |
+|---|---|---|---|
+| 1 | Raw-timestamp signature verification (`chrono::to_rfc3339` `Z` vs `+00:00`) | **Yes** | Interop with SDK's `Date.toISOString()`. Upstream has not adopted. |
+| 2 | Session-aware connection management (ghost-connection fix) | **Yes** | Reconnect correctness under network drops. |
+
+## Patch status — `vendor/agentmesh-registry`
+
+Source of truth: `vendor/agentmesh-registry/README.md`.
+
+| # | Title | Still required? | Notes |
+|---|---|---|---|
+| 1 | Raw-timestamp signature verification (same root cause as relay Patch 1) | **Yes** | Prekey uploads fail 401 without it. |
+| 2 | Ghost agent cleanup + heartbeat + search freshness | **Yes** | Sub-agent restart hygiene. |
+
+## Re-audit cadence
+
+- On every AGT SDK version bump.
+- On every `vendor/**` file change.
+- On every `@agentmesh/sdk` version bump (if we ever upgrade the npm-published
+  upstream, which we currently do not, since we overlay the vendored dist).
+- At Phase 1 / Phase 2 / Phase 3 close-out, as part of the phase success gate.
+
+On each re-audit: update this file with a new "audited by / date / AGT SDK
+version / upstream version" entry at the bottom and mark any patch as
+`Upstream-absorbed` or `Superseded by AgtMeshProvider` with a link to the
+commit/PR that absorbed it.
+
+## Re-audit history
+
+| Date | AGT SDK | SDK upstream | Relay upstream | Registry upstream | Auditor | Delta |
+|---|---|---|---|---|---|---|
+| 2026-04-24 | TBD (landing in Phase 0) | v0.1.2 | v0.3.0 | v0.3.0 | *(initial entry — to be co-signed at first Phase 0 PR)* | Baseline; no patches absorbed upstream yet. |

--- a/docs/internal-boundaries.md
+++ b/docs/internal-boundaries.md
@@ -1,0 +1,59 @@
+# Internal MSFT Product Boundaries
+
+**Status:** internal. Not published externally.
+**Companion:** `docs/implementation-plan.md` §3 is the canonical version; this
+file is the standalone reference.
+
+AzureClaw does not compete with other Microsoft products. Every overlap with
+a neighbouring MSFT product resolves to one of three postures:
+
+- **Consume** — we call their API / include their capability.
+- **Be consumed** — they call ours / embed ours.
+- **Orthogonal** — explicitly non-overlapping scope.
+
+A new CRD or capability in AzureClaw MUST be added to the table below with a
+declared posture before it merges. `ci/security-audit-required.sh` checks for
+the posture reference in the relevant security-audit doc.
+
+---
+
+## Boundary matrix
+
+| MSFT product | Overlap surface | Posture | How we stay separate |
+|---|---|---|---|
+| **Azure AI Foundry** | Model serving, agent orchestration, Memory Store, Evals | **Consume** | `ClawMemory` is a Foundry Memory Store *binding* CR, never an in-cluster memory backend. `ClawEval` integrates with Foundry Evals + Promptflow. `InferencePolicy` is a budget/guardrail CR, not a model-router. Router calls Foundry, never replaces it. |
+| **KAITO** | Model deployment on K8s | **Orthogonal** | KAITO deploys models (payload). AzureClaw deploys *agents that consume models*. A KAITO inference workspace can be the target of an AzureClaw `InferencePolicy`. |
+| **Azure Container Apps Dynamic Sessions** | Code-exec sandboxes | **Orthogonal** | ACA is serverless one-shot exec. AzureClaw is a full agent runtime on AKS with mesh, governance, persistent identity. ACA can be a *target* tool via `McpServer`. |
+| **AKS-core (Istio / Gateway API / Workload Identity)** | K8s primitives AzureClaw uses | **Consume** | We use Gateway API for ingress, Workload Identity for federated auth, native K8s NetworkPolicy. We do not ship a fork of any of these. |
+| **Entra ID / Workload Identity Federation** | Identity | **Consume** | `ClawAgentIdentity` (Phase 4) federates SPIFFE SVIDs through Entra WIF; we never reimplement identity. |
+| **Microsoft Defender for Cloud** | Cloud security posture | **Orthogonal** | Defender reports on cluster-level posture. AzureClaw's audit chain is agent-operation-scoped. They nest naturally. |
+| **Azure Policy / OPA Gatekeeper** | Admission | **Complementary** | Azure Policy handles org-wide AKS policy. AzureClaw ships agent-scoped VAP/MAP. Both run; not a replacement. |
+| **Microsoft Sentinel** | SIEM | **Be consumed** | AGT audit receipts feed Sentinel via OTel. Sentinel consumes; we never replace. |
+| **Microsoft 365 Agent Framework / Copilot Studio** | Agent authoring | **Orthogonal + partial consume** | M365/Copilot Studio authors agents at the SaaS layer; AzureClaw is the AKS-hosted runtime for developer-authored agents (via OpenClaw, Claude Agent SDK, OpenAI SDK, etc.). Copilot Studio agents can invoke AzureClaw-hosted MCP servers. |
+| **Microsoft Intune / Purview** | Compliance | **Be consumed** | Audit chain is queryable by compliance tools. |
+
+---
+
+## Rule for new CRDs
+
+Every new CRD merges only if:
+
+1. It has a row in the matrix above.
+2. Posture is one of `Consume`, `Be consumed`, or `Orthogonal`.
+3. The security-audit doc for the CRD cites this row.
+4. If the posture is `Consume` against a partner team, we have a written
+   statement from that team. `ClawMemory` (Phase 2) is the first such case —
+   see `docs/implementation-plan.md` §14 open decision #5.
+
+## Rule for CLI commands
+
+New CLI commands do not need a matrix row unless they introduce a new
+integration surface (e.g., a new channel plugin). Channel plugins go under
+`docs/internal-boundaries-channels.md` (Phase 1, when we add the first
+non-Telegram channel).
+
+## Non-goals
+
+- This file is not a competitive positioning document. That lives in
+  `docs/competitive.md` (gitignored) for external/competitive landscape,
+  not for internal MSFT relationships.

--- a/docs/security-audits/README.md
+++ b/docs/security-audits/README.md
@@ -1,0 +1,55 @@
+# Security Audit Records
+
+Every capability-introducing PR ships with a security-audit record in this
+directory — enforced by `ci/security-audit-required.sh` and principle §0.2 #9
+of `docs/implementation-plan.md`.
+
+## What is a "capability" for audit purposes?
+
+Any change to:
+
+- CRDs (`controller/src/crd/**`)
+- Reconcilers (`controller/src/reconcilers/**`)
+- Admission policies (`controller/src/admission/**`)
+- Router modules (`inference-router/src/{mcp,a2a,providers,routes}/**`)
+- CLI commands / adapters / migrations
+  (`cli/src/{commands,migrate,adapters}/**`)
+- Sandbox images (`sandbox-images/*/Dockerfile`, `entrypoint.sh`)
+- Policy-engine profiles (`policy-engine/**`)
+- Vendored patch updates (`vendor/*/src/**`, `vendor/*/dist/**`)
+
+## Workflow
+
+1. Copy `_template.md` to `<YYYY-MM-DD>-<slug>.md` in this directory, e.g.
+   `2026-04-24-mcp-streamable-http.md`.
+2. Fill every section. "N/A" is acceptable — with a one-line justification.
+3. Author signs Section 11 sign-off block.
+4. A second engineer reviews. For router data-plane, sandbox-image, or
+   admission-policy changes, the second signer must be from the roster in
+   `docs/security-reviewers.md`.
+5. Commit alongside the capability code in the same PR.
+6. `ci/security-audit-required.sh` blocks merge unless the file exists.
+
+## Why this exists
+
+We have been bitten by "looks like it works" bugs — base64 wrappers
+pretending to be Signal, routers returning 200 without running Content Safety,
+prekey bundles with empty signatures nobody noticed. Security audit records
+force an explicit answer to *how do we know the control actually ran?* before
+the capability ships.
+
+## Non-goals
+
+This is NOT a CAB. It is not a bottleneck. Two engineers, a completed
+template, and the PR moves. If the doc is trivially fillable, that is a signal
+the capability is well-scoped. If it is not, that is a signal the design needs
+more thought before code is written.
+
+## References
+
+- `docs/security-audits/_template.md` — the template
+- `docs/security-reviewers.md` — the roster
+- `docs/agt-boundary.md` — AGT responsibilities (don't duplicate)
+- `docs/internal-boundaries.md` — MSFT product non-compete posture
+- `docs/agt-vendored-patch-audit.md` — vendored AgentMesh patch status
+- `ci/security-audit-required.sh` — the enforcing script

--- a/docs/security-audits/_template.md
+++ b/docs/security-audits/_template.md
@@ -1,0 +1,147 @@
+# Security Audit — `<capability slug>`
+
+**Date:** YYYY-MM-DD
+**PR:** #XXXX
+**Author:** @github-handle
+**Independent reviewer:** @github-handle (from `docs/security-reviewers.md` if
+router-data-plane / sandbox-image / admission-policy)
+**Capability scope:**
+<!-- one paragraph. What is landing? Which files? -->
+
+---
+
+## 1. Summary
+
+<!-- one paragraph. What the capability is in plain language. Not marketing;
+technical. -->
+
+## 2. Threat model delta
+
+<!-- Which assets gain new exposure. STRIDE categories touched. Diff against
+`docs/threat-model.md` (cite section). Any new trust boundaries. Any weakened
+or strengthened existing boundaries. -->
+
+| STRIDE | New exposure? | Mitigation in this PR |
+|---|---|---|
+| Spoofing | | |
+| Tampering | | |
+| Repudiation | | |
+| Information Disclosure | | |
+| Denial of Service | | |
+| Elevation of Privilege | | |
+
+## 3. OWASP mapping
+
+<!-- Explicit OWASP LLM Top 10 v2.0 and OWASP MCP Top 10 items this
+capability touches. For each, name the chosen control. -->
+
+| OWASP item | Applies? | Control in this PR |
+|---|---|---|
+| LLM01 Prompt Injection | | |
+| LLM02 Sensitive Information Disclosure | | |
+| LLM03 Supply Chain | | |
+| LLM04 Data and Model Poisoning | | |
+| LLM05 Improper Output Handling | | |
+| LLM06 Excessive Agency | | |
+| LLM07 System Prompt Leakage | | |
+| LLM08 Vector and Embedding Weaknesses | | |
+| LLM09 Misinformation | | |
+| LLM10 Unbounded Consumption | | |
+| MCP01 Shadow MCP | | |
+| MCP02 Tool Description Injection | | |
+| MCP03 Scope Escalation | | |
+| MCP04 Token Passthrough | | |
+| MCP05 Confused Deputy | | |
+| MCP06 Malicious Tool Output | | |
+| MCP07 Session Hijacking | | |
+| MCP08 Over-privileged Tool | | |
+| MCP09 Unverified Tool Publisher | | |
+| MCP10 Transport Tampering | | |
+
+## 4. AuthN / AuthZ path
+
+<!-- Who calls this surface? How do they prove identity? What AGT policy
+decision gates it? What's the outage behaviour (Strict / CachedRead /
+DegradedDev)? -->
+
+- **Caller identity:**
+- **Identity proof (token type, signing algo):**
+- **AGT policy decision point:**
+- **Outage behaviour (Strict / CachedRead / DegradedDev):**
+- **Default for prod tenants:** Strict (fail-closed)
+
+## 5. Secret + key custody
+
+<!-- Where do secrets live? Who can read them? Rotation story? Answer
+explicitly: can UID 1000 (the agent) read this secret? If yes, justify. -->
+
+| Secret / key | Storage | Reader identities | Rotation | Agent (UID 1000) can read? |
+|---|---|---|---|---|
+
+## 6. Egress surface delta
+
+<!-- New outbound destinations (FQDN or IP range). How egress-guard / router
+enforces them. DNS or IP pinning where applicable. -->
+
+| New egress target | Purpose | Enforcement | Failure mode |
+|---|---|---|---|
+
+## 7. Audit events emitted
+
+<!-- For each operation, what lands in AGT AuditLogger? Receipt id only; no
+PII. How does `kubectl claw attest` surface it? -->
+
+| Operation | Event | Contents | Attest-visible? |
+|---|---|---|---|
+
+## 8. Failure mode
+
+<!-- Every failure path. Default is fail-closed. Any fail-open path MUST be
+justified here and gated by a `spec.outageMode` value. -->
+
+| Failure | Behaviour | `outageMode` gate |
+|---|---|---|
+
+## 9. Negative-test coverage
+
+<!-- Pointer to `tests/conformance/` entries (§5.4 of implementation plan).
+Each negative case enumerated. -->
+
+| Test | Location | Asserts |
+|---|---|---|
+
+## 10. Vendored / third-party dependency delta
+
+<!-- New crates or npm packages. SCA scan result. License. Vendored-patch
+audit updated if `vendor/*` touched. -->
+
+| Dep | Version | License | SCA scan | Why needed (citation) |
+|---|---|---|---|---|
+
+**Source citations (principle §0.2 #10):**
+<!-- URL + commit SHA or version for every external spec / API / protocol
+used. -->
+
+## 11. Sign-offs
+
+### Author sign-off
+
+- [ ] I have read principles §0.2 #8, #9, #10 of `docs/implementation-plan.md`.
+- [ ] The capability contains no pseudo-implementations. Every claimed
+      control actually runs on the production code path.
+- [ ] No custom crypto was added (verified by `ci/no-custom-crypto.sh`).
+- [ ] Negative tests (Section 9) exist and pass.
+- [ ] The attestation chain (Section 7) is visible via `kubectl claw attest`
+      or explicitly deferred with a ticket.
+
+Signed: @author-handle  — `<date>`
+
+### Independent reviewer sign-off
+
+- [ ] I independently reviewed the diff, not just this document.
+- [ ] I verified negative tests fail without the capability and pass with it.
+- [ ] I verified the failure mode (Section 8) is fail-closed by default.
+- [ ] For admission / router-data-plane / sandbox-image changes, I am on the
+      `docs/security-reviewers.md` roster.
+
+Signed: @reviewer-handle — `<date>`

--- a/docs/security-reviewers.md
+++ b/docs/security-reviewers.md
@@ -1,0 +1,42 @@
+# Security Reviewer Roster
+
+Independent reviewers qualified to sign off on security-sensitive changes per
+`docs/security-audits/_template.md` §11 ("Independent reviewer sign-off").
+
+## Roster governance
+
+- **Maintainer:** TBD (open decision — see `docs/implementation-plan.md` §14.9).
+- **Review SLA:** TBD.
+- **Fallback when primary reviewer is unavailable:** TBD.
+- **Addition/removal policy:** TBD.
+
+This section is a placeholder until leadership confirms governance. Until then,
+any two-engineer review by maintainers of the AzureClaw Controller / Router /
+CLI is acceptable for non-router-data-plane capabilities; router-data-plane,
+admission-policy, and sandbox-image changes require a named reviewer below.
+
+## Reviewer roster (placeholders — to be populated)
+
+| Handle | Area of depth | Backup for |
+|---|---|---|
+| _(populate before first Phase 1 merge)_ | | |
+
+## Scopes that require a named roster reviewer
+
+Per principle §0.2 #9 of the implementation plan:
+
+- Anything under `controller/src/admission/**`
+- Anything under `controller/src/reconcilers/**` that changes a trust or
+  identity-binding surface (`fedcred.rs`, `pairing.rs`, `mesh_peer.rs` today)
+- Anything under `inference-router/src/{mcp,a2a,providers,routes}/**`
+- Anything under `sandbox-images/*/Dockerfile`, `entrypoint.sh`,
+  `policy-engine/profiles/**`
+- Vendored patch updates (`vendor/*/src/**`, `vendor/*/dist/**`)
+
+## Scopes that accept any maintainer as second signer
+
+- CLI commands that do not manipulate secrets/keys
+- Migration adapters
+- Docs-only changes
+- Test additions (though the corresponding capability's audit doc still
+  needs a roster reviewer when in scope above)


### PR DESCRIPTION
## Phase 0 · foundation docs

First of nine Phase 0 branches landing the Composite-Verdict roadmap scaffolding.

### What's in this PR
- `docs/security-audits/README.md` — audit-roster + review process (2-signoff rule).
- `docs/security-audits/_template.md` — audit template used by every capability-introducing PR in Phase 0+.
- `docs/agt-vendored-patch-audit.md` — audit index for the 8 vendored AgentMesh SDK patches already in `vendor/`.
- AGT-boundary + non-compete language added where we already had process docs.

### Why now
Principle §0.2 #9 (security-first-audited) is enforced by a CI gate in the next PR; this PR sets up the template it consumes.

### Verification
- Docs-only, no runtime change.
- No CI gates touched yet (that's the next PR).

### Stack
This is PR 1/9. The full Phase 0 stack lands in sequence; each PR stacks on its predecessor.
