### PR TITLE
Phase 0 (4/9): provider-contract trait scaffolds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +252,7 @@ dependencies = [
  "aes-gcm",
  "agentmesh",
  "anyhow",
+ "async-trait",
  "axum",
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ prometheus = "0.14"
 # Error handling
 thiserror = "2"
 anyhow = "1"
+async-trait = "0.1"
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/cli/src/providers.test.ts
+++ b/cli/src/providers.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PROVIDER_SELECTION,
+  DEV_ONLY_LABEL_KEY,
+  DEV_ONLY_LABEL_VALUE,
+  parseOutageMode,
+  parseProviderKind,
+  selectionHasNull,
+  selectionToEnv,
+} from "./providers.js";
+
+describe("providers — parseProviderKind", () => {
+  it("accepts canonical values", () => {
+    expect(parseProviderKind("vendored")).toBe("vendored");
+    expect(parseProviderKind("agt")).toBe("agt");
+    expect(parseProviderKind("null")).toBe("null");
+  });
+
+  it("tolerates whitespace and case", () => {
+    expect(parseProviderKind("  Vendored\n")).toBe("vendored");
+    expect(parseProviderKind("AGT")).toBe("agt");
+  });
+
+  it("rejects aliases the controller accepts (noop / disabled) on purpose", () => {
+    expect(parseProviderKind("noop")).toBeNull();
+    expect(parseProviderKind("disabled")).toBeNull();
+    expect(parseProviderKind("")).toBeNull();
+    expect(parseProviderKind("custom")).toBeNull();
+  });
+});
+
+describe("providers — default selection", () => {
+  it("is vendored across the board", () => {
+    expect(DEFAULT_PROVIDER_SELECTION.mesh).toBe("vendored");
+    expect(DEFAULT_PROVIDER_SELECTION.policy).toBe("vendored");
+    expect(DEFAULT_PROVIDER_SELECTION.audit).toBe("vendored");
+    expect(DEFAULT_PROVIDER_SELECTION.signing).toBe("vendored");
+    expect(selectionHasNull(DEFAULT_PROVIDER_SELECTION)).toBe(false);
+  });
+
+  it("is frozen so accidental mutation fails loudly in strict mode", () => {
+    expect(Object.isFrozen(DEFAULT_PROVIDER_SELECTION)).toBe(true);
+  });
+});
+
+describe("providers — selectionHasNull", () => {
+  it("flags a selection where any field is null", () => {
+    expect(selectionHasNull({ ...DEFAULT_PROVIDER_SELECTION, audit: "null" })).toBe(true);
+    expect(selectionHasNull({ ...DEFAULT_PROVIDER_SELECTION, mesh: "null" })).toBe(true);
+  });
+
+  it("returns false when all fields are non-null", () => {
+    expect(selectionHasNull({ ...DEFAULT_PROVIDER_SELECTION, policy: "agt" })).toBe(false);
+  });
+});
+
+describe("providers — selectionToEnv", () => {
+  it("emits the four AZURECLAW_PROVIDER_* env vars", () => {
+    const env = selectionToEnv({
+      mesh: "vendored",
+      policy: "agt",
+      audit: "vendored",
+      signing: "agt",
+    });
+    expect(env).toEqual({
+      AZURECLAW_PROVIDER_MESH: "vendored",
+      AZURECLAW_PROVIDER_POLICY: "agt",
+      AZURECLAW_PROVIDER_AUDIT: "vendored",
+      AZURECLAW_PROVIDER_SIGNING: "agt",
+    });
+  });
+});
+
+describe("providers — outage mode", () => {
+  it("parses the three supported modes, tolerating hyphen variants", () => {
+    expect(parseOutageMode("strict")).toBe("strict");
+    expect(parseOutageMode("cached-read")).toBe("cached-read");
+    expect(parseOutageMode("cachedread")).toBe("cached-read");
+    expect(parseOutageMode("degraded-dev")).toBe("degraded-dev");
+    expect(parseOutageMode("degradeddev")).toBe("degraded-dev");
+  });
+
+  it("rejects unknown modes", () => {
+    expect(parseOutageMode("lenient")).toBeNull();
+    expect(parseOutageMode("")).toBeNull();
+  });
+});
+
+describe("providers — dev-only label constants", () => {
+  it("match the controller-side / ci/no-null-provider-prod.sh expectations", () => {
+    expect(DEV_ONLY_LABEL_KEY).toBe("azureclaw.azure.com/dev-only");
+    expect(DEV_ONLY_LABEL_VALUE).toBe("true");
+  });
+});

--- a/cli/src/providers.ts
+++ b/cli/src/providers.ts
@@ -1,0 +1,107 @@
+/**
+ * Provider contracts — TypeScript side.
+ *
+ * Mirrors `controller/src/providers/` and `inference-router/src/providers/`
+ * but scoped to CLI/plugin concerns: reads `spec.agt.providers`, emits
+ * feature flags into sandbox env vars, validates user input before
+ * submission.
+ *
+ * **Phase 0 status:** type + helper definitions only. No plugin.ts
+ * call-site migrations land here. Wiring happens in Phase 1 per
+ * `docs/implementation-plan.md` §7.
+ *
+ * Runtime-side implementations live in Rust (router + controller). The TS
+ * side only needs to:
+ *   - validate user-provided provider choices before they hit the CRD,
+ *   - construct env vars for sandbox images based on the selection,
+ *   - detect Null* provider use and require the dev-only label.
+ */
+
+export type ProviderKind = "vendored" | "agt" | "null";
+
+export interface ProviderSelection {
+  mesh: ProviderKind;
+  policy: ProviderKind;
+  audit: ProviderKind;
+  signing: ProviderKind;
+}
+
+/**
+ * Default provider selection — everything vendored (Phase 0 zero-behaviour-
+ * change baseline). Callers override individual fields per tenant.
+ */
+export const DEFAULT_PROVIDER_SELECTION: ProviderSelection = Object.freeze({
+  mesh: "vendored",
+  policy: "vendored",
+  audit: "vendored",
+  signing: "vendored",
+}) as ProviderSelection;
+
+/**
+ * Reject `"noop" | "disabled"` as spec strings — the CLI accepts only
+ * the canonical `"null"` alias. Controller-side admission policy
+ * accepts all three; we keep CLI strict to catch typos early.
+ */
+export function parseProviderKind(s: string): ProviderKind | null {
+  switch (s.trim().toLowerCase()) {
+    case "vendored":
+      return "vendored";
+    case "agt":
+      return "agt";
+    case "null":
+      return "null";
+    default:
+      return null;
+  }
+}
+
+/** Does the selection include any `null` provider? */
+export function selectionHasNull(sel: ProviderSelection): boolean {
+  return (
+    sel.mesh === "null" ||
+    sel.policy === "null" ||
+    sel.audit === "null" ||
+    sel.signing === "null"
+  );
+}
+
+/**
+ * Label used by the admission policy (VAP) to permit `null` providers.
+ * `ci/no-null-provider-prod.sh` is the static mirror.
+ */
+export const DEV_ONLY_LABEL_KEY = "azureclaw.azure.com/dev-only";
+export const DEV_ONLY_LABEL_VALUE = "true";
+
+/**
+ * Env vars passed to the sandbox image telling it which provider to use
+ * for each capability. Router reads these at boot.
+ */
+export function selectionToEnv(sel: ProviderSelection): Record<string, string> {
+  return {
+    AZURECLAW_PROVIDER_MESH: sel.mesh,
+    AZURECLAW_PROVIDER_POLICY: sel.policy,
+    AZURECLAW_PROVIDER_AUDIT: sel.audit,
+    AZURECLAW_PROVIDER_SIGNING: sel.signing,
+  };
+}
+
+/**
+ * Outage mode selected per `ClawSandbox.spec.agt.outageMode`.
+ * See `docs/implementation-plan.md` §1.3.
+ */
+export type OutageMode = "strict" | "cached-read" | "degraded-dev";
+
+export function parseOutageMode(s: string): OutageMode | null {
+  switch (s.trim().toLowerCase()) {
+    case "strict":
+      return "strict";
+    case "cached-read":
+    case "cachedread":
+      return "cached-read";
+    case "degraded-dev":
+    case "degradeddev":
+      return "degraded-dev";
+    default:
+      return null;
+  }
+}

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -16,6 +16,7 @@ mod fedcred;
 mod mesh_peer;
 mod pairing;
 mod pairing_reconciler;
+mod providers;
 mod reconciler;
 
 use anyhow::Result;

--- a/controller/src/providers/mod.rs
+++ b/controller/src/providers/mod.rs
@@ -1,0 +1,153 @@
+//! Provider contracts for the AzureClaw controller.
+//!
+//! Mirrors `inference-router/src/providers/` but scoped to controller-side
+//! concerns: the controller chooses and wires providers based on
+//! `ClawSandbox.spec.agt.providers`, and passes selected references through
+//! to the router via ConfigMap.
+//!
+//! **Phase 0 status:** contracts only. No implementations and no
+//! reconciler migrations land here. Provider construction and wiring are
+//! Phase 1 scope per `docs/implementation-plan.md` §7.
+//!
+//! **Server-Side Apply** (plan §6 #4): each controller-side write that
+//! touches provider-owned fields uses SSA with a stable field manager:
+//!
+//! - `azureclaw-controller/reconciler`  — base reconciler
+//! - `azureclaw-controller/mesh`        — mesh provider ownership
+//! - `azureclaw-controller/pairing`     — pairing reconciler
+//! - `azureclaw-controller/provider-bridge` — provider-kind selection
+//!
+//! See [`field_managers`].
+
+// Scaffolding for Phase 1 — see docs/implementation-plan.md §7. Dead-code
+// lints are silenced at the module level until call-sites land.
+#![allow(dead_code)]
+
+pub mod field_managers {
+    //! Stable Server-Side Apply field managers per plan §6 #4.
+    //!
+    //! Every write that touches provider-owned fields carries one of these
+    //! as `fieldManager`. The same manager is used across controller
+    //! restarts and versions so conflict resolution converges.
+    pub const RECONCILER: &str = "azureclaw-controller/reconciler";
+    pub const MESH: &str = "azureclaw-controller/mesh";
+    pub const PAIRING: &str = "azureclaw-controller/pairing";
+    pub const PROVIDER_BRIDGE: &str = "azureclaw-controller/provider-bridge";
+}
+
+/// Provider selection as read from `ClawSandbox.spec.agt.providers`.
+/// See `docs/implementation-plan.md` §1.4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    Vendored,
+    Agt,
+    /// Admission-policy-rejected in prod. Only accepted when the manifest
+    /// carries `metadata.labels.azureclaw.azure.com/dev-only: "true"`.
+    /// Static mirror: `ci/no-null-provider-prod.sh`.
+    Null,
+}
+
+impl ProviderKind {
+    /// Parse from the spec string. Returns `None` for unknown values so
+    /// the controller can fail fast on unsupported input.
+    pub fn from_spec(s: &str) -> Option<Self> {
+        match s {
+            "vendored" => Some(Self::Vendored),
+            "agt" => Some(Self::Agt),
+            "null" | "noop" | "disabled" => Some(Self::Null),
+            _ => None,
+        }
+    }
+
+    /// Is this choice allowed in production (no dev-only label)?
+    pub fn allowed_in_prod(self) -> bool {
+        !matches!(self, Self::Null)
+    }
+}
+
+/// The four provider kinds a `ClawSandbox` selects. Each field reads from
+/// `spec.agt.providers.{mesh,policy,audit,signing}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderSelection {
+    pub mesh: ProviderKind,
+    pub policy: ProviderKind,
+    pub audit: ProviderKind,
+    pub signing: ProviderKind,
+}
+
+impl Default for ProviderSelection {
+    fn default() -> Self {
+        // Phase 0 default: vendored across the board (zero behaviour change).
+        Self {
+            mesh: ProviderKind::Vendored,
+            policy: ProviderKind::Vendored,
+            audit: ProviderKind::Vendored,
+            signing: ProviderKind::Vendored,
+        }
+    }
+}
+
+impl ProviderSelection {
+    /// Returns `true` if any provider is `Null`. Admission-policy callers
+    /// combine this with the dev-only label check; the same logic lives in
+    /// `ci/no-null-provider-prod.sh` for static enforcement.
+    pub fn has_null(&self) -> bool {
+        self.mesh == ProviderKind::Null
+            || self.policy == ProviderKind::Null
+            || self.audit == ProviderKind::Null
+            || self.signing == ProviderKind::Null
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_kind_parses_all_aliases() {
+        assert_eq!(ProviderKind::from_spec("vendored"), Some(ProviderKind::Vendored));
+        assert_eq!(ProviderKind::from_spec("agt"), Some(ProviderKind::Agt));
+        assert_eq!(ProviderKind::from_spec("null"), Some(ProviderKind::Null));
+        assert_eq!(ProviderKind::from_spec("noop"), Some(ProviderKind::Null));
+        assert_eq!(ProviderKind::from_spec("disabled"), Some(ProviderKind::Null));
+        assert_eq!(ProviderKind::from_spec("vendoreed"), None);
+        assert_eq!(ProviderKind::from_spec(""), None);
+    }
+
+    #[test]
+    fn null_is_not_allowed_in_prod() {
+        assert!(ProviderKind::Vendored.allowed_in_prod());
+        assert!(ProviderKind::Agt.allowed_in_prod());
+        assert!(!ProviderKind::Null.allowed_in_prod());
+    }
+
+    #[test]
+    fn default_selection_is_vendored_across_the_board() {
+        let sel = ProviderSelection::default();
+        assert_eq!(sel.mesh, ProviderKind::Vendored);
+        assert_eq!(sel.policy, ProviderKind::Vendored);
+        assert_eq!(sel.audit, ProviderKind::Vendored);
+        assert_eq!(sel.signing, ProviderKind::Vendored);
+        assert!(!sel.has_null());
+    }
+
+    #[test]
+    fn has_null_detects_any_null_field() {
+        let sel = ProviderSelection {
+            audit: ProviderKind::Null,
+            ..ProviderSelection::default()
+        };
+        assert!(sel.has_null());
+    }
+
+    #[test]
+    fn field_managers_are_stable_strings() {
+        assert_eq!(field_managers::RECONCILER, "azureclaw-controller/reconciler");
+        assert_eq!(field_managers::MESH, "azureclaw-controller/mesh");
+        assert_eq!(field_managers::PAIRING, "azureclaw-controller/pairing");
+        assert_eq!(
+            field_managers::PROVIDER_BRIDGE,
+            "azureclaw-controller/provider-bridge"
+        );
+    }
+}

--- a/docs/security-audits/2026-04-24-phase0-provider-seams.md
+++ b/docs/security-audits/2026-04-24-phase0-provider-seams.md
@@ -1,0 +1,119 @@
+# Security audit — Phase 0 provider-seam scaffolds
+
+**Date:** 2026-04-24
+**Capability:** provider trait/interface scaffolds (Rust router, Rust controller, TS CLI)
+**Branch:** `phase0/provider-trait-scaffolds`
+**Companion plan section:** `docs/implementation-plan.md` §6 items 4 + §1.2 + §1.4
+
+## 1. Summary
+
+Land the four provider contracts as trait/interface definitions:
+
+- **Rust router** (`inference-router/src/providers/`): `MeshProvider`,
+  `PolicyDecisionProvider`, `AuditSink`, `SigningProvider` — async traits
+  with canonical request/response types, `thiserror`-based error types, and
+  module-level `#![allow(dead_code)]` until Phase 1 wires call-sites.
+- **Rust controller** (`controller/src/providers/`): `ProviderKind`,
+  `ProviderSelection`, `field_managers` — for CRD-spec parsing and SSA
+  field-manager discipline per plan §6 #4.
+- **TS CLI** (`cli/src/providers.ts`): `ProviderKind`, `ProviderSelection`,
+  `parseProviderKind`, `selectionHasNull`, `selectionToEnv`,
+  `parseOutageMode`, `DEV_ONLY_LABEL_{KEY,VALUE}`.
+
+No runtime behaviour change; no implementation code added; no call-sites
+migrated. This PR is pure type scaffolding.
+
+## 2. Threat model
+
+| STRIDE | Applies? | Notes |
+|---|---|---|
+| Spoofing | No | No network-facing code added. |
+| Tampering | No | No persistence / SSA / CRD writes added. |
+| Repudiation | No | No audit-emission code added. |
+| Information disclosure | No | No secret handling added. |
+| Denial of service | No | No new endpoints / reconciler loops. |
+| Elevation of privilege | No | No admission / RBAC changes. |
+
+**OWASP LLM Top 10:** N/A — no runtime path touched.
+**OWASP MCP Top 10:** N/A — no MCP handler modified.
+
+## 3. AuthN / AuthZ path
+
+None added.
+
+## 4. Secret custody
+
+None added. `SigningProvider` contract *documents* the invariant that key
+material never crosses the boundary — enforcement comes when
+`VendoredSigningProvider` lands in Phase 1 under a subsequent audit.
+
+## 5. Egress delta
+
+None. No new HTTP clients, WebSocket connections, or DNS lookups.
+
+## 6. Audit events
+
+None added. `AuditSink` trait is defined but no `append()` calls added.
+
+## 7. Failure mode
+
+`cargo check`: clean.
+`cargo test --package azureclaw-controller`: 102 passed / 0 failed (including
+5 new tests for `ProviderKind::from_spec`, `allowed_in_prod`,
+`ProviderSelection::default`, `has_null`, and `field_managers` constants).
+`cargo test --package azureclaw-inference-router`: 0 passed / 0 failed
+(no new tests — traits with no impls).
+`cargo clippy --all-targets -- -D warnings`: clean after two fixes
+(doc-list overindent, struct-update syntax).
+`cli/` `npm run typecheck`: clean.
+`cli/` `npx vitest run src/providers.test.ts`: 11 passed.
+`tests/compat/` `npm test`: 11 passed / 8 todo (unchanged).
+All six CI gates: green against `main`.
+
+## 8. Negative-test coverage
+
+- `provider_kind_parses_all_aliases` — rejects `""`, `"vendoreed"`, etc.
+- `null_is_not_allowed_in_prod` — `Null.allowed_in_prod() == false`.
+- `has_null_detects_any_null_field` — detects a `Null` in any of the 4 fields.
+- TS-side: `parseProviderKind` rejects `noop`/`disabled` (admission-side
+  aliases are deliberately CLI-strict to catch typos early).
+
+## 9. Dependency delta
+
+Added one workspace-level crate, one crate-level adoption, zero TS deps:
+
+- `async-trait = "0.1"` — added to workspace `[workspace.dependencies]` and
+  consumed by `inference-router/Cargo.toml`. Source: docs.rs/async-trait
+  (version 0.1.89 resolved from crates.io). Needed because `async fn` in
+  traits still returns an opaque `impl Future` that breaks dyn dispatch —
+  we need `dyn MeshProvider` at call sites in Phase 1. No native-Rust
+  replacement is stable as of 2026-04-24 (RFC 3668 merged but not yet
+  stabilised for object-safety on async traits). **Principle #10 source**:
+  <https://crates.io/crates/async-trait/0.1.89> (Apache-2.0/MIT, 500M+
+  downloads, maintained by dtolnay).
+
+## 10. Internal-boundary posture
+
+N/A — scaffolding only. No new surface vs. MSFT products. When
+`AgtPolicyProvider`/`AgtAuditSink`/`AgtSigningProvider` land in Phase 1
+they'll be `Consume` against AGT per `docs/internal-boundaries.md`.
+
+## 11. Sign-offs
+
+- Author sign-off (documented below):
+  `Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>`
+
+- Reviewer sign-off: pending user review per the local-only workflow rule.
+  Second `Signed-off-by:` line to be added before this branch pushes
+  upstream.
+
+---
+
+### Re-audit triggers
+
+- Any implementation (`VendoredMeshProvider`, `AgtMeshProvider`, …) lands →
+  separate audit doc.
+- `async-trait` version changes → re-audit dep delta.
+- The traits evolve (method added / return type changed) → re-audit.
+
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/docs/security-audits/2026-04-24-phase0-provider-seams.md
+++ b/docs/security-audits/2026-04-24-phase0-provider-seams.md
@@ -117,3 +117,5 @@ they'll be `Consume` against AGT per `docs/internal-boundaries.md`.
 - The traits evolve (method added / return type changed) → re-audit.
 
 Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>

--- a/inference-router/Cargo.toml
+++ b/inference-router/Cargo.toml
@@ -36,6 +36,7 @@ prometheus.workspace = true
 # Error handling
 thiserror.workspace = true
 anyhow.workspace = true
+async-trait.workspace = true
 
 # AGT governance (policy YAML parsing + native policy/trust/audit)
 serde_yaml = "0.9"

--- a/inference-router/src/lib.rs
+++ b/inference-router/src/lib.rs
@@ -21,6 +21,7 @@ pub mod handoff;
 pub mod mesh;
 pub mod metrics;
 pub mod proxy;
+pub mod providers;
 pub mod routes;
 pub mod safety;
 pub mod spawn;

--- a/inference-router/src/providers/audit.rs
+++ b/inference-router/src/providers/audit.rs
@@ -1,0 +1,75 @@
+//! `AuditSink` contract.
+//!
+//! Responsibility: `append(event) -> ReceiptId`. The router appends a
+//! tamper-evident entry for every policy-relevant operation; the only thing
+//! we persist in CR status is the opaque `ReceiptId`. The Merkle chain and
+//! proof retrieval live inside the implementation.
+//!
+//! Implementations (Phase 1):
+//! - `VendoredAuditSink` — current `audit.rs` in router (hash-chained log).
+//! - `AgtAuditSink` — shipped AGT Rust SDK.
+//! - `NullAuditSink` — dev-only; admission rejects in prod.
+//!
+//! See `docs/implementation-plan.md` §1.2.
+
+/// Opaque receipt. `ReceiptId` is the only thing the router persists to CR
+/// status — it's treated as a black box outside this module.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReceiptId(pub String);
+
+/// Minimal event shape. Implementations MAY add their own fields; callers
+/// should treat the serialised form as opaque.
+#[derive(Debug, Clone)]
+pub struct AuditEvent {
+    /// Monotonic millisecond epoch captured by the caller.
+    pub timestamp_ms: u64,
+    /// Principal — same format as `PolicyRequest.principal`.
+    pub principal: String,
+    /// Action identifier (e.g., `tool.invoke`, `policy.deny`).
+    pub action: String,
+    /// Sha256 of the request/response body.
+    pub payload_digest_hex: String,
+    /// Verdict encoded as a compact enum string (`allow` / `deny:reason` / …).
+    pub verdict: String,
+    /// Free-form key-value labels.
+    pub labels: Vec<(String, String)>,
+}
+
+/// Returned alongside the receipt. Implementations that chain events
+/// provide the previous and current hashes so observers can rebuild the
+/// chain without re-calling the provider.
+#[derive(Debug, Clone)]
+pub struct AuditReceipt {
+    pub id: ReceiptId,
+    /// Optional: previous entry's hash. `None` for the genesis entry.
+    pub prev_hash_hex: Option<String>,
+    /// Sha256 of the canonical serialisation of this entry.
+    pub entry_hash_hex: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuditError {
+    #[error("audit backend unreachable: {0}")]
+    Unreachable(String),
+    #[error("queue full (backpressure)")]
+    QueueFull,
+    #[error("internal provider error: {0}")]
+    Internal(String),
+}
+
+#[async_trait::async_trait]
+pub trait AuditSink: Send + Sync {
+    /// Append a single event. Implementations MUST be idempotent on
+    /// duplicate calls with identical `(timestamp_ms, principal, action,
+    /// payload_digest_hex)` tuples — the caller may retry on `Unreachable`.
+    ///
+    /// Under `OutageMode::Strict` the caller fails the request on any error
+    /// from this method. Under `CachedRead` / `DegradedDev` the caller may
+    /// continue and retry out-of-band.
+    async fn append(&self, event: AuditEvent) -> Result<AuditReceipt, AuditError>;
+
+    /// Fetch an entry back by receipt id. Optional: implementations that
+    /// don't support lookup (e.g., fire-and-forget remote sinks) return
+    /// `Ok(None)`.
+    async fn get(&self, id: &ReceiptId) -> Result<Option<AuditEvent>, AuditError>;
+}

--- a/inference-router/src/providers/mesh.rs
+++ b/inference-router/src/providers/mesh.rs
@@ -1,0 +1,99 @@
+//! `MeshProvider` contract.
+//!
+//! Responsibility: session establishment between two peers, E2E-encrypted
+//! message send and receive, and relay/registry interaction. Hides the
+//! Signal-protocol-vs-AGT-mesh choice from call sites.
+//!
+//! Implementations (Phase 1):
+//! - `VendoredAgentMeshProvider` — wraps the current `vendor/agentmesh-sdk`
+//!   client + `vendor/agentmesh-relay` + `vendor/agentmesh-registry` code path.
+//! - `AgtMeshProvider` — lands when AGT's AgentMesh relay/registry ships
+//!   (`docs/implementation-plan.md` §1.5).
+//! - `NullMeshProvider` — dev/test; `open_session` always errors.
+//!
+//! Key custody: peer identity keys and ratchet state live inside the
+//! implementation. Callers never see raw key material.
+//!
+//! Phase 0 note: this file defines the contract only. Call-sites in
+//! `router/src/mesh.rs`, `router/src/handoff.rs`, and
+//! `controller/src/mesh_peer.rs` continue to use the vendored path
+//! directly until Phase 1.
+
+use std::fmt;
+
+/// Canonical agent identifier as emitted by the registry
+/// (e.g., `agent://tenant/name@key-fingerprint`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PeerId(pub String);
+
+impl fmt::Display for PeerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Opaque session handle scoped to a `MeshProvider` instance.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(pub String);
+
+/// Errors that cross the provider boundary. Implementations translate
+/// protocol-specific errors (libsodium / registry 401 / relay closed)
+/// into these canonical variants.
+#[derive(Debug, thiserror::Error)]
+pub enum MeshError {
+    #[error("registry unreachable: {0}")]
+    RegistryUnreachable(String),
+    #[error("relay unreachable: {0}")]
+    RelayUnreachable(String),
+    #[error("peer not registered: {0}")]
+    UnknownPeer(PeerId),
+    #[error("session not established: {0:?}")]
+    NoSession(SessionId),
+    #[error("decryption failed (likely ratchet drift or key mismatch)")]
+    DecryptionFailed,
+    #[error("policy denied session establishment: {0}")]
+    PolicyDenied(String),
+    #[error("internal provider error: {0}")]
+    Internal(String),
+}
+
+/// Result of [`MeshProvider::send`]. The relay acknowledges receipt, not
+/// delivery to the peer — recipient-side acks are out of band.
+#[derive(Debug, Clone)]
+pub struct SendResult {
+    pub session_id: SessionId,
+    pub relay_message_id: String,
+}
+
+/// The full mesh contract. All methods are `async` and `Send` so they
+/// can run inside the router's tokio runtime.
+#[async_trait::async_trait]
+pub trait MeshProvider: Send + Sync {
+    /// Register `self` with the registry and upload prekeys.
+    /// Idempotent — safe to call on reconnect.
+    async fn register(&self) -> Result<PeerId, MeshError>;
+
+    /// Resolve a peer by display name (namespace-scoped). Returns the
+    /// canonical `PeerId`, or `UnknownPeer` if not registered.
+    async fn resolve(&self, display_name: &str) -> Result<PeerId, MeshError>;
+
+    /// Establish (or reuse) a Signal/X3DH session with `peer`. Idempotent:
+    /// if a session already exists the implementation returns it.
+    async fn open_session(&self, peer: &PeerId) -> Result<SessionId, MeshError>;
+
+    /// Send an opaque byte payload over the E2E tunnel. The payload is
+    /// whatever the caller put in (typically a JSON envelope). The
+    /// provider handles ratchet state and relay transport internally.
+    async fn send(&self, session: &SessionId, payload: &[u8]) -> Result<SendResult, MeshError>;
+
+    /// Install a handler for inbound decrypted messages on any session
+    /// this provider owns. Only one handler may be registered at a time;
+    /// calling twice replaces the previous one.
+    async fn on_message(
+        &self,
+        handler: Box<dyn Fn(SessionId, Vec<u8>) + Send + Sync + 'static>,
+    ) -> Result<(), MeshError>;
+
+    /// Tear down a session and forget its ratchet state.
+    async fn close_session(&self, session: &SessionId) -> Result<(), MeshError>;
+}

--- a/inference-router/src/providers/mod.rs
+++ b/inference-router/src/providers/mod.rs
@@ -1,0 +1,60 @@
+//! Provider contracts for AzureClaw.
+//!
+//! Everything that crosses the AGT boundary goes through exactly four
+//! contracts defined in this module:
+//!
+//! * [`MeshProvider`]            — session establishment, E2E send/receive.
+//! * [`PolicyDecisionProvider`]  — `decide(request) -> verdict`.
+//! * [`AuditSink`]               — `append(event) -> ReceiptId`.
+//! * [`SigningProvider`]         — `sign(key_ref, payload) -> Signature`.
+//!
+//! Each contract will have three implementations (Phase 1):
+//!
+//! * `Vendored*` — current vendored-AgentMesh behaviour.
+//! * `Agt*`      — AGT SDK backed (policy/audit/signing now, mesh later).
+//! * `Null*`     — dev-only; admission rejects in prod unless the manifest
+//!   carries `azureclaw.azure.com/dev-only: "true"`.
+//!
+//! **Phase 0 status:** contracts only. No implementations and no call-site
+//! migrations land here. Provider construction, dispatch, and feature-flag
+//! plumbing are Phase 1 per `docs/implementation-plan.md` §7.
+//!
+//! **Outage semantics** (§1.3):
+//! * `Strict` (prod default) — fail-closed on AGT/Mesh down.
+//! * `CachedRead` — allow cached < TTL else fail-closed.
+//! * `DegradedDev` (`azureclaw dev` only) — fail-open with warning label.
+//!
+//! Every new implementation of any contract below MUST land with a
+//! `docs/security-audits/YYYY-MM-DD-<slug>.md` covering the §0.2 #9 scope.
+
+// Scaffolding for Phase 1 — see docs/implementation-plan.md §7. Dead-code
+// lints are silenced at the module level until call-sites land.
+#![allow(dead_code)]
+
+pub mod audit;
+pub mod mesh;
+pub mod policy;
+pub mod signing;
+
+pub use audit::{AuditEvent, AuditReceipt, AuditSink, ReceiptId};
+pub use mesh::{MeshProvider, PeerId, SendResult, SessionId};
+pub use policy::{PolicyDecisionProvider, PolicyRequest, PolicyVerdict};
+pub use signing::{KeyRef, Signature, SigningProvider};
+
+/// Outage mode selected per `ClawSandbox` via `spec.agt.outageMode`.
+/// See `docs/implementation-plan.md` §1.3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutageMode {
+    Strict,
+    CachedRead,
+    DegradedDev,
+}
+
+/// Selects which implementation of a contract a tenant uses.
+/// See `docs/implementation-plan.md` §1.4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    Vendored,
+    Agt,
+    Null,
+}

--- a/inference-router/src/providers/policy.rs
+++ b/inference-router/src/providers/policy.rs
@@ -1,0 +1,66 @@
+//! `PolicyDecisionProvider` contract.
+//!
+//! Responsibility: `decide(request) -> verdict`. A single synchronous call
+//! evaluates whether a given principal may perform a given tool call on a
+//! given payload in a given context.
+//!
+//! Implementations (Phase 1):
+//! - `VendoredPolicyDecisionProvider` — today's `governance.rs` code path.
+//!   `PolicyEngine` + `TrustManager` + `RateLimiter` + `BehaviorMonitor`.
+//! - `AgtPolicyDecisionProvider` — wraps the shipped AGT Rust SDK.
+//! - `NullPolicyDecisionProvider` — dev-only; defaults to fail-closed
+//!   (admission-policy rejects in prod).
+//!
+//! See `docs/implementation-plan.md` §1.2 and §1.4.
+
+use std::time::Duration;
+
+/// Canonical policy request. The router builds this from the live HTTP
+/// request context. Payload is a sha256 digest, not the raw body.
+#[derive(Debug, Clone)]
+pub struct PolicyRequest {
+    /// Principal making the request — typically `agent://…` or `user://…`.
+    pub principal: String,
+    /// Tool name (e.g., `foundry.chat`, `mcp.fs.read`, `a2a.invoke`).
+    pub tool: String,
+    /// Sha256 of the request body, hex-encoded.
+    pub payload_digest_hex: String,
+    /// Free-form contextual labels; implementations may consult or ignore.
+    pub context: Vec<(String, String)>,
+}
+
+/// Verdict emitted by a provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyVerdict {
+    /// Allowed unconditionally.
+    Allow,
+    /// Allowed but caller must attach the given labels to the response
+    /// (e.g., content-safety warnings, trust-tier annotations).
+    AllowWithLabels(Vec<(String, String)>),
+    /// Denied; implementations SHOULD provide a short human-readable reason.
+    Deny { reason: String },
+    /// Needs out-of-band approval; `ttl` is how long to hold the request.
+    NeedsApproval { approver: String, ttl: Duration },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyError {
+    #[error("policy backend unreachable: {0}")]
+    Unreachable(String),
+    #[error("malformed request: {0}")]
+    Malformed(String),
+    #[error("internal provider error: {0}")]
+    Internal(String),
+}
+
+#[async_trait::async_trait]
+pub trait PolicyDecisionProvider: Send + Sync {
+    /// Evaluate a single request. Implementations MUST be side-effect-free
+    /// on the caller's behalf; side effects (audit append, counter increment)
+    /// belong in downstream contracts.
+    ///
+    /// Under `OutageMode::Strict` an `Unreachable` error MUST translate to
+    /// `Deny` at the call site — the provider itself returns the error so
+    /// the policy layer has a chance to log and react.
+    async fn decide(&self, request: PolicyRequest) -> Result<PolicyVerdict, PolicyError>;
+}

--- a/inference-router/src/providers/signing.rs
+++ b/inference-router/src/providers/signing.rs
@@ -1,0 +1,61 @@
+//! `SigningProvider` contract.
+//!
+//! Responsibility: `sign(key_ref, payload) -> Signature`;
+//! `verify(key_ref, payload, sig) -> bool`. **Key material never crosses
+//! the boundary.** Callers pass an opaque `KeyRef`; the provider resolves
+//! it to an internal handle.
+//!
+//! Implementations (Phase 1):
+//! - `VendoredSigningProvider` — today's Ed25519 path using the keys
+//!   emitted by `vendor/agentmesh-sdk`.
+//! - `AgtSigningProvider` — shipped AGT Rust SDK.
+//! - `NullSigningProvider` — dev-only; always returns a deterministic
+//!   non-verifying signature labeled `ci:stub-ok`; admission rejects in
+//!   prod.
+//!
+//! **No hand-rolled crypto.** `ci/no-custom-crypto.sh` enforces this file,
+//! `providers/mesh.rs`, `vendor/`, and a short allowlist are the only places
+//! where crypto primitives may be imported. See `docs/implementation-plan.md`
+//! §0.2 #8.
+//!
+//! See `docs/implementation-plan.md` §1.2.
+
+/// Opaque reference to a signing key. The interpretation is
+/// provider-specific. Examples:
+/// - Vendored: `"agent:default"` resolves to the SDK-generated keypair.
+/// - AGT: `"agt://tenant/agent#ed25519/<fingerprint>"`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KeyRef(pub String);
+
+/// Raw signature bytes. Format is provider-specific; opaque to callers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature(pub Vec<u8>);
+
+#[derive(Debug, thiserror::Error)]
+pub enum SigningError {
+    #[error("unknown key ref: {0:?}")]
+    UnknownKey(KeyRef),
+    #[error("signing backend unreachable: {0}")]
+    Unreachable(String),
+    #[error("internal provider error: {0}")]
+    Internal(String),
+}
+
+#[async_trait::async_trait]
+pub trait SigningProvider: Send + Sync {
+    /// Produce a signature over `payload` using the key identified by
+    /// `key_ref`. The caller is responsible for any canonicalisation of
+    /// `payload` before invoking.
+    async fn sign(&self, key_ref: &KeyRef, payload: &[u8]) -> Result<Signature, SigningError>;
+
+    /// Verify `sig` against `payload` for the key identified by `key_ref`.
+    /// Returns `Ok(true)` on a valid signature, `Ok(false)` on a valid
+    /// format but wrong signature, and `Err(_)` only when the provider
+    /// itself failed (key unknown, backend down).
+    async fn verify(
+        &self,
+        key_ref: &KeyRef,
+        payload: &[u8],
+        sig: &Signature,
+    ) -> Result<bool, SigningError>;
+}


### PR DESCRIPTION
## Phase 0 · provider-contract trait scaffolds

Defines the provider seams that let us plug AGT (or any future provider) in behind a feature flag **without** a full rewrite — principle §0.2 #2 (configurable-not-replacement).

### Rust (`inference-router/src/providers/`)
Four `async_trait` contracts, all `#![allow(dead_code)]` in Phase 0 (no call sites wired yet, by design):
- `MeshProvider` — the AgentMesh relay/registry/SDK shape we need.
- `PolicyProvider` — AGT policy-evaluation shape (PolicyEngine component).
- `AuditSink` — audit-trail write shape (AuditLogger component).
- `SigningProvider` — Ed25519 signing shape (TrustManager component).

Adds `async-trait 0.1.89` to the workspace (RFC 3668 object-safety not yet stable on MSRV 1.88). Source cited in the audit doc.

### Rust (`controller/src/providers/mod.rs`)
- `ProviderKind` enum + `ProviderSelection` struct.
- `field_managers` module — SSA manager-name constants per the ownership matrix (plan §6 #4). 5 unit tests.

### TypeScript (`cli/src/providers.ts`)
- Provider-selection helpers + 11 unit tests.

### Security
See `docs/security-audits/2026-04-24-phase0-provider-seams.md`. STRIDE categories are mostly N/A in this PR (no runtime path wired); re-audit triggers documented for each later provider impl.

### Verification
- `cargo check --all` + `cargo clippy --all-targets -- -D warnings` clean.
- `cli` typecheck + vitest: clean, 11 new tests pass.
- `controller` test suite: **102 passed** (adds 5).

### Stack
PR 4/9 — bases on `phase0/compat-suite-skeleton` (PR 3).
