### PR TITLE
docs(use-cases): correct any-OpenClaw flow + add roadmap scenario + surface in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ AzureClaw is **not a fork of OpenClaw** — it extends OpenClaw via its native p
 4. **Operational footprint** — `azureclaw up` provisions AKS + ACR + Foundry + Foundry-side Content Safety + sandbox in one go; `azureclaw operator` gives a live TUI for running fleets.
 5. **Multi-runtime future** — see [Roadmap](#roadmap-extending-beyond-openclaw) below: protocol scaffolding (MCP, A2A, AP2) is in place so the same sandbox can host non-OpenClaw agents over the wire.
 
+> 📖 **See [`docs/use-cases.md`](docs/use-cases.md)** for the four end-to-end scenarios — AzureClaw-native agents, **any-OpenClaw → AzureClaw cloud offload** (no AzureClaw CLI on the laptop), AzureClaw ↔ AzureClaw mesh, and the roadmap for non-OpenClaw runtimes via MCP / A2A / AP2.
+
 ---
 
 ## Architecture
@@ -212,7 +214,7 @@ The protocol scaffolding for that future is being landed now in tightly scoped, 
 | **Pluggable governance providers** | `PolicyDecisionProvider`, `AuditSink`, `SigningProvider` traits live; in-tree implementations are the production path today | Future swap-in of AGT's Rust SDK alternates without rewriting call sites; multi-tenant per-capability provider selection |
 | **`McpServer` / `ToolPolicy` CRDs** | Schema-only in this branch; reconcilers planned for the next phase | Declarative tool-server publication and per-tool policy (rate limits, commerce caps, allowlists) |
 
-The full plan for these surfaces — what is implemented today, what is wiring-pending, and what is deferred — is captured in [`docs/phase-0-1-capabilities.md`](docs/phase-0-1-capabilities.md). For three end-to-end scenarios spanning today's runtime and these in-flight extensions, see [`docs/use-cases.md`](docs/use-cases.md).
+The full plan for these surfaces — what is implemented today, what is wiring-pending, and what is deferred — is captured in [`docs/phase-0-1-capabilities.md`](docs/phase-0-1-capabilities.md). For the four end-to-end scenarios — three shipping today, plus a roadmap track for non-OpenClaw runtimes — see [`docs/use-cases.md`](docs/use-cases.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ AzureClaw is **not a fork of OpenClaw** — it extends OpenClaw via its native p
 4. **Operational footprint** — `azureclaw up` provisions AKS + ACR + Foundry + Foundry-side Content Safety + sandbox in one go; `azureclaw operator` gives a live TUI for running fleets.
 5. **Multi-runtime future** — see [Roadmap](#roadmap-extending-beyond-openclaw) below: protocol scaffolding (MCP, A2A, AP2) is in place so the same sandbox can host non-OpenClaw agents over the wire.
 
-> 📖 **See [`docs/use-cases.md`](docs/use-cases.md)** for the four end-to-end scenarios — AzureClaw-native agents, **any-OpenClaw → AzureClaw cloud offload** (no AzureClaw CLI on the laptop), AzureClaw ↔ AzureClaw mesh, and the roadmap for non-OpenClaw runtimes via MCP / A2A / AP2.
+> 📖 **See [`docs/use-cases.md`](docs/use-cases.md)** for the four end-to-end scenarios — AzureClaw-native agents, **any-OpenClaw → AzureClaw cloud offload** (no AzureClaw CLI on the laptop), AzureClaw ↔ AzureClaw mesh, and the roadmap for non-OpenClaw runtimes via MCP / A2A / AP2. For deployment shapes (developer inner-loop, enterprise self-hosted, managed public offload, cross-org federation, sovereign / air-gapped) with topology + trust-boundary + flow diagrams, see [`docs/blueprints/`](docs/blueprints/00-index.md).
 
 ---
 

--- a/docs/blueprints/00-index.md
+++ b/docs/blueprints/00-index.md
@@ -1,0 +1,40 @@
+# AzureClaw Deployment Blueprints
+
+Concrete, end-to-end shapes for running AzureClaw. Each blueprint pins down **who runs what**, **where the trust boundary sits**, and **how a single agent task flows from prompt to completion** — including which CRDs, controllers, network paths, and identity surfaces are in play.
+
+The four [use cases in `docs/use-cases.md`](../use-cases.md) describe *what* AzureClaw does. The blueprints below describe *how you run it for a given audience*. They are not mutually exclusive — a single AzureClaw cluster can serve multiple blueprints simultaneously (e.g. Blueprint 02 for internal employees + Blueprint 03 for external partners).
+
+## Blueprint catalogue
+
+| # | Blueprint | Audience | Where AzureClaw runs | Today's status |
+|---|---|---|---|---|
+| **01** | [Developer inner-loop](01-developer-inner-loop.md) | Individual contributor on a laptop | Local Docker / kind, single-node | ✅ Shipping |
+| **02** | [Enterprise self-hosted cluster](02-enterprise-self-hosted.md) | Platform team inside a single org | Customer-owned AKS, single tenant | ✅ Shipping |
+| **03** | [Managed public offload service](03-managed-public-offload.md) | SaaS provider serving many external tenants | Provider-owned AKS, multi-tenant | 🚧 Roadmap (token + plugin protocol shipping today) |
+| **04** | [Cross-org federation](04-cross-org-federation.md) | Two or more orgs collaborating | Two AKS clusters meshed E2E | ✅ Shipping |
+| **05** | [Sovereign / air-gapped](05-sovereign-airgapped.md) | Regulated, classified, disconnected, or sovereign-cloud workloads | Customer-owned AKS in an isolated network island | 🚧 Patterns documented; reproducible bundle on roadmap |
+
+## Reading guide
+
+Each blueprint has the same shape:
+
+1. **Persona & intent** — who you are, what you want.
+2. **Topology** — Mermaid diagram of who-runs-what.
+3. **Trust boundary** — where the credential / control boundary sits.
+4. **Primary flow** — sequence diagram of the main happy-path interaction.
+5. **What you provision** — concrete CLI / kubectl invocations.
+6. **What's unique to this blueprint** — the property that makes it not just a sub-case of another blueprint.
+7. **References** — code, CRDs, ADRs.
+
+## Cross-cutting properties
+
+Regardless of blueprint, every AzureClaw deployment ships:
+
+- **Egress isolation** — agent UID 1000 can only reach `localhost` + DNS. The router (UID 1001) is the sole external path.
+- **Foundry-side Content Safety** — `Microsoft.DefaultV2` Prompt Shields on every inference.
+- **AGT-native governance** — `PolicyEngine`, `TrustManager`, `AuditLogger`, `RateLimiter`, `BehaviorMonitor` evaluated in-process on every tool call, every inference, every mesh message.
+- **Tamper-evident audit chain** — hash-chained log persisted via `AuditSink`.
+- **Signal-Protocol mesh** — X3DH + Double Ratchet. Relay sees only ciphertext. No plaintext fallback; failed-decrypt is a `security_event`, never a delivered cleartext message.
+- **CRD-driven control plane** — `ClawSandbox`, `Pairing`, `MeshPeer`, `A2AAgent`, `McpServer`, `ToolPolicy` (the last three are Phase 1 schema; reconcilers in Phase 2).
+
+If your environment can't support one of those, you're outside the AzureClaw threat model — open an issue before deploying.

--- a/docs/blueprints/01-developer-inner-loop.md
+++ b/docs/blueprints/01-developer-inner-loop.md
@@ -1,0 +1,133 @@
+# Blueprint 01 — Developer inner-loop
+
+> "I'm on my laptop. I want to iterate on AzureClaw — controller, router, sandbox image, plugin — without provisioning AKS, without paying for Azure, and without weakening the security model so much that what I test locally diverges from what runs in production."
+
+## Persona & intent
+
+- **You are:** an individual contributor or maintainer.
+- **You want:** sub-minute reload of controller / router / CLI / plugin / sandbox image. Real Foundry calls *optional* (`stub-foundry` mode for offline). Real K8s reconciliation. Real seccomp + NetworkPolicy enforcement so a green local run means something.
+- **You do not want:** to provision AKS for every PR; to share Azure credentials with experimental builds; to maintain a parallel "dev mock" code path that drifts from prod.
+
+## Topology
+
+```mermaid
+flowchart LR
+  subgraph Laptop["💻 Laptop (your machine)"]
+    direction TB
+    KIND[("🔵 kind cluster<br/>1 node")]
+    REG[("📦 local registry<br/>:5001")]
+
+    subgraph KINDCONTENT[" "]
+      direction TB
+      CTRL["azureclaw-controller<br/>(operator)"]
+      SBX["ClawSandbox 'dev'<br/>📦 openclaw + 🛡 router"]
+    end
+
+    KIND --- KINDCONTENT
+    DOCKER["docker engine<br/>(builds + kind nodes)"]
+    CLI["azureclaw CLI"]
+  end
+
+  CLI -->|"azureclaw up<br/>--mode local"| KIND
+  DOCKER -->|"docker push :5001"| REG
+  REG -->|"image pull"| KIND
+
+  CLI -.->|"azureclaw connect dev<br/>(port-forward 18789)"| SBX
+
+  subgraph Foundry["☁️ Azure AI Foundry (optional)"]
+    FND["gpt-4.1, gpt-5-mini, …"]
+  end
+
+  SBX -.->|"only if AZURE_OPENAI_*<br/>env vars set"| FND
+
+  classDef opt stroke-dasharray:5 5;
+  class Foundry,FND opt;
+```
+
+## Trust boundary
+
+The trust boundary is **identical to production**:
+
+- Agent UID 1000 inside the sandbox pod can reach only `localhost` + DNS. The router on UID 1001 is the sole external path.
+- The custom strict seccomp profile is loaded by kind (annotation: `localhostProfile: azureclaw-strict.json`).
+- NetworkPolicy default-deny is enforced by Cilium-on-kind.
+- Foundry calls go to the real Foundry endpoint via Workload Identity *only if* the user has configured one; otherwise the router runs in `--stub-foundry` mode and returns deterministic canned responses.
+
+The only thing that's *not* like production is the host: `kind` instead of AKS, no Application Gateway, no Confidential Containers (kata + SEV-SNP) — Confidential mode silently degrades to standard mode in local-dev.
+
+## Primary flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Dev as 👤 You
+    participant CLI as azureclaw CLI
+    participant Docker as docker
+    participant Reg as local registry
+    participant Kind as kind
+    participant Ctrl as controller pod
+    participant SBX as ClawSandbox 'dev'
+
+    Dev->>CLI: azureclaw up --mode local
+    CLI->>Docker: docker compose up (registry)
+    CLI->>Kind: kind create cluster
+    CLI->>CLI: helm install azureclaw …
+    Kind->>Ctrl: schedule controller
+    Dev->>Docker: cargo build && docker build sandbox
+    Docker->>Reg: docker push :5001/sandbox:latest
+    Dev->>CLI: azureclaw add dev --model stub-foundry
+    CLI->>Kind: kubectl apply ClawSandbox
+    Ctrl->>Kind: reconcile → Deployment + NP + ConfigMap
+    Kind->>SBX: pull from :5001 → start
+    Dev->>CLI: azureclaw connect dev
+    CLI->>SBX: kubectl port-forward 18789
+    Dev->>SBX: chat over WebUI
+    SBX-->>Dev: deterministic response (stub-foundry)
+```
+
+## What you provision
+
+```bash
+# One-time
+git clone https://github.com/Azure/azureclaw && cd azureclaw
+make dev-prereqs                  # installs kind, helm, kubectl, cargo, node 22
+
+# Every-loop
+make build                        # cargo build + cli npm run build
+make images                       # docker build for controller, router, sandbox
+azureclaw up --mode local         # spins kind + local registry + helm install
+azureclaw add dev --model stub-foundry --governance
+azureclaw connect dev             # port-forward to WebUI on :18789
+
+# When you change Rust code:
+make build images && azureclaw push --only sandbox --apply
+
+# Tear down:
+azureclaw down --mode local       # kind delete + docker compose down
+```
+
+For the cross-runtime mesh path (Blueprint 04 reduced to one machine), the same stack supports:
+
+```bash
+azureclaw mesh promote --port-forward      # exposes registry+relay on :18080/:18765
+azureclaw pair generate --name laptop-self # mints a token you can paste back into a NemoClaw also running locally
+```
+
+## What's unique to this blueprint
+
+- **Real reconciliation, fake cloud.** The controller does real K8s API calls against a real apiserver; only Foundry is optionally stubbed. No mock controllers, no in-memory K8s clients.
+- **Same image, same seccomp, same NP.** What you test locally is what gets pushed to AKS — modulo Confidential mode and Application Gateway.
+- **No Azure credentials anywhere on the laptop** in stub-foundry mode. Safe to run on shared / personal machines, in CI, in dependabot autoruns.
+
+## What this blueprint is NOT
+
+- Not a production deployment. `kind` is a single-node cluster on your laptop; if your laptop dies, your sandbox dies.
+- Not a security-audited environment. Local-dev disables some isolation features that require real AKS (Confidential Containers, Application Gateway WAF, Foundry-side Prompt Shields when in stub-foundry).
+- Not a substitute for the [conformance + compat suites](../conformance-suite.md) — those need a real cluster.
+
+## References
+
+- `cli/src/commands/up.ts` (`--mode local` branch)
+- `docker-compose.dev.yml` (local registry + helm-install harness)
+- `Makefile` (`dev-prereqs`, `build`, `images`, `images-load`)
+- `tests/e2e/` (kind-based e2e harness, same shape as this blueprint)

--- a/docs/blueprints/02-enterprise-self-hosted.md
+++ b/docs/blueprints/02-enterprise-self-hosted.md
@@ -1,0 +1,171 @@
+# Blueprint 02 — Enterprise self-hosted cluster
+
+> "I'm a platform team inside one organisation. I want to give my engineers and product teams a hardened, governed AI agent runtime on AKS that I own end-to-end — same Entra tenant, same network island, same audit destination, no third-party SaaS in the data path."
+
+## Persona & intent
+
+- **You are:** the platform / infra / SRE team inside one company. You own an Azure subscription, an Entra tenant, and a security-approved Azure AI Foundry project.
+- **You want:** to run AzureClaw as a single-tenant cluster for *your own* employees and *your own* services. Anyone consuming agents is inside the same Entra tenant or paired in via your operator-managed pairing tokens.
+- **You do not want:** any agent traffic to leave your VNet. Any provider you can't audit in the data path. Any plaintext in the relay.
+
+## Topology
+
+```mermaid
+flowchart TB
+  subgraph Corp["🏢 Your organisation (single Entra tenant)"]
+    direction TB
+
+    subgraph Ops["Platform team"]
+      OpsLaptop["operator workstation<br/>azureclaw CLI + kubectl"]
+    end
+
+    subgraph Azure["☁️ Your Azure subscription"]
+      direction TB
+      AKS[("☸️ AKS<br/>Cilium + Workload Identity")]
+      ACR[("📦 ACR (private)")]
+      AGW[("🛡 App Gateway + WAF<br/>private endpoint")]
+      FND[("🧠 Foundry project<br/>Content Safety + memory store")]
+      KV[("🔐 Key Vault")]
+      LAW[("📊 Log Analytics + App Insights")]
+
+      subgraph AKSContent[" "]
+        direction TB
+        CTRL["azureclaw-controller"]
+        REG["mesh registry"]
+        RLY["mesh relay"]
+        PG[("Postgres")]
+
+        subgraph SBX1["📦 ClawSandbox 'research-bot'"]
+          OC1["openclaw (UID 1000)"]
+          IR1["router (UID 1001)"]
+        end
+        subgraph SBX2["📦 ClawSandbox 'ops-bot'"]
+          OC2["openclaw"]
+          IR2["router"]
+        end
+      end
+      AKS --- AKSContent
+    end
+
+    subgraph Users["👥 Your employees"]
+      Eng["engineer<br/>(NemoClaw / OpenClaw on laptop)"]
+      Slack["Slack / Telegram channel"]
+    end
+  end
+
+  OpsLaptop -->|"azureclaw up<br/>azureclaw add"| AKS
+  IR1 -->|"Workload Identity<br/>OIDC"| FND
+  IR2 -->|"Workload Identity"| FND
+  IR1 -.->|"audit chain"| LAW
+  IR2 -.->|"audit chain"| LAW
+  AGW -->|"private endpoint"| REG
+  AGW -->|"private endpoint"| RLY
+  REG --- PG
+  RLY --- PG
+  KV -.->|"secrets via CSI"| AKS
+
+  OpsLaptop -->|"azureclaw mesh promote<br/>--allow-ip <corp-cidr><br/>azureclaw pair generate"| AGW
+  Eng -->|"one-time token<br/>in NemoClaw chat"| AGW
+
+  Slack -.->|"webhook"| OC1
+```
+
+## Trust boundary
+
+```mermaid
+flowchart LR
+  subgraph TB1["🏢 Corp Entra tenant + VNet"]
+    direction TB
+    Eng["employee laptop"]
+    AKS["AzureClaw AKS"]
+    FND["Foundry"]
+    LAW["Log Analytics"]
+  end
+
+  Eng -->|"E2E (Signal Protocol)<br/>via private App Gateway"| AKS
+  AKS -->|"Workload Identity"| FND
+  AKS -->|"audit"| LAW
+
+  classDef boundary stroke:#0078d4,stroke-width:3px,fill:#f0f7ff;
+  class TB1 boundary;
+```
+
+- **Single trust domain.** Everything inside the Entra tenant.
+- **No cleartext at rest** — pairing token hashes only, audit chain hash-chained, mesh sessions Double-Ratchet keyed.
+- **No cleartext in flight** — App Gateway private endpoint terminates corp TLS; relay traffic remains Signal-protocol-encrypted end-to-end *inside* the TLS tunnel.
+
+## Primary flow — onboarding a new employee laptop
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Eng as 👤 Engineer
+    participant Ops as Platform team
+    participant CLI as azureclaw CLI
+    participant Ctrl as controller
+    participant Reg as registry
+    participant Rly as relay
+    participant Plg as azureclaw-mesh plugin (in NemoClaw)
+
+    Ops->>CLI: azureclaw mesh promote --allow-ip 10.0.0.0/8
+    CLI->>Ctrl: provision App Gateway endpoint, IP allowlist
+    Ops->>CLI: azureclaw pair generate --name alice-laptop --slots 3
+    CLI-->>Ops: azc_pair_v1_… token
+    Ops->>Eng: secret-share / Teams DM / SMS<br/>(secure channel)
+    Eng->>Plg: paste token in NemoClaw chat<br/>(or set AZURECLAW_PAIRING_TOKEN env)
+    Plg->>Reg: claim slot + register Ed25519 identity
+    Plg->>Rly: KNOCK + X3DH prekeys
+    Rly-->>Plg: session established
+    Note over Eng,Plg: Pairing complete.<br/>Token is single-use, auto-zeroized.
+
+    Eng->>Plg: "offload analyze_repo to AzureClaw"
+    Plg->>Rly: encrypted offload request
+    Rly->>Ctrl: deliver to controller AMID
+    Ctrl->>Ctrl: spawn ClawSandbox offload-N (token budget enforced)
+    Ctrl-->>Plg: result via E2E reply
+```
+
+## What you provision
+
+```bash
+# One-time per cluster
+azureclaw up                                      # AKS + ACR + Foundry + Key Vault + initial sandboxes
+azureclaw operator                                # live TUI for the cluster
+
+# Per agent
+azureclaw add research-bot --model gpt-4.1 --governance --learn-egress
+azureclaw add ops-bot --model gpt-5-mini --governance
+azureclaw credentials update research-bot --telegram-token "<bot-token>"
+
+# Onboard a NemoClaw / OpenClaw user (no AzureClaw CLI on their laptop)
+azureclaw mesh promote --allow-ip 10.0.0.0/8      # one-time, exposes registry+relay over private App Gateway
+azureclaw pair generate --name alice-laptop --slots 3 --capabilities offload,handoff
+
+# Day-2 ops
+azureclaw policy allow research-bot api.example.com
+azureclaw model set research-bot gpt-5-mini
+azureclaw egress research-bot --learned
+azureclaw trace research-bot --network
+```
+
+## What's unique to this blueprint
+
+- **Single tenant, single audit destination.** Everything an employee or a CI job does flows into your Log Analytics + audit chain. No third party.
+- **Workload Identity instead of API keys.** The router binds to a federated K8s ServiceAccount → Entra workload identity. Foundry sees the request as your tenant.
+- **Pairing replaces VPN-for-agents.** Employees don't need a VPN tunnel to AzureClaw — they get a one-time token that scopes them to one slot of one capability set with one budget cap. Lost laptop = revoke one Pairing CR.
+- **You can scale Confidential Containers in.** AKS supports kata + AMD SEV-SNP node pools today. Set `ClawSandbox.spec.isolation: confidential` per-agent for sensitive workloads; sub-agents inherit and cannot downgrade.
+
+## What this blueprint is NOT
+
+- Not a multi-tenant SaaS. If you serve external customers, see Blueprint 03.
+- Not a federation pattern. If you collaborate with another org's AzureClaw, see Blueprint 04.
+- Not air-gapped. If your network can't reach Foundry, see Blueprint 05.
+
+## References
+
+- `cli/src/commands/up.ts` (Bicep + Helm provisioning)
+- `controller/src/reconciler/mod.rs` (sandbox composition)
+- `controller/src/pairing.rs` + `cli/src/commands/pair.ts` (token issuance)
+- `inference-router/src/auth.rs` (Workload Identity OIDC exchange)
+- `deploy/helm/azureclaw/values.yaml` (Helm contract)
+- ADR-0001 — A2A ingress front-edge (`docs/adr/0001-a2a-ingress-front-edge.md`)

--- a/docs/blueprints/03-managed-public-offload.md
+++ b/docs/blueprints/03-managed-public-offload.md
@@ -1,0 +1,190 @@
+# Blueprint 03 — Managed public offload service
+
+> "I'm a SaaS provider. I want to run AzureClaw as a managed offload service for many external customers — each one a different Entra tenant, none of them with kubectl access, all of them onboarded by token, all of them isolated from each other at every layer."
+
+## Persona & intent
+
+- **You are:** the SaaS provider running an AzureClaw cloud. Your customers run OpenClaw / NemoClaw / any-OpenClaw on their laptops, in their offices, in their own clusters — anywhere — and offload heavy or sensitive tasks to your AKS.
+- **You want:** a single AKS cluster (or a few regional clusters) hosting many tenants. Self-service onboarding via your portal. Per-tenant token budgets, slot caps, capability scopes. Provider-side observability without ever decrypting customer mesh traffic.
+- **You do not want:** to ever hold customer-side LLM context in cleartext. To require customers to install your CLI. To leak one tenant's audit chain to another.
+
+## Topology
+
+```mermaid
+flowchart TB
+  subgraph Provider["☁️ Provider AKS (multi-tenant)"]
+    direction TB
+    Portal["customer portal<br/>(Entra ID + billing)"]
+    PairAPI["pair-issuance API<br/>wraps azureclaw pair generate"]
+
+    subgraph AKS["☸️ AKS cluster"]
+      direction TB
+      AGW["App Gateway + WAF<br/>public endpoint"]
+      Reg["mesh registry"]
+      Rly["mesh relay"]
+      PG[("Postgres")]
+      Ctrl["controller"]
+
+      subgraph T1NS["namespace: tenant-acme"]
+        T1SBX["ClawSandbox 'offload-N'"]
+      end
+      subgraph T2NS["namespace: tenant-globex"]
+        T2SBX["ClawSandbox 'offload-M'"]
+      end
+    end
+
+    Fnd["Foundry project (provider-owned)"]
+    Mon["per-tenant Log Analytics workspaces"]
+  end
+
+  subgraph Cust1["🏢 Customer 'Acme' (no AzureClaw CLI)"]
+    A1["NemoClaw on laptop"]
+  end
+  subgraph Cust2["🏢 Customer 'Globex' (no AzureClaw CLI)"]
+    G1["custom OpenClaw image<br/>+ azureclaw-mesh plugin"]
+  end
+
+  Portal -->|"signup + checkout"| PairAPI
+  PairAPI -->|"azc_pair_v1_… (one-time)"| Cust1
+  PairAPI -->|"azc_pair_v1_… (one-time)"| Cust2
+  PairAPI -->|"creates Pairing CR<br/>tokenHash only"| Ctrl
+
+  A1 -->|"E2E via App Gateway"| AGW
+  G1 -->|"E2E via App Gateway"| AGW
+  AGW --> Reg
+  AGW --> Rly
+  Reg --- PG
+  Rly --- PG
+
+  Ctrl -->|"spawns into tenant ns"| T1SBX
+  Ctrl -->|"spawns into tenant ns"| T2SBX
+  T1SBX -->|"Workload Identity"| Fnd
+  T2SBX -->|"Workload Identity"| Fnd
+  T1SBX -.->|"audit"| Mon
+  T2SBX -.->|"audit"| Mon
+
+  classDef tenant1 fill:#fef3c7,stroke:#a16207;
+  classDef tenant2 fill:#dbeafe,stroke:#1e40af;
+  class T1NS,Cust1,A1 tenant1;
+  class T2NS,Cust2,G1 tenant2;
+```
+
+## Trust boundary
+
+```mermaid
+flowchart LR
+  subgraph Cust["Customer trust domain"]
+    UserCtx["agent context, prompts,<br/>files (cleartext)"]
+  end
+  subgraph Provider["Provider trust domain"]
+    Edge["App Gateway<br/>+ WAF"]
+    Relay["relay<br/>(ciphertext only)"]
+    Sandbox["per-tenant<br/>sandbox + router"]
+    Foundry["Foundry"]
+  end
+
+  UserCtx -->|"plugin encrypts<br/>(X3DH + Double Ratchet)"| Edge
+  Edge --> Relay
+  Relay -->|"deliver ciphertext"| Sandbox
+  Sandbox -->|"decrypt at agent UID 1000<br/>(only place cleartext exists provider-side)"| Sandbox
+  Sandbox -->|"Workload Identity"| Foundry
+
+  classDef cust fill:#fef3c7,stroke:#a16207;
+  classDef prov fill:#dbeafe,stroke:#1e40af;
+  class Cust cust;
+  class Provider prov;
+```
+
+The trust boundary lives **at the sandbox pod**, not at the App Gateway:
+
+- The relay sees only ciphertext.
+- The customer's prompts + files exist as cleartext only inside one ephemeral sandbox pod, in one tenant namespace, for the duration of one offload, fronted by Foundry-side Content Safety.
+- The pairing token is single-use, scoped to one Pairing CR (one tenant namespace, one slot count, one token budget, one capability list, one expiration).
+
+## Primary flow — customer signs up + offloads a task
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cust as 👤 Customer dev
+    participant Portal as Provider portal
+    participant API as pair-issuance API
+    participant Ctrl as controller
+    participant Plugin as azureclaw-mesh plugin
+    participant Reg as registry
+    participant Rly as relay
+    participant SBX as offload sandbox
+
+    Cust->>Portal: sign up (Entra B2C / billing)
+    Portal->>API: POST /pair { tenantId, plan }
+    API->>API: azureclaw pair generate \<br/>--namespace tenant-acme --slots 5 \<br/>--token-budget 5M --expires 30d
+    API->>Ctrl: kubectl apply Pairing (tokenHash only)
+    API-->>Portal: token (one-time)
+    Portal-->>Cust: download token / copy to clipboard
+
+    Cust->>Plugin: paste token into NemoClaw chat
+    Plugin->>Reg: claim slot + register identity
+    Plugin->>Rly: KNOCK + X3DH
+    Rly-->>Plugin: session established
+
+    Cust->>Plugin: "offload <task> to AzureClaw"
+    Plugin->>Rly: encrypted request
+    Rly->>Ctrl: route to controller AMID
+    Ctrl->>SBX: spawn into tenant-acme ns,<br/>cap to plan budget
+    SBX->>Plugin: encrypted result
+    SBX->>SBX: emit audit chain entry<br/>(tenant-acme workspace)
+    Note over SBX: self-destruct
+```
+
+## What you provision
+
+The CRDs and CLI are identical to Blueprint 02; the difference is **scale + automation + per-tenant scoping**.
+
+```bash
+# Per regional cluster (one-time):
+azureclaw up --multi-tenant --regions eastus,westeurope
+azureclaw mesh promote                    # public endpoint, NOT --allow-ip
+helm install provider-portal …            # your portal + billing on the same AKS
+
+# Per tenant onboarding (automated by your portal, not a human):
+kubectl create namespace tenant-acme
+kubectl apply -f tenant-acme-rbac.yaml    # ServiceAccount + Workload Identity
+azureclaw pair generate \
+  --name acme-prod \
+  --namespace tenant-acme \
+  --slots 5 \
+  --token-budget 5000000 \
+  --expires 30d \
+  --capabilities offload,handoff,a2a
+
+# Day-2:
+azureclaw operator --tenant tenant-acme   # operator TUI scoped to one tenant
+```
+
+## What's unique to this blueprint
+
+- **Customers don't install your CLI.** Customer-side install is the OpenClaw plugin, which is upstreamed. Your portal hands them a token; that's the entire onboarding UX.
+- **Per-tenant namespace + per-tenant audit destination.** AzureClaw already namespaces every sandbox by name; the SaaS pattern just stamps a tenant prefix. Audit chains land in per-tenant Log Analytics workspaces (one workspace per Pairing CR's `tenantId` annotation).
+- **Pairing tokens are commerce-aware.** `--token-budget`, `--slots`, `--expires`, `--capabilities` map directly to your billing plan. Plan upgrade = new Pairing CR with bigger limits; old token revoked.
+- **Provider observability without decryption.** You can see *that* tenant `acme` exchanged 142 mesh frames in the last hour and consumed 1.2M Foundry tokens. You cannot see *what was in those frames*.
+- **Future:** managed AP2 (Agent Payments Protocol) lets your customers spend their token budget through signed mandates with audit. Today: schema present; mounting deferred to a future phase.
+
+## What this blueprint is NOT
+
+- Not a deployment customers run themselves. For that, see Blueprint 02 — they get the same controller and CRDs in their own subscription.
+- Not a substitute for tenant-level WAF / DDoS controls — App Gateway + Front Door are still your job.
+- Not a model marketplace. The Foundry project remains provider-side; if a customer wants their own model, route to a tenant-bound Foundry connection (`azureclaw model set --tenant`).
+
+## Operational guardrails
+
+- **Cross-tenant escape is treated as a P0.** NetworkPolicy default-deny + per-tenant namespace scoping + per-tenant ServiceAccount token audience + sandbox UID isolation collectively block the obvious paths. The fuzz/conformance suite covers cross-tenant token spoofing.
+- **Pairing-token revocation must be immediate.** `kubectl delete pairing acme-prod` synchronously evicts active mesh sessions for that tenant; the registry refuses new connects.
+- **Foundry quota is per-tenant.** Either issue per-tenant Foundry projects or use Foundry's quota policies; the router enforces a soft cap via `--token-budget` regardless.
+
+## References
+
+- `controller/src/pairing.rs` (multi-tenant `Pairing.spec.namespace` field)
+- `inference-router/src/auth.rs` (per-namespace Workload Identity selection)
+- `cli/src/commands/pair.ts` (`--namespace`, `--capabilities`, `--token-budget`)
+- ADR-0001 (A2A ingress front-edge, identical pattern for A2A 1.0.0 inbound)
+- `docs/use-cases.md` Scenario 2 (the customer-side experience)

--- a/docs/blueprints/04-cross-org-federation.md
+++ b/docs/blueprints/04-cross-org-federation.md
@@ -1,0 +1,178 @@
+# Blueprint 04 — Cross-org federation
+
+> "We're two organisations who want our agents to collaborate. Each side runs their own AzureClaw cluster. Neither side trusts the other's network, the other's Foundry quota, or the other's audit destination. We want E2E-encrypted, mutually-policy-evaluated agent-to-agent collaboration without merging trust domains."
+
+## Persona & intent
+
+- **You are:** the platform team in *one* of two collaborating organisations. The other org also runs their own AzureClaw — Blueprint 02 in their tenant.
+- **You want:** named agents on either side to exchange messages, hand off tasks, and run sub-agents on each other's substrate, with both sides' AGT policies enforced on every hop.
+- **You do not want:** to share kubeconfigs. To share Foundry quotas. To share Entra tenants. To trust the other side's audit chain to alibi misbehaviour from your own agents.
+
+## Topology
+
+```mermaid
+flowchart TB
+  subgraph OrgA["🏢 Org A — Entra tenant A, AKS A"]
+    direction TB
+    AGwA[("App Gateway A<br/>+ WAF")]
+    RegA["registry A"]
+    RlyA["relay A"]
+    AgentA["ClawSandbox 'planner'"]
+    AuditA[("Log Analytics A")]
+  end
+
+  subgraph OrgB["🏢 Org B — Entra tenant B, AKS B"]
+    direction TB
+    AGwB[("App Gateway B<br/>+ WAF")]
+    RegB["registry B"]
+    RlyB["relay B"]
+    AgentB["ClawSandbox 'worker'"]
+    AuditB[("Log Analytics B")]
+  end
+
+  AgentA -->|"mesh send (E2E)"| RlyA
+  RlyA -->|"federation peering<br/>over public/peered VNet"| AGwB
+  AGwB --> RlyB
+  RlyB -->|"deliver ciphertext"| AgentB
+
+  AgentB -->|"reply (E2E)"| RlyB
+  RlyB -->|"federation peering"| AGwA
+  AGwA --> RlyA
+  RlyA --> AgentA
+
+  AgentA -.->|"local audit"| AuditA
+  AgentB -.->|"local audit"| AuditB
+
+  classDef orgA fill:#fef3c7,stroke:#a16207;
+  classDef orgB fill:#dbeafe,stroke:#1e40af;
+  class OrgA,AGwA,RegA,RlyA,AgentA,AuditA orgA;
+  class OrgB,AGwB,RegB,RlyB,AgentB,AuditB orgB;
+```
+
+## Trust boundary
+
+```mermaid
+flowchart LR
+  subgraph A["Org A trust domain"]
+    PA["AGT policy A<br/>(ingress + egress)"]
+    AuditA["Audit A"]
+  end
+
+  subgraph Wire[" mesh wire (ciphertext) "]
+    direction LR
+    Frame["Signal Protocol envelope<br/>(X3DH + Double Ratchet)"]
+  end
+
+  subgraph B["Org B trust domain"]
+    PB["AGT policy B<br/>(ingress + egress)"]
+    AuditB["Audit B"]
+  end
+
+  PA -->|"approve send"| Wire
+  Wire -->|"approve receive"| PB
+  PB -.->|"audit B"| AuditB
+  PA -.->|"audit A"| AuditA
+
+  classDef boundary stroke-width:3px;
+  classDef a stroke:#a16207,fill:#fef3c7;
+  classDef b stroke:#1e40af,fill:#dbeafe;
+  class A a;
+  class B b;
+```
+
+The crucial property: **every mesh frame is policy-evaluated twice**:
+
+- Org A's `PolicyEngine` says "yes, planner is allowed to message worker about commit reviews".
+- Org B's `PolicyEngine` says "yes, we accept code-review tasks from planner@OrgA at trust tier 'verified'".
+
+Neither side relies on the other's audit chain. Both sides write their own.
+
+## Primary flow — pairing two clusters, then a handoff
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant OpsA as Ops A
+    participant OpsB as Ops B
+    participant CtrlA as controller A
+    participant RlyA as relay A
+    participant RlyB as relay B
+    participant CtrlB as controller B
+    participant Planner as planner@OrgA
+    participant Worker as worker@OrgB
+
+    Note over OpsA,OpsB: Pairing phase (one-time)
+    OpsA->>CtrlA: azureclaw mesh promote (publish AGw A)
+    OpsB->>CtrlB: azureclaw mesh promote (publish AGw B)
+    OpsA->>OpsA: azureclaw pair generate \<br/>--name orgB-cluster --slots 100 \<br/>--capabilities mesh,handoff
+    OpsA-->>OpsB: secure-share token (out-of-band)
+    OpsB->>CtrlB: azureclaw mesh peer add \<br/>--token azc_pair_v1_… --as orgB-cluster
+    CtrlB->>RlyA: register OrgB AMID prefix as peer
+    Note over CtrlA,CtrlB: KNOCK + X3DH between cluster identities
+
+    Note over Planner,Worker: Day-2 — actual collaboration
+    Planner->>Planner: needs code review from Worker@OrgB
+    Planner->>RlyA: encrypted "review_commit" frame
+    RlyA->>RlyB: federation peering
+    RlyB->>Worker: deliver ciphertext
+    Worker->>Worker: AGT eval ingress<br/>(verify peer trust + policy)
+    Worker->>Worker: run review (Foundry B)
+    Worker->>RlyB: encrypted reply
+    RlyB->>RlyA: federation peering
+    RlyA->>Planner: deliver ciphertext
+    Planner->>Planner: AGT eval ingress
+```
+
+## What you provision
+
+```bash
+# Once per cluster (both sides do this):
+azureclaw up
+azureclaw mesh promote                            # exposes registry+relay through AGw
+
+# Pairing (one side mints, one side accepts):
+# Org A:
+azureclaw pair generate \
+  --name peer-orgB-cluster \
+  --slots 100 \
+  --token-budget 50000000 \
+  --capabilities mesh,handoff \
+  --expires 365d
+# … secure-share to Org B …
+# Org B:
+azureclaw mesh peer add \
+  --token "azc_pair_v1_…" \
+  --as peer-orgA
+
+# Day-2 — name a cross-org agent in chat just like any other peer:
+@worker@orgB-cluster please review commit abc123
+```
+
+## What's unique to this blueprint
+
+- **Two policy boundaries on every frame.** Both sides' AGT decides on ingress AND egress; this is the only way two organisations can collaborate without merging trust.
+- **Two audit chains.** Both sides have a verifiable, hash-chained record of what their agents said and what was said to them. Disputes are decidable from each org's own logs.
+- **Mesh peering is *cluster-scoped*, not agent-scoped.** Once Org A and Org B are peered, any number of agents on either side can address each other (subject to per-agent AGT policy). This is fundamentally different from Blueprint 03 where each customer is a Pairing slot.
+- **No shared identity provider.** No need for cross-tenant Entra B2B, no need to share Workload Identity audiences. Each side authenticates the other through Ed25519 mesh identities + the federation pairing.
+
+## Hardening checklist (cross-org reality)
+
+- [ ] Trust tier for the peer cluster is set to **`verified`** (not `trusted`) — peer agents must pass per-message policy.
+- [ ] Inbound `mesh.handoff` capability is **disabled by default** unless your `PolicyEngine` explicitly lists peer agent IDs that may spawn sub-agents on your substrate.
+- [ ] Foundry token budget on inbound handoffs is capped per-peer (`Pairing.spec.tokenBudget`).
+- [ ] Outbound prompt-shield evaluation runs on egress as well as ingress (so your agent can't be used as a side-channel to leak data to the peer org).
+- [ ] App Gateway WAF rules block known prompt-injection payloads at L7.
+
+## What this blueprint is NOT
+
+- Not a single-cluster pattern — a single cluster's agents-talking-to-agents is just regular `azureclaw pair` between two `ClawSandbox`es (Use Case 3).
+- Not a SaaS pattern — federation assumes both sides have ops teams. If one side is a self-service customer, you want Blueprint 03.
+- Not a substitute for a contract / DPA. AzureClaw enforces *what's technically possible*; what's *commercially permitted* is still legal-team work.
+
+## References
+
+- `controller/src/mesh_peer/` (federation peer reconciler)
+- `cli/src/commands/mesh.ts` (`peer`, `promote`, `unpair`, `security`, `status`)
+- `inference-router/src/governance.rs` (ingress policy evaluation)
+- `docs/e2e-encryption-proof.md` (the cryptographic proof for cross-org E2E)
+- ADR-0001 (front-edge architecture for non-mesh ingress; relevant if you also want A2A 1.0.0 cross-org)

--- a/docs/blueprints/05-sovereign-airgapped.md
+++ b/docs/blueprints/05-sovereign-airgapped.md
@@ -1,0 +1,182 @@
+# Blueprint 05 — Sovereign / air-gapped
+
+> "We run regulated, classified, sovereign-cloud, or fully air-gapped workloads. There is no public internet. There is no commercial Foundry endpoint. There is no Microsoft-hosted MCP catalogue. We still want AzureClaw's isolation + governance + audit guarantees, on locally-hosted models, with everything reproducible from a signed bundle."
+
+> **Status: 🚧 Patterns documented; reproducible-bundle tooling on roadmap.** Today this blueprint is achievable by hand using the standard CRDs + a private model endpoint; the goal is a one-command `azureclaw bundle` that emits a signed, reproducible offline kit.
+
+## Persona & intent
+
+- **You are:** a defence, intelligence, regulator, financial-services, or sovereign-cloud operator. Or an enterprise that has chosen to self-host LLMs.
+- **You want:** AzureClaw's threat model, but with the model running on private hardware (e.g. Foundry-Edge, vLLM, llama.cpp, ONNX Runtime, an on-prem Triton) and zero traffic crossing the network island.
+- **You do not want:** any default outbound destination — every domain in the blocklist, the Foundry SDK, Application Insights, and the audit sink — to be assumed reachable.
+
+## Topology
+
+```mermaid
+flowchart TB
+  subgraph AirGap["🔒 Air-gapped network island"]
+    direction TB
+
+    subgraph Bundle["📦 signed offline bundle"]
+      Imgs["controller, router, sandbox<br/>(cosign-signed images)"]
+      Helm["helm charts + values"]
+      Mdl["model weights + tokenizer"]
+      Pol["policy profiles + blocklists"]
+      Doc["bundle manifest + SBOM"]
+    end
+
+    subgraph AKS["☸️ Local AKS / Azure Stack HCI / k3s"]
+      direction TB
+      Reg2[("private registry<br/>(no public ACR)")]
+      Ctrl["controller"]
+      RlyL["relay (cluster-local only)"]
+      RegL["registry (cluster-local only)"]
+      Mdlsvc["model server<br/>(Foundry-Edge / vLLM / Triton)"]
+
+      subgraph SBX["📦 ClawSandbox 'analyst'"]
+        OC["openclaw"]
+        IR["router<br/>(--local-model https://model-svc)"]
+      end
+    end
+
+    subgraph SIEM["📊 local SIEM"]
+      Splunk["Splunk / Sentinel On-Prem"]
+    end
+
+    Bundle -->|"transferred via<br/>signed media"| Reg2
+    Reg2 --> AKS
+
+    IR -->|"only outbound:<br/>cluster-local model"| Mdlsvc
+    IR -.->|"audit chain"| Splunk
+  end
+
+  subgraph Outside["🌐 Outside (DOES NOT HAPPEN)"]
+    Public["public Foundry, Microsoft.com,<br/>any blocklist update,<br/>any telemetry"]
+  end
+
+  AirGap -. "❌ no path"  .- Outside
+
+  classDef gap fill:#0c0c1f,stroke:#fbbf24,color:#fff;
+  classDef out fill:#fee2e2,stroke:#dc2626,color:#7f1d1d;
+  class AirGap,AKS,Bundle,SIEM gap;
+  class Outside,Public out;
+```
+
+## Trust boundary
+
+```mermaid
+flowchart TB
+  subgraph Inside["🔒 Air-gapped trust domain"]
+    direction LR
+    Agent["agent (UID 1000)"]
+    Router["router (UID 1001)"]
+    Model["model server"]
+    Audit["local SIEM"]
+  end
+
+  Agent -->|"localhost only"| Router
+  Router -->|"cluster-local DNS"| Model
+  Router -.->|"audit chain"| Audit
+
+  classDef gap fill:#0c0c1f,stroke:#fbbf24,color:#fff;
+  class Inside gap;
+```
+
+The trust boundary is the **network island**. Nothing inside it talks to anything outside it; nothing outside it talks to anything inside it. The router's allow-list is configured to a single internal model service DNS name; the blocklist is irrelevant because the egress NetworkPolicy denies *everything else* by default.
+
+## Primary flow — bundle build, transfer, install
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Build as build host (online)
+    participant Sign as cosign / sigstore
+    participant Media as physical media / one-way diode
+    participant Air as air-gapped admin
+    participant Reg as private registry
+    participant Cls as local cluster
+
+    Build->>Build: make bundle<br/>(images + helm + weights + policy)
+    Build->>Sign: cosign sign + SBOM
+    Sign-->>Build: signature attestations
+    Build->>Media: write bundle.tar.gz + sigs
+    Media->>Air: physical transfer
+    Air->>Air: cosign verify (offline, public key only)
+    Air->>Reg: docker load + push
+    Air->>Cls: helm install azureclaw \<br/>--values offline-values.yaml \<br/>--set router.model.localUrl=https://model-svc
+    Cls->>Cls: ClawSandbox spawn,<br/>NetworkPolicy enforces<br/>internal-only egress
+```
+
+## What you provision
+
+```bash
+# On the (online) build host:
+make bundle                                       # 🚧 roadmap; today: assemble manually
+cosign sign-blob ./bundle.tar.gz \
+  --key cosign.key \
+  --output-file bundle.sig
+
+# Physical / diode transfer.
+
+# On the air-gapped admin host:
+cosign verify-blob ./bundle.tar.gz \
+  --key cosign.pub \
+  --signature ./bundle.sig
+docker load < bundle.tar.gz
+docker push private-registry.local/azureclaw/{controller,router,sandbox}:vX
+
+helm install azureclaw deploy/helm/azureclaw \
+  --values offline-values.yaml \
+  --set image.repository=private-registry.local/azureclaw \
+  --set router.model.provider=local-openai-compat \
+  --set router.model.endpoint=https://model-svc.ml.svc.cluster.local \
+  --set audit.sink=splunk-hec://siem.local
+
+azureclaw add analyst --model llama-3.1-70b --governance \
+  --egress-policy deny-all-except=model-svc.ml.svc.cluster.local
+```
+
+## What's unique to this blueprint
+
+- **Local-model adapter.** The router has an OpenAI-compatible local-model adapter (`router.model.provider=local-openai-compat`) so any model server speaking that wire format slots in. No code change to the agent; the same `gpt-4.1`-style interface is preserved.
+- **Egress NetworkPolicy is the primary control,** not the 51k-domain blocklist. The blocklist is irrelevant when default-deny is enforced and only one internal DNS name is allowed.
+- **Audit chain stays local.** The default `AuditSink` writes to a configurable destination (App Insights, Log Analytics, Splunk HEC, file). For sovereign deployments, a Splunk HEC or local file backend is the typical choice; the hash chain is preserved either way.
+- **No telemetry leaks.** All Microsoft-hosted telemetry (App Insights, Microsoft Defender for Cloud) is off-by-default and replaced by your local SIEM.
+- **Cosign-signed bundle.** The reproducible bundle is the only authenticated trust root; the air-gapped side has only a public key.
+
+## What this blueprint is NOT
+
+- Not "regular AzureClaw with no internet." Foundry, the blocklist refresh, and several telemetry paths assume reachability and must be deliberately disabled or replaced.
+- Not a substitute for cross-domain solutions (CDS) — this blueprint covers the runtime; data ingestion / sanitisation across the boundary is your CDS team's problem.
+- Not a fast onramp. Building a verified bundle, transferring it, and standing up a local cluster is multi-step. The reward is reproducibility.
+
+## Bundle contents (current target)
+
+```
+bundle.tar.gz
+├── manifest.yaml                    # bundle version + signed SBOM
+├── images/
+│   ├── controller-vX.tar
+│   ├── router-vX.tar
+│   └── sandbox-vX.tar
+├── helm/
+│   └── azureclaw-vX.tgz
+├── policy-profiles/
+│   ├── seccomp/azureclaw-strict.json
+│   └── agt/{policy,trust,audit,rate-limit}.yaml
+├── blocklists/
+│   └── domains.txt                  # snapshot, since auto-refresh is off
+├── values/
+│   └── offline-values.yaml
+└── attestations/
+    ├── sbom.cdx.json                # CycloneDX SBOM
+    └── cosign.sig
+```
+
+## References
+
+- `inference-router/src/foundry.rs` (provider switch incl. `local-openai-compat` mode)
+- `deploy/helm/azureclaw/values.yaml` (`audit.sink`, `router.model.provider`)
+- `policy-engine/profiles/` (offline-portable policy bundle)
+- `Makefile` `bundle` target (🚧 to be added)
+- `docs/security.md` § "Air-gapped operating mode"

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -2,6 +2,8 @@
 
 Three canonical scenarios shipping today, plus a roadmap track for future agentic runtimes. Each shipping scenario is implemented end-to-end on `main` and exercised by the compat / conformance / e2e harness before any merge.
 
+> **Looking for "how do I run AzureClaw for *audience X*?"** see [`docs/blueprints/`](blueprints/00-index.md) for the five end-to-end deployment shapes (developer inner-loop, enterprise self-hosted, managed public offload, cross-org federation, sovereign / air-gapped) — each with topology + trust-boundary + flow Mermaid diagrams.
+
 | # | Scenario | Where the user runs | Network shape | Status | Reference |
 |---|---|---|---|---|---|
 | 1 | **AzureClaw-native agent** | AKS (operator owns the cluster) | Cluster-internal | ✅ Shipping | [`docs/architecture.md`](architecture.md) |

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,15 +1,15 @@
 # AzureClaw Use Cases
 
-Three canonical scenarios. Each is implemented end-to-end on dev and is
-exercised by the compat / conformance / e2e harness before any merge to `main`.
+Three canonical scenarios shipping today, plus a roadmap track for future agentic runtimes. Each shipping scenario is implemented end-to-end on `main` and exercised by the compat / conformance / e2e harness before any merge.
 
-| # | Scenario | Primary user | Network shape | Reference |
-|---|---|---|---|---|
-| 1 | **AzureClaw-native agent** | Operator who owns the AKS cluster | Cluster-internal | [`docs/architecture.md`](architecture.md) |
-| 2 | **Any-OpenClaw → AzureClaw cloud offload** | Developer running OpenClaw on a laptop or a non-AzureClaw runtime | Laptop ↔ AKS via AgentMesh relay (E2E) | [`docs/any-openclaw-cloud-offload.md`](any-openclaw-cloud-offload.md) |
-| 3 | **AzureClaw ↔ AzureClaw mesh** | Two AKS-hosted agents, possibly across tenants/clusters | Cluster ↔ cluster via AgentMesh relay (E2E) | [`docs/e2e-encryption-proof.md`](e2e-encryption-proof.md) |
+| # | Scenario | Where the user runs | Network shape | Status | Reference |
+|---|---|---|---|---|---|
+| 1 | **AzureClaw-native agent** | AKS (operator owns the cluster) | Cluster-internal | ✅ Shipping | [`docs/architecture.md`](architecture.md) |
+| 2 | **Any OpenClaw → AzureClaw cloud offload** | Laptop / NemoClaw / any OpenClaw host (no AzureClaw CLI required) | Host ↔ AKS via AgentMesh relay (E2E) | ✅ Shipping | [`docs/any-openclaw-cloud-offload.md`](any-openclaw-cloud-offload.md) |
+| 3 | **AzureClaw ↔ AzureClaw mesh** | Two AKS-hosted agents, possibly across tenants/clusters | Cluster ↔ cluster via AgentMesh relay (E2E) | ✅ Shipping | [`docs/e2e-encryption-proof.md`](e2e-encryption-proof.md) |
+| 4 | **Any agentic runtime → AzureClaw** (LangChain, AutoGen, Semantic Kernel, custom) | Anywhere the runtime runs | Host ↔ AKS via MCP / A2A / AP2 | 🚧 On roadmap | [`docs/phase-0-1-capabilities.md`](phase-0-1-capabilities.md) |
 
-All three share the same trust boundary:
+All shipping scenarios share the same trust boundary:
 
 - The agent process (UID 1000) **never** sees Azure credentials.
 - All external traffic flows through the per-sandbox **inference router** (UID 1001).
@@ -67,46 +67,75 @@ azureclaw trace research-bot --network      # eBPF trace
 
 ---
 
-## 2. Any-OpenClaw → AzureClaw cloud offload
+## 2. Any OpenClaw → AzureClaw cloud offload
 
-> "I run OpenClaw on my laptop (or in NemoClaw, or in any other OpenClaw host).
+> "I run OpenClaw on my laptop (or NemoClaw, or any other OpenClaw host).
 > A heavy task came in; I want to offload it to a hardened AKS sandbox without
-> sharing local credentials, and stream the result back."
+> sharing local credentials or installing anything cloud-specific."
 
-### What you do
+The defining property of this scenario is that **the laptop user does not install AzureClaw**. They install an OpenClaw plugin. AzureClaw is somebody else's problem — a managed AzureClaw provider runs the AKS cluster, mints a one-time pairing token for the user, and the LLM in the user's host registers itself the first time it sees the token.
 
-On the host (laptop / NemoClaw / etc.), install the standalone offload plugin:
+### Roles
+
+- **AzureClaw operator** — runs the AKS cluster. Has the `azureclaw` CLI. Mints pairing tokens. Today this is typically a self-hosted instance per organisation; the same pattern works for managed AzureClaw providers (cloud or in-house) who hand out tokens via their own portal, SMS, or any secure-share channel.
+- **Plugin user** — runs OpenClaw / NemoClaw / any OpenClaw-compatible host on a laptop. Has only the `azureclaw-mesh` plugin installed (we aim to upstream this to OpenClaw). Has **no** `azureclaw` CLI, no kubeconfig, no Azure credentials.
+
+### What the operator does (once per user)
 
 ```bash
-# the azureclaw-mesh plugin is published at sandbox-images/nemoclaw/scripts/azureclaw-mesh/
-# (the exact install path depends on the host runtime — see any-openclaw-cloud-offload.md)
-azureclaw mesh auth --registry https://registry.<your-domain> --provider github
+# On the AKS-side operator workstation:
+azureclaw mesh promote --port-forward       # (one-time) expose registry + relay so the laptop can reach them
+azureclaw pair generate --name alice-laptop --slots 3 --expires 90d \
+  --capabilities offload,handoff
 ```
 
-Then in the agent prompt:
+`mesh promote` is what makes the cluster's relay/registry reachable from off-cluster — see [§How the laptop reaches the AKS mesh edge](#how-the-laptop-reaches-the-aks-mesh-edge) below for the available modes. `pair generate` then prints (and copies to clipboard) a one-time, opaque, expiring token of the form `azc_pair_v1_<base64url-payload>` containing the controller AMID, the relay/registry URLs that `mesh promote` just established, and a sealed pairing secret. The token is sent to the user via any secure channel — secret-share link, SMS, encrypted email, in-person, etc. Today's self-hosted operator typically uses a one-tap secret-share UI; a managed AzureClaw provider would issue tokens through its own portal.
 
-> "Offload `analyze_repo("/big-codebase")` to AzureClaw cloud."
+### What the plugin user does
 
-### What happens (no credentials leave the host)
+1. Install the `azureclaw-mesh` plugin in their OpenClaw host (today: bundled into NemoClaw images; goal: upstreamed into OpenClaw plugin marketplace).
+2. Either:
+   - Set the token as an OpenClaw system environment variable (`AZURECLAW_PAIRING_TOKEN=azc_pair_v1_…`), **or**
+   - Paste it once into chat: *"Pair this OpenClaw to AzureClaw cloud with token `azc_pair_v1_…`."*
+3. The LLM calls the plugin's `azureclaw_pair` tool with the token. The plugin handshakes with the AzureClaw registry, claims a pairing slot, exchanges X3DH prekeys, and the host is now a registered mesh peer. The token is single-use and auto-zeroized.
+4. From that point on the user can simply say: *"Offload `analyze_repo("/big-codebase")` to AzureClaw cloud."*
 
-1. The `azureclaw-mesh` plugin opens a **CONNECT tunnel** through the egress proxy (Node.js 22 + undici quirks documented in `mesh-plugin/src/connection.ts`).
-2. The host registers in the **AgentMesh registry** with an Ed25519-derived AMID.
+### What happens under the hood
+
+1. Plugin opens a CONNECT tunnel through the egress proxy (Node.js 22 + undici quirks documented in `mesh-plugin/src/connection.ts`).
+2. Plugin registers in the AgentMesh registry with an Ed25519-derived AMID, scoped to the pairing slot.
 3. KNOCK handshake → trust evaluation → X3DH key agreement → Double Ratchet session.
-4. The host sends an offload request frame to the AzureClaw `controller`.
-5. The controller spawns an offload sub-agent sandbox (`offload-<id>`) with the requested model + the parent's task descriptor.
-6. The sub-agent runs the task inside the AzureClaw security perimeter — Foundry inference, Content Safety, audit chain, blocklist all in effect.
+4. Plugin sends an offload request frame to the AzureClaw `controller`.
+5. Controller spawns an offload sub-agent sandbox (`offload-<id>`) with the requested model + the parent's task descriptor, capped to the pairing's `tokenBudget` and `slots`.
+6. Sub-agent runs the task inside the AzureClaw security perimeter — Foundry inference, Content Safety, audit chain, blocklist all in effect.
 7. Result + any produced files flow back over the same E2E channel as a `file_transfer` payload.
 8. Sub-agent self-destructs.
 
+### How the laptop reaches the AKS mesh edge
+
+The relay and registry live inside the cluster on private ClusterIP services. Something has to expose them so the laptop's plugin can reach them. We ship two mechanisms today and have two more on the roadmap:
+
+| Mode | How | Status | When to use |
+|---|---|---|---|
+| **Port-forward** (default for testing) | `azureclaw mesh promote --port-forward` opens `kubectl port-forward` tunnels for the registry (`:18080`) and relay (`:18765`) on the operator's workstation; the operator publishes those reachable endpoints in the pairing token. | ✅ Shipping | Single operator laptop, demos, CI, e2e harness. |
+| **LoadBalancer + IP allowlist** | `azureclaw mesh promote --allow-ip <cidr>` provisions a public LoadBalancer in front of the registry/relay services, restricted to the supplied CIDR. | ✅ Shipping | Trusted internal network or known external user IPs. |
+| **Public managed mesh edge** | A globally addressable, WAF-fronted relay/registry endpoint provisioned for the operator (Application Gateway Ingress + WAF, or a managed cloud edge), no per-user CIDR pinning. | 🚧 Roadmap | Self-hosted operators handing out tokens to anonymous-IP laptops. |
+| **Managed AzureClaw provider edge** | The provider runs the relay/registry as part of their service; the pairing token they mint already points at their public endpoints. The plugin user never sees an operator-side detail. | 🚧 Roadmap | SaaS-style consumption. Same wire protocol; pairing token + plugin path are unchanged. |
+
+Whichever edge is in use, the pairing token carries the `relay_url` and `registry_url` fields verbatim, so the plugin doesn't need any additional configuration to follow the operator's edge choice.
+
 ### Why this matters
 
-- The host **never** sees Azure credentials. The router on the AzureClaw side authenticates via Workload Identity.
+- The plugin user **never** holds Azure credentials, never installs a cloud CLI, never sees a kubeconfig. Onboarding is "paste a string once."
+- The token is single-use, expiring, slot-bounded, budget-bounded, capability-bounded — leaking it gives an attacker at most one pairing slot inside one tenant.
 - The relay sees only ciphertext.
 - Both sides emit AGT audit chain entries (visible to the AKS operator via `kubectl claw attest` once Phase 2 lands; today via `GET /agt/audit`).
-- The host's local-data scope is unchanged: only what was sent in the task descriptor leaves.
+- The host's local data scope is unchanged: only what was sent in the offload task descriptor leaves the laptop.
 
 ### Code references
-- Plugin (host side): `sandbox-images/nemoclaw/scripts/azureclaw-mesh/`
+- Plugin (host side): `mesh-plugin/src/` and the bundled drop in `sandbox-images/nemoclaw/scripts/azureclaw-mesh/`
+- Pairing CRD + token format: `controller/src/pairing.rs`, `cli/src/commands/pair.ts`
+- Mesh edge exposure: `cli/src/commands/mesh.ts` (`promote` subcommand)
 - Offload reconcile: `controller/src/mesh_peer/offload.rs`
 - Spawn handler: `inference-router/src/routes/spawn_policy.rs`, `routes/inference.rs`
 - AgentMesh wire patches: `vendor/agentmesh-{sdk,relay,registry}/`
@@ -164,9 +193,36 @@ In a chat:
 
 ---
 
+## 4. Any agentic runtime → AzureClaw  *(roadmap)*
+
+> "I'm not running OpenClaw. I'm running LangChain / AutoGen / Semantic Kernel
+> / a hand-rolled agent. Can I still get an AzureClaw sandbox as a tool surface?"
+
+The Phase 1 protocol scaffolding (MCP 2026 Streamable HTTP, A2A 1.0.0, AP2 mandates) is in the tree precisely so the answer becomes "yes" without a second framework integration. The modules are implemented and unit-tested today; **route mounting is deferred to Phase 2** so we never expose a default-keys / no-auth path.
+
+### Target shapes
+
+- **MCP (Model Context Protocol).** Any MCP-aware client (Copilot, Claude Desktop, VS Code, custom agents) connects to a `ClawSandbox`'s `/mcp` endpoint and gets the sandbox's tools + governance + audit as a remote MCP server. AzureClaw becomes a hosted-MCP provider that any agent can plug into. Today: modules implemented + tested in `inference-router/src/mcp/`; deferred to Phase 2 mount once the `McpServer` reconciler ships JWKS + signing keys via K8s Secrets.
+- **A2A (Agent-to-Agent 1.0.0).** Any A2A-aware peer fetches a signed `/.well-known/agent.json` from a `ClawSandbox` and invokes JSON-RPC `message/send` / `tasks/get` / `tasks/cancel`. Cross-organisation agent collaboration without each side adopting the other's mesh stack. Today: modules implemented + tested in `inference-router/src/a2a/` (14 modules); deferred to Phase 2 mount once the `A2AAgent` reconciler ships agent-card signing keys via K8s Secrets.
+- **AP2 (Agent Payments Protocol).** Agents transact under signed mandates (IntentMandate → CartMandate → PaymentMandate) with full audit. Today: ledger + signing scaffolding present; integrating-payments use cases tracked for a later phase.
+- **`sigs/agent-sandbox` translator.** A K8s SIG-style standardised sandbox object translates to / from `ClawSandbox`, so anyone using the upstream sandbox API gets AzureClaw's controls automatically. Design landed in Phase 0; reconciler in a later phase.
+
+### Why phase this
+
+Mounting `/mcp` or `/a2a` before keys are CRD-bound would create a default-keys path that an external agent could speak to without authentication — exactly the foot-gun the Phase 0 `no-stubs` and `no-null-provider-prod` CI gates exist to prevent. So the modules ship behind the seams in Phase 1, the reconcilers ship in Phase 2, and the routes mount on the same merge.
+
+### Code references
+- MCP modules: `inference-router/src/mcp/{jsonrpc,streamable_http,error,initialize,tools,pipeline,oauth,oauth_layer}.rs`
+- A2A modules: `inference-router/src/a2a/` (14 modules)
+- Phase status: [`docs/phase-0-1-capabilities.md`](phase-0-1-capabilities.md)
+- ADR-0001 (A2A ingress front-edge): [`docs/adr/0001-a2a-ingress-front-edge.md`](adr/0001-a2a-ingress-front-edge.md)
+
+---
+
 ## What's NOT a use case
 
 - AzureClaw is **not** a model router. Model selection sits in Foundry; `InferencePolicy` (Phase 2) is a budget/guardrail CR, not a router.
 - AzureClaw is **not** a memory backend. `ClawMemory` (Phase 2) is a Foundry Memory Store binding CR, never an in-cluster store.
-- AzureClaw is **not** a managed-MCP host. `McpServer` (schema-only on Phase 1, full reconciler in Phase 2) is for **AKS-hosted private/custom** tool servers; managed MCP stays with Foundry.
+- AzureClaw is **not** a managed-MCP host *for the public Microsoft-managed catalog*. `McpServer` (schema-only on Phase 1, full reconciler in Phase 2) is for **AKS-hosted private/custom** tool servers; the publicly managed MCP surface stays with Foundry.
 - AzureClaw is **not** a SaaS agent author. Agent authoring lives in Microsoft 365 Agent Framework / Copilot Studio. AzureClaw is the AKS runtime substrate; M365 Copilot Studio agents can invoke AzureClaw-hosted MCP servers as a tool surface.
+


### PR DESCRIPTION
## Summary

Fixes hallucinated content in `docs/use-cases.md` Scenario 2 (any-OpenClaw → AzureClaw cloud offload) and adds the missing context the user flagged after PR #44 landed:

> *"this one is full hallucinated - azureclaw mesh auth is there but the whole point of any openclaw → azureclaw that you don't need azureclaw on the laptop machine where you run nemoclaw, or any other openclaw"*

## What was wrong

Old Scenario 2 documented a fictional `azureclaw mesh auth --registry --provider github` command run on the laptop. **The laptop user does not install the azureclaw CLI at all** — they install only the `azureclaw-mesh` OpenClaw plugin. `azureclaw mesh auth` is a real command, but it lives on the operator side for cluster-to-cluster federation identity, not on the user's laptop.

## What the rewrite says

**Operator side (one-time per user):**
```bash
azureclaw mesh promote --port-forward   # expose registry + relay so off-cluster hosts can reach them
azureclaw pair generate --name alice-laptop --slots 3 --expires 90d \
  --capabilities offload,handoff
```

Produces a one-time, expiring, slot/budget/capability-bounded `azc_pair_v1_<base64url>` token containing controller AMID, relay/registry URLs, and a sealed pairing secret. Sent via any secure channel.

**Plugin user side:**
- Install `azureclaw-mesh` plugin (today bundled into NemoClaw images; goal: upstream into OpenClaw)
- Either set `AZURECLAW_PAIRING_TOKEN` env var or paste the token once into chat
- LLM auto-registers via the plugin's `azureclaw_pair` tool — X3DH + Double Ratchet handshake, single-use token, auto-zeroized

## Edge exposure modes documented

| Mode | Status | When to use |
|---|---|---|
| `mesh promote --port-forward` | ✅ Shipping | Single operator workstation, demos, CI |
| `mesh promote --allow-ip <cidr>` (LoadBalancer) | ✅ Shipping | Trusted internal network or known external IPs |
| Public managed mesh edge (App Gateway + WAF) | 🚧 Roadmap | Self-hosted operators handing tokens to anonymous-IP laptops |
| Managed AzureClaw provider edge | 🚧 Roadmap | SaaS-style consumption — provider mints tokens already pointing at their endpoints |

## Other changes

- **New Scenario 4 (roadmap):** any agentic runtime (LangChain, AutoGen, Semantic Kernel, custom) → AzureClaw via MCP 2026 / A2A 1.0.0 / AP2. Notes the modules are implemented + tested in tree but route mounting is intentionally deferred to Phase 2 (so we never expose a default-keys / no-auth path).
- **Expanded "What's NOT a use case":** added M365 Agent Framework / Copilot Studio non-overlap.
- **README:** surfaces a prominent one-line link to `docs/use-cases.md` right after "What problems does it solve?" (the user asked for a reference "at the beginning of mainpage where it fits", not just buried in Roadmap line 217 + Docs table line 492).

## Validation

Docs-only PR; no code paths touched. CI gates that apply: markdown lint, link check.

Refs: `mesh-plugin/src/`, `controller/src/pairing.rs`, `cli/src/commands/{pair.ts,mesh.ts}`