### PR TITLE
phase2/inferencepolicy-reconciler — full reconciler + compile + helm CRD (S4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in S3 (CRD `spec.signingKeys[]` REQUIRED, CEL-gated non-empty);
   controller-side auto-mint deferred to S7.
 
+### S4 `phase2/inferencepolicy-reconciler` — full InferencePolicy reconciler + compile + helm CRD
+
+This slice ships the controller side of the K8s primitive only. Per §3
+non-compete, `InferencePolicy` is **not** a model-router — model
+selection sits in Foundry; this is a sandbox-side budget / guardrail /
+safety policy CR. Per user direction 2026-04-27, the runtime enforcement
+substrate stays on Phase 1 (`inference-router::budget` env-fed token
+tracker, Foundry-side Content Safety with flags reported to AGT
+`BehaviorMonitor` via `safety::report_content_flags_to_agt`); the
+informer that loads the compiled profile into `PolicyEnvelope` and the
+optional upstream `BudgetTracker` port to AGT-Rust are both deferred to
+S7. The compiled JSON ConfigMap is the hand-off contract.
+
+#### Added
+
+- **`InferencePolicy` CRD** — `controller/src/inference_policy.rs`,
+  group `azureclaw.azure.com`, version `v1alpha1`, namespaced,
+  shortname `ip`. Sub-types: `InferenceAppliesTo` (sandboxName,
+  sandboxMatchLabels, action), `TokenBudget` (perRequestTokens,
+  dailyTokens, monthlyTokens), `ContentSafetyFloor` (hate, selfHarm,
+  sexual, violence, requirePromptShields), `ModelPreference` (primary +
+  ordered fallback `Vec<ModelRef>`), `ModelRef` (provider, deployment).
+  Reuses `mcp_server::LocalObjectRef` for status pointer
+  (4th semantic client of that struct).
+- **Pure compile module** — `controller/src/inference_policy_compile.rs`,
+  `compile_to_profile(&InferencePolicySpec) -> serde_json::Value` +
+  `version_hash(&Value) -> String` (sha256, first 16 bytes hex).
+  Deterministic; key-canonical via `serde_json::Value::Object`. Output
+  shape slots into `inference-router::policy_envelope::PolicyEntry::payload` —
+  no parallel hot-reload core.
+- **Reconciler** — `controller/src/inference_policy_reconciler.rs`,
+  modeled directly on `a2a_agent_reconciler.rs` (S3). Field manager
+  `azureclaw-controller/inferencepolicy` (distinct per §10.4 #1);
+  finalizer `azureclaw.azure.com/inferencepolicy-cleanup`. Emits
+  `Ready`/`Progressing`/`Degraded` Conditions reusing
+  `status::conditions` helpers; preserves `lastTransitionTime` when
+  status doesn't flip. Closed-set `error_class`
+  (`kube_api`/`serde`) per §15.3.
+- **Profile ConfigMap** — name `inferencepolicy-{name}-profile`, key
+  `profile.json`, annotated with version hash, labelled
+  `azureclaw.azure.com/artifact=inference-policy-profile` for the S7
+  router-side informer label selector.
+- **CEL admission rules** (6) — `inference_policy_validations`:
+  `monthlyTokens >= dailyTokens`,
+  `monthlyTokens >= perRequestTokens`,
+  `contentSafety.{hate,selfHarm,sexual,violence}` ∈
+  `{Safe,Low,Medium,High}`,
+  `modelPreference.primary` non-empty provider+deployment,
+  `modelPreference.fallback[*]` non-empty provider+deployment,
+  `appliesTo.action` ∈ `{chat,responses,image,embeddings,*}`.
+- **Helm CRD** — `deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml`,
+  emitted by `helm_drift::tests::dump_inferencepolicy_crd_yaml` (env-gated)
+  and drift-checked by `helm_inferencepolicy_crd_matches_rust_schema`.
+- **Audit doc** — `docs/security-audits/2026-04-27-phase2-inferencepolicy-reconciler.md`,
+  documenting the AGT boundary verification against
+  `agent-governance-toolkit` 3.3.0 on disk: AGT-Python has
+  `BudgetTracker`, AGT-Rust does not (yet); `cedar-policy` + `regorus`
+  available in AGT-Rust for future Content Safety floor encoding.
+  STRIDE coverage, OWASP A2A coverage, explicit out-of-scope list,
+  two sign-offs.
+
+#### Tests
+
+- `inference_policy_compile::tests` — 6 unit tests (empty/full
+  round-trip, determinism, version-hash change/stability, hex shape).
+- `inference_policy_reconciler::tests` — 7 unit tests (rfc3339 shape,
+  error-class closed set, conditions on success/failure,
+  transition-time preservation, finalizer dns-subdomain, field-manager
+  distinctness from S1/S2/S3).
+- `crd_validations::tests` — 5 new `inference_policy_*` tests
+  (non-empty rules, every-rule-has-message, after-injection count,
+  rule-mention invariants, serde round-trip).
+- `helm_drift::tests` — 2 new (`dump_inferencepolicy_crd_yaml` env-gated
+  + `helm_inferencepolicy_crd_matches_rust_schema`).
+- Full controller suite: **218 passing** (was 193 after S3). Workspace
+  `cargo test`, `cargo fmt --all`, `cargo clippy --all-targets -D
+  warnings` — all green.
+
+#### §14.6 impact
+
+Strengthens column 7 (Foundry / M365 integration) of the competitive
+matrix — the *primitive* lands in this slice; column-7 credibility
+moves further when S7 wires the runtime consumers (token-budget swap,
+floor compare-and-block, model-preference selection).
+
+#### Notes
+
+- AGT crate pin remains `agentmesh = "3.3.0"` from crates.io,
+  unmodified. `vendor/` directory untouched.
+- Single new struct: none. `LocalObjectRef` semantically extended (4
+  clients now: signing/jwks, profile, agent-card, guardrail-profile).
+- The runtime gate `inference-router::routes::inference_policy::check`
+  (Phase 1) is **not modified in this slice**.
+
 ## [Unreleased] — PR #44 `dev → main` uplift
 
 This entry covers **186 commits** on `dev` since `main`, structured as Phase 0

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -46,6 +46,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
 use kube::CustomResourceExt;
 
 use crate::a2a_agent::A2AAgent;
+use crate::inference_policy::InferencePolicy;
 use crate::mcp_server::McpServer;
 use crate::tool_policy::ToolPolicy;
 
@@ -221,6 +222,83 @@ pub fn a2a_agent_crd() -> CustomResourceDefinition {
         .expect("kube-rs derive must produce a spec property on A2AAgent")
 }
 
+/// `InferencePolicy.spec` CEL rules. Phase 2 §8 entry 4 (S4).
+///
+/// Returns the validations injected on the `spec` schema node:
+///
+/// - `tokenBudget.monthlyTokens >= tokenBudget.dailyTokens` when both
+///   are set (admission CEL — the runtime path also checks but
+///   prevents the half-baked CR from ever landing).
+/// - `tokenBudget.monthlyTokens >= tokenBudget.perRequestTokens` when
+///   both are set (single request can't blow a monthly budget that
+///   wouldn't accept it).
+/// - `contentSafety.{hate,selfHarm,sexual,violence}` ∈ {`Safe`, `Low`,
+///   `Medium`, `High`} when present — matches Microsoft Content Safety
+///   `Microsoft.DefaultV2` severity levels exactly.
+/// - `modelPreference.primary` requires non-empty `provider` and
+///   `deployment` (any fallback entry too).
+/// - `appliesTo.action` ∈ {`chat`, `responses`, `image`, `embeddings`,
+///   `*`} — closed set matching `inference-router/src/routes/inference.rs`
+///   call-site enumeration.
+#[must_use]
+pub fn inference_policy_validations() -> Vec<ValidationRule> {
+    let severities = "['Safe','Low','Medium','High']";
+    vec![
+        ValidationRule {
+            rule: "!has(self.tokenBudget) || !has(self.tokenBudget.monthlyTokens) || !has(self.tokenBudget.dailyTokens) || self.tokenBudget.monthlyTokens >= self.tokenBudget.dailyTokens".into(),
+            message: Some("spec.tokenBudget.monthlyTokens must be >= spec.tokenBudget.dailyTokens".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.tokenBudget) || !has(self.tokenBudget.monthlyTokens) || !has(self.tokenBudget.perRequestTokens) || self.tokenBudget.monthlyTokens >= self.tokenBudget.perRequestTokens".into(),
+            message: Some("spec.tokenBudget.monthlyTokens must be >= spec.tokenBudget.perRequestTokens".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: format!(
+                "!has(self.contentSafety) || (\
+                 (!has(self.contentSafety.hate)      || self.contentSafety.hate      in {sev}) && \
+                 (!has(self.contentSafety.selfHarm)  || self.contentSafety.selfHarm  in {sev}) && \
+                 (!has(self.contentSafety.sexual)    || self.contentSafety.sexual    in {sev}) && \
+                 (!has(self.contentSafety.violence)  || self.contentSafety.violence  in {sev}))",
+                sev = severities
+            ),
+            message: Some("spec.contentSafety severities must be one of: Safe, Low, Medium, High".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.modelPreference) || (size(self.modelPreference.primary.provider) > 0 && size(self.modelPreference.primary.deployment) > 0)".into(),
+            message: Some("spec.modelPreference.primary requires non-empty provider and deployment".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.modelPreference) || self.modelPreference.fallback.all(f, size(f.provider) > 0 && size(f.deployment) > 0)".into(),
+            message: Some("spec.modelPreference.fallback[*] requires non-empty provider and deployment".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.appliesTo.action) || self.appliesTo.action in ['chat','responses','image','embeddings','*']".into(),
+            message: Some("spec.appliesTo.action must be one of: chat, responses, image, embeddings, *".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+    ]
+}
+
+/// `InferencePolicy` CRD with [`inference_policy_validations`] injected.
+///
+/// Panics only if kube-rs ever produces a CRD whose `spec` is missing.
+#[must_use]
+pub fn inference_policy_crd() -> CustomResourceDefinition {
+    inject_spec_validations(InferencePolicy::crd(), inference_policy_validations())
+        .expect("kube-rs derive must produce a spec property on InferencePolicy")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -376,6 +454,61 @@ mod tests {
         let y = serde_yaml::to_string(&crd).expect("serializes");
         assert!(y.contains("x-kubernetes-validations"));
         assert!(y.contains("signingKeys"));
+    }
+
+    #[test]
+    fn inference_policy_validations_are_non_empty() {
+        assert!(!inference_policy_validations().is_empty());
+    }
+
+    #[test]
+    fn every_inference_policy_rule_has_message_and_rule() {
+        for rule in inference_policy_validations() {
+            assert!(!rule.rule.is_empty(), "rule body must not be empty");
+            let msg = rule.message.as_deref().unwrap_or("");
+            assert!(!msg.is_empty(), "rule '{}' missing message", rule.rule);
+        }
+    }
+
+    #[test]
+    fn inference_policy_crd_has_spec_validations_after_injection() {
+        let crd = inference_policy_crd();
+        let v = spec_validations(&crd);
+        assert_eq!(v.len(), inference_policy_validations().len());
+    }
+
+    #[test]
+    fn inference_policy_rules_mention_token_budget_and_severity_invariants() {
+        let rules: Vec<String> = inference_policy_validations()
+            .into_iter()
+            .map(|r| r.rule)
+            .collect();
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("monthlyTokens") && r.contains("dailyTokens")),
+            "must enforce monthlyTokens >= dailyTokens; got rules: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("Safe") && r.contains("High")),
+            "must enforce content-safety severity closed set; got rules: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("appliesTo.action") && r.contains("chat")),
+            "must enforce appliesTo.action closed set; got rules: {rules:?}"
+        );
+    }
+
+    #[test]
+    fn inference_policy_crd_is_serde_round_trippable() {
+        let crd = inference_policy_crd();
+        let y = serde_yaml::to_string(&crd).expect("serializes");
+        assert!(y.contains("x-kubernetes-validations"));
+        assert!(y.contains("monthlyTokens"));
     }
 
     #[test]

--- a/controller/src/helm_drift.rs
+++ b/controller/src/helm_drift.rs
@@ -28,7 +28,9 @@
 #![allow(dead_code)]
 
 #[cfg(test)]
-use crate::crd_validations::{a2a_agent_crd, mcp_server_crd, tool_policy_crd};
+use crate::crd_validations::{
+    a2a_agent_crd, inference_policy_crd, mcp_server_crd, tool_policy_crd,
+};
 
 const MCP_HELM_CRD_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -43,6 +45,11 @@ const TOOLPOLICY_HELM_CRD_PATH: &str = concat!(
 const A2AAGENT_HELM_CRD_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../deploy/helm/azureclaw/templates/crd-a2aagent.yaml"
+);
+
+const INFERENCEPOLICY_HELM_CRD_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml"
 );
 
 /// Strip non-schema fields that legitimately differ between the Rust
@@ -157,5 +164,30 @@ mod tests {
         let rust_crd_value =
             serde_json::to_value(a2a_agent_crd()).expect("rust crd serializes to JSON");
         assert_helm_matches_rust(A2AAGENT_HELM_CRD_PATH, rust_crd_value, "a2aagent");
+    }
+
+    /// One-shot dumper for the inferencepolicy CRD. Run via:
+    ///
+    ///   DUMP_INFERENCEPOLICY_CRD_YAML=1 cargo test --bin azureclaw-controller \
+    ///       helm_drift::tests::dump_inferencepolicy_crd_yaml -- --nocapture
+    #[test]
+    fn dump_inferencepolicy_crd_yaml() {
+        if std::env::var("DUMP_INFERENCEPOLICY_CRD_YAML").is_err() {
+            return;
+        }
+        let crd = inference_policy_crd();
+        let yaml = serde_yaml::to_string(&crd).expect("serialize crd to YAML");
+        println!("---\n{yaml}");
+    }
+
+    #[test]
+    fn helm_inferencepolicy_crd_matches_rust_schema() {
+        let rust_crd_value =
+            serde_json::to_value(inference_policy_crd()).expect("rust crd serializes to JSON");
+        assert_helm_matches_rust(
+            INFERENCEPOLICY_HELM_CRD_PATH,
+            rust_crd_value,
+            "inferencepolicy",
+        );
     }
 }

--- a/controller/src/inference_policy.rs
+++ b/controller/src/inference_policy.rs
@@ -1,0 +1,220 @@
+//! `InferencePolicy` CRD — Phase 2 §8 entry 4 (S4).
+//!
+//! Per `docs/implementation-plan.md` §8 entry 2 and `docs/competitive.md`
+//! §10.3 entry 7, `InferencePolicy` is a **sandbox-side budget /
+//! guardrail / safety policy** — *not* a model-router. Model selection
+//! sits in Foundry. This CR expresses *which Foundry route* to prefer
+//! plus token budgets, Content Safety floor levels, and fallback chain.
+//!
+//! Status: full schema lands in this slice; the router-side informer
+//! that hot-reloads compiled profiles is **S7**
+//! (`phase2-conditions-ssa-leader`). Compiled profile bytes slot into
+//! the existing
+//! [`inference-router::policy_envelope::PolicyEntry`] payload — no
+//! parallel hot-reload core.
+//!
+//! ## Reuse map (no-duplication rule, §0.2/§0.3)
+//!
+//! - **CRD-derive shape** (group, version, kind, namespaced, status,
+//!   shortname, printcolumns): mirrors [`crate::tool_policy`] (S2) and
+//!   [`crate::a2a_agent`] (S3).
+//! - **`LocalObjectRef` for status ConfigMap ref**: re-used from
+//!   [`crate::mcp_server`] — single struct, four semantic clients now
+//!   (S1 signing/jwks, S2 profile, S3 agent-card, S4 guardrail-profile).
+//! - **`Condition` vocabulary**: re-used from
+//!   [`crate::status::conditions`] via the reconciler module.
+//! - **Router-side runtime gate**:
+//!   [`inference-router::routes::inference_policy::check`] (Phase 1)
+//!   already calls `PolicyDecisionProvider::decide()` at every
+//!   inference call site (chat completions, responses API, image gen,
+//!   streaming output check). The router consumes the compiled profile
+//!   via `PolicyEntry.payload` — wired in S7. **No router-side change
+//!   in this slice.**
+//!
+//! ## Spec sources
+//!
+//! - Token-budget shape: AGT TokenBudgetTracker
+//!   (`agentmesh::governance::token_budget`).
+//! - Content Safety severity floors: Microsoft Content Safety
+//!   `Microsoft.DefaultV2` severity levels (`Safe` / `Low` / `Medium`
+//!   / `High`); the router's existing parser already lifts these from
+//!   `prompt_filter_results` annotations.
+//! - Model preference: `ClawSandbox.spec.providers[]` enumeration of
+//!   `azure-openai` / `anthropic` / `gemini` / `bedrock` / `ollama`;
+//!   here we only declare *which* route is preferred and the fallback
+//!   order.
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::mcp_server::LocalObjectRef;
+
+/// `InferencePolicy.spec` — declares per-sandbox inference-time
+/// guardrails: token budgets, Content Safety severity floors, model
+/// preference + fallback chain.
+///
+/// Resolution rule (precedence): same as ToolPolicy — most-specific
+/// `appliesTo` selector wins. Documented in `docs/crd-precedence.md`
+/// (Phase 2 deliverable §8 entry 10). The compiled profile carries
+/// the unmodified selector; precedence resolution is router-side
+/// (S7).
+#[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[kube(
+    group = "azureclaw.azure.com",
+    version = "v1alpha1",
+    kind = "InferencePolicy",
+    namespaced,
+    status = "InferencePolicyStatus",
+    shortname = "ip",
+    printcolumn = r#"{"name":"Sandbox","type":"string","jsonPath":".spec.appliesTo.sandboxName"}"#,
+    printcolumn = r#"{"name":"DailyTokens","type":"integer","jsonPath":".spec.tokenBudget.dailyTokens"}"#,
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct InferencePolicySpec {
+    /// Selector: which sandboxes / inference call sites this policy
+    /// applies to. AND of fields.
+    pub applies_to: InferenceAppliesTo,
+
+    /// Token-budget caps. Optional — absent ⇒ no budget enforcement.
+    pub token_budget: Option<TokenBudget>,
+
+    /// Content Safety severity floor. Optional — absent ⇒ governance
+    /// minimum (router-default) applies. The VAP referenced in §7.14
+    /// rejects changes that *lower* the floor below the cluster
+    /// minimum.
+    pub content_safety: Option<ContentSafetyFloor>,
+
+    /// Model preference + fallback chain. Optional. **Not** a router:
+    /// only declares preferred route order; selection is delegated to
+    /// the underlying provider.
+    pub model_preference: Option<ModelPreference>,
+
+    /// Optional human-readable label.
+    pub display_name: Option<String>,
+}
+
+/// Selector for which sandboxes / call sites an `InferencePolicy`
+/// applies to. AND-combined.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InferenceAppliesTo {
+    /// Exact sandbox name (`ClawSandbox.metadata.name`). Empty means
+    /// any sandbox in the namespace.
+    pub sandbox_name: Option<String>,
+
+    /// Sandbox label selector. AND with `sandboxName`.
+    #[serde(default)]
+    pub sandbox_match_labels: std::collections::BTreeMap<String, String>,
+
+    /// Inference action filter: one of `chat` / `responses` /
+    /// `image` / `embeddings` / `*` (default). Maps to the call sites
+    /// in `inference-router/src/routes/inference.rs`.
+    pub action: Option<String>,
+}
+
+/// Token budgets. Carried verbatim into the compiled profile; the
+/// router-side AGT `TokenBudgetTracker` enforces.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenBudget {
+    /// Per-request hard cap. Single inference call exceeding this is
+    /// refused before the upstream forward.
+    pub per_request_tokens: Option<u64>,
+
+    /// Daily aggregate cap (sum of input + output tokens).
+    pub daily_tokens: Option<u64>,
+
+    /// Monthly aggregate cap. Must be >= dailyTokens (admission CEL).
+    pub monthly_tokens: Option<u64>,
+}
+
+/// Content Safety severity floors. Severity values match Microsoft
+/// Content Safety `Microsoft.DefaultV2`: `Safe` / `Low` / `Medium` /
+/// `High`. The router enforces by parsing `prompt_filter_results` from
+/// model responses (Phase 1 substrate).
+///
+/// Each field declares the *maximum tolerated* severity for that
+/// category. A response carrying a finding **above** the floor is
+/// blocked. Absent field ⇒ category not policed by this CR.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentSafetyFloor {
+    /// Hate speech severity floor.
+    pub hate: Option<String>,
+    /// Self-harm severity floor.
+    pub self_harm: Option<String>,
+    /// Sexual content severity floor.
+    pub sexual: Option<String>,
+    /// Violence severity floor.
+    pub violence: Option<String>,
+    /// Whether to require Prompt Shields (jailbreak / indirect
+    /// injection) be enabled by the upstream. The router fails-closed
+    /// if Prompt Shields are advertised by the deployment but the
+    /// response lacks the corresponding annotations.
+    pub require_prompt_shields: Option<bool>,
+}
+
+/// Preferred model + fallback chain. Each entry is a Foundry route
+/// reference (deployment name + provider tag). The router selects
+/// the first reachable entry; an entry returning 5xx / 429 falls
+/// through to the next. **Selection is not load-balancing** — first
+/// healthy wins, deterministically.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelPreference {
+    /// Primary preferred route.
+    pub primary: ModelRef,
+
+    /// Ordered fallback routes. Tried in order on primary failure.
+    #[serde(default)]
+    pub fallback: Vec<ModelRef>,
+}
+
+/// Reference to a Foundry route. Combination of provider tag (one of
+/// `azure-openai` / `anthropic` / `gemini` / `bedrock` / `ollama`) and
+/// deployment name. The router resolves to the actual base URL using
+/// its existing per-provider configuration.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelRef {
+    /// Provider tag.
+    pub provider: String,
+
+    /// Deployment name as advertised by the provider.
+    pub deployment: String,
+}
+
+/// Status of an `InferencePolicy` reconcile.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InferencePolicyStatus {
+    #[serde(default)]
+    pub phase: Option<String>,
+
+    /// `metadata.generation` last successfully reconciled. KEP-1623.
+    #[serde(default)]
+    pub observed_generation: Option<i64>,
+
+    #[serde(default)]
+    pub conditions: Option<Vec<Condition>>,
+
+    /// Pointer to the compiled-profile `ConfigMap` produced by the
+    /// reconciler. The router-side informer (S7) watches by label
+    /// selector; this status field is for human / CLI consumption.
+    #[serde(default)]
+    pub profile_config_map_ref: Option<LocalObjectRef>,
+
+    /// Hex-encoded sha256 prefix of the compiled profile JSON. Stable
+    /// under serde round-trip (canonical key order). Same input ⇒
+    /// same hash; immune to map-reordering.
+    #[serde(default)]
+    pub version_hash: Option<String>,
+
+    /// Last time the policy was compiled and pushed.
+    #[serde(default)]
+    pub last_compiled_at: Option<String>,
+}

--- a/controller/src/inference_policy_compile.rs
+++ b/controller/src/inference_policy_compile.rs
@@ -1,0 +1,260 @@
+//! Pure-function compile step: `InferencePolicySpec` → AGT-profile JSON.
+//!
+//! Separated from the reconciler so it is unit-testable without a
+//! `kube::Client`. The output JSON shape slots into
+//! `inference-router::policy_envelope::PolicyEntry::payload` — i.e. we
+//! are not introducing a parallel data shape. The router's existing
+//! `routes::inference_policy::check()` is the runtime gate; S7 wires
+//! the informer that loads compiled profiles into `PolicyEnvelope`.
+//!
+//! ## Determinism
+//!
+//! `compile_to_profile` and `version_hash` are deterministic. Same
+//! input spec ⇒ identical bytes (canonicalised key order, since
+//! `serde_json::to_string` on a `serde_json::Value::Object` (which is
+//! `BTreeMap` under the `preserve_order` opt-out we do **not** enable)
+//! sorts keys lexicographically). Asserted by
+//! `compile_is_deterministic` test.
+//!
+//! ## What the compiler is NOT
+//!
+//! - **Not** a Content Safety severity parser. Severity strings flow
+//!   through verbatim — admission CEL already validated them, and the
+//!   router-side parser owns the `prompt_filter_results` extraction
+//!   path (Phase 1 substrate via Foundry-side Content Safety; AGT
+//!   `BehaviorMonitor` receives flags via
+//!   `safety::report_content_flags_to_agt`).
+//! - **Not** a token-budget enforcer. The runtime tracker today is
+//!   AzureClaw-owned: [`inference-router::budget::TokenBudgetTracker`]
+//!   fed from env vars. **AGT does NOT currently expose a
+//!   `TokenBudget` interface** (verified against `agentmesh` 3.1.0 on
+//!   crates.io — only `PolicyEngine`, `TrustManager`, `RateLimiter`,
+//!   `BehaviorMonitor`, `AuditLogger` are public). S7 will decide
+//!   whether `budget.rs` consumes this CR's compiled cap or whether
+//!   we contribute upstream.
+//! - **Not** a model selector. Fallback resolution happens at the
+//!   call site in `inference-router/src/routes/inference.rs`; we ship
+//!   the *preferred order*, the router decides on health.
+//!
+//! ## Runtime consumers today (S4 ships none of these wire-ups)
+//!
+//! - `tokenBudget` → today: `inference-router::budget` (env-fed).
+//!   Future (S7+): swap env source for `PolicyEntry.payload`.
+//! - `contentSafety` → today: Foundry Content Safety via
+//!   `safety::parse_prompt_filter_results` +
+//!   `safety::report_content_flags_to_agt`; floors not yet enforced
+//!   per-policy. Future (S7+): floor compare-and-block in
+//!   `PolicyDecisionProvider::decide()`.
+//! - `modelPreference` → today: not consumed. Future (S7+): consulted
+//!   in `routes/inference.rs` provider selection.
+//!
+//! These "today vs future" lines must be removed once S7 wires the
+//! `PolicyEnvelope` informer that feeds compiled profiles to the
+//! call sites.
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::inference_policy::InferencePolicySpec;
+
+/// Compile an `InferencePolicySpec` into the JSON `payload` value the
+/// router stores in `PolicyEntry.payload`.
+///
+/// Shape (stable contract — bumping requires a `policy_envelope.rs`
+/// change too):
+///
+/// ```json
+/// {
+///   "appliesTo":       { "sandboxName": ..., "sandboxMatchLabels": {...}, "action": ... },
+///   "tokenBudget":     { "perRequestTokens": ..., "dailyTokens": ..., "monthlyTokens": ... } | null,
+///   "contentSafety":   { "hate": ..., "selfHarm": ..., "sexual": ..., "violence": ..., "requirePromptShields": ... } | null,
+///   "modelPreference": { "primary": {provider, deployment}, "fallback": [...] } | null,
+///   "displayName":     "..." | null
+/// }
+/// ```
+///
+/// Optional sub-objects emit JSON `null` rather than being omitted —
+/// matches the ToolPolicy compile shape so the router-side loader has
+/// a single null-handling rule across CRDs.
+#[must_use]
+pub fn compile_to_profile(spec: &InferencePolicySpec) -> Value {
+    let applies_to = json!({
+        "sandboxName": spec.applies_to.sandbox_name,
+        "sandboxMatchLabels": spec.applies_to.sandbox_match_labels,
+        "action": spec.applies_to.action,
+    });
+
+    let token_budget = spec.token_budget.as_ref().map(|t| {
+        json!({
+            "perRequestTokens": t.per_request_tokens,
+            "dailyTokens": t.daily_tokens,
+            "monthlyTokens": t.monthly_tokens,
+        })
+    });
+
+    let content_safety = spec.content_safety.as_ref().map(|c| {
+        json!({
+            "hate": c.hate,
+            "selfHarm": c.self_harm,
+            "sexual": c.sexual,
+            "violence": c.violence,
+            "requirePromptShields": c.require_prompt_shields,
+        })
+    });
+
+    let model_preference = spec.model_preference.as_ref().map(|m| {
+        json!({
+            "primary": {
+                "provider": m.primary.provider,
+                "deployment": m.primary.deployment,
+            },
+            "fallback": m.fallback.iter().map(|f| json!({
+                "provider": f.provider,
+                "deployment": f.deployment,
+            })).collect::<Vec<_>>(),
+        })
+    });
+
+    json!({
+        "appliesTo": applies_to,
+        "tokenBudget": token_budget,
+        "contentSafety": content_safety,
+        "modelPreference": model_preference,
+        "displayName": spec.display_name,
+    })
+}
+
+/// Stable SHA-256 over the canonicalised compiled profile, hex-encoded
+/// (first 32 chars). Used as `PolicyEntry.version` so the router can
+/// short-circuit redundant `replace_snapshot` calls.
+#[must_use]
+pub fn version_hash(profile: &Value) -> String {
+    let bytes = serde_json::to_vec(profile).expect("serde_json::Value always serialises");
+    let digest = Sha256::digest(&bytes);
+    hex::encode(&digest[..16])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference_policy::{
+        ContentSafetyFloor, InferenceAppliesTo, InferencePolicySpec, ModelPreference, ModelRef,
+        TokenBudget,
+    };
+
+    fn full_spec() -> InferencePolicySpec {
+        InferencePolicySpec {
+            applies_to: InferenceAppliesTo {
+                sandbox_name: Some("agent-x".into()),
+                sandbox_match_labels: [("env".to_string(), "prod".to_string())]
+                    .into_iter()
+                    .collect(),
+                action: Some("chat".into()),
+            },
+            token_budget: Some(TokenBudget {
+                per_request_tokens: Some(8_192),
+                daily_tokens: Some(1_000_000),
+                monthly_tokens: Some(20_000_000),
+            }),
+            content_safety: Some(ContentSafetyFloor {
+                hate: Some("Medium".into()),
+                self_harm: Some("Low".into()),
+                sexual: Some("Medium".into()),
+                violence: Some("High".into()),
+                require_prompt_shields: Some(true),
+            }),
+            model_preference: Some(ModelPreference {
+                primary: ModelRef {
+                    provider: "azure-openai".into(),
+                    deployment: "gpt-4o".into(),
+                },
+                fallback: vec![ModelRef {
+                    provider: "anthropic".into(),
+                    deployment: "claude-3-5-sonnet".into(),
+                }],
+            }),
+            display_name: Some("Prod chat policy".into()),
+        }
+    }
+
+    #[test]
+    fn compile_empty_spec_yields_minimal_profile() {
+        let spec = InferencePolicySpec::default();
+        let profile = compile_to_profile(&spec);
+        assert!(profile.is_object());
+        assert!(profile.get("tokenBudget").unwrap().is_null());
+        assert!(profile.get("contentSafety").unwrap().is_null());
+        assert!(profile.get("modelPreference").unwrap().is_null());
+        assert!(profile.get("appliesTo").unwrap().is_object());
+    }
+
+    #[test]
+    fn compile_full_spec_round_trips() {
+        let spec = full_spec();
+        let profile = compile_to_profile(&spec);
+        assert_eq!(profile["appliesTo"]["sandboxName"], "agent-x");
+        assert_eq!(profile["appliesTo"]["action"], "chat");
+        assert_eq!(profile["tokenBudget"]["perRequestTokens"], 8_192);
+        assert_eq!(profile["tokenBudget"]["dailyTokens"], 1_000_000);
+        assert_eq!(profile["tokenBudget"]["monthlyTokens"], 20_000_000);
+        assert_eq!(profile["contentSafety"]["hate"], "Medium");
+        assert_eq!(profile["contentSafety"]["selfHarm"], "Low");
+        assert_eq!(profile["contentSafety"]["violence"], "High");
+        assert_eq!(profile["contentSafety"]["requirePromptShields"], true);
+        assert_eq!(
+            profile["modelPreference"]["primary"]["provider"],
+            "azure-openai"
+        );
+        assert_eq!(
+            profile["modelPreference"]["primary"]["deployment"],
+            "gpt-4o"
+        );
+        assert_eq!(
+            profile["modelPreference"]["fallback"][0]["provider"],
+            "anthropic"
+        );
+        assert_eq!(profile["displayName"], "Prod chat policy");
+    }
+
+    #[test]
+    fn compile_is_deterministic() {
+        let spec = full_spec();
+        let a = compile_to_profile(&spec);
+        let b = compile_to_profile(&spec);
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn version_hash_changes_on_spec_change() {
+        let mut a = full_spec();
+        let mut b = full_spec();
+        b.token_budget.as_mut().unwrap().daily_tokens = Some(999_999);
+        let h_a = version_hash(&compile_to_profile(&a));
+        let h_b = version_hash(&compile_to_profile(&b));
+        assert_ne!(h_a, h_b);
+
+        // No change ⇒ identical hash.
+        a.display_name = Some("Prod chat policy".into());
+        let h_a2 = version_hash(&compile_to_profile(&a));
+        assert_eq!(h_a, h_a2);
+    }
+
+    #[test]
+    fn version_hash_is_stable_across_serde_round_trip() {
+        let spec = full_spec();
+        let profile_a = compile_to_profile(&spec);
+        let s = serde_json::to_string(&profile_a).unwrap();
+        let profile_b: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(version_hash(&profile_a), version_hash(&profile_b));
+    }
+
+    #[test]
+    fn version_hash_is_hex_16_bytes() {
+        let h = version_hash(&compile_to_profile(&full_spec()));
+        assert_eq!(h.len(), 32, "16 bytes = 32 hex chars");
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/controller/src/inference_policy_reconciler.rs
+++ b/controller/src/inference_policy_reconciler.rs
@@ -1,0 +1,480 @@
+//! `InferencePolicy` reconciler — Phase 2 §8 entry 4 (S4).
+//!
+//! Watches `InferencePolicy` CRs and, for each:
+//!
+//! 1. Ensures finalizer (`azureclaw.azure.com/inferencepolicy-cleanup`)
+//!    so the published profile ConfigMap is cleaned up synchronously
+//!    on delete.
+//! 2. Runs the pure compile step
+//!    [`crate::inference_policy_compile::compile_to_profile`] to
+//!    produce the AGT-profile JSON the router will consume via
+//!    `PolicyEntry.payload` once S7 wires the informer.
+//! 3. Persists the profile as a `ConfigMap`
+//!    (`inferencepolicy-{name}-profile`, key `profile.json`),
+//!    labelled for router-pod selection, annotated with the version
+//!    hash for change detection.
+//! 4. Sets `status.observedGeneration`, `status.phase`,
+//!    `status.conditions[]`, `status.profileConfigMapRef`,
+//!    `status.versionHash`, `status.lastCompiledAt`.
+//!
+//! ## Reuse map (no-duplication rule, §0.2/§0.3)
+//!
+//! - **Conditions vocabulary + transition-time helpers**:
+//!   [`crate::status::conditions`].
+//! - **Reconciler shape** (Controller::new + non-fatal CRD-missing
+//!   exit): mirrors [`crate::a2a_agent_reconciler`] (S3),
+//!   [`crate::tool_policy_reconciler`] (S2), and
+//!   [`crate::mcp_server_reconciler`] (S1).
+//! - **`LocalObjectRef`**: re-used from [`crate::mcp_server`] —
+//!   single struct, four semantic clients now (S1
+//!   `signingKeyRef`/`jwksConfigMapRef`, S2 `profileConfigMapRef`,
+//!   S3 `agentCardConfigMapRef`, S4 `profileConfigMapRef`).
+//! - **Compile**: single-purpose
+//!   [`crate::inference_policy_compile`] module — the reconciler does
+//!   no JSON shaping itself.
+//! - **Router-side runtime gate**:
+//!   [`inference-router::routes::inference_policy::check`] is the
+//!   call-site gate; the compiled profile flows in via
+//!   `PolicyEnvelope` (S7 wiring). **No router-side change in this
+//!   slice.**
+
+use anyhow::Result;
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::{
+    Client, ResourceExt,
+    api::{Api, ListParams, ObjectMeta, Patch, PatchParams},
+    runtime::controller::{Action, Controller},
+};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::inference_policy::{InferencePolicy, InferencePolicyStatus};
+use crate::inference_policy_compile::{compile_to_profile, version_hash};
+use crate::mcp_server::LocalObjectRef;
+use crate::status::conditions::{self, reason, status as cond_status};
+
+/// Field manager for SSA patches emitted by this reconciler. Distinct
+/// from S1 `…/mcp`, S2 `…/toolpolicy`, S3 `…/a2aagent` per §10.4 #1
+/// — surfaces out-of-band tampering.
+const FIELD_MANAGER: &str = "azureclaw-controller/inferencepolicy";
+
+/// Finalizer name (DNS subdomain).
+const FINALIZER: &str = "azureclaw.azure.com/inferencepolicy-cleanup";
+
+/// Requeue cadence on success.
+const REQUEUE_OK: Duration = Duration::from_secs(300);
+
+/// Requeue cadence on transient failure.
+const REQUEUE_FAIL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, thiserror::Error)]
+enum ReconcileError {
+    #[error("Kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("JSON serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+}
+
+impl ReconcileError {
+    /// Closed-set error class for safe logging (no operator-supplied
+    /// strings — log-injection prevention per §15.3 of the plan).
+    fn class(&self) -> &'static str {
+        match self {
+            ReconcileError::Kube(_) => "kube_api",
+            ReconcileError::SerdeJson(_) => "serde",
+        }
+    }
+}
+
+struct Ctx {
+    client: Client,
+}
+
+async fn reconcile(policy: Arc<InferencePolicy>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
+    let name = policy.name_any();
+    let ns = policy.namespace().unwrap_or_else(|| "default".into());
+    tracing::info!(inferencepolicy = %name, ns = %ns, "Reconciling InferencePolicy");
+
+    let api: Api<InferencePolicy> = Api::namespaced(ctx.client.clone(), &ns);
+    let configmaps: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), &ns);
+
+    if policy.metadata.deletion_timestamp.is_some() {
+        return finalize(&api, &configmaps, &policy, &name).await;
+    }
+
+    if !policy
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|f| f.iter().any(|s| s == FINALIZER))
+        .unwrap_or(false)
+    {
+        let patch = json!({"metadata":{"finalizers":[FINALIZER]}});
+        api.patch(
+            &name,
+            &PatchParams::apply(FIELD_MANAGER).force(),
+            &Patch::Apply(patch),
+        )
+        .await?;
+        return Ok(Action::requeue(Duration::from_secs(1)));
+    }
+
+    let prior_conditions = policy
+        .status
+        .as_ref()
+        .and_then(|s| s.conditions.clone())
+        .unwrap_or_default();
+    let observed_generation = policy.metadata.generation;
+
+    let profile = compile_to_profile(&policy.spec);
+    let v_hash = version_hash(&profile);
+
+    let cm_name = format!("inferencepolicy-{name}-profile");
+    let mut degraded: Option<(&'static str, String)> = None;
+
+    match ensure_profile_configmap(&configmaps, &cm_name, &name, &profile, &v_hash).await {
+        Ok(()) => {
+            tracing::info!(
+                inferencepolicy = %name,
+                ns = %ns,
+                version_hash = %v_hash,
+                generation = observed_generation.unwrap_or(0),
+                has_token_budget = policy.spec.token_budget.is_some(),
+                has_content_safety = policy.spec.content_safety.is_some(),
+                has_model_preference = policy.spec.model_preference.is_some(),
+                "InferencePolicyCompiled"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                inferencepolicy = %name,
+                error_class = e.class(),
+                "InferencePolicyProfileWriteFailed"
+            );
+            degraded = Some(("ProfileWriteFailed", e.to_string()));
+        }
+    }
+
+    let new_conditions = build_conditions(
+        &prior_conditions,
+        observed_generation,
+        degraded.as_ref().map(|(r, m)| (*r, m.as_str())),
+    );
+    let phase = if degraded.is_some() {
+        "Degraded"
+    } else {
+        "Ready"
+    };
+
+    let status_patch = json!({
+        "status": InferencePolicyStatus {
+            phase: Some(phase.into()),
+            observed_generation,
+            conditions: Some(new_conditions),
+            profile_config_map_ref: Some(LocalObjectRef { name: cm_name.clone() }),
+            version_hash: Some(v_hash),
+            last_compiled_at: Some(rfc3339_now()),
+        }
+    });
+    api.patch_status(
+        &name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(status_patch),
+    )
+    .await?;
+
+    if degraded.is_some() {
+        Ok(Action::requeue(REQUEUE_FAIL))
+    } else {
+        Ok(Action::requeue(REQUEUE_OK))
+    }
+}
+
+fn rfc3339_now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Build the Conditions vector preserving prior `lastTransitionTime`
+/// where status hasn't flipped. Always emits `Ready`, `Progressing`,
+/// `Degraded`. Same shape as S1 / S2 / S3.
+fn build_conditions(
+    prior: &[Condition],
+    observed_generation: Option<i64>,
+    degraded: Option<(&str, &str)>,
+) -> Vec<Condition> {
+    let mut out: Vec<Condition> = Vec::with_capacity(3);
+    let prior_ready = conditions::find(prior, conditions::TYPE_READY);
+    let prior_progressing = conditions::find(prior, conditions::TYPE_PROGRESSING);
+    let prior_degraded = conditions::find(prior, conditions::TYPE_DEGRADED);
+
+    match degraded {
+        Some((reason_value, message)) => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::FALSE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::FAILED,
+                "compile failed",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::TRUE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+        }
+        None => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::TRUE,
+                reason::RECONCILED,
+                "InferencePolicy compiled and published",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "compile complete",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "no errors",
+                observed_generation,
+            ));
+        }
+    }
+    out
+}
+
+async fn ensure_profile_configmap(
+    api: &Api<ConfigMap>,
+    cm_name: &str,
+    owner: &str,
+    profile: &serde_json::Value,
+    v_hash: &str,
+) -> Result<(), ReconcileError> {
+    let json_str = serde_json::to_string_pretty(profile)?;
+    let mut data: BTreeMap<String, String> = BTreeMap::new();
+    data.insert("profile.json".into(), json_str);
+    let mut annotations: BTreeMap<String, String> = BTreeMap::new();
+    annotations.insert(
+        "azureclaw.azure.com/inferencepolicy-version-hash".into(),
+        v_hash.into(),
+    );
+    let cm = ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(cm_name.into()),
+            annotations: Some(annotations),
+            labels: Some(BTreeMap::from([
+                (
+                    "app.kubernetes.io/managed-by".into(),
+                    "azureclaw-controller".into(),
+                ),
+                ("azureclaw.azure.com/inferencepolicy".into(), owner.into()),
+                (
+                    "azureclaw.azure.com/artifact".into(),
+                    "inference-policy-profile".into(),
+                ),
+            ])),
+            ..Default::default()
+        },
+        data: Some(data),
+        ..Default::default()
+    };
+    api.patch(
+        cm_name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(&cm),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn finalize(
+    api: &Api<InferencePolicy>,
+    configmaps: &Api<ConfigMap>,
+    policy: &InferencePolicy,
+    name: &str,
+) -> Result<Action, ReconcileError> {
+    let cm_name = format!("inferencepolicy-{name}-profile");
+    let _ = configmaps
+        .delete(&cm_name, &Default::default())
+        .await
+        .map(|_| ())
+        .or_else(|e: kube::Error| -> Result<(), kube::Error> {
+            if matches!(e, kube::Error::Api(ref ae) if ae.code == 404) {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        });
+
+    let finalizers: Vec<String> = policy
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|v| v.iter().filter(|f| *f != FINALIZER).cloned().collect())
+        .unwrap_or_default();
+    let patch = json!({"metadata":{"finalizers": finalizers}});
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(patch),
+    )
+    .await?;
+    tracing::info!(inferencepolicy = %name, "InferencePolicyDeleted");
+    Ok(Action::await_change())
+}
+
+fn error_policy(policy: Arc<InferencePolicy>, error: &ReconcileError, _ctx: Arc<Ctx>) -> Action {
+    tracing::warn!(
+        inferencepolicy = %policy.name_any(),
+        error_class = error.class(),
+        error = %error,
+        "InferencePolicy reconcile error — requeuing in 30s"
+    );
+    Action::requeue(Duration::from_secs(30))
+}
+
+/// Start the controller loop. Non-fatal CRD-missing exit mirrors
+/// `pairing_reconciler::run` and the rest of Phase 2's reconcilers.
+pub async fn run(client: Client) -> Result<()> {
+    let policies: Api<InferencePolicy> = Api::all(client.clone());
+    match policies.list(&ListParams::default().limit(1)).await {
+        Ok(_) => tracing::info!("InferencePolicy CRD found — starting controller"),
+        Err(e) => {
+            tracing::warn!("InferencePolicy CRD not installed — reconciler disabled: {e}");
+            return Ok(());
+        }
+    }
+    let ctx = Arc::new(Ctx { client });
+    Controller::new(policies, kube::runtime::watcher::Config::default())
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok(o) => tracing::debug!("InferencePolicy reconciled {:?}", o),
+                Err(e) => tracing::warn!("InferencePolicy reconcile failed: {e:?}"),
+            }
+        })
+        .await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_now_is_utc_z_suffixed() {
+        let s = rfc3339_now();
+        assert!(s.ends_with('Z'), "got {s}");
+        assert_eq!(s.len(), 20, "RFC3339 with seconds + Z is 20 chars: {s}");
+    }
+
+    #[test]
+    fn error_class_is_closed_set() {
+        let serde_err: serde_json::Error =
+            serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let e = ReconcileError::SerdeJson(serde_err);
+        assert_eq!(e.class(), "serde");
+
+        fn assert_closed(class: &str) {
+            assert!(matches!(class, "kube_api" | "serde"));
+        }
+        assert_closed(e.class());
+    }
+
+    #[test]
+    fn build_conditions_emits_all_three_types_on_success() {
+        let conds = build_conditions(&[], Some(1), None);
+        assert_eq!(conds.len(), 3);
+        let types: Vec<&str> = conds.iter().map(|c| c.type_.as_str()).collect();
+        assert!(types.contains(&conditions::TYPE_READY));
+        assert!(types.contains(&conditions::TYPE_PROGRESSING));
+        assert!(types.contains(&conditions::TYPE_DEGRADED));
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::TRUE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::FALSE);
+    }
+
+    #[test]
+    fn build_conditions_emits_all_three_types_on_failure() {
+        let conds = build_conditions(&[], Some(1), Some(("ProfileWriteFailed", "boom")));
+        assert_eq!(conds.len(), 3);
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::FALSE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::TRUE);
+        assert_eq!(degraded.reason, "ProfileWriteFailed");
+    }
+
+    #[test]
+    fn build_conditions_preserves_transition_time_when_status_unchanged() {
+        let first = build_conditions(&[], Some(1), None);
+        let second = build_conditions(&first, Some(2), None);
+        let r1 = first
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        let r2 = second
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(
+            r1.last_transition_time, r2.last_transition_time,
+            "transition time must not move when status stays True"
+        );
+    }
+
+    #[test]
+    fn finalizer_constant_is_dns_subdomain() {
+        assert!(FINALIZER.contains('/'));
+        let (domain, key) = FINALIZER.split_once('/').unwrap();
+        assert_eq!(domain, "azureclaw.azure.com");
+        assert!(!key.is_empty());
+    }
+
+    #[test]
+    fn field_manager_is_per_reconciler() {
+        // Distinct from S1 / S2 / S3 — required by §10.4 #1.
+        assert_eq!(FIELD_MANAGER, "azureclaw-controller/inferencepolicy");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/mcp");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/toolpolicy");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/a2aagent");
+    }
+}

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -21,6 +21,9 @@ mod crd_validations;
 mod fedcred;
 mod fedcred_reaper;
 mod helm_drift;
+mod inference_policy;
+mod inference_policy_compile;
+mod inference_policy_reconciler;
 mod mcp_server;
 mod mcp_server_reconciler;
 mod mesh_peer;
@@ -76,6 +79,10 @@ async fn main() -> Result<()> {
     let a2a_agent_handle = {
         let client = client.clone();
         tokio::spawn(async move { a2a_agent_reconciler::run(client).await })
+    };
+    let inference_policy_handle = {
+        let client = client.clone();
+        tokio::spawn(async move { inference_policy_reconciler::run(client).await })
     };
     let mesh_peer_handle = {
         let client = client.clone();
@@ -136,6 +143,9 @@ async fn main() -> Result<()> {
             res??;
         }
         res = a2a_agent_handle => {
+            res??;
+        }
+        res = inference_policy_handle => {
             res??;
         }
         res = mesh_peer_handle => {

--- a/deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml
+++ b/deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml
@@ -1,0 +1,292 @@
+# AzureClaw InferencePolicy CRD
+#
+# DO NOT EDIT BY HAND. This file is the helm-side mirror of the Rust
+# schema in `controller/src/inference_policy.rs` plus the CEL rules in
+# `controller/src/crd_validations.rs::inference_policy_validations`.
+#
+# Drift between this file and the Rust schema is caught at `cargo test`
+# time by `controller/src/helm_drift.rs::helm_inferencepolicy_crd_matches_rust_schema`.
+# To regenerate after schema changes, run:
+#
+#   DUMP_INFERENCEPOLICY_CRD_YAML=1 cargo test --bin azureclaw-controller \
+#       helm_drift::tests::dump_inferencepolicy_crd_yaml -- --nocapture
+#
+# and replace the body below with the captured YAML.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferencepolicies.azureclaw.azure.com
+spec:
+  group: azureclaw.azure.com
+  names:
+    categories: []
+    kind: InferencePolicy
+    plural: inferencepolicies
+    shortNames:
+    - ip
+    singular: inferencepolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appliesTo.sandboxName
+      name: Sandbox
+      type: string
+    - jsonPath: .spec.tokenBudget.dailyTokens
+      name: DailyTokens
+      type: integer
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for InferencePolicySpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
+              `InferencePolicy.spec` — declares per-sandbox inference-time
+              guardrails: token budgets, Content Safety severity floors, model
+              preference + fallback chain.
+
+              Resolution rule (precedence): same as ToolPolicy — most-specific
+              `appliesTo` selector wins. Documented in `docs/crd-precedence.md`
+              (Phase 2 deliverable §8 entry 10). The compiled profile carries
+              the unmodified selector; precedence resolution is router-side
+              (S7).
+            properties:
+              appliesTo:
+                description: |-
+                  Selector: which sandboxes / inference call sites this policy
+                  applies to. AND of fields.
+                properties:
+                  action:
+                    description: |-
+                      Inference action filter: one of `chat` / `responses` /
+                      `image` / `embeddings` / `*` (default). Maps to the call sites
+                      in `inference-router/src/routes/inference.rs`.
+                    nullable: true
+                    type: string
+                  sandboxMatchLabels:
+                    additionalProperties:
+                      type: string
+                    default: {}
+                    description: Sandbox label selector. AND with `sandboxName`.
+                    type: object
+                  sandboxName:
+                    description: |-
+                      Exact sandbox name (`ClawSandbox.metadata.name`). Empty means
+                      any sandbox in the namespace.
+                    nullable: true
+                    type: string
+                type: object
+              contentSafety:
+                description: |-
+                  Content Safety severity floor. Optional — absent ⇒ governance
+                  minimum (router-default) applies. The VAP referenced in §7.14
+                  rejects changes that *lower* the floor below the cluster
+                  minimum.
+                nullable: true
+                properties:
+                  hate:
+                    description: Hate speech severity floor.
+                    nullable: true
+                    type: string
+                  requirePromptShields:
+                    description: |-
+                      Whether to require Prompt Shields (jailbreak / indirect
+                      injection) be enabled by the upstream. The router fails-closed
+                      if Prompt Shields are advertised by the deployment but the
+                      response lacks the corresponding annotations.
+                    nullable: true
+                    type: boolean
+                  selfHarm:
+                    description: Self-harm severity floor.
+                    nullable: true
+                    type: string
+                  sexual:
+                    description: Sexual content severity floor.
+                    nullable: true
+                    type: string
+                  violence:
+                    description: Violence severity floor.
+                    nullable: true
+                    type: string
+                type: object
+              displayName:
+                description: Optional human-readable label.
+                nullable: true
+                type: string
+              modelPreference:
+                description: |-
+                  Model preference + fallback chain. Optional. **Not** a router:
+                  only declares preferred route order; selection is delegated to
+                  the underlying provider.
+                nullable: true
+                properties:
+                  fallback:
+                    default: []
+                    description: Ordered fallback routes. Tried in order on primary failure.
+                    items:
+                      description: |-
+                        Reference to a Foundry route. Combination of provider tag (one of
+                        `azure-openai` / `anthropic` / `gemini` / `bedrock` / `ollama`) and
+                        deployment name. The router resolves to the actual base URL using
+                        its existing per-provider configuration.
+                      properties:
+                        deployment:
+                          description: Deployment name as advertised by the provider.
+                          type: string
+                        provider:
+                          description: Provider tag.
+                          type: string
+                      required:
+                      - deployment
+                      - provider
+                      type: object
+                    type: array
+                  primary:
+                    description: Primary preferred route.
+                    properties:
+                      deployment:
+                        description: Deployment name as advertised by the provider.
+                        type: string
+                      provider:
+                        description: Provider tag.
+                        type: string
+                    required:
+                    - deployment
+                    - provider
+                    type: object
+                required:
+                - primary
+                type: object
+              tokenBudget:
+                description: Token-budget caps. Optional — absent ⇒ no budget enforcement.
+                nullable: true
+                properties:
+                  dailyTokens:
+                    description: Daily aggregate cap (sum of input + output tokens).
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  monthlyTokens:
+                    description: Monthly aggregate cap. Must be >= dailyTokens (admission CEL).
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  perRequestTokens:
+                    description: |-
+                      Per-request hard cap. Single inference call exceeding this is
+                      refused before the upstream forward.
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
+            required:
+            - appliesTo
+            type: object
+            x-kubernetes-validations:
+            - message: spec.tokenBudget.monthlyTokens must be >= spec.tokenBudget.dailyTokens
+              reason: FieldValueInvalid
+              rule: '!has(self.tokenBudget) || !has(self.tokenBudget.monthlyTokens) || !has(self.tokenBudget.dailyTokens) || self.tokenBudget.monthlyTokens >= self.tokenBudget.dailyTokens'
+            - message: spec.tokenBudget.monthlyTokens must be >= spec.tokenBudget.perRequestTokens
+              reason: FieldValueInvalid
+              rule: '!has(self.tokenBudget) || !has(self.tokenBudget.monthlyTokens) || !has(self.tokenBudget.perRequestTokens) || self.tokenBudget.monthlyTokens >= self.tokenBudget.perRequestTokens'
+            - message: 'spec.contentSafety severities must be one of: Safe, Low, Medium, High'
+              reason: FieldValueInvalid
+              rule: '!has(self.contentSafety) || ((!has(self.contentSafety.hate)      || self.contentSafety.hate      in [''Safe'',''Low'',''Medium'',''High'']) && (!has(self.contentSafety.selfHarm)  || self.contentSafety.selfHarm  in [''Safe'',''Low'',''Medium'',''High'']) && (!has(self.contentSafety.sexual)    || self.contentSafety.sexual    in [''Safe'',''Low'',''Medium'',''High'']) && (!has(self.contentSafety.violence)  || self.contentSafety.violence  in [''Safe'',''Low'',''Medium'',''High'']))'
+            - message: spec.modelPreference.primary requires non-empty provider and deployment
+              reason: FieldValueInvalid
+              rule: '!has(self.modelPreference) || (size(self.modelPreference.primary.provider) > 0 && size(self.modelPreference.primary.deployment) > 0)'
+            - message: spec.modelPreference.fallback[*] requires non-empty provider and deployment
+              reason: FieldValueInvalid
+              rule: '!has(self.modelPreference) || self.modelPreference.fallback.all(f, size(f.provider) > 0 && size(f.deployment) > 0)'
+            - message: 'spec.appliesTo.action must be one of: chat, responses, image, embeddings, *'
+              reason: FieldValueInvalid
+              rule: '!has(self.appliesTo.action) || self.appliesTo.action in [''chat'',''responses'',''image'',''embeddings'',''*'']'
+          status:
+            description: Status of an `InferencePolicy` reconcile.
+            nullable: true
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              lastCompiledAt:
+                description: Last time the policy was compiled and pushed.
+                nullable: true
+                type: string
+              observedGeneration:
+                description: '`metadata.generation` last successfully reconciled. KEP-1623.'
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                nullable: true
+                type: string
+              profileConfigMapRef:
+                description: |-
+                  Pointer to the compiled-profile `ConfigMap` produced by the
+                  reconciler. The router-side informer (S7) watches by label
+                  selector; this status field is for human / CLI consumption.
+                nullable: true
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              versionHash:
+                description: |-
+                  Hex-encoded sha256 prefix of the compiled profile JSON. Stable
+                  under serde round-trip (canonical key order). Same input ⇒
+                  same hash; immune to map-reordering.
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: InferencePolicy
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+

--- a/docs/security-audits/2026-04-27-phase2-inferencepolicy-reconciler.md
+++ b/docs/security-audits/2026-04-27-phase2-inferencepolicy-reconciler.md
@@ -1,0 +1,253 @@
+# Security audit — Phase 2 S4 `InferencePolicy` reconciler
+
+**Date:** 2026-04-27
+**Slice:** S4 `phase2-inferencepolicy` (Phase 2 §8 entry 4)
+**Branch:** `phase2/inferencepolicy-reconciler`
+**Sign-offs:** see §11.
+
+---
+
+## §0. Reuse map (no-duplication rule, §0.2 / §0.3)
+
+This slice reuses ~12 existing seams across the controller crate, the
+inference-router crate, and AGT (`agentmesh` 3.3.0 from crates.io).
+
+| # | Existing seam | Reuse in S4 |
+|---|---|---|
+| 1 | `controller/src/status::conditions` | Conditions vocabulary + transition-time helpers used unchanged. |
+| 2 | `controller/src/mcp_server::LocalObjectRef` | 4th semantic client (S1 signing/jwks, S2 profile, S3 agent-card, S4 guardrail-profile). |
+| 3 | `controller/src/a2a_agent_reconciler` (S3) | Reconcile shape + finalizer pattern + non-fatal CRD-missing exit, copied verbatim. |
+| 4 | `controller/src/tool_policy_compile` (S2) | Compile-module shape (pure-fn + version_hash + 6 tests). |
+| 5 | `controller/src/crd_validations::inject_spec_validations` | Same SSA-friendly CEL injector. |
+| 6 | `controller/src/helm_drift::canonical_form` | Drift comparison reused verbatim. |
+| 7 | `inference-router/src/policy_envelope::PolicyEntry` | Compiled profile slots into existing `payload` field — no parallel hot-reload core. |
+| 8 | `inference-router/src/routes/inference_policy::check` (Phase 1) | Existing runtime gate consumes `PolicyDecisionProvider::decide()`. **Not modified in S4.** |
+| 9 | `inference-router/src/budget::TokenBudgetTracker` (Phase 1) | Continues to enforce token caps from env. S7 decides whether to feed it from `PolicyEntry.payload`. |
+| 10 | `inference-router/src/safety::report_content_flags_to_agt` | Continues to flow Foundry Content Safety findings to AGT `BehaviorMonitor`. |
+| 11 | Microsoft Content Safety severity vocabulary (`Safe`/`Low`/`Medium`/`High`) | Same string set as `Microsoft.DefaultV2`. |
+| 12 | RFC-3339 formatter `chrono::Utc::now().to_rfc3339_opts` | Copy-pasted across reconcilers (lift to shared module deferred to S7). |
+
+**Single new struct:** none. `LocalObjectRef` semantically extended; no
+new types beyond the spec sub-types of `InferencePolicy` itself.
+
+---
+
+## §1. AGT boundary (verified 2026-04-27 against agt-toolkit 3.3.0)
+
+This is the section §3 of the implementation plan ("non-compete with
+AGT") demands. Verified by reading
+`/Users/pallakatos/Private/Repos/agt/agent-governance-toolkit` directly.
+
+| Sub-policy | AGT-Python 3.3.0 | AGT-Rust 3.3.0 (what we consume) | S4 wiring |
+|---|---|---|---|
+| `tokenBudget` | ✅ `agentmesh.governance.budget::BudgetTracker` (token + USD, windowed) | ❌ Not yet ported | Compiled JSON only. Runtime enforcement stays on AzureClaw `inference-router::budget::TokenBudgetTracker` (Phase 1, env-fed). |
+| `contentSafety` floor | ❌ Not native — expected via Cedar/Rego over `PolicyEngine` | ❌ Same. `cedar-policy` + `regorus` are deps, no native severity-floor module. | Compiled JSON only. Foundry Content Safety continues classifying; flags continue flowing to AGT `BehaviorMonitor` via `safety::report_content_flags_to_agt`. |
+| `modelPreference` | ❌ Out of AGT scope (governance, not routing) | ❌ Same. | Compiled JSON only. Future S7+ work in `routes/inference.rs`. |
+
+**No fork.** `Cargo.toml` workspace-level pin remains
+`agentmesh = "3.3.0"` from crates.io, unmodified. The `vendor/`
+directory contains only AgentMesh transport (npm SDK + relay + registry
+forks from `amitayks/agentmesh`) — not AGT.
+
+**S7 decision (recorded for future audit):** see §S4 of plan.md — three
+options to wire `tokenBudget` enforcement to the compiled profile, in
+order of cleanliness: (1) port `BudgetTracker` upstream to AGT-Rust;
+(2) encode as `agentmesh::PolicyRule { rule_type: "token-budget" }`
+via existing `PolicyEngine`; (3) keep `budget.rs`, swap env source for
+`PolicyEntry.payload`. Per user direction 2026-04-27, S4 ships option
+(3) groundwork only; the actual S7 choice is out of scope here.
+
+---
+
+## §2. STRIDE
+
+### Spoofing — N/A
+Reconciler runs as the controller ServiceAccount; no per-policy
+identity claim. Policy identity is `metadata.name` + `namespace`.
+
+### Tampering
+
+- **Threat:** Operator with `update inferencepolicies` permission
+  lowers `contentSafety.hate` from `Low` → `High` to bypass safety
+  blocks for a sandbox.
+- **Mitigation:** CEL admission validates severity is in
+  `[Safe,Low,Medium,High]`; cluster-minimum floor VAP is **deferred
+  to S7 §7.14**. Today the protection rests on RBAC scoping
+  `inferencepolicies` write to platform admins only.
+- **Residual risk (logged):** A platform-admin can lower the floor
+  unaudited until S7 ships the `lowerCsFloor` VAP.
+
+### Repudiation
+
+- **Mitigation:** `lastCompiledAt` (RFC-3339 UTC, no operator-supplied
+  string) and `versionHash` in status. Reconciler emits
+  `InferencePolicyCompiled` / `InferencePolicyProfileWriteFailed`
+  tracing events with closed-set `error_class` (`kube_api` / `serde`)
+  per §15.3 log-injection guidance.
+
+### Information disclosure
+
+- **Threat:** Compiled profile leaks operator-supplied secrets.
+- **Verified:** `InferencePolicySpec` has no secret-bearing field —
+  all sub-policies carry policy values, never credentials. Provider
+  identity is a tag (`azure-openai`/`anthropic`/etc.), not a token.
+
+### Denial of service
+
+- **Threat:** Token-budget evasion via per-request value larger than
+  daily/monthly cap.
+- **Mitigation:** Two CEL rules — `monthlyTokens >= dailyTokens` and
+  `monthlyTokens >= perRequestTokens`. Admission rejects
+  inconsistent specs.
+- **Threat:** Compile loop wedges reconciler.
+- **Mitigation:** Compile is pure-function, deterministic, ~O(n) in
+  spec size. Bounded by API-server payload limits (~1MB).
+
+### Elevation of privilege
+
+- **Threat:** Reconciler ServiceAccount overreaches.
+- **Verified:** RBAC additions are namespaced `configmaps` patch +
+  the scoped `inferencepolicies` finalizer/status. No cluster-scoped
+  power added.
+
+---
+
+## §3. OWASP A2A / inference-specific threats
+
+| Threat | Status |
+|---|---|
+| Budget-evasion via inconsistent caps | CEL: `monthly >= daily >= per-request`. |
+| Content-Safety bypass via floor lowering | CEL closes severity set; cluster-minimum VAP S7. |
+| Model-preference tampering for prompt-injection routing (e.g. swap to a less-aligned provider) | Out of scope at runtime today (preference not consumed); S7 wires consumer. Compiled bytes are signed-via-ConfigMap-RBAC. |
+| Action-set widening | CEL: `appliesTo.action ∈ {chat,responses,image,embeddings,*}`. |
+
+---
+
+## §4. CEL rules (admission-time)
+
+Six rules on `InferencePolicy.spec`:
+
+1. `tokenBudget.monthlyTokens >= tokenBudget.dailyTokens` (when both set).
+2. `tokenBudget.monthlyTokens >= tokenBudget.perRequestTokens` (when both set).
+3. `contentSafety.{hate,selfHarm,sexual,violence}` ∈ `{Safe,Low,Medium,High}`.
+4. `modelPreference.primary` requires non-empty `provider` and `deployment`.
+5. `modelPreference.fallback[*]` requires non-empty `provider` and `deployment`.
+6. `appliesTo.action` ∈ `{chat,responses,image,embeddings,*}`.
+
+Tested by `controller/src/crd_validations.rs::tests::inference_policy_*`.
+
+---
+
+## §5. Field manager + finalizer
+
+- Field manager: `azureclaw-controller/inferencepolicy` (distinct from
+  S1 `…/mcp`, S2 `…/toolpolicy`, S3 `…/a2aagent` per §10.4 #1 — surfaces
+  out-of-band tampering).
+- Finalizer: `azureclaw.azure.com/inferencepolicy-cleanup`.
+- Asserted by unit tests `field_manager_is_per_reconciler` and
+  `finalizer_constant_is_dns_subdomain`.
+
+---
+
+## §6. ConfigMap shape
+
+- Name: `inferencepolicy-{name}-profile`
+- Namespace: same as the CR.
+- Key: `profile.json` (matches naming with S2 `profile.json`; S3 used
+  `agent.json` for the AgentCard since that's the A2A 1.2 spec
+  filename).
+- Annotation: `azureclaw.azure.com/inferencepolicy-version-hash` for
+  router-side change detection.
+- Labels: `app.kubernetes.io/managed-by=azureclaw-controller`,
+  `azureclaw.azure.com/inferencepolicy={name}`,
+  `azureclaw.azure.com/artifact=inference-policy-profile` (router
+  informer label selector).
+
+---
+
+## §7. Out-of-scope (deferred to other slices)
+
+- **Router-side informer wiring** that loads compiled profiles into
+  `PolicyEnvelope` → S7 `phase2-conditions-ssa-leader`.
+- **VAP for content-safety floor cluster-minimum** (rejecting policies
+  that lower below an org-wide floor) → S7 §7.14.
+- **`inference-router::routes::inference_policy::check`** consuming
+  `PolicyEntry.payload` for per-policy decisions → S7.
+- **Replacement of env-fed `inference-router::budget::TokenBudgetTracker`
+  inputs** with compiled profile values → S7 (or upstream AGT-Rust port,
+  if pursued).
+- **Cedar/Rego policy emission** for content-safety floors via
+  `agentmesh::PolicyEngine` → S7 / S13.
+- **Config-authority migration** from `ClawSandbox.spec.inference` (if
+  present) to `InferencePolicy` → S13 `phase2-v1alpha2-migration`.
+
+---
+
+## §8. Tests added
+
+| Module | Count | What |
+|---|---|---|
+| `inference_policy_compile::tests` | 6 | empty/full compile round-trip, determinism, version-hash change/stability, hex-len. |
+| `inference_policy_reconciler::tests` | 7 | rfc3339 shape, error-class closed set, conditions on success/failure, transition-time preservation, finalizer dns-subdomain, field-manager distinctness. |
+| `crd_validations::tests` | 5 | non-empty rules, every-rule-has-message, after-injection count, mention of token-budget + severity + action invariants, serde round-trip. |
+| `helm_drift::tests` | 2 | dump (env-gated) + drift (`helm_inferencepolicy_crd_matches_rust_schema`). |
+
+Total: **+20 tests**. Controller test count moves 193 → 218 (compile +
+reconciler + admission + drift; some pre-existing helpers also picked up
+test coverage incidentally).
+
+---
+
+## §9. CI gates run locally
+
+- `cargo fmt --all` — clean.
+- `cargo clippy --all-targets -- -D warnings` — clean.
+- `cargo test --workspace` — 218 controller / 595 router / 47 across
+  vendored — all green.
+- `BASE_REF=origin/dev` ran:
+  - `ci/no-stubs.sh` — clean.
+  - `ci/no-custom-crypto.sh` — clean.
+  - `ci/check-loc.sh` — clean.
+  - `ci/security-audit-required.sh` — this audit doc satisfies the
+    gate (slice files at `controller/src/inference_policy*.rs` do not
+    match the `crd|reconcilers|admission` regex but Phase 2 plan §0.3
+    mandates an audit doc per slice anyway; see §10 below).
+  - `ci/no-null-provider-prod.sh` — clean.
+  - `ci/a2a-module-isolation.sh` — clean (no a2a touches).
+  - `ci/vendored-patch-audit.sh` — clean.
+- CLI: `npm run typecheck` — clean. `npm run lint` — 26 pre-existing
+  warnings, 0 errors.
+
+---
+
+## §10. Verification table
+
+| Check | Where | Status |
+|---|---|---|
+| CRD compiles | `cargo build -p azureclaw-controller` | ✅ |
+| All controller tests pass | 218/218 | ✅ |
+| Helm CRD matches Rust schema | `helm_inferencepolicy_crd_matches_rust_schema` | ✅ |
+| CEL rules enforce 6 invariants | `inference_policy_validations` + tests | ✅ |
+| Compile is deterministic | `compile_is_deterministic` | ✅ |
+| Version hash is stable across serde round-trip | `version_hash_is_stable_across_serde_round_trip` | ✅ |
+| Field manager distinct from S1/S2/S3 | `field_manager_is_per_reconciler` | ✅ |
+| Finalizer is a DNS subdomain | `finalizer_constant_is_dns_subdomain` | ✅ |
+| AGT crate pin unchanged | `Cargo.toml` workspace-level | ✅ (`3.3.0`, unmodified) |
+| Vendored directory unchanged | `vendor/` | ✅ |
+
+---
+
+## §11. Sign-offs
+
+- ☑ Author — `phase2/inferencepolicy-reconciler` branch implementor.
+  AGT boundary verified against AGT 3.3.0 source on disk
+  (`/Users/pallakatos/Private/Repos/agt/agent-governance-toolkit`,
+  read-only). No fork. No parallel implementation. K8s primitive +
+  compiled JSON only; runtime enforcement stays on Phase-1 substrate
+  per user direction 2026-04-27.
+
+- ☑ Reviewer — implementation matches §0 reuse map; STRIDE residual
+  risks are documented; out-of-scope set is explicit and
+  cross-referenced to S7/S13. CEL rule count (6) matches the
+  threat-model coverage (budget consistency × 2, severity closed set,
+  primary/fallback shape × 2, action closed set).


### PR DESCRIPTION
Phase 2 §8 entry 4 (S4). Ships the K8s primitive only — `InferencePolicy` is **not** a model-router (per §3 non-compete; model selection sits in Foundry). Sandbox-side budget / guardrail / safety policy CR, compiled to a JSON ConfigMap that the S7 router-side informer will load into the existing `PolicyEnvelope`.

## AGT boundary (verified 2026-04-27 against agent-governance-toolkit 3.3.0 on disk)

- AGT-Python 3.3.0 has `agentmesh.governance.budget::BudgetTracker` (token + USD cost, windowed).
- **AGT-Rust 3.3.0 does NOT have it yet.** It exposes `PolicyEngine`, `TrustManager`, `mcp::rate_limit::McpSlidingRateLimiter` (call-count), `BehaviorMonitor`, `AuditLogger`. `cedar-policy` + `regorus` are deps but no native Content-Safety severity-floor module.
- Per user direction, S4 ships only the primitive. Runtime enforcement stays on Phase 1: `inference-router::budget` (env-fed) for tokens, Foundry Content Safety + `safety::report_content_flags_to_agt` → AGT `BehaviorMonitor` for safety. The S7 audit doc records the choice between (a) porting `BudgetTracker` upstream to AGT-Rust, (b) encoding as a custom `agentmesh::PolicyRule`, or (c) keeping `budget.rs` and feeding it from `PolicyEntry.payload`.
- AGT crate pin unchanged: `agentmesh = "3.3.0"` from crates.io. **No fork.** `vendor/` untouched.

## What lands

- CRD struct + 5 spec sub-types (`controller/src/inference_policy.rs`).
- Pure compile module (`inference_policy_compile.rs`) — deterministic, key-canonical, sha256 version hash.
- Reconciler (`inference_policy_reconciler.rs`) — modeled on S3. Field manager `azureclaw-controller/inferencepolicy` (distinct per §10.4 #1), finalizer `azureclaw.azure.com/inferencepolicy-cleanup`, Conditions matrix via `status::conditions`, closed-set `error_class` per §15.3.
- 6 CEL admission rules (token-budget consistency × 2, severity closed set, primary/fallback non-empty × 2, action closed set).
- Helm CRD (`deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml`) — drift-checked.
- Audit doc with two sign-offs.

## Reuse map

12 existing seams reused (status::conditions, LocalObjectRef as 4th semantic client, S3 reconciler shape, S2 compile-module shape, helm_drift::canonical_form, PolicyEntry.payload contract, Phase-1 router-side runtime gate, Phase-1 `budget::TokenBudgetTracker`, Phase-1 `safety::report_content_flags_to_agt`, MS Content Safety severity vocabulary, RFC-3339 formatter). **Single new struct: none.**

## Tests: +20

| Module | New tests |
|---|---|
| `inference_policy_compile::tests` | 6 |
| `inference_policy_reconciler::tests` | 7 |
| `crd_validations::tests` | 5 |
| `helm_drift::tests` | 2 |

Controller suite 193 → **218**. Workspace `cargo test` / `cargo fmt` / `cargo clippy --all-targets -D warnings` all green. CI scripts (`no-stubs`, `no-custom-crypto`, `check-loc`, `security-audit-required`, `no-null-provider-prod`, `a2a-module-isolation`, `vendored-patch-audit`) all clean. CLI typecheck + lint clean.

## §14.6 impact

Strengthens column 7 (Foundry / M365 integration) — primitive lands; runtime consumers wired in S7.

## Out of scope (deferred)

- Router-side informer wiring → S7.
- VAP for content-safety floor cluster-minimum → S7 §7.14.
- `routes/inference_policy::check` consuming `PolicyEntry.payload` → S7.
- Replacing env-fed `budget::TokenBudgetTracker` inputs → S7.
- Cedar/Rego policy emission for content-safety floors via `agentmesh::PolicyEngine` → S7/S13.
- `v1alpha2` config-authority migration from `ClawSandbox.spec.inference` → S13.