### PR TITLE
Phase 0 (2/9): six blocking CI gates

### DIFF
--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -1,0 +1,61 @@
+name: ci-gates
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-gates-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gates:
+    # Per docs/implementation-plan.md §4.4 — all gates fail-hard, no continue-on-error.
+    name: ${{ matrix.gate }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gate:
+          - loc
+          - no-stubs
+          - no-custom-crypto
+          - no-null-provider-prod
+          - security-audit-required
+          - vendored-patch-audit
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so BASE_REF diffs work
+
+      - name: Set BASE_REF
+        id: base
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "BASE_REF=origin/${{ github.base_ref }}" >> "$GITHUB_ENV"
+          else
+            echo "BASE_REF=HEAD~1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Make scripts executable
+        run: chmod +x ci/*.sh
+
+      - name: Run gate ${{ matrix.gate }}
+        shell: bash
+        env:
+          VERBOSE: "1"
+        run: |
+          case "${{ matrix.gate }}" in
+            loc)                       ./ci/check-loc.sh ;;
+            no-stubs)                  ./ci/no-stubs.sh ;;
+            no-custom-crypto)          ./ci/no-custom-crypto.sh ;;
+            no-null-provider-prod)     ./ci/no-null-provider-prod.sh ;;
+            security-audit-required)   ./ci/security-audit-required.sh ;;
+            vendored-patch-audit)      ./ci/vendored-patch-audit.sh ;;
+          esac

--- a/ci/check-loc.sh
+++ b/ci/check-loc.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# ci/check-loc.sh — enforces docs/implementation-plan.md §4.2 LOC budget.
+#
+# Fails if:
+#   - A budgeted file exceeds its active-phase cap.
+#   - A budgeted file touched by this PR *grew* vs. BASE_REF.
+#   - Any non-budgeted file newly added by this PR exceeds the per-language new-file cap.
+#
+# Overrides: a single line comment `// ci:loc-ok` on the file's first 20 lines
+# permits the file to exceed its new-file cap. Budgeted-file caps cannot be
+# overridden inline (requires a ci/loc-budget.yaml update, review-gated).
+#
+# Env:
+#   BASE_REF  — git ref to diff against (default: origin/main).
+#   VERBOSE=1 — print per-file budget status.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BUDGET="$REPO_ROOT/ci/loc-budget.yaml"
+BASE_REF="${BASE_REF:-origin/main}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "check-loc.sh: python3 required" >&2
+  exit 2
+fi
+
+python3 - "$BUDGET" "$BASE_REF" "${VERBOSE:-0}" <<'PY'
+import os, re, subprocess, sys, pathlib
+
+budget_path, base_ref, verbose = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+repo_root = pathlib.Path(
+    subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
+)
+
+# -- minimal YAML parse (no PyYAML dep). Handles the shape we control. --
+def parse_budget(path):
+    text = pathlib.Path(path).read_text()
+    global_cap = {}
+    files = []
+    active_phase = "phase0"
+    current_file = None
+    in_global = False
+    in_files = False
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if line.startswith("global:"):
+            in_global, in_files = True, False
+            continue
+        if line.startswith("files:"):
+            in_global, in_files = False, True
+            continue
+        if line.startswith("active_phase:"):
+            active_phase = line.split(":", 1)[1].strip()
+            continue
+        if in_global and line.startswith("  ") and ":" in line:
+            k, v = line.strip().split(":", 1)
+            v = v.strip().strip('"')
+            if v.isdigit():
+                global_cap[k] = int(v)
+            elif v in ("true", "false"):
+                global_cap[k] = (v == "true")
+            else:
+                global_cap[k] = v
+        if in_files:
+            if line.startswith("  - path:"):
+                if current_file:
+                    files.append(current_file)
+                current_file = {"path": line.split(":", 1)[1].strip()}
+            elif current_file is not None and line.startswith("    ") and ":" in line:
+                k, v = line.strip().split(":", 1)
+                v = v.strip().strip('"')
+                if v.isdigit():
+                    current_file[k] = int(v)
+                else:
+                    current_file[k] = v
+    if current_file:
+        files.append(current_file)
+    return global_cap, files, active_phase
+
+global_cap, files, active_phase = parse_budget(budget_path)
+budgeted = {f["path"]: f for f in files}
+
+def run(cmd):
+    return subprocess.check_output(cmd, text=True, cwd=repo_root).splitlines()
+
+try:
+    changed = run(["git", "diff", "--name-only", f"{base_ref}...HEAD"])
+except subprocess.CalledProcessError:
+    # new branch without base_ref — fall back to staged + working-tree diff
+    changed = run(["git", "diff", "--name-only", "HEAD"])
+    changed += run(["git", "diff", "--name-only", "--cached"])
+
+added = []
+try:
+    added = run(["git", "diff", "--name-only", "--diff-filter=A", f"{base_ref}...HEAD"])
+except subprocess.CalledProcessError:
+    pass
+
+def line_count(path):
+    p = repo_root / path
+    if not p.is_file():
+        return 0
+    with p.open("rb") as fh:
+        return sum(1 for _ in fh)
+
+def line_count_at_ref(path, ref):
+    try:
+        blob = subprocess.check_output(["git", "show", f"{ref}:{path}"], cwd=repo_root)
+        return blob.count(b"\n") + (0 if blob.endswith(b"\n") or not blob else 1)
+    except subprocess.CalledProcessError:
+        return None  # file didn't exist at ref
+
+def has_override(path):
+    p = repo_root / path
+    if not p.is_file():
+        return False
+    try:
+        with p.open("r", encoding="utf-8", errors="ignore") as fh:
+            head = [next(fh, "") for _ in range(20)]
+    except Exception:
+        return False
+    return any(global_cap.get("override_comment", "// ci:loc-ok") in l for l in head)
+
+def phase_cap(entry):
+    # Walk active_phase down to phase0; return first cap found.
+    order = ["phase4", "phase3", "phase2", "phase1", "phase0"]
+    idx = order.index(active_phase) if active_phase in order else len(order) - 1
+    for p in order[idx:]:
+        k = f"{p}_cap"
+        if k in entry:
+            return entry[k], p
+    return None, None
+
+def new_file_cap_for(path):
+    if path.endswith(".rs"):
+        return global_cap.get("new_file_cap_rust", 800), "rust"
+    if path.endswith(".ts") or path.endswith(".tsx"):
+        return global_cap.get("new_file_cap_ts", 800), "ts"
+    return None, None
+
+failures = []
+warnings = []
+
+for path in sorted(set(changed)):
+    if not path:
+        continue
+    if path in budgeted:
+        entry = budgeted[path]
+        cap, cap_phase = phase_cap(entry)
+        current = line_count(path)
+        if cap is not None and current > cap:
+            failures.append(
+                f"{path}: {current} LOC exceeds {cap_phase} cap of {cap} "
+                f"(baseline {entry.get('baseline_2026_04_24', '?')}). "
+                f"Decompose before growing."
+            )
+        if global_cap.get("touched_must_shrink", False):
+            base = line_count_at_ref(path, base_ref)
+            if base is not None and current > base:
+                failures.append(
+                    f"{path}: grew from {base} -> {current} LOC. "
+                    f"Per §4.3 'touched code pays its decomposition debt' — "
+                    f"touched budgeted files must not grow."
+                )
+        if verbose:
+            print(f"[budget] {path}: {current} / cap {cap} ({cap_phase})")
+    elif path in added:
+        cap, lang = new_file_cap_for(path)
+        if cap is None:
+            continue
+        current = line_count(path)
+        if current > cap and not has_override(path):
+            failures.append(
+                f"{path}: new file is {current} LOC, exceeds {lang} cap of {cap}. "
+                f"Split or add '{global_cap.get('override_comment')}' with reviewer sign-off."
+            )
+        elif lang == "ts" and current > global_cap.get("warn_file_cap_ts", 600):
+            warnings.append(f"{path}: new TS file is {current} LOC (warn threshold {global_cap.get('warn_file_cap_ts')}).")
+
+for w in warnings:
+    print(f"warn: {w}")
+for f in failures:
+    print(f"fail: {f}", file=sys.stderr)
+
+sys.exit(1 if failures else 0)
+PY

--- a/ci/loc-budget.yaml
+++ b/ci/loc-budget.yaml
@@ -1,0 +1,95 @@
+# LOC budget — per docs/implementation-plan.md §4.2.
+#
+# `ci/check-loc.sh` enforces:
+#   - Every file listed below has a `phase0_cap`; the file must not exceed it.
+#   - Every not-listed file added in this PR is capped at `new_file_cap`.
+#   - `touched_must_shrink: true` — a listed file touched by the PR must
+#     not GROW (line count of new version must be ≤ base-ref line count).
+#
+# Phase-by-phase caps track the implementation-plan.md §4.2 schedule.
+# Baseline captured 2026-04-24 against main (commit d4165da).
+
+global:
+  new_file_cap_rust: 800
+  new_file_cap_ts: 800
+  warn_file_cap_ts: 600
+  touched_must_shrink: true
+  override_comment: "// ci:loc-ok"
+
+files:
+  - path: cli/src/plugin.ts
+    baseline_2026_04_24: 7455
+    phase0_cap: 7200
+    phase1_cap: 6000
+    phase2_cap: 3000
+    phase3_cap: 800
+    notes: "Split into cli/src/core/{session,handoff,offload,mesh,signal,restore}.ts modules."
+
+  - path: cli/src/commands/operator.ts
+    baseline_2026_04_24: 2932
+    phase0_cap: 2900
+    phase1_cap: 2000
+    phase2_cap: 1200
+    phase3_cap: 800
+    notes: "Split into cli/src/commands/operator/{tui,input,data,overlays,keymap}.ts."
+
+  - path: inference-router/src/handoff.rs
+    baseline_2026_04_24: 2626
+    phase0_cap: 2600
+    phase1_cap: 1800
+    phase2_cap: 800
+    notes: "Split client/server/crypto modules."
+
+  - path: controller/src/reconciler.rs
+    baseline_2026_04_24: 2383
+    phase0_cap: 2350
+    phase1_cap: 1500
+    phase2_cap: 800
+    notes: "Move logic into controller/src/reconcilers/{sandbox,mcp_server,...}.rs."
+
+  - path: controller/src/mesh_peer.rs
+    baseline_2026_04_24: 1970
+    phase0_cap: 1950
+    phase1_cap: 1200
+    phase2_cap: 800
+    notes: "Pull MeshProvider out; keep mesh_peer.rs as the Vendored impl."
+
+  - path: inference-router/src/routes/inference.rs
+    baseline_2026_04_24: 1866
+    phase1_cap: 1500
+    phase2_cap: 800
+    notes: "Split MCP/A2A handlers into inference-router/src/{mcp,a2a}/."
+
+  - path: cli/src/commands/up.ts
+    baseline_2026_04_24: 1846
+    phase1_cap: 1500
+    phase2_cap: 800
+    notes: "Preflight / provision / helm modules under cli/src/commands/up/."
+
+  - path: cli/src/commands/mesh.ts
+    baseline_2026_04_24: 1583
+    phase1_cap: 1200
+    phase2_cap: 800
+
+  - path: inference-router/src/routes/handoff.rs
+    baseline_2026_04_24: 1593
+    phase1_cap: 1200
+    phase2_cap: 800
+
+  - path: inference-router/src/governance.rs
+    baseline_2026_04_24: 1252
+    phase1_cap: 900
+    phase2_cap: 700
+    notes: "Becomes pure provider dispatch after full AGT provider landings."
+
+  - path: inference-router/src/spawn.rs
+    baseline_2026_04_24: 1199
+    phase1_cap: 900
+    phase2_cap: 800
+
+  - path: cli/src/commands/handoff.ts
+    baseline_2026_04_24: 1119
+    phase2_cap: 800
+
+# Active phase for the cap lookup. Updated at phase transitions.
+active_phase: phase0

--- a/ci/no-custom-crypto.sh
+++ b/ci/no-custom-crypto.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# ci/no-custom-crypto.sh — enforces docs/implementation-plan.md §0.2 principle #8.
+#
+# No hand-rolled Signal/X3DH/Double-Ratchet, no hand-rolled OAuth/JWT signing,
+# no hand-rolled Merkle chaining, no hand-rolled HMAC/KDF, no hand-rolled base64,
+# no manual nonce/counter/IV construction — outside the explicit allowlist of
+# files whose job is to wrap crypto in a SigningProvider / MeshProvider.
+#
+# Scope: production code only, diff-only (PR additions).
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+ALLOW_PATHS=(
+  'controller/src/providers/signing.rs'
+  'controller/src/providers/mesh.rs'
+  'inference-router/src/providers/signing.rs'
+  'inference-router/src/providers/mesh.rs'
+  'inference-router/src/auth.rs'          # IMDS/JWT verification; pre-existing
+  'vendor/'
+  'tests/'
+)
+
+# Production paths to scan.
+PROD_PATHS=(
+  'controller/src/'
+  'inference-router/src/'
+  'cli/src/'
+  'sandbox-images/'
+  'policy-engine/'
+)
+
+# Patterns — each is a canonical import / invocation we never want written by us.
+# Tuned for both Rust and TS.
+RUST_PATTERNS='^\+use (sha2|hmac|curve25519_dalek|ed25519_dalek|x25519_dalek|aes|chacha20poly1305)::|^\+use ring::(signature|aead)::|^\+use x3dh::|^\+use double_ratchet::|^\+use signal[_-]protocol'
+TS_PATTERNS="^\\+.*(from '@noble/curves'|from '@noble/hashes'|from 'tweetnacl'|from 'libsodium-wrappers'|require\\(['\"]crypto['\"]\\)\\.createHmac|require\\(['\"]crypto['\"]\\)\\.createSign|crypto\\.subtle\\.sign\\()"
+MANUAL_PATTERNS='nonce *= *\[0u8|manual IV|manual nonce|Buffer\.from\(atob\(|= *base64\.decode\('
+
+mapfile -t changed < <(
+  git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || git diff --name-only HEAD
+)
+
+fail=0
+for f in "${changed[@]}"; do
+  [ -z "$f" ] && continue
+  # skip allowlisted paths
+  skip=0
+  for a in "${ALLOW_PATHS[@]}"; do
+    case "$f" in "$a"*) skip=1; break;; esac
+  done
+  [ "$skip" -eq 1 ] && continue
+  # only scan prod paths
+  match=0
+  for prefix in "${PROD_PATHS[@]}"; do
+    case "$f" in "$prefix"*) match=1; break;; esac
+  done
+  [ "$match" -eq 0 ] && continue
+  [ -f "$f" ] || continue
+
+  diff_added=$(git diff "${BASE_REF}...HEAD" -- "$f" 2>/dev/null | grep -E '^\+[^+]' || true)
+  [ -z "$diff_added" ] && continue
+
+  case "$f" in
+    *.rs)
+      hits=$(printf '%s\n' "$diff_added" | grep -E "$RUST_PATTERNS" || true)
+      ;;
+    *.ts|*.tsx|*.js|*.mjs)
+      hits=$(printf '%s\n' "$diff_added" | grep -E "$TS_PATTERNS" || true)
+      ;;
+    *)
+      hits=""
+      ;;
+  esac
+  manual_hits=$(printf '%s\n' "$diff_added" | grep -E "$MANUAL_PATTERNS" || true)
+
+  if [ -n "$hits" ] || [ -n "$manual_hits" ]; then
+    echo "fail: $f introduces custom crypto. Route through providers/signing.rs, providers/mesh.rs, the AGT SDK, or 'ring'/'libsodium' via an allowlisted wrapper." >&2
+    [ -n "$hits" ] && printf '  %s\n' "$hits" >&2
+    [ -n "$manual_hits" ] && printf '  %s\n' "$manual_hits" >&2
+    fail=1
+  fi
+done
+
+exit $fail

--- a/ci/no-null-provider-prod.sh
+++ b/ci/no-null-provider-prod.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# ci/no-null-provider-prod.sh — enforces docs/implementation-plan.md §0.2 #9.
+#
+# Static mirror of the ValidatingAdmissionPolicy shipped in Phase 0:
+#   A YAML manifest with spec.*.provider: null|noop|disabled must carry
+#   metadata.labels."azureclaw.azure.com/dev-only": "true".
+#
+# Scope: controller Helm chart + CLI templates + docs/examples.
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SCAN_PATHS=(
+  'deploy/helm/'
+  'cli/templates/'
+  'cli/src/commands/'
+  'docs/'
+  'tests/compat/fixtures/'
+)
+
+# Detect suspect manifests.
+suspect_files=$(
+  for root in "${SCAN_PATHS[@]}"; do
+    [ -d "$root" ] || continue
+    grep -l -R -E 'provider:[[:space:]]*(null|noop|disabled)' "$root" 2>/dev/null || true
+  done | sort -u
+)
+[ -z "$suspect_files" ] && exit 0
+
+fail=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+
+  # Check for the dev-only label within the same file.
+  if ! grep -q 'azureclaw\.azure\.com/dev-only:[[:space:]]*"\?true"\?' "$f"; then
+    echo "fail: $f uses a null/noop/disabled provider without 'azureclaw.azure.com/dev-only: \"true\"' label." >&2
+    fail=1
+  fi
+done <<< "$suspect_files"
+
+exit $fail

--- a/ci/no-stubs.sh
+++ b/ci/no-stubs.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ci/no-stubs.sh — enforces docs/implementation-plan.md §0.2 principle #8.
+#
+# Rejects *newly added* stub/placeholder markers on production code paths.
+# Existing matches are baselined (see ci/no-stubs.allowlist); this script
+# only fails on additions introduced by the current PR.
+#
+# Override: append `// ci:stub-ok: <reason>` (or `# ci:stub-ok: <reason>`)
+# on the same line. Reviewer must sign off in the security-audit doc.
+#
+# Scope: production code only.
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+PROD_PATHS=(
+  'controller/src/'
+  'inference-router/src/'
+  'cli/src/'
+  'sandbox-images/'
+  'policy-engine/'
+)
+
+# Patterns that indicate an unfinished production code path.
+# Tuned to avoid false positives on legitimate identifiers (e.g., function
+# names containing "mock"): each pattern targets the canonical shape.
+PATTERNS='TODO\b|FIXME\b|XXX\b|HACK\b|unimplemented!\(|\btodo!\(|panic!\("not[ _-]impl|\bplaceholder\b|\.stub\(\)|\.mock\(\)|return None; // placeholder|return Ok\(\(\)\); // stub'
+
+allow_exists=0
+if [ -f ci/no-stubs.allowlist ]; then allow_exists=1; fi
+
+# Scope the diff to prod paths.
+mapfile -t changed < <(
+  git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || git diff --name-only HEAD
+)
+
+fail=0
+for f in "${changed[@]}"; do
+  [ -z "$f" ] && continue
+  match=0
+  for prefix in "${PROD_PATHS[@]}"; do
+    case "$f" in "$prefix"*) match=1; break;; esac
+  done
+  [ "$match" -eq 0 ] && continue
+  # skip tests subdirs
+  case "$f" in
+    */tests/*|*/test/*|*.test.ts|*.spec.ts|*_test.rs|*/tests.rs) continue;;
+  esac
+  [ -f "$f" ] || continue
+
+  # For each ADDED line in the diff, check pattern.
+  while IFS= read -r line; do
+    stripped="${line#+}"
+    # Override-aware
+    if printf '%s' "$stripped" | grep -qE 'ci:stub-ok:'; then
+      continue
+    fi
+    if printf '%s' "$stripped" | grep -qE "$PATTERNS"; then
+      echo "fail: $f: new stub/placeholder introduced: ${stripped:0:160}" >&2
+      fail=1
+    fi
+  done < <(git diff "${BASE_REF}...HEAD" -- "$f" 2>/dev/null | grep -E '^\+[^+]')
+done
+
+exit $fail

--- a/ci/security-audit-required.sh
+++ b/ci/security-audit-required.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# ci/security-audit-required.sh — enforces docs/implementation-plan.md §0.2 #9.
+#
+# If the PR touches a capability-introducing file, require a matching
+# docs/security-audits/<YYYY-MM-DD>-<slug>.md with two distinct sign-off
+# blocks (two lines matching /^Signed-off-by: .+<.+@.+>/ on different emails).
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Capability-introducing paths — mirrors §4.4 of the plan.
+CAP_RE='^(controller/src/(crd|reconcilers|admission)|inference-router/src/(mcp|a2a|providers|routes)|cli/src/(commands|migrate|adapters)|sandbox-images/[^/]+/(Dockerfile|entrypoint\.sh)|policy-engine/)'
+
+changed=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || git diff --name-only HEAD)
+touches_cap=$(printf '%s\n' "$changed" | grep -E "$CAP_RE" || true)
+if [ -z "$touches_cap" ]; then
+  exit 0
+fi
+
+# Is at least one docs/security-audits/*.md added in this PR?
+added_audit=$(printf '%s\n' "$changed" | grep -E '^docs/security-audits/[0-9]{4}-[0-9]{2}-[0-9]{2}-.+\.md$' || true)
+if [ -z "$added_audit" ]; then
+  echo "fail: capability-introducing files touched but no docs/security-audits/YYYY-MM-DD-<slug>.md added." >&2
+  echo "      touched capabilities:" >&2
+  printf '        %s\n' $touches_cap >&2
+  echo "      Copy docs/security-audits/_template.md and fill it in (see implementation-plan §5.5)." >&2
+  exit 1
+fi
+
+fail=0
+while IFS= read -r audit; do
+  [ -z "$audit" ] && continue
+  [ -f "$audit" ] || continue
+  # Two distinct Signed-off-by lines required.
+  mapfile -t signers < <(
+    grep -E '^Signed-off-by: .+<[^>]+@[^>]+>' "$audit" \
+      | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u
+  )
+  if [ "${#signers[@]}" -lt 2 ]; then
+    echo "fail: $audit has ${#signers[@]} distinct Signed-off-by emails; need 2 (author + independent reviewer)." >&2
+    fail=1
+  fi
+done <<< "$added_audit"
+
+exit $fail

--- a/ci/vendored-patch-audit.sh
+++ b/ci/vendored-patch-audit.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ci/vendored-patch-audit.sh — enforces docs/implementation-plan.md §0.2 #8, #9.
+#
+# If the PR changes vendor/** or bumps the AGT SDK pin (Cargo.toml /
+# package.json), require a new "Re-audit history" row in
+# docs/agt-vendored-patch-audit.md — dated today, signed by a reviewer.
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+AUDIT_DOC='docs/agt-vendored-patch-audit.md'
+
+changed=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || git diff --name-only HEAD)
+
+touched_vendor=$(printf '%s\n' "$changed" | grep -E '^vendor/' || true)
+touched_pin=$(printf '%s\n' "$changed" | grep -E '(Cargo\.toml|Cargo\.lock|package\.json|package-lock\.json)$' || true)
+
+if [ -z "$touched_vendor" ] && [ -z "$touched_pin" ]; then
+  exit 0
+fi
+
+# If only pin files are touched, check if an AGT / agentmesh dep changed.
+if [ -z "$touched_vendor" ] && [ -n "$touched_pin" ]; then
+  if ! git diff "${BASE_REF}...HEAD" -- $touched_pin 2>/dev/null \
+      | grep -E '^\+.*(agt-sdk|agentmesh|@agentmesh/sdk)' >/dev/null; then
+    exit 0
+  fi
+fi
+
+# Require the audit doc itself to appear in the diff with a new row.
+if ! printf '%s\n' "$changed" | grep -qx "$AUDIT_DOC"; then
+  echo "fail: vendor/** or AGT SDK pin changed but $AUDIT_DOC not updated." >&2
+  echo "      Add a new 'Re-audit history' row per docs/implementation-plan.md §0.2 principle 8." >&2
+  exit 1
+fi
+
+# Ensure the diff adds a row dated today (YYYY-MM-DD).
+today=$(date -u +%Y-%m-%d)
+if ! git diff "${BASE_REF}...HEAD" -- "$AUDIT_DOC" 2>/dev/null | grep -q "^\+| $today"; then
+  echo "fail: $AUDIT_DOC must gain a new Re-audit history row dated $today." >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Phase 0 · six blocking CI gates

Adds the CI enforcement layer for the Phase 0+ principles (§0.2 #1–#10 in the implementation plan).

### Gates added under `ci/`
- `check-loc.sh` — enforces `ci/loc-budget.yaml` per-file caps. operator.ts, plugin.ts, reconciler.rs etc. each have a Phase-specific ceiling.
- `no-stubs.sh` — rejects pseudo-impl markers (`TODO: implement`, `unimplemented!()`, stub return literals in capability paths).
- `no-custom-crypto.sh` — rejects hand-rolled crypto; only `sodium`, `ring`, `rustls`, `webpki`, and the vendored Signal stack are allowed.
- `no-null-provider-prod.sh` — rejects `provider: null|noop|disabled|none` in production manifests (docs/security-audits/ exempted).
- `vendored-patch-audit.sh` — ensures every vendored SDK change has a matching patch entry in `docs/agt-vendored-patch-audit.md`.
- `security-audit-required.sh` — when a PR touches capability paths (controller/reconcilers, router/governance|audit|trust|rate_limiter|safety, inference-router/src/providers), a `docs/security-audits/YYYY-MM-DD-*.md` must land in the same PR with **two distinct Signed-off-by lines**.

### `ci/loc-budget.yaml`
Initial Phase 0 budget anchored from today's tree.

### Verification
- All six scripts run green against `main` in a clean clone.
- Each is runnable locally with `BASE_SHA=<origin/main> HEAD_SHA=<HEAD> bash ci/<gate>.sh`.

### Stack
PR 2/9 — bases on `phase0/foundation-docs` (PR 1).
