### PR TITLE
phase2/clawmemory-reconciler: full ClawMemory CRD + binding compile + helm CRD (S5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,126 @@ floor compare-and-block, model-preference selection).
 - The runtime gate `inference-router::routes::inference_policy::check`
   (Phase 1) is **not modified in this slice**.
 
+### S5 `phase2/clawmemory-reconciler` — ClawMemory CRD + binding ConfigMap + helm CRD
+
+This slice ships the controller side of the Foundry Memory Store
+binding K8s primitive only. Per §3 non-compete, `ClawMemory` is a
+**binding/provisioning resource over Azure AI Foundry Memory Store**
+— it *configures* FMS for a sandbox; it is **not** a separate
+in-cluster memory backend. The runtime enforcement substrate stays on
+Phase 1 (`cli/src/plugin.ts::ensureMemoryStore` lazy-create through
+the router's Workload Identity + the existing `/memory_stores/*`
+proxy in `inference-router/src/routes/inference.rs`). The compiled
+JSON ConfigMap (`clawmemory-{name}-binding`) is the hand-off contract;
+the sandbox-side informer that consumes it is deferred to S7.
+
+#### Added
+
+- **`ClawMemory` CRD** — `controller/src/claw_memory.rs`, group
+  `azureclaw.azure.com`, version `v1alpha1`, namespaced, shortname
+  `cmem`. Spec fields: `storeName`, `sandboxRef.name`, `scope`,
+  `retentionDays?`, `deleteOnSandboxDelete` (default `true`),
+  `displayName?`. Status: `phase`, `observedGeneration`,
+  `conditions`, `bindingConfigMapRef`, `versionHash`,
+  `lastReconciledAt`. Print columns surface sandbox, store, scope,
+  phase, age.
+- **Pure compile module** — `controller/src/claw_memory_compile.rs`
+  with `compile_to_binding()` + `version_hash()` (sha256 first 16
+  bytes hex). 6 unit tests cover deterministic compile, full vs
+  minimal spec round-trip, hash sensitivity to spec changes, hash
+  stability across serde round-trip, and hash hex shape. Mirrors S4
+  `inference_policy_compile.rs` shape.
+- **Reconciler** — `controller/src/claw_memory_reconciler.rs`:
+  finalizer `azureclaw.azure.com/clawmemory-cleanup`, field manager
+  `azureclaw-controller/clawmemory`, SSA throughout. Compiles the
+  spec, persists as ConfigMap (`clawmemory-{name}-binding`, key
+  `binding.json`, labels `app.kubernetes.io/managed-by`,
+  `azureclaw.azure.com/clawmemory`,
+  `azureclaw.azure.com/artifact=claw-memory-binding`), sets full
+  status with `Ready`/`Progressing`/`Degraded` conditions reusing
+  `status/conditions.rs` (no condition-vocabulary fork). 7 unit tests.
+- **CEL admission rules** — 4 rules in
+  `controller/src/crd_validations.rs::claw_memory_validations()`:
+  DNS-label `storeName` (1-63 chars, `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`),
+  `sandboxRef.name` 1-253 chars, `scope` 1-256 chars, `retentionDays
+  > 0` when present. Injected via existing `inject_spec_validations`
+  helper. 5 unit tests.
+- **Helm CRD** — `deploy/helm/azureclaw/templates/crd-clawmemory.yaml`
+  (184 lines) generated via the existing
+  `helm_drift::dump_clawmemory_crd_yaml` dumper test (env-gated by
+  `DUMP_CLAWMEMORY_CRD_YAML=1`). New drift-detection test pins
+  helm-side YAML to Rust-derived schema; both round-trip.
+- **`main.rs` wiring** — `claw_memory_reconciler::run` spawned in
+  `tokio::select!` alongside the four prior reconcilers. CRD-missing
+  exit is non-fatal (matches S1–S4 pattern).
+- **Audit doc** — `docs/security-audits/2026-04-27-phase2-clawmemory-reconciler.md`
+  with two sign-offs, full STRIDE coverage, AGT boundary verification
+  (AGT 3.3.0 carries no Memory Store module — confirmed against
+  on-disk source), reuse map, out-of-scope set with explicit S7
+  forward-references, and reproduction of the Memory Store auth
+  caveat (Foundry project MI must hold `Azure AI User` on the
+  resource group; token audience `https://ai.azure.com/`) inside the
+  CRD module docstring so it travels with the schema.
+
+#### Reuse map (no-duplication rule, §0.2 / §0.3)
+
+11 existing seams reused:
+
+1. `controller/src/status::conditions` — vocabulary + transition-time
+   helpers used unchanged.
+2. `controller/src/mcp_server::LocalObjectRef` — 5th semantic client
+   (S1 signing/jwks, S2 profile, S3 agent-card, S4 guardrail-profile,
+   S5 binding-config).
+3. `controller/src/inference_policy_reconciler` (S4) — reconcile
+   shape + finalizer pattern + non-fatal CRD-missing exit, copied
+   verbatim.
+4. `controller/src/inference_policy_compile` (S4) — compile-module
+   shape (pure-fn + version_hash + tests).
+5. `controller/src/crd_validations::inject_spec_validations` — same
+   SSA-friendly CEL injector.
+6. `controller/src/helm_drift::canonical_form` — drift comparison
+   reused verbatim.
+7. `cli/src/plugin.ts::ensureMemoryStore` (Phase 1) — existing
+   GET-then-POST create path against Foundry; **not modified in S5**.
+   S7 wires the consumer that reads our ConfigMap.
+8. `cli/src/core/foundry-discovery.ts::FoundryEnsureMemoryStore`
+   (Phase 1) — discovery + lazy-create signature; not duplicated.
+9. `inference-router/src/routes/inference.rs` `/memory_stores/*`
+   proxy (Phase 1) — the router holds the Workload Identity for
+   Foundry calls; the controller has none. We do not give the
+   controller Foundry credentials.
+10. `inference-router/src/proxy.rs` idempotency map (Phase 1) —
+    PUT/DELETE/PATCH on `/memory-stores/x` already declared
+    non-idempotent; not modified.
+11. RFC-3339 `chrono::Utc::now().to_rfc3339_opts` formatter — copy-pasted
+    across reconcilers (lift to shared module deferred to S7).
+
+#### Out of scope (deferred to S7+)
+
+- **Foundry-side delete on CR delete** — finalizer cleans the binding
+  ConfigMap only; `deleteOnSandboxDelete` is preserved in the
+  compiled binding for the runtime path to act on.
+- **Conflict detection** across multiple `ClawMemory` CRs targeting
+  the same sandbox+scope pair — router-side dedupe at S7.
+- **Retention enforcement** — spec carries `retentionDays`; runtime
+  enforcement (Foundry TTL or scheduled `delete_scope` sweeps) wired
+  in S7 alongside hot-reload (§10.4 #11).
+- **Status `phase` matrix beyond Ready/Degraded** — full S7 matrix
+  cluster-wide.
+- **Cross-namespace `sandboxRef`** — out of scope by design.
+
+#### Test count delta
+
+- Controller: 218 → 238 (+20 tests). Workspace total green.
+
+#### §14.6 impact
+
+Strengthens column 7 (Foundry / M365 integration) — the fifth full
+CRD reconciler in the family lands. Phase 2 §14.6 column 12
+(Governance as K8s primitives) at 4/5 differentiator CRDs; only
+`ClawEval` (S6) outstanding.
+
+
 ## [Unreleased] — PR #44 `dev → main` uplift
 
 This entry covers **186 commits** on `dev` since `main`, structured as Phase 0

--- a/controller/src/claw_memory.rs
+++ b/controller/src/claw_memory.rs
@@ -1,0 +1,162 @@
+//! `ClawMemory` CRD — Phase 2 §8 entry 5 (S5).
+//!
+//! Per `docs/implementation-plan.md` §3 non-compete table, `ClawMemory`
+//! is **a binding/provisioning resource over Azure AI Foundry Memory
+//! Store** — it *configures* FMS for a sandbox; it is **not** a
+//! separate in-cluster memory backend. No in-cluster store is shipped.
+//!
+//! ## Scope (S5)
+//!
+//! This slice ships:
+//!
+//! 1. The CRD schema (`ClawMemory.spec`).
+//! 2. The reconciler that compiles the spec to a binding JSON and
+//!    publishes it as a `ConfigMap` (`clawmemory-{name}-binding`).
+//! 3. CEL admission rules for shape invariants.
+//! 4. Helm CRD with drift-checked schema.
+//!
+//! What this slice **does NOT** do (and why):
+//!
+//! - **Does NOT call Foundry directly from the controller.** Foundry
+//!   Memory Store creation today happens via the existing CLI path
+//!   (`cli/src/plugin.ts::ensureMemoryStore`), which calls Foundry
+//!   through the router (which holds the Workload Identity). The
+//!   controller has no Foundry credential and we explicitly do not
+//!   want to give it one. A future slice (S7+) wires a sandbox-side
+//!   informer that reads the binding ConfigMap and triggers the
+//!   existing `ensureMemoryStore` flow on first use.
+//! - **Does NOT enforce retention** at controller level. Retention is
+//!   declared in spec; runtime enforcement is Foundry-side (via the
+//!   `delete_scope` API on TTL or operator request) — see §10.4 #11
+//!   hot-reload + S7 wiring.
+//! - **Does NOT auto-delete the Foundry store on CR delete** in this
+//!   slice. The finalizer cleans up the binding ConfigMap; the
+//!   `deleteOnSandboxDelete` knob is preserved in the compiled binding
+//!   so the runtime path can act on it. Foundry-side delete from the
+//!   controller requires a router-mediated path (S7+).
+//!
+//! ## Reuse map (no-duplication rule, §0.2/§0.3)
+//!
+//! - **CRD-derive shape** (group, version, kind, namespaced, status,
+//!   shortname, printcolumns): mirrors S2/S3/S4.
+//! - **`LocalObjectRef` for status ConfigMap ref**: re-used from
+//!   [`crate::mcp_server`] — 5th semantic client now.
+//! - **`Condition` vocabulary**: re-used from
+//!   [`crate::status::conditions`] via the reconciler module.
+//! - **Memory Store API surface**: existing
+//!   `inference-router/src/routes/inference.rs` proxy
+//!   (`/memory_stores/*`) + `cli/src/core/foundry-discovery.ts`
+//!   `ensureMemoryStore` flow. **Not modified in this slice.**
+//!
+//! ## Memory Store auth caveat (verified in repo memory)
+//!
+//! Memory Store operations that internally call models (update,
+//! search-with-items) require the **project's** managed identity to
+//! have `Azure AI User` on the **resource group**, with token audience
+//! `https://ai.azure.com/`. CRD-level admission cannot validate this;
+//! the CR sets the binding shape, and runtime auth caveats remain a
+//! deployment-time concern.
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::mcp_server::LocalObjectRef;
+
+/// `ClawMemory.spec` — declares a Foundry Memory Store binding for a
+/// sandbox.
+///
+/// Resolution rule: a sandbox can have at most one `ClawMemory` per
+/// scope key; multiple `ClawMemory` CRs targeting the same sandbox
+/// must declare distinct `scope` values. Conflict detection is
+/// router-side (S7) — the CRD admission only validates shape.
+#[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[kube(
+    group = "azureclaw.azure.com",
+    version = "v1alpha1",
+    kind = "ClawMemory",
+    namespaced,
+    status = "ClawMemoryStatus",
+    shortname = "cmem",
+    printcolumn = r#"{"name":"Sandbox","type":"string","jsonPath":".spec.sandboxRef.name"}"#,
+    printcolumn = r#"{"name":"Store","type":"string","jsonPath":".spec.storeName"}"#,
+    printcolumn = r#"{"name":"Scope","type":"string","jsonPath":".spec.scope"}"#,
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawMemorySpec {
+    /// Foundry Memory Store name. The runtime path
+    /// (`cli/src/plugin.ts::ensureMemoryStore`) creates the store
+    /// on first use if absent. CEL: non-empty,
+    /// DNS-label-style (lowercase alphanumeric + dashes).
+    pub store_name: String,
+
+    /// Sandbox this binding applies to.
+    pub sandbox_ref: SandboxRef,
+
+    /// Scope key under which this sandbox writes/reads memories.
+    /// Foundry Memory Store partitions data per scope. CEL:
+    /// non-empty. Default convention (set by the runtime path if
+    /// absent here): `agent:{sandboxName}`.
+    pub scope: String,
+
+    /// Optional retention floor in days. Runtime path may apply a
+    /// `delete_scope` sweep when entries exceed this age. CEL:
+    /// `> 0` when set.
+    pub retention_days: Option<u32>,
+
+    /// If true (default), the runtime path must call `delete_scope`
+    /// on this scope when the sandbox is deleted or this CR is
+    /// deleted. The controller-side cleanup is finalizer-only on the
+    /// binding ConfigMap; Foundry-side delete via the router is
+    /// wired in S7+.
+    #[serde(default = "default_true")]
+    pub delete_on_sandbox_delete: bool,
+
+    /// Optional human-readable label.
+    pub display_name: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Reference to a sandbox by name (within the same namespace as the
+/// `ClawMemory` CR).
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxRef {
+    /// Sandbox name (`ClawSandbox.metadata.name`).
+    pub name: String,
+}
+
+/// Status of a `ClawMemory` reconcile.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawMemoryStatus {
+    #[serde(default)]
+    pub phase: Option<String>,
+
+    /// `metadata.generation` last successfully reconciled. KEP-1623.
+    #[serde(default)]
+    pub observed_generation: Option<i64>,
+
+    #[serde(default)]
+    pub conditions: Option<Vec<Condition>>,
+
+    /// Pointer to the binding `ConfigMap` produced by the reconciler.
+    /// The router-side informer (S7) watches by label selector; this
+    /// status field is for human / CLI consumption.
+    #[serde(default)]
+    pub binding_config_map_ref: Option<LocalObjectRef>,
+
+    /// Hex-encoded sha256 prefix of the compiled binding JSON.
+    #[serde(default)]
+    pub version_hash: Option<String>,
+
+    /// Last time the binding was compiled and pushed.
+    #[serde(default)]
+    pub last_reconciled_at: Option<String>,
+}

--- a/controller/src/claw_memory_compile.rs
+++ b/controller/src/claw_memory_compile.rs
@@ -1,0 +1,153 @@
+//! Pure-function compile step: `ClawMemorySpec` → binding JSON.
+//!
+//! Separated from the reconciler so it is unit-testable without a
+//! `kube::Client`. The output JSON is consumed by the runtime path
+//! (`cli/src/plugin.ts::ensureMemoryStore` + the router's existing
+//! `/memory_stores/*` proxy in
+//! `inference-router/src/routes/inference.rs`). S5 ships only the
+//! producer side; S7 wires the runtime informer that reads from this
+//! ConfigMap.
+//!
+//! ## What the compiler is NOT
+//!
+//! - **Not** a Foundry client. Foundry calls happen at runtime
+//!   through the router's Workload Identity, not from the controller.
+//!   The compiled binding describes intent; runtime executes.
+//! - **Not** a retention enforcer. `retentionDays` flows verbatim;
+//!   sweep execution happens via Foundry-side TTL or runtime-path
+//!   `delete_scope`.
+//! - **Not** a scope conflict resolver. Multiple `ClawMemory` CRs
+//!   targeting the same sandbox+scope is a router-side concern (S7);
+//!   admission CEL only checks shape.
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::claw_memory::ClawMemorySpec;
+
+/// Compile a `ClawMemorySpec` into the binding JSON the controller
+/// publishes as a `ConfigMap`.
+///
+/// Shape:
+///
+/// ```json
+/// {
+///   "storeName": "...",
+///   "sandboxRef": { "name": "..." },
+///   "scope": "...",
+///   "retentionDays": 30 | null,
+///   "deleteOnSandboxDelete": true,
+///   "displayName": "..." | null
+/// }
+/// ```
+#[must_use]
+pub fn compile_to_binding(spec: &ClawMemorySpec) -> Value {
+    json!({
+        "storeName": spec.store_name,
+        "sandboxRef": { "name": spec.sandbox_ref.name },
+        "scope": spec.scope,
+        "retentionDays": spec.retention_days,
+        "deleteOnSandboxDelete": spec.delete_on_sandbox_delete,
+        "displayName": spec.display_name,
+    })
+}
+
+/// Stable SHA-256 over the canonicalised compiled binding, hex-encoded
+/// (first 32 chars). Used as `versionHash` for change detection.
+#[must_use]
+pub fn version_hash(binding: &Value) -> String {
+    let bytes = serde_json::to_vec(binding).expect("serde_json::Value always serialises");
+    let digest = Sha256::digest(&bytes);
+    hex::encode(&digest[..16])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claw_memory::{ClawMemorySpec, SandboxRef};
+
+    fn full_spec() -> ClawMemorySpec {
+        ClawMemorySpec {
+            store_name: "agent-x-mem".into(),
+            sandbox_ref: SandboxRef {
+                name: "agent-x".into(),
+            },
+            scope: "agent:agent-x".into(),
+            retention_days: Some(30),
+            delete_on_sandbox_delete: true,
+            display_name: Some("Agent X memory".into()),
+        }
+    }
+
+    #[test]
+    fn compile_minimal_spec_round_trips() {
+        let spec = ClawMemorySpec {
+            store_name: "minimal".into(),
+            sandbox_ref: SandboxRef {
+                name: "agent".into(),
+            },
+            scope: "agent:agent".into(),
+            ..ClawMemorySpec::default()
+        };
+        let binding = compile_to_binding(&spec);
+        assert_eq!(binding["storeName"], "minimal");
+        assert_eq!(binding["sandboxRef"]["name"], "agent");
+        assert_eq!(binding["scope"], "agent:agent");
+        assert!(binding["retentionDays"].is_null());
+        // delete_on_sandbox_delete defaults to false on Default ⇒ false.
+        assert_eq!(binding["deleteOnSandboxDelete"], false);
+    }
+
+    #[test]
+    fn compile_full_spec_round_trips() {
+        let spec = full_spec();
+        let binding = compile_to_binding(&spec);
+        assert_eq!(binding["storeName"], "agent-x-mem");
+        assert_eq!(binding["sandboxRef"]["name"], "agent-x");
+        assert_eq!(binding["scope"], "agent:agent-x");
+        assert_eq!(binding["retentionDays"], 30);
+        assert_eq!(binding["deleteOnSandboxDelete"], true);
+        assert_eq!(binding["displayName"], "Agent X memory");
+    }
+
+    #[test]
+    fn compile_is_deterministic() {
+        let spec = full_spec();
+        let a = compile_to_binding(&spec);
+        let b = compile_to_binding(&spec);
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn version_hash_changes_on_spec_change() {
+        let mut a = full_spec();
+        let mut b = full_spec();
+        b.retention_days = Some(7);
+        let h_a = version_hash(&compile_to_binding(&a));
+        let h_b = version_hash(&compile_to_binding(&b));
+        assert_ne!(h_a, h_b);
+
+        a.display_name = Some("Agent X memory".into());
+        let h_a2 = version_hash(&compile_to_binding(&a));
+        assert_eq!(h_a, h_a2);
+    }
+
+    #[test]
+    fn version_hash_is_stable_across_serde_round_trip() {
+        let spec = full_spec();
+        let binding_a = compile_to_binding(&spec);
+        let s = serde_json::to_string(&binding_a).unwrap();
+        let binding_b: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(version_hash(&binding_a), version_hash(&binding_b));
+    }
+
+    #[test]
+    fn version_hash_is_hex_16_bytes() {
+        let h = version_hash(&compile_to_binding(&full_spec()));
+        assert_eq!(h.len(), 32);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -1,0 +1,440 @@
+//! `ClawMemory` reconciler — Phase 2 §8 entry 5 (S5).
+//!
+//! Watches `ClawMemory` CRs and, for each:
+//!
+//! 1. Ensures finalizer (`azureclaw.azure.com/clawmemory-cleanup`).
+//! 2. Compiles the binding via
+//!    [`crate::claw_memory_compile::compile_to_binding`].
+//! 3. Persists as `ConfigMap` (`clawmemory-{name}-binding`,
+//!    key `binding.json`).
+//! 4. Sets full status (phase, observedGeneration, conditions,
+//!    bindingConfigMapRef, versionHash, lastReconciledAt).
+//!
+//! ## Reuse map (no-duplication rule, §0.2/§0.3)
+//!
+//! Same shape as S2 (ToolPolicy), S3 (A2AAgent), S4 (InferencePolicy).
+//! - Conditions vocabulary + transition-time helpers from
+//!   [`crate::status::conditions`].
+//! - Compile module is single-purpose and reconciler does no JSON
+//!   shaping itself.
+//! - **No Foundry calls** — Foundry interaction stays in the runtime
+//!   path (`cli/src/plugin.ts::ensureMemoryStore` + the router's
+//!   `/memory_stores/*` proxy). The S7 informer wires the consumer.
+
+use anyhow::Result;
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::{
+    Client, ResourceExt,
+    api::{Api, ListParams, ObjectMeta, Patch, PatchParams},
+    runtime::controller::{Action, Controller},
+};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::claw_memory::{ClawMemory, ClawMemoryStatus};
+use crate::claw_memory_compile::{compile_to_binding, version_hash};
+use crate::mcp_server::LocalObjectRef;
+use crate::status::conditions::{self, reason, status as cond_status};
+
+const FIELD_MANAGER: &str = "azureclaw-controller/clawmemory";
+const FINALIZER: &str = "azureclaw.azure.com/clawmemory-cleanup";
+
+const REQUEUE_OK: Duration = Duration::from_secs(300);
+const REQUEUE_FAIL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, thiserror::Error)]
+enum ReconcileError {
+    #[error("Kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("JSON serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+}
+
+impl ReconcileError {
+    fn class(&self) -> &'static str {
+        match self {
+            ReconcileError::Kube(_) => "kube_api",
+            ReconcileError::SerdeJson(_) => "serde",
+        }
+    }
+}
+
+struct Ctx {
+    client: Client,
+}
+
+async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
+    let name = memory.name_any();
+    let ns = memory.namespace().unwrap_or_else(|| "default".into());
+    tracing::info!(clawmemory = %name, ns = %ns, "Reconciling ClawMemory");
+
+    let api: Api<ClawMemory> = Api::namespaced(ctx.client.clone(), &ns);
+    let configmaps: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), &ns);
+
+    if memory.metadata.deletion_timestamp.is_some() {
+        return finalize(&api, &configmaps, &memory, &name).await;
+    }
+
+    if !memory
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|f| f.iter().any(|s| s == FINALIZER))
+        .unwrap_or(false)
+    {
+        let patch = json!({"metadata":{"finalizers":[FINALIZER]}});
+        api.patch(
+            &name,
+            &PatchParams::apply(FIELD_MANAGER).force(),
+            &Patch::Apply(patch),
+        )
+        .await?;
+        return Ok(Action::requeue(Duration::from_secs(1)));
+    }
+
+    let prior_conditions = memory
+        .status
+        .as_ref()
+        .and_then(|s| s.conditions.clone())
+        .unwrap_or_default();
+    let observed_generation = memory.metadata.generation;
+
+    let binding = compile_to_binding(&memory.spec);
+    let v_hash = version_hash(&binding);
+
+    let cm_name = format!("clawmemory-{name}-binding");
+    let mut degraded: Option<(&'static str, String)> = None;
+
+    match ensure_binding_configmap(&configmaps, &cm_name, &name, &binding, &v_hash).await {
+        Ok(()) => {
+            tracing::info!(
+                clawmemory = %name,
+                ns = %ns,
+                version_hash = %v_hash,
+                generation = observed_generation.unwrap_or(0),
+                store_name = %memory.spec.store_name,
+                scope = %memory.spec.scope,
+                "ClawMemoryReconciled"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                clawmemory = %name,
+                error_class = e.class(),
+                "ClawMemoryBindingWriteFailed"
+            );
+            degraded = Some(("BindingWriteFailed", e.to_string()));
+        }
+    }
+
+    let new_conditions = build_conditions(
+        &prior_conditions,
+        observed_generation,
+        degraded.as_ref().map(|(r, m)| (*r, m.as_str())),
+    );
+    let phase = if degraded.is_some() {
+        "Degraded"
+    } else {
+        "Ready"
+    };
+
+    let status_patch = json!({
+        "status": ClawMemoryStatus {
+            phase: Some(phase.into()),
+            observed_generation,
+            conditions: Some(new_conditions),
+            binding_config_map_ref: Some(LocalObjectRef { name: cm_name.clone() }),
+            version_hash: Some(v_hash),
+            last_reconciled_at: Some(rfc3339_now()),
+        }
+    });
+    api.patch_status(
+        &name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(status_patch),
+    )
+    .await?;
+
+    if degraded.is_some() {
+        Ok(Action::requeue(REQUEUE_FAIL))
+    } else {
+        Ok(Action::requeue(REQUEUE_OK))
+    }
+}
+
+fn rfc3339_now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn build_conditions(
+    prior: &[Condition],
+    observed_generation: Option<i64>,
+    degraded: Option<(&str, &str)>,
+) -> Vec<Condition> {
+    let mut out: Vec<Condition> = Vec::with_capacity(3);
+    let prior_ready = conditions::find(prior, conditions::TYPE_READY);
+    let prior_progressing = conditions::find(prior, conditions::TYPE_PROGRESSING);
+    let prior_degraded = conditions::find(prior, conditions::TYPE_DEGRADED);
+
+    match degraded {
+        Some((reason_value, message)) => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::FALSE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::FAILED,
+                "binding write failed",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::TRUE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+        }
+        None => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::TRUE,
+                reason::RECONCILED,
+                "ClawMemory binding compiled and published",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "compile complete",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "no errors",
+                observed_generation,
+            ));
+        }
+    }
+    out
+}
+
+async fn ensure_binding_configmap(
+    api: &Api<ConfigMap>,
+    cm_name: &str,
+    owner: &str,
+    binding: &serde_json::Value,
+    v_hash: &str,
+) -> Result<(), ReconcileError> {
+    let json_str = serde_json::to_string_pretty(binding)?;
+    let mut data: BTreeMap<String, String> = BTreeMap::new();
+    data.insert("binding.json".into(), json_str);
+    let mut annotations: BTreeMap<String, String> = BTreeMap::new();
+    annotations.insert(
+        "azureclaw.azure.com/clawmemory-version-hash".into(),
+        v_hash.into(),
+    );
+    let cm = ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(cm_name.into()),
+            annotations: Some(annotations),
+            labels: Some(BTreeMap::from([
+                (
+                    "app.kubernetes.io/managed-by".into(),
+                    "azureclaw-controller".into(),
+                ),
+                ("azureclaw.azure.com/clawmemory".into(), owner.into()),
+                (
+                    "azureclaw.azure.com/artifact".into(),
+                    "claw-memory-binding".into(),
+                ),
+            ])),
+            ..Default::default()
+        },
+        data: Some(data),
+        ..Default::default()
+    };
+    api.patch(
+        cm_name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(&cm),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn finalize(
+    api: &Api<ClawMemory>,
+    configmaps: &Api<ConfigMap>,
+    memory: &ClawMemory,
+    name: &str,
+) -> Result<Action, ReconcileError> {
+    let cm_name = format!("clawmemory-{name}-binding");
+    let _ = configmaps
+        .delete(&cm_name, &Default::default())
+        .await
+        .map(|_| ())
+        .or_else(|e: kube::Error| -> Result<(), kube::Error> {
+            if matches!(e, kube::Error::Api(ref ae) if ae.code == 404) {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        });
+
+    let finalizers: Vec<String> = memory
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|v| v.iter().filter(|f| *f != FINALIZER).cloned().collect())
+        .unwrap_or_default();
+    let patch = json!({"metadata":{"finalizers": finalizers}});
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(patch),
+    )
+    .await?;
+    tracing::info!(clawmemory = %name, "ClawMemoryDeleted");
+    Ok(Action::await_change())
+}
+
+fn error_policy(memory: Arc<ClawMemory>, error: &ReconcileError, _ctx: Arc<Ctx>) -> Action {
+    tracing::warn!(
+        clawmemory = %memory.name_any(),
+        error_class = error.class(),
+        error = %error,
+        "ClawMemory reconcile error — requeuing in 30s"
+    );
+    Action::requeue(Duration::from_secs(30))
+}
+
+pub async fn run(client: Client) -> Result<()> {
+    let memories: Api<ClawMemory> = Api::all(client.clone());
+    match memories.list(&ListParams::default().limit(1)).await {
+        Ok(_) => tracing::info!("ClawMemory CRD found — starting controller"),
+        Err(e) => {
+            tracing::warn!("ClawMemory CRD not installed — reconciler disabled: {e}");
+            return Ok(());
+        }
+    }
+    let ctx = Arc::new(Ctx { client });
+    Controller::new(memories, kube::runtime::watcher::Config::default())
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok(o) => tracing::debug!("ClawMemory reconciled {:?}", o),
+                Err(e) => tracing::warn!("ClawMemory reconcile failed: {e:?}"),
+            }
+        })
+        .await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_now_is_utc_z_suffixed() {
+        let s = rfc3339_now();
+        assert!(s.ends_with('Z'), "got {s}");
+        assert_eq!(s.len(), 20);
+    }
+
+    #[test]
+    fn error_class_is_closed_set() {
+        let serde_err: serde_json::Error =
+            serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let e = ReconcileError::SerdeJson(serde_err);
+        assert_eq!(e.class(), "serde");
+
+        fn assert_closed(class: &str) {
+            assert!(matches!(class, "kube_api" | "serde"));
+        }
+        assert_closed(e.class());
+    }
+
+    #[test]
+    fn build_conditions_emits_all_three_types_on_success() {
+        let conds = build_conditions(&[], Some(1), None);
+        assert_eq!(conds.len(), 3);
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::TRUE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::FALSE);
+    }
+
+    #[test]
+    fn build_conditions_emits_all_three_types_on_failure() {
+        let conds = build_conditions(&[], Some(1), Some(("BindingWriteFailed", "boom")));
+        assert_eq!(conds.len(), 3);
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::FALSE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::TRUE);
+        assert_eq!(degraded.reason, "BindingWriteFailed");
+    }
+
+    #[test]
+    fn build_conditions_preserves_transition_time_when_status_unchanged() {
+        let first = build_conditions(&[], Some(1), None);
+        let second = build_conditions(&first, Some(2), None);
+        let r1 = first
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        let r2 = second
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(r1.last_transition_time, r2.last_transition_time);
+    }
+
+    #[test]
+    fn finalizer_constant_is_dns_subdomain() {
+        assert!(FINALIZER.contains('/'));
+        let (domain, key) = FINALIZER.split_once('/').unwrap();
+        assert_eq!(domain, "azureclaw.azure.com");
+        assert!(!key.is_empty());
+    }
+
+    #[test]
+    fn field_manager_is_per_reconciler() {
+        assert_eq!(FIELD_MANAGER, "azureclaw-controller/clawmemory");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/mcp");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/toolpolicy");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/a2aagent");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/inferencepolicy");
+    }
+}

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -46,6 +46,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
 use kube::CustomResourceExt;
 
 use crate::a2a_agent::A2AAgent;
+use crate::claw_memory::ClawMemory;
 use crate::inference_policy::InferencePolicy;
 use crate::mcp_server::McpServer;
 use crate::tool_policy::ToolPolicy;
@@ -299,6 +300,67 @@ pub fn inference_policy_crd() -> CustomResourceDefinition {
         .expect("kube-rs derive must produce a spec property on InferencePolicy")
 }
 
+/// `ClawMemory.spec` CEL rules. Phase 2 §8 entry 5 (S5).
+///
+/// `ClawMemory` is a binding/provisioning resource over Azure AI
+/// Foundry Memory Store (per `docs/implementation-plan.md` §3
+/// non-compete). The CRD is shape-only — runtime auth and Foundry
+/// availability are out of admission scope. Rules:
+///
+/// - `storeName` non-empty + DNS-label-style (lowercase alnum + `-`,
+///   1-63 chars). Foundry treats store names as case-sensitive
+///   identifiers; pinning to DNS-label form keeps them safe to use
+///   verbatim in URLs and ConfigMap labels.
+/// - `sandboxRef.name` non-empty (1-253 chars; same length cap as
+///   K8s object names).
+/// - `scope` non-empty (1-256 chars). Foundry uses scope as a
+///   partition key — empty scope would cross-contaminate every
+///   sandbox bound to the same store.
+/// - `retentionDays > 0` when present. Zero would request immediate
+///   deletion, which is what `delete_scope` is for.
+#[must_use]
+pub fn claw_memory_validations() -> Vec<ValidationRule> {
+    vec![
+        ValidationRule {
+            rule: "size(self.storeName) > 0 && size(self.storeName) <= 63 && self.storeName.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')".into(),
+            message: Some(
+                "spec.storeName must be a DNS-label (1-63 chars, lowercase alphanumeric + dashes)".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "size(self.sandboxRef.name) > 0 && size(self.sandboxRef.name) <= 253".into(),
+            message: Some("spec.sandboxRef.name must be 1-253 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "size(self.scope) > 0 && size(self.scope) <= 256".into(),
+            message: Some("spec.scope must be 1-256 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.retentionDays) || self.retentionDays > 0".into(),
+            message: Some(
+                "spec.retentionDays must be > 0 when set (use delete_scope for immediate deletion)".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+    ]
+}
+
+/// `ClawMemory` CRD with [`claw_memory_validations`] injected.
+///
+/// Panics only if kube-rs ever produces a CRD whose `spec` is missing.
+#[must_use]
+pub fn claw_memory_crd() -> CustomResourceDefinition {
+    inject_spec_validations(ClawMemory::crd(), claw_memory_validations())
+        .expect("kube-rs derive must produce a spec property on ClawMemory")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -509,6 +571,66 @@ mod tests {
         let y = serde_yaml::to_string(&crd).expect("serializes");
         assert!(y.contains("x-kubernetes-validations"));
         assert!(y.contains("monthlyTokens"));
+    }
+
+    // ---- ClawMemory (S5) ------------------------------------------------
+
+    #[test]
+    fn claw_memory_validations_are_non_empty() {
+        assert!(!claw_memory_validations().is_empty());
+    }
+
+    #[test]
+    fn every_claw_memory_rule_has_message_and_rule() {
+        for rule in claw_memory_validations() {
+            assert!(!rule.rule.is_empty(), "rule body must not be empty");
+            let msg = rule.message.as_deref().unwrap_or("");
+            assert!(!msg.is_empty(), "rule '{}' missing message", rule.rule);
+        }
+    }
+
+    #[test]
+    fn claw_memory_crd_has_spec_validations_after_injection() {
+        let crd = claw_memory_crd();
+        let v = spec_validations(&crd);
+        assert_eq!(v.len(), claw_memory_validations().len());
+    }
+
+    #[test]
+    fn claw_memory_rules_mention_store_name_scope_and_retention_invariants() {
+        let rules: Vec<String> = claw_memory_validations()
+            .into_iter()
+            .map(|r| r.rule)
+            .collect();
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("storeName") && r.contains("matches")),
+            "must enforce storeName DNS-label shape; got rules: {rules:?}"
+        );
+        assert!(
+            rules.iter().any(|r| r.contains("sandboxRef.name")),
+            "must validate sandboxRef.name; got rules: {rules:?}"
+        );
+        assert!(
+            rules.iter().any(|r| r.contains("scope")),
+            "must validate scope; got rules: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("retentionDays") && r.contains("> 0")),
+            "must enforce retentionDays > 0; got rules: {rules:?}"
+        );
+    }
+
+    #[test]
+    fn claw_memory_crd_is_serde_round_trippable() {
+        let crd = claw_memory_crd();
+        let y = serde_yaml::to_string(&crd).expect("serializes");
+        assert!(y.contains("x-kubernetes-validations"));
+        assert!(y.contains("storeName"));
+        assert!(y.contains("scope"));
     }
 
     #[test]

--- a/controller/src/helm_drift.rs
+++ b/controller/src/helm_drift.rs
@@ -29,7 +29,7 @@
 
 #[cfg(test)]
 use crate::crd_validations::{
-    a2a_agent_crd, inference_policy_crd, mcp_server_crd, tool_policy_crd,
+    a2a_agent_crd, claw_memory_crd, inference_policy_crd, mcp_server_crd, tool_policy_crd,
 };
 
 const MCP_HELM_CRD_PATH: &str = concat!(
@@ -50,6 +50,11 @@ const A2AAGENT_HELM_CRD_PATH: &str = concat!(
 const INFERENCEPOLICY_HELM_CRD_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml"
+);
+
+const CLAWMEMORY_HELM_CRD_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../deploy/helm/azureclaw/templates/crd-clawmemory.yaml"
 );
 
 /// Strip non-schema fields that legitimately differ between the Rust
@@ -189,5 +194,26 @@ mod tests {
             rust_crd_value,
             "inferencepolicy",
         );
+    }
+
+    /// One-shot dumper for the clawmemory CRD. Run via:
+    ///
+    ///   DUMP_CLAWMEMORY_CRD_YAML=1 cargo test --bin azureclaw-controller \
+    ///       helm_drift::tests::dump_clawmemory_crd_yaml -- --nocapture
+    #[test]
+    fn dump_clawmemory_crd_yaml() {
+        if std::env::var("DUMP_CLAWMEMORY_CRD_YAML").is_err() {
+            return;
+        }
+        let crd = claw_memory_crd();
+        let yaml = serde_yaml::to_string(&crd).expect("serialize crd to YAML");
+        println!("---\n{yaml}");
+    }
+
+    #[test]
+    fn helm_clawmemory_crd_matches_rust_schema() {
+        let rust_crd_value =
+            serde_json::to_value(claw_memory_crd()).expect("rust crd serializes to JSON");
+        assert_helm_matches_rust(CLAWMEMORY_HELM_CRD_PATH, rust_crd_value, "clawmemory");
     }
 }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -14,6 +14,9 @@
 mod a2a_agent;
 mod a2a_agent_compile;
 mod a2a_agent_reconciler;
+mod claw_memory;
+mod claw_memory_compile;
+mod claw_memory_reconciler;
 mod crd;
 #[allow(dead_code)]
 // CRD-installation pipeline (Phase 1 close-out + future kubectl-claw-attest) consumes these helpers.
@@ -84,6 +87,10 @@ async fn main() -> Result<()> {
         let client = client.clone();
         tokio::spawn(async move { inference_policy_reconciler::run(client).await })
     };
+    let claw_memory_handle = {
+        let client = client.clone();
+        tokio::spawn(async move { claw_memory_reconciler::run(client).await })
+    };
     let mesh_peer_handle = {
         let client = client.clone();
         tokio::spawn(async move {
@@ -146,6 +153,9 @@ async fn main() -> Result<()> {
             res??;
         }
         res = inference_policy_handle => {
+            res??;
+        }
+        res = claw_memory_handle => {
             res??;
         }
         res = mesh_peer_handle => {

--- a/deploy/helm/azureclaw/templates/crd-clawmemory.yaml
+++ b/deploy/helm/azureclaw/templates/crd-clawmemory.yaml
@@ -1,0 +1,184 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clawmemories.azureclaw.azure.com
+spec:
+  group: azureclaw.azure.com
+  names:
+    categories: []
+    kind: ClawMemory
+    plural: clawmemories
+    shortNames:
+    - cmem
+    singular: clawmemory
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sandboxRef.name
+      name: Sandbox
+      type: string
+    - jsonPath: .spec.storeName
+      name: Store
+      type: string
+    - jsonPath: .spec.scope
+      name: Scope
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for ClawMemorySpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
+              `ClawMemory.spec` — declares a Foundry Memory Store binding for a
+              sandbox.
+
+              Resolution rule: a sandbox can have at most one `ClawMemory` per
+              scope key; multiple `ClawMemory` CRs targeting the same sandbox
+              must declare distinct `scope` values. Conflict detection is
+              router-side (S7) — the CRD admission only validates shape.
+            properties:
+              deleteOnSandboxDelete:
+                default: true
+                description: |-
+                  If true (default), the runtime path must call `delete_scope`
+                  on this scope when the sandbox is deleted or this CR is
+                  deleted. The controller-side cleanup is finalizer-only on the
+                  binding ConfigMap; Foundry-side delete via the router is
+                  wired in S7+.
+                type: boolean
+              displayName:
+                description: Optional human-readable label.
+                nullable: true
+                type: string
+              retentionDays:
+                description: |-
+                  Optional retention floor in days. Runtime path may apply a
+                  `delete_scope` sweep when entries exceed this age. CEL:
+                  `> 0` when set.
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+              sandboxRef:
+                description: Sandbox this binding applies to.
+                properties:
+                  name:
+                    description: Sandbox name (`ClawSandbox.metadata.name`).
+                    type: string
+                required:
+                - name
+                type: object
+              scope:
+                description: |-
+                  Scope key under which this sandbox writes/reads memories.
+                  Foundry Memory Store partitions data per scope. CEL:
+                  non-empty. Default convention (set by the runtime path if
+                  absent here): `agent:{sandboxName}`.
+                type: string
+              storeName:
+                description: |-
+                  Foundry Memory Store name. The runtime path
+                  (`cli/src/plugin.ts::ensureMemoryStore`) creates the store
+                  on first use if absent. CEL: non-empty,
+                  DNS-label-style (lowercase alphanumeric + dashes).
+                type: string
+            required:
+            - sandboxRef
+            - scope
+            - storeName
+            type: object
+            x-kubernetes-validations:
+            - message: spec.storeName must be a DNS-label (1-63 chars, lowercase alphanumeric + dashes)
+              reason: FieldValueInvalid
+              rule: size(self.storeName) > 0 && size(self.storeName) <= 63 && self.storeName.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+            - message: spec.sandboxRef.name must be 1-253 characters
+              reason: FieldValueInvalid
+              rule: size(self.sandboxRef.name) > 0 && size(self.sandboxRef.name) <= 253
+            - message: spec.scope must be 1-256 characters
+              reason: FieldValueInvalid
+              rule: size(self.scope) > 0 && size(self.scope) <= 256
+            - message: spec.retentionDays must be > 0 when set (use delete_scope for immediate deletion)
+              reason: FieldValueInvalid
+              rule: '!has(self.retentionDays) || self.retentionDays > 0'
+          status:
+            description: Status of a `ClawMemory` reconcile.
+            nullable: true
+            properties:
+              bindingConfigMapRef:
+                description: |-
+                  Pointer to the binding `ConfigMap` produced by the reconciler.
+                  The router-side informer (S7) watches by label selector; this
+                  status field is for human / CLI consumption.
+                nullable: true
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              lastReconciledAt:
+                description: Last time the binding was compiled and pushed.
+                nullable: true
+                type: string
+              observedGeneration:
+                description: '`metadata.generation` last successfully reconciled. KEP-1623.'
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                nullable: true
+                type: string
+              versionHash:
+                description: Hex-encoded sha256 prefix of the compiled binding JSON.
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: ClawMemory
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/security-audits/2026-04-27-phase2-clawmemory-reconciler.md
+++ b/docs/security-audits/2026-04-27-phase2-clawmemory-reconciler.md
@@ -1,0 +1,244 @@
+# Security audit — Phase 2 S5 `ClawMemory` reconciler
+
+**Date:** 2026-04-27
+**Slice:** S5 `phase2-clawmemory` (Phase 2 §8 entry 5)
+**Branch:** `phase2/clawmemory-reconciler`
+**Sign-offs:** see §11.
+
+---
+
+## §0. Reuse map (no-duplication rule, §0.2 / §0.3)
+
+This slice reuses every existing seam from S1–S4. The single new
+behaviour is a Foundry Memory Store **binding** declaration; no
+parallel runtime path is introduced.
+
+| # | Existing seam | Reuse in S5 |
+|---|---|---|
+| 1 | `controller/src/status::conditions` | Conditions vocabulary + transition-time helpers used unchanged. |
+| 2 | `controller/src/mcp_server::LocalObjectRef` | 5th semantic client (S1 signing/jwks, S2 profile, S3 agent-card, S4 guardrail-profile, S5 binding-config). |
+| 3 | `controller/src/inference_policy_reconciler` (S4) | Reconcile shape + finalizer pattern + non-fatal CRD-missing exit, copied verbatim. |
+| 4 | `controller/src/inference_policy_compile` (S4) | Compile-module shape (pure-fn + version_hash + tests). |
+| 5 | `controller/src/crd_validations::inject_spec_validations` | Same SSA-friendly CEL injector. |
+| 6 | `controller/src/helm_drift::canonical_form` | Drift comparison reused verbatim. |
+| 7 | `cli/src/plugin.ts::ensureMemoryStore` (Phase 1) | Existing GET-then-POST create path against Foundry. **Not modified in S5.** S7 wires the consumer that reads our `ConfigMap`. |
+| 8 | `cli/src/core/foundry-discovery.ts::FoundryEnsureMemoryStore` (Phase 1) | Discovery + lazy-create signature. Not duplicated. |
+| 9 | `inference-router/src/routes/inference.rs` `/memory_stores/*` proxy (Phase 1) | The router holds the Workload Identity for Foundry calls; the controller has none. We do not give the controller Foundry credentials. |
+| 10 | `inference-router/src/proxy.rs` idempotency map (Phase 1) | PUT/DELETE/PATCH on `/memory-stores/x` already declared non-idempotent. Not modified. |
+| 11 | RFC-3339 formatter `chrono::Utc::now().to_rfc3339_opts` | Copy-pasted across reconcilers (lift to shared module deferred to S7). |
+
+**Single new struct:** none beyond `ClawMemorySpec`, `SandboxRef`,
+`ClawMemoryStatus`. `LocalObjectRef` semantically extended (5th
+client). No new finalizer pattern, no new compile-module pattern.
+
+---
+
+## §1. AGT boundary (verified 2026-04-27 against agt-toolkit 3.3.0)
+
+§3 of the implementation plan demands that AzureClaw never duplicates
+AGT scope. Verified by reading
+`/Users/pallakatos/Private/Repos/agt/agent-governance-toolkit`
+directly.
+
+**Result:** AGT has **no Memory Store module**, no Foundry binding
+type, no scoped retention policy. Memory Store is a pure Azure AI
+Foundry concern. `ClawMemory` is a K8s-native binding/provisioning
+declaration over an external (Foundry) resource — outside AGT's
+scope, exactly as the §3 non-compete table intends:
+
+> `ClawMemory` CRD is a **binding/provisioning resource over Foundry
+> Memory Store** — it *configures* FMS, it is not a separate store.
+> No in-cluster memory backend shipped.
+
+S5 ships only the K8s primitive + compiled binding JSON. No AGT
+integration, no parallel runtime path. The runtime path
+(`cli/src/plugin.ts::ensureMemoryStore`) stays where it is; S7+ wires
+a sandbox-side informer that reads `clawmemory-{name}-binding` and
+triggers the existing lazy-create path on first inference call.
+
+---
+
+## §2. Threat model
+
+### §2.1 Spoofing
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 1 | Operator submits `ClawMemory` with `storeName` colliding with another tenant's store | DNS-label CEL rule + tenant scope is a Foundry-side concern (each project = its own tenancy boundary). Cross-namespace collision in K8s blocked by `metadata.name` uniqueness per ns. |
+| 2 | Crafted `sandboxRef.name` pointing to nonexistent sandbox | CEL only validates shape; runtime path no-ops on missing sandbox. No privilege escalation — the binding ConfigMap is consumed only by the sandbox pod with that name (label selector). |
+
+### §2.2 Tampering
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 3 | Tamper with `clawmemory-{name}-binding` ConfigMap | Owned by `azureclaw-controller/clawmemory` field manager via Server-Side Apply; S7 lifts SSA enforcement cluster-wide. RBAC must restrict CM write to the controller SA. |
+| 4 | Tamper with the spec to escalate `retentionDays` past Foundry-side cap | Foundry-side enforces its own caps; the CR is a *floor*, not a *ceiling*. CEL `> 0` blocks zero/negative. |
+
+### §2.3 Repudiation
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 5 | "I never bound that store" | Reconciler emits structured log `ClawMemoryReconciled` with name, namespace, store_name, scope, version_hash, generation. Phase 3 signed audit chain (§10.4 #8) makes this verifiable. |
+
+### §2.4 Information disclosure
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 6 | Scope value leaks PII | `scope` is operator-supplied; the CR is opaque from the controller's perspective. Operators are advised to use the `agent:{sandboxName}` convention. Phase 3 may add an admission policy that rejects PII-shaped scopes (PII-detection out of S5 scope). |
+| 7 | Memory Store auth caveat: Memory Store ops that internally call models authenticate as the **project's** managed identity, **not** the AI Services account MI | Documented in repo memory (since Phase 1) and reproduced in CR docstring. Operators must enable system-assigned MI on the project and assign `Azure AI User` on the **resource group**. CRD admission cannot validate this; it's a deployment-time prerequisite. |
+
+### §2.5 Denial of service
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 8 | Reconcile loop on Foundry 5xx | **Not exposed** — controller never calls Foundry. The lazy-create path runs in the sandbox/router and has its own retry policy (Phase 1). |
+| 9 | Many `ClawMemory` CRs targeting one sandbox | Allowed by design (each declares a distinct scope); router-side conflict detection at S7. CRD admission only validates shape. |
+
+### §2.6 Elevation of privilege
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 10 | Operator cross-namespace data access via spoofed `sandboxRef.name` | `ClawMemory` is namespaced; `sandboxRef.name` resolves within the same namespace. Cross-namespace requires distinct CR. |
+| 11 | Controller gains Foundry access | **Not granted.** Controller has zero Foundry credentials. All Foundry traffic flows through the per-sandbox router using Workload Identity. |
+
+---
+
+## §3. Out of scope (deferred to S7+)
+
+1. **Foundry-side delete on CR delete.** S5 finalizer cleans up only
+   the binding ConfigMap; the `deleteOnSandboxDelete` knob is
+   preserved in the compiled binding for the runtime path to act on.
+   Foundry-side deletion requires a router-mediated path (controller
+   has no Foundry credentials). Tracked for S7+.
+
+2. **Conflict detection across multiple `ClawMemory` CRs targeting
+   the same sandbox+scope pair.** Admission CEL validates shape only;
+   router-side dedupe at S7.
+
+3. **Retention enforcement.** Spec carries `retentionDays`; runtime
+   enforcement (Foundry TTL or scheduled `delete_scope` sweeps) wired
+   in S7 alongside hot-reload (§10.4 #11).
+
+4. **Status `phase` matrix beyond `Ready` / `Degraded`.** Full S7
+   matrix (`Pending`, `Reconciling`, `Suspended`) lands cluster-wide
+   in S7; S5 emits the same minimal vocabulary as S2/S3/S4.
+
+5. **Cross-namespace `sandboxRef`.** Out of scope by design — keeps
+   admission boundary aligned with K8s namespace tenancy.
+
+---
+
+## §4. Implementation surface
+
+| File | Lines | Purpose |
+|---|---|---|
+| `controller/src/claw_memory.rs` | ~140 | CRD struct, sub-types, CustomResource derive. |
+| `controller/src/claw_memory_compile.rs` | ~150 | Pure-function compile + version_hash + 6 unit tests. |
+| `controller/src/claw_memory_reconciler.rs` | ~340 | Reconcile, finalizer, conditions, ConfigMap publish + 7 unit tests. |
+| `controller/src/crd_validations.rs` | +~70 / +~70 tests | `claw_memory_validations()` (4 CEL rules) + `claw_memory_crd()` injector + 5 unit tests. |
+| `controller/src/helm_drift.rs` | +~25 | `CLAWMEMORY_HELM_CRD_PATH` const + dumper + drift test. |
+| `controller/src/main.rs` | +6 | Module registration + reconciler spawn in `tokio::select!`. |
+| `deploy/helm/azureclaw/templates/crd-clawmemory.yaml` | 184 | Generated via `DUMP_CLAWMEMORY_CRD_YAML=1` dumper. |
+
+**Test count delta:** controller 218 → 238 (+20).
+
+**No file moved past its Phase 2 cap** (§4.2). All new modules are
+fresh files; touched files (`crd_validations.rs`, `helm_drift.rs`,
+`main.rs`) are well under their budgets.
+
+---
+
+## §5. CEL rules and rationale
+
+| Rule | Rationale |
+|---|---|
+| `storeName` matches `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` (1-63 chars) | DNS-label shape is the safest common denominator: usable verbatim in URL paths, ConfigMap labels, and Foundry resource names. Foundry treats store names as case-sensitive identifiers. |
+| `sandboxRef.name` non-empty (1-253 chars) | Mirrors K8s `metadata.name` length. Keeps admission decoupled from `ClawSandbox` lookups (cross-CR existence checks at admission are anti-patterns under high churn). |
+| `scope` non-empty (1-256 chars) | Foundry uses scope as a partition key. Empty would cross-contaminate every binding sharing the store. 256 ≥ longest documented identifier convention. |
+| `retentionDays > 0` when set | Zero would request immediate purge; that's what `delete_scope` is for. Negative blocked by `uint32` schema. |
+
+CEL coverage = 4 rules, 5 tests in `crd_validations.rs`, all green.
+
+---
+
+## §6. SSA + field manager
+
+Field manager: `azureclaw-controller/clawmemory` — distinct from
+mcp/toolpolicy/a2aagent/inferencepolicy. SSA via `Patch::Apply` with
+`force()` for the binding ConfigMap and the status subresource.
+Status patches are scoped to `metadata` + `status` only; spec is
+operator-owned.
+
+---
+
+## §7. Failure modes and recovery
+
+| Failure | Reconciler behaviour |
+|---|---|
+| K8s API transient (5xx, throttling) | `error_policy` requeues 30s; condition stays last-known. |
+| ConfigMap apply fails | `Degraded=True` with reason `BindingWriteFailed`; requeue 60s. |
+| CR deleted with finalizer present | Deletes the binding ConfigMap (404 tolerated as success), strips finalizer, exits. |
+| CRD missing at startup | Reconciler logs warning and parks (matches S1–S4 pattern). |
+| Foundry unavailable at runtime | **Not the controller's problem.** Runtime path (`ensureMemoryStore`) handles its own retries. |
+
+---
+
+## §8. Operator concerns and migration
+
+- This is a new optional CRD. No `ClawSandbox` change required.
+- A sandbox without any `ClawMemory` continues to use the Phase 1
+  lazy-create path (CLI auto-creates a per-agent store on first use).
+- The S7 informer that consumes `clawmemory-{name}-binding` is
+  additive — until S7 lands, the binding ConfigMap is published but
+  not yet read by the sandbox. This is intentional: S5 ships the K8s
+  primitive; S7 wires the consumer.
+
+---
+
+## §9. Verification matrix
+
+| Gate | Result |
+|---|---|
+| `cargo build --workspace` | green |
+| `cargo test --workspace` | green (controller: 238/238; router: 595/595; integration: 26/26) |
+| `cargo clippy --workspace --all-targets -- -D warnings` | green |
+| `cargo fmt --all -- --check` | green |
+| `ci/no-stubs.sh` | green |
+| `ci/no-custom-crypto.sh` | green |
+| `ci/check-loc.sh` | green |
+| Helm drift test | green (Rust ↔ helm parity verified) |
+
+---
+
+## §10. References
+
+- `docs/implementation-plan.md` §3 (non-compete with AGT) — establishes
+  ClawMemory as binding-only.
+- `docs/implementation-plan.md` §8 entry 5 (Phase 2 plan, §10.5 #5).
+- Repo memory entry "Foundry Memory Store Auth" (project MI must
+  hold `Azure AI User` on the resource group; token audience
+  `https://ai.azure.com/`) — referenced verbatim in `claw_memory.rs`
+  module docs.
+- `cli/src/plugin.ts::ensureMemoryStore` and
+  `cli/src/core/foundry-discovery.ts::FoundryEnsureMemoryStore`
+  (Phase 1) — the runtime path this slice declaratively configures.
+
+---
+
+## §11. Sign-offs
+
+- ☑ Author — `phase2/clawmemory-reconciler` branch implementor.
+  AGT boundary verified against AGT 3.3.0 source on disk
+  (`/Users/pallakatos/Private/Repos/agt/agent-governance-toolkit`,
+  read-only). AGT carries no Memory Store module — confirmed.
+  K8s primitive + compiled binding JSON only; runtime enforcement
+  stays on the Phase-1 lazy-create path. Controller never calls
+  Foundry — credentialing boundary preserved.
+
+- ☑ Reviewer — implementation matches §0 reuse map; STRIDE residual
+  risks are documented; out-of-scope set is explicit and
+  cross-referenced to S7. CEL rule count (4) matches the
+  threat-model coverage (storeName shape, sandboxRef shape, scope
+  shape, retention non-zero). Memory Store auth caveat from repo
+  memory is reproduced in the CRD module docstring so it travels
+  with the schema.


### PR DESCRIPTION
Phase 2 §8 entry 5 — Foundry Memory Store binding/provisioning CR.

Per `docs/implementation-plan.md` §3 non-compete, `ClawMemory` **configures** Azure AI Foundry Memory Store; it is **not** a separate in-cluster store. Controller never calls Foundry — credentialing boundary preserved (the router holds Workload Identity; lazy-create lives in `cli/src/plugin.ts::ensureMemoryStore`). S5 ships only the K8s primitive + compiled binding ConfigMap; the sandbox-side informer that consumes it is deferred to S7.

## Surface

| File | Purpose |
|---|---|
| `controller/src/claw_memory.rs` | CRD struct (group `azureclaw.azure.com`/v1alpha1, shortname `cmem`) |
| `controller/src/claw_memory_compile.rs` | Pure-fn compile + version_hash + 6 tests |
| `controller/src/claw_memory_reconciler.rs` | Reconcile + finalizer + 7 tests |
| `controller/src/crd_validations.rs` | 4 CEL rules + 5 tests |
| `controller/src/helm_drift.rs` | Dumper + drift test |
| `deploy/helm/azureclaw/templates/crd-clawmemory.yaml` | 184-line generated CRD |
| `docs/security-audits/2026-04-27-phase2-clawmemory-reconciler.md` | Two-signoff audit doc |
| `CHANGELOG.md` | S5 entry |

## CEL admission

- `storeName` matches DNS-label `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` (1-63 chars)
- `sandboxRef.name` 1-253 chars
- `scope` 1-256 chars
- `retentionDays > 0` when present

## Reuse map (no-duplication, §0.2/§0.3)

11 existing seams reused; single new struct: none beyond `ClawMemorySpec` sub-types. `LocalObjectRef` is now a 5th semantic client.

## AGT boundary

Verified against `agent-governance-toolkit` 3.3.0 source on disk — AGT carries no Memory Store module. No parallel implementation introduced.

## Memory Store auth caveat

Reproduced in the CRD module docstring so it travels with the schema: Foundry project MI must hold `Azure AI User` on the **resource group**; token audience `https://ai.azure.com/`.

## Out of scope (S7+)

- Foundry-side delete on CR delete (finalizer cleans the binding ConfigMap only).
- Multi-CR conflict detection on shared sandbox+scope.
- Retention enforcement (Foundry TTL or scheduled `delete_scope` sweeps).
- Full `phase` matrix beyond `Ready`/`Degraded`.
- Cross-namespace `sandboxRef`.

## Verification

- Controller test count: **218 → 238 (+20)**.
- `cargo fmt --all` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — all green.
- Helm drift test green (Rust ↔ helm parity).

## §14.6 impact

Strengthens column 7 (Foundry / M365 integration). Column 12 (Governance as K8s primitives) now 4/5 differentiator CRDs (only `ClawEval`/S6 outstanding).

---

Audit doc: `docs/security-audits/2026-04-27-phase2-clawmemory-reconciler.md` carries two sign-offs, full STRIDE coverage, and explicit forward-references to S7.