### PR TITLE
phase2/claweval-reconciler: full ClawEval CRD + binding compile + helm CRD (S6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,94 @@ floor compare-and-block, model-preference selection).
 - The runtime gate `inference-router::routes::inference_policy::check`
   (Phase 1) is **not modified in this slice**.
 
+### S6 `phase2-claweval` — ClawEval CRD + binding ConfigMap + helm CRD
+
+This slice ships the controller side of the Azure AI Foundry Evals
+binding K8s primitive only. Per §3 non-compete, `ClawEval` is a
+**binding/provisioning resource over Foundry Evals** — it *configures*
+eval runs; it is **not** an in-cluster eval engine. The runtime
+enforcement substrate stays on Phase 1 (`cli/src/commands/eval.ts` →
+`/openai/evals` + `/evaluators` proxies in
+`inference-router/src/routes/inference.rs`, executed under the
+sandbox router's Workload Identity). The compiled JSON ConfigMap
+(`claweval-{name}-binding`) is the hand-off contract; the sandbox-side
+cron actuator / on-demand trigger that consumes it is deferred to S7.
+
+#### Added
+
+- **`ClawEval` CRD** — `controller/src/claw_eval.rs`, group
+  `azureclaw.azure.com`, version `v1alpha1`, namespaced, shortname
+  `ceval`. Spec fields: `sandboxRef.name`, `suite`
+  (`foundry-evals` | `promptfoo` | `inspect-ai`, default
+  `foundry-evals`), `evaluators?` (required + non-empty when
+  `foundry-evals`), `model?`, `schedule?` (cron line),
+  `dataset?` (mutually-exclusive `configMapRef` | `inline`),
+  `threshold?` (`score` ∈ `[0,1]`, `op` ∈ `Gte`/`Gt`),
+  `regressionAction?` (default `Suspend`), `displayName?`. Status:
+  `phase`, `observedGeneration`, `conditions`,
+  `bindingConfigMapRef`, `versionHash`, `lastReconciledAt`, plus
+  three **runtime-owned** fields (`lastRunAt`, `lastScore`,
+  `lastPass`) declared in the schema for SSA preservation by the
+  S7 runtime writer. Six print columns surface sandbox, suite,
+  schedule, score, pass, age.
+- **Pure compile module** — `controller/src/claw_eval_compile.rs`
+  with `compile_to_binding()` + `version_hash()` (sha256 first 16
+  bytes hex). 9 unit tests cover deterministic compile, all suite
+  serialisations, both threshold ops, default `regressionAction`
+  always materialising, hash sensitivity, hash stability across
+  serde round-trip. Mirrors S5 `claw_memory_compile.rs` shape.
+- **Reconciler** — `controller/src/claw_eval_reconciler.rs`:
+  finalizer `azureclaw.azure.com/claweval-cleanup`, field manager
+  `azureclaw-controller/claweval`, SSA throughout. Compiles the
+  spec, persists as ConfigMap (`claweval-{name}-binding`, key
+  `binding.json`, standard labels). Status patch sets all six
+  controller-owned fields and explicit `None` for the three
+  runtime-owned fields so SSA leaves them untouched once the
+  S7-side writer (`azureclaw-router/claweval`) applies them. Seven
+  unit tests including `field_manager_distinct_from_runtime_writer`
+  which documents and asserts the S7 forward contract.
+- **CEL admission rules** — `controller/src/crd_validations.rs`
+  `claw_eval_validations()` ships eight rules: `sandboxRef.name`
+  shape, `evaluators` required+bounded for `foundry-evals` suite,
+  per-evaluator length cap, `schedule` 5-or-6 token cron shape,
+  `threshold.score` ∈ `[0,1]`, `dataset.configMapRef`/`inline`
+  mutual exclusion, `dataset.inline` capped at 64 entries,
+  `displayName` length cap. Five unit tests assert non-emptiness,
+  message presence, post-injection rule count, core invariants
+  coverage, and serde round-trip.
+- **Helm CRD mirror** — `deploy/helm/azureclaw/templates/crd-claweval.yaml`
+  generated via `DUMP_CLAWEVAL_CRD_YAML=1` dumper.
+  `helm_claweval_crd_matches_rust_schema` drift test enforces
+  Rust ↔ helm parity on every CI run.
+- **Controller wiring** — `controller/src/main.rs` registers the
+  three new modules and spawns `claw_eval_reconciler::run` in
+  the existing `tokio::select!` (REQUEUE_OK 300s, REQUEUE_FAIL 60s).
+- **Audit doc** —
+  `docs/security-audits/2026-04-27-phase2-claweval-reconciler.md`
+  with two sign-offs, full STRIDE coverage, AGT boundary
+  verification (AGT 3.3.0 has no eval module — confirmed), 12-seam
+  reuse map, explicit out-of-scope list (runtime trigger,
+  pass/fail computation, regression actuator, runtime status
+  fields).
+
+#### Notes
+
+- Test count delta (controller): 238 → 264 (+26).
+- Single new struct: none beyond the spec/status/sub-types.
+  `LocalObjectRef` semantically extended (6 clients now:
+  signing/jwks, profile, agent-card, guardrail-profile,
+  memory-binding, eval-dataset).
+- Controller never calls Foundry. The runtime path
+  (`cli/src/commands/eval.ts`) is **not modified in this slice**.
+- This slice closes the §14.6 column-12 destination: five full
+  CRDs (`McpServer`, `ToolPolicy`, `InferencePolicy`, `A2AAgent`,
+  `ClawEval`) + the `ClawMemory` binding now ship as K8s
+  primitives. Governance-as-K8s-primitives → ✓.
+- Hard-deferred to S7+: runtime trigger (cron actuator), threshold
+  pass/fail computation, regression actuator (mutating
+  `ClawSandbox.spec.suspend`), AGT chain emission of eval
+  outcomes.
+
 ### S5 `phase2/clawmemory-reconciler` — ClawMemory CRD + binding ConfigMap + helm CRD
 
 This slice ships the controller side of the Foundry Memory Store

--- a/controller/src/claw_eval.rs
+++ b/controller/src/claw_eval.rs
@@ -1,0 +1,265 @@
+//! `ClawEval` CRD — Phase 2 §8 entry 6 (S6).
+//!
+//! Per `docs/implementation-plan.md` §10.5 #6, `ClawEval` is **a binding
+//! resource over Azure AI Foundry Evals + future suite adapters**. It
+//! declares an evaluation workflow over a sandbox; it is **not** an
+//! in-cluster eval engine and the controller does **not** run evals.
+//!
+//! ## Scope (S6)
+//!
+//! This slice ships:
+//!
+//! 1. The CRD schema (`ClawEval.spec`).
+//! 2. The reconciler that compiles the spec to a binding JSON and
+//!    publishes it as a `ConfigMap` (`claweval-{name}-binding`).
+//! 3. CEL admission rules for shape invariants.
+//! 4. Helm CRD with drift-checked schema.
+//!
+//! What this slice **does NOT** do (and why):
+//!
+//! - **Does NOT call Foundry directly from the controller.** The Foundry
+//!   Evals API is reached from the existing CLI path
+//!   (`cli/src/commands/eval.ts`) and the router proxy
+//!   (`/openai/evals`, `/evaluators` in
+//!   `inference-router/src/routes/inference.rs`). The controller has
+//!   no Foundry credential and we explicitly do not want one.
+//! - **Does NOT run a CronJob** to trigger evals. The `schedule` field
+//!   is preserved verbatim in the binding; S7 wires the trigger
+//!   (sandbox-side timer or router-side scheduler).
+//! - **Does NOT enforce regression actions.** `regressionAction` is
+//!   declared in spec; runtime path (S7) reads the binding, observes
+//!   the eval result, and patches the `ClawSandbox` status / spec
+//!   accordingly (e.g., `suspend=true`).
+//! - **Does NOT compute pass/fail.** The threshold is preserved in the
+//!   binding; the runtime path compares the observed score against it
+//!   and writes `lastPass`, `lastScore`, and an `EvalsPassed` condition
+//!   to status using its own field manager
+//!   (`azureclaw-router/claweval`). The controller never touches those
+//!   fields.
+//!
+//! ## Reuse map (no-duplication rule, §0.2/§0.3)
+//!
+//! - **CRD-derive shape**: mirrors S2/S3/S4/S5.
+//! - **`LocalObjectRef`** for `bindingConfigMapRef`: re-used from
+//!   [`crate::mcp_server`] — 6th semantic client.
+//! - **`Condition`** vocabulary: re-used from
+//!   [`crate::status::conditions`] via the reconciler module.
+//! - **Foundry Evals API surface**: existing
+//!   `inference-router/src/routes/inference.rs` proxy and
+//!   `cli/src/commands/eval.ts` flow. **Not modified in this slice.**
+//!
+//! ## Field-manager split (S7 forward-compat)
+//!
+//! Status fields owned by the **controller** (this slice):
+//! `phase`, `observedGeneration`, `conditions` (Ready / Progressing /
+//! Degraded), `bindingConfigMapRef`, `versionHash`, `lastReconciledAt`.
+//!
+//! Status fields reserved for the **runtime** (S7):
+//! `lastRunAt`, `lastScore`, `lastPass`, plus an additional
+//! `EvalsPassed` condition appended via SSA with a distinct field
+//! manager. Both sides use `Patch::Apply` so SSA arbitrates ownership.
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::mcp_server::LocalObjectRef;
+
+/// `ClawEval.spec` — declares an evaluation workflow over a sandbox.
+///
+/// Resolution rule: a sandbox can have multiple `ClawEval` CRs (one
+/// per suite or schedule). The runtime path indexes them by name.
+#[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[kube(
+    group = "azureclaw.azure.com",
+    version = "v1alpha1",
+    kind = "ClawEval",
+    namespaced,
+    status = "ClawEvalStatus",
+    shortname = "ceval",
+    printcolumn = r#"{"name":"Sandbox","type":"string","jsonPath":".spec.sandboxRef.name"}"#,
+    printcolumn = r#"{"name":"Suite","type":"string","jsonPath":".spec.suite"}"#,
+    printcolumn = r#"{"name":"Schedule","type":"string","jsonPath":".spec.schedule"}"#,
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"LastScore","type":"string","jsonPath":".status.lastScore"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawEvalSpec {
+    /// Sandbox this eval applies to.
+    pub sandbox_ref: SandboxRef,
+
+    /// Eval suite. `foundry-evals` is the only suite with a runtime
+    /// path today; `promptfoo` and `inspect-ai` are reserved for
+    /// future runtime adapters and are accepted by admission so
+    /// operators can pre-author manifests.
+    pub suite: ClawEvalSuite,
+
+    /// Foundry evaluator IDs (e.g., `relevance`, `coherence`,
+    /// `fluency`). Required when `suite=foundry-evals`. Other suites
+    /// ignore this list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evaluators: Vec<String>,
+
+    /// Model identifier the runtime path should evaluate against.
+    /// Optional; runtime defaults to the sandbox's primary model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Optional dataset reference. The runtime path resolves either
+    /// `configMapRef` (operator-managed JSONL) or `inline` (small
+    /// inline list). Mutually exclusive — admission enforces.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset: Option<ClawEvalDataset>,
+
+    /// Cron schedule (5 or 6 space-separated tokens). When absent,
+    /// the eval is manual-trigger only (`azureclaw eval <name>`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<String>,
+
+    /// Pass/fail threshold. When absent, the runtime records the
+    /// score but never marks the eval failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threshold: Option<ClawEvalThreshold>,
+
+    /// Action to take when an eval run fails the threshold.
+    /// Defaults to `Suspend`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regression_action: Option<ClawEvalRegressionAction>,
+
+    /// Optional human-readable label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+/// Eval suite identifier.
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq, Default)]
+pub enum ClawEvalSuite {
+    /// Azure AI Foundry built-in evaluators (the only suite with a
+    /// runtime path today). Routed through `/openai/evals` +
+    /// `/evaluators` Foundry endpoints.
+    #[default]
+    #[serde(rename = "foundry-evals")]
+    FoundryEvals,
+    /// Reserved for a future `promptfoo` adapter.
+    #[serde(rename = "promptfoo")]
+    Promptfoo,
+    /// Reserved for a future `inspect-ai` adapter.
+    #[serde(rename = "inspect-ai")]
+    InspectAi,
+}
+
+/// Dataset reference. Either a `ConfigMap` containing JSONL or an
+/// inline list. Mutually exclusive — CEL enforces.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawEvalDataset {
+    /// Reference to a `ConfigMap` whose `dataset.jsonl` key contains
+    /// the eval cases.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_map_ref: Option<LocalObjectRef>,
+
+    /// Inline list of eval cases. Each entry is a free-form JSON
+    /// object the runtime path passes through to the suite. Bounded
+    /// to 64 entries by CEL to keep the CR small.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inline: Vec<serde_json::Value>,
+}
+
+/// Pass/fail threshold over the suite's primary score.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawEvalThreshold {
+    /// Numeric pass threshold, in `[0.0, 1.0]`.
+    pub score: f64,
+
+    /// Comparison operator. Defaults to `Gte`.
+    #[serde(default)]
+    pub op: ClawEvalThresholdOp,
+}
+
+/// Threshold comparison operator.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema, PartialEq, Eq)]
+pub enum ClawEvalThresholdOp {
+    /// `score >= threshold` → pass.
+    #[default]
+    #[serde(rename = "Gte")]
+    Gte,
+    /// `score > threshold` → pass.
+    #[serde(rename = "Gt")]
+    Gt,
+}
+
+/// Action to take when an eval run fails the threshold.
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq, Default)]
+pub enum ClawEvalRegressionAction {
+    /// Set `ClawSandbox.spec.suspend = true` (default). Wired by S7.
+    #[default]
+    #[serde(rename = "Suspend")]
+    Suspend,
+    /// Record the failure in conditions but take no action.
+    #[serde(rename = "None")]
+    None,
+}
+
+/// Reference to a sandbox by name (within the same namespace as the
+/// `ClawEval` CR).
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxRef {
+    /// Sandbox name (`ClawSandbox.metadata.name`).
+    pub name: String,
+}
+
+/// Status of a `ClawEval` reconcile.
+///
+/// **Field ownership** (see module docstring): the controller owns
+/// `phase`, `observedGeneration`, `conditions`, `bindingConfigMapRef`,
+/// `versionHash`, `lastReconciledAt`. The runtime (S7) owns
+/// `lastRunAt`, `lastScore`, `lastPass`. Both sides use SSA with
+/// distinct field managers so updates do not race.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawEvalStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+
+    /// `metadata.generation` last successfully reconciled. KEP-1623.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<Vec<Condition>>,
+
+    /// Pointer to the binding `ConfigMap` produced by the reconciler.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_config_map_ref: Option<LocalObjectRef>,
+
+    /// Hex-encoded sha256 prefix of the compiled binding JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_hash: Option<String>,
+
+    /// Last time the binding was compiled and pushed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reconciled_at: Option<String>,
+
+    // ---------------------------------------------------------------
+    // Runtime-owned fields (S7). Declared in schema so the API server
+    // accepts them; the controller never sets these.
+    // ---------------------------------------------------------------
+    /// RFC3339 timestamp of the last completed eval run, written by
+    /// the runtime path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<String>,
+
+    /// Score of the last completed eval run, written by the runtime
+    /// path. Range `[0.0, 1.0]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_score: Option<f64>,
+
+    /// Whether the last completed eval run passed `spec.threshold`,
+    /// written by the runtime path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_pass: Option<bool>,
+}

--- a/controller/src/claw_eval_compile.rs
+++ b/controller/src/claw_eval_compile.rs
@@ -1,0 +1,312 @@
+//! Pure-function compile step: `ClawEvalSpec` → binding JSON.
+//!
+//! Separated from the reconciler so it is unit-testable without a
+//! `kube::Client`. The output JSON is consumed by the runtime path
+//! (`cli/src/commands/eval.ts` + the router's existing `/openai/evals`
+//! and `/evaluators` proxies in
+//! `inference-router/src/routes/inference.rs`). S6 ships only the
+//! producer side; S7 wires the runtime trigger and result writer.
+//!
+//! ## What the compiler is NOT
+//!
+//! - **Not** a Foundry client. Foundry calls happen at runtime
+//!   through the router's Workload Identity, not from the controller.
+//! - **Not** a scheduler. `schedule` flows verbatim; the trigger is
+//!   wired in S7 (sandbox-side timer or router-side scheduler).
+//! - **Not** a pass/fail evaluator. The threshold flows verbatim;
+//!   the runtime path compares scores and writes status fields it
+//!   owns.
+//! - **Not** a regression actuator. `regressionAction` flows verbatim;
+//!   the runtime patches the `ClawSandbox` per the operator's intent.
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::claw_eval::{ClawEvalRegressionAction, ClawEvalSpec, ClawEvalThresholdOp};
+
+/// Compile a `ClawEvalSpec` into the binding JSON the controller
+/// publishes as a `ConfigMap`.
+///
+/// Shape (omitting `null`/empty fields):
+///
+/// ```json
+/// {
+///   "sandboxRef": { "name": "agent" },
+///   "suite": "foundry-evals",
+///   "evaluators": ["relevance", "coherence"],
+///   "model": "gpt-4.1",
+///   "dataset": { "configMapRef": { "name": "evals-cm" } },
+///   "schedule": "0 */6 * * *",
+///   "threshold": { "score": 0.8, "op": "Gte" },
+///   "regressionAction": "Suspend",
+///   "displayName": "Daily Quality Check"
+/// }
+/// ```
+#[must_use]
+pub fn compile_to_binding(spec: &ClawEvalSpec) -> Value {
+    let mut out = serde_json::Map::new();
+    out.insert(
+        "sandboxRef".into(),
+        json!({ "name": spec.sandbox_ref.name }),
+    );
+    out.insert("suite".into(), Value::String(suite_str(&spec.suite).into()));
+    if !spec.evaluators.is_empty() {
+        out.insert("evaluators".into(), json!(spec.evaluators));
+    }
+    if let Some(m) = &spec.model {
+        out.insert("model".into(), Value::String(m.clone()));
+    }
+    if let Some(ds) = &spec.dataset {
+        let mut ds_obj = serde_json::Map::new();
+        if let Some(r) = &ds.config_map_ref {
+            ds_obj.insert("configMapRef".into(), json!({ "name": r.name }));
+        }
+        if !ds.inline.is_empty() {
+            ds_obj.insert("inline".into(), Value::Array(ds.inline.clone()));
+        }
+        if !ds_obj.is_empty() {
+            out.insert("dataset".into(), Value::Object(ds_obj));
+        }
+    }
+    if let Some(s) = &spec.schedule {
+        out.insert("schedule".into(), Value::String(s.clone()));
+    }
+    if let Some(t) = &spec.threshold {
+        out.insert(
+            "threshold".into(),
+            json!({
+                "score": t.score,
+                "op": match t.op {
+                    ClawEvalThresholdOp::Gte => "Gte",
+                    ClawEvalThresholdOp::Gt => "Gt",
+                },
+            }),
+        );
+    }
+    let regression = spec
+        .regression_action
+        .clone()
+        .unwrap_or(ClawEvalRegressionAction::Suspend);
+    out.insert(
+        "regressionAction".into(),
+        Value::String(
+            match regression {
+                ClawEvalRegressionAction::Suspend => "Suspend",
+                ClawEvalRegressionAction::None => "None",
+            }
+            .into(),
+        ),
+    );
+    if let Some(d) = &spec.display_name {
+        out.insert("displayName".into(), Value::String(d.clone()));
+    }
+    Value::Object(out)
+}
+
+fn suite_str(s: &crate::claw_eval::ClawEvalSuite) -> &'static str {
+    match s {
+        crate::claw_eval::ClawEvalSuite::FoundryEvals => "foundry-evals",
+        crate::claw_eval::ClawEvalSuite::Promptfoo => "promptfoo",
+        crate::claw_eval::ClawEvalSuite::InspectAi => "inspect-ai",
+    }
+}
+
+/// Stable SHA-256 over the canonicalised compiled binding, hex-encoded
+/// (first 32 chars). Used as `versionHash` for change detection.
+#[must_use]
+pub fn version_hash(binding: &Value) -> String {
+    let bytes = serde_json::to_vec(binding).expect("serde_json::Value always serialises");
+    let digest = Sha256::digest(&bytes);
+    hex::encode(&digest[..16])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claw_eval::{
+        ClawEvalDataset, ClawEvalRegressionAction, ClawEvalSpec, ClawEvalSuite, ClawEvalThreshold,
+        ClawEvalThresholdOp, SandboxRef,
+    };
+    use crate::mcp_server::LocalObjectRef;
+
+    fn full_spec() -> ClawEvalSpec {
+        ClawEvalSpec {
+            sandbox_ref: SandboxRef {
+                name: "agent-x".into(),
+            },
+            suite: ClawEvalSuite::FoundryEvals,
+            evaluators: vec!["relevance".into(), "coherence".into()],
+            model: Some("gpt-4.1".into()),
+            dataset: Some(ClawEvalDataset {
+                config_map_ref: Some(LocalObjectRef {
+                    name: "evals-cm".into(),
+                }),
+                inline: vec![],
+            }),
+            schedule: Some("0 */6 * * *".into()),
+            threshold: Some(ClawEvalThreshold {
+                score: 0.8,
+                op: ClawEvalThresholdOp::Gte,
+            }),
+            regression_action: Some(ClawEvalRegressionAction::Suspend),
+            display_name: Some("Daily Quality Check".into()),
+        }
+    }
+
+    #[test]
+    fn compile_minimal_spec_round_trips() {
+        let spec = ClawEvalSpec {
+            sandbox_ref: SandboxRef {
+                name: "agent".into(),
+            },
+            suite: ClawEvalSuite::FoundryEvals,
+            ..ClawEvalSpec::default()
+        };
+        let binding = compile_to_binding(&spec);
+        assert_eq!(binding["sandboxRef"]["name"], "agent");
+        assert_eq!(binding["suite"], "foundry-evals");
+        // Default regressionAction always materialises in binding.
+        assert_eq!(binding["regressionAction"], "Suspend");
+        assert!(binding.get("schedule").is_none());
+        assert!(binding.get("evaluators").is_none());
+        assert!(binding.get("dataset").is_none());
+        assert!(binding.get("threshold").is_none());
+    }
+
+    #[test]
+    fn compile_full_spec_round_trips() {
+        let spec = full_spec();
+        let binding = compile_to_binding(&spec);
+        assert_eq!(binding["sandboxRef"]["name"], "agent-x");
+        assert_eq!(binding["suite"], "foundry-evals");
+        assert_eq!(binding["evaluators"][0], "relevance");
+        assert_eq!(binding["evaluators"][1], "coherence");
+        assert_eq!(binding["model"], "gpt-4.1");
+        assert_eq!(binding["dataset"]["configMapRef"]["name"], "evals-cm");
+        assert_eq!(binding["schedule"], "0 */6 * * *");
+        assert_eq!(binding["threshold"]["score"], 0.8);
+        assert_eq!(binding["threshold"]["op"], "Gte");
+        assert_eq!(binding["regressionAction"], "Suspend");
+        assert_eq!(binding["displayName"], "Daily Quality Check");
+    }
+
+    #[test]
+    fn compile_emits_inline_dataset_when_set() {
+        let spec = ClawEvalSpec {
+            sandbox_ref: SandboxRef {
+                name: "agent".into(),
+            },
+            suite: ClawEvalSuite::FoundryEvals,
+            dataset: Some(ClawEvalDataset {
+                config_map_ref: None,
+                inline: vec![
+                    json!({"input": "hello", "expected": "hi"}),
+                    json!({"input": "ping", "expected": "pong"}),
+                ],
+            }),
+            ..ClawEvalSpec::default()
+        };
+        let binding = compile_to_binding(&spec);
+        assert!(binding["dataset"]["inline"].is_array());
+        assert_eq!(binding["dataset"]["inline"].as_array().unwrap().len(), 2);
+        assert!(binding["dataset"].get("configMapRef").is_none());
+    }
+
+    #[test]
+    fn compile_promptfoo_and_inspect_ai_serialise_with_kebab_case() {
+        let promptfoo = ClawEvalSpec {
+            sandbox_ref: SandboxRef { name: "a".into() },
+            suite: ClawEvalSuite::Promptfoo,
+            ..ClawEvalSpec::default()
+        };
+        assert_eq!(compile_to_binding(&promptfoo)["suite"], "promptfoo");
+        let inspect = ClawEvalSpec {
+            sandbox_ref: SandboxRef { name: "a".into() },
+            suite: ClawEvalSuite::InspectAi,
+            ..ClawEvalSpec::default()
+        };
+        assert_eq!(compile_to_binding(&inspect)["suite"], "inspect-ai");
+    }
+
+    #[test]
+    fn compile_threshold_op_gt_round_trips() {
+        let spec = ClawEvalSpec {
+            sandbox_ref: SandboxRef { name: "a".into() },
+            suite: ClawEvalSuite::FoundryEvals,
+            threshold: Some(ClawEvalThreshold {
+                score: 0.5,
+                op: ClawEvalThresholdOp::Gt,
+            }),
+            ..ClawEvalSpec::default()
+        };
+        let b = compile_to_binding(&spec);
+        assert_eq!(b["threshold"]["op"], "Gt");
+        assert_eq!(b["threshold"]["score"], 0.5);
+    }
+
+    #[test]
+    fn compile_regression_action_none_serialises() {
+        let spec = ClawEvalSpec {
+            sandbox_ref: SandboxRef { name: "a".into() },
+            suite: ClawEvalSuite::FoundryEvals,
+            regression_action: Some(ClawEvalRegressionAction::None),
+            ..ClawEvalSpec::default()
+        };
+        assert_eq!(compile_to_binding(&spec)["regressionAction"], "None");
+    }
+
+    #[test]
+    fn compile_default_regression_action_is_suspend() {
+        let spec = ClawEvalSpec {
+            sandbox_ref: SandboxRef { name: "a".into() },
+            suite: ClawEvalSuite::FoundryEvals,
+            regression_action: None,
+            ..ClawEvalSpec::default()
+        };
+        assert_eq!(compile_to_binding(&spec)["regressionAction"], "Suspend");
+    }
+
+    #[test]
+    fn compile_is_deterministic() {
+        let spec = full_spec();
+        let a = compile_to_binding(&spec);
+        let b = compile_to_binding(&spec);
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn version_hash_changes_on_spec_change() {
+        let mut a = full_spec();
+        let mut b = full_spec();
+        b.threshold = Some(ClawEvalThreshold {
+            score: 0.95,
+            op: ClawEvalThresholdOp::Gte,
+        });
+        let h_a = version_hash(&compile_to_binding(&a));
+        let h_b = version_hash(&compile_to_binding(&b));
+        assert_ne!(h_a, h_b);
+
+        a.display_name = Some("Daily Quality Check".into());
+        let h_a2 = version_hash(&compile_to_binding(&a));
+        assert_eq!(h_a, h_a2);
+    }
+
+    #[test]
+    fn version_hash_is_stable_across_serde_round_trip() {
+        let spec = full_spec();
+        let binding_a = compile_to_binding(&spec);
+        let s = serde_json::to_string(&binding_a).unwrap();
+        let binding_b: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(version_hash(&binding_a), version_hash(&binding_b));
+    }
+
+    #[test]
+    fn version_hash_is_hex_16_bytes() {
+        let h = version_hash(&compile_to_binding(&full_spec()));
+        assert_eq!(h.len(), 32);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/controller/src/claw_eval_reconciler.rs
+++ b/controller/src/claw_eval_reconciler.rs
@@ -1,0 +1,459 @@
+//! `ClawEval` reconciler — Phase 2 §8 entry 6 (S6).
+//!
+//! Watches `ClawEval` CRs and, for each:
+//!
+//! 1. Ensures finalizer (`azureclaw.azure.com/claweval-cleanup`).
+//! 2. Compiles the binding via
+//!    [`crate::claw_eval_compile::compile_to_binding`].
+//! 3. Persists as `ConfigMap` (`claweval-{name}-binding`,
+//!    key `binding.json`).
+//! 4. Sets controller-owned status (phase, observedGeneration,
+//!    conditions, bindingConfigMapRef, versionHash, lastReconciledAt).
+//!    The runtime (S7) writes `lastRunAt`, `lastScore`, `lastPass`
+//!    using a distinct field manager.
+//!
+//! ## Reuse map (no-duplication rule, §0.2/§0.3)
+//!
+//! Same shape as S2 (ToolPolicy), S3 (A2AAgent), S4 (InferencePolicy),
+//! S5 (ClawMemory).
+//! - Conditions vocabulary + transition-time helpers from
+//!   [`crate::status::conditions`].
+//! - Compile module is single-purpose and reconciler does no JSON
+//!   shaping itself.
+//! - **No Foundry calls** — Foundry interaction stays in the runtime
+//!   path (`cli/src/commands/eval.ts` + the router's `/openai/evals`
+//!   and `/evaluators` proxies).
+
+use anyhow::Result;
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::{
+    Client, ResourceExt,
+    api::{Api, ListParams, ObjectMeta, Patch, PatchParams},
+    runtime::controller::{Action, Controller},
+};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::claw_eval::{ClawEval, ClawEvalStatus};
+use crate::claw_eval_compile::{compile_to_binding, version_hash};
+use crate::mcp_server::LocalObjectRef;
+use crate::status::conditions::{self, reason, status as cond_status};
+
+const FIELD_MANAGER: &str = "azureclaw-controller/claweval";
+const FINALIZER: &str = "azureclaw.azure.com/claweval-cleanup";
+
+const REQUEUE_OK: Duration = Duration::from_secs(300);
+const REQUEUE_FAIL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, thiserror::Error)]
+enum ReconcileError {
+    #[error("Kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("JSON serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+}
+
+impl ReconcileError {
+    fn class(&self) -> &'static str {
+        match self {
+            ReconcileError::Kube(_) => "kube_api",
+            ReconcileError::SerdeJson(_) => "serde",
+        }
+    }
+}
+
+struct Ctx {
+    client: Client,
+}
+
+async fn reconcile(eval: Arc<ClawEval>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
+    let name = eval.name_any();
+    let ns = eval.namespace().unwrap_or_else(|| "default".into());
+    tracing::info!(claweval = %name, ns = %ns, "Reconciling ClawEval");
+
+    let api: Api<ClawEval> = Api::namespaced(ctx.client.clone(), &ns);
+    let configmaps: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), &ns);
+
+    if eval.metadata.deletion_timestamp.is_some() {
+        return finalize(&api, &configmaps, &eval, &name).await;
+    }
+
+    if !eval
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|f| f.iter().any(|s| s == FINALIZER))
+        .unwrap_or(false)
+    {
+        let patch = json!({"metadata":{"finalizers":[FINALIZER]}});
+        api.patch(
+            &name,
+            &PatchParams::apply(FIELD_MANAGER).force(),
+            &Patch::Apply(patch),
+        )
+        .await?;
+        return Ok(Action::requeue(Duration::from_secs(1)));
+    }
+
+    let prior_conditions = eval
+        .status
+        .as_ref()
+        .and_then(|s| s.conditions.clone())
+        .unwrap_or_default();
+    let observed_generation = eval.metadata.generation;
+
+    let binding = compile_to_binding(&eval.spec);
+    let v_hash = version_hash(&binding);
+
+    let cm_name = format!("claweval-{name}-binding");
+    let mut degraded: Option<(&'static str, String)> = None;
+
+    match ensure_binding_configmap(&configmaps, &cm_name, &name, &binding, &v_hash).await {
+        Ok(()) => {
+            tracing::info!(
+                claweval = %name,
+                ns = %ns,
+                version_hash = %v_hash,
+                generation = observed_generation.unwrap_or(0),
+                sandbox = %eval.spec.sandbox_ref.name,
+                "ClawEvalReconciled"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                claweval = %name,
+                error_class = e.class(),
+                "ClawEvalBindingWriteFailed"
+            );
+            degraded = Some(("BindingWriteFailed", e.to_string()));
+        }
+    }
+
+    let new_conditions = build_conditions(
+        &prior_conditions,
+        observed_generation,
+        degraded.as_ref().map(|(r, m)| (*r, m.as_str())),
+    );
+    let phase = if degraded.is_some() {
+        "Degraded"
+    } else {
+        "Ready"
+    };
+
+    let status_patch = json!({
+        "status": ClawEvalStatus {
+            phase: Some(phase.into()),
+            observed_generation,
+            conditions: Some(new_conditions),
+            binding_config_map_ref: Some(LocalObjectRef { name: cm_name.clone() }),
+            version_hash: Some(v_hash),
+            last_reconciled_at: Some(rfc3339_now()),
+            // Runtime-owned fields are intentionally None — the
+            // controller's field manager does not own them and SSA
+            // leaves them untouched.
+            last_run_at: None,
+            last_score: None,
+            last_pass: None,
+        }
+    });
+    api.patch_status(
+        &name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(status_patch),
+    )
+    .await?;
+
+    if degraded.is_some() {
+        Ok(Action::requeue(REQUEUE_FAIL))
+    } else {
+        Ok(Action::requeue(REQUEUE_OK))
+    }
+}
+
+fn rfc3339_now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn build_conditions(
+    prior: &[Condition],
+    observed_generation: Option<i64>,
+    degraded: Option<(&str, &str)>,
+) -> Vec<Condition> {
+    let mut out: Vec<Condition> = Vec::with_capacity(3);
+    let prior_ready = conditions::find(prior, conditions::TYPE_READY);
+    let prior_progressing = conditions::find(prior, conditions::TYPE_PROGRESSING);
+    let prior_degraded = conditions::find(prior, conditions::TYPE_DEGRADED);
+
+    match degraded {
+        Some((reason_value, message)) => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::FALSE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::FAILED,
+                "binding write failed",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::TRUE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+        }
+        None => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::TRUE,
+                reason::RECONCILED,
+                "ClawEval binding compiled and published",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "compile complete",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "no errors",
+                observed_generation,
+            ));
+        }
+    }
+    out
+}
+
+async fn ensure_binding_configmap(
+    api: &Api<ConfigMap>,
+    cm_name: &str,
+    owner: &str,
+    binding: &serde_json::Value,
+    v_hash: &str,
+) -> Result<(), ReconcileError> {
+    let json_str = serde_json::to_string_pretty(binding)?;
+    let mut data: BTreeMap<String, String> = BTreeMap::new();
+    data.insert("binding.json".into(), json_str);
+    let mut annotations: BTreeMap<String, String> = BTreeMap::new();
+    annotations.insert(
+        "azureclaw.azure.com/claweval-version-hash".into(),
+        v_hash.into(),
+    );
+    let cm = ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(cm_name.into()),
+            annotations: Some(annotations),
+            labels: Some(BTreeMap::from([
+                (
+                    "app.kubernetes.io/managed-by".into(),
+                    "azureclaw-controller".into(),
+                ),
+                ("azureclaw.azure.com/claweval".into(), owner.into()),
+                (
+                    "azureclaw.azure.com/artifact".into(),
+                    "claw-eval-binding".into(),
+                ),
+            ])),
+            ..Default::default()
+        },
+        data: Some(data),
+        ..Default::default()
+    };
+    api.patch(
+        cm_name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(&cm),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn finalize(
+    api: &Api<ClawEval>,
+    configmaps: &Api<ConfigMap>,
+    eval: &ClawEval,
+    name: &str,
+) -> Result<Action, ReconcileError> {
+    let cm_name = format!("claweval-{name}-binding");
+    let _ = configmaps
+        .delete(&cm_name, &Default::default())
+        .await
+        .map(|_| ())
+        .or_else(|e: kube::Error| -> Result<(), kube::Error> {
+            if matches!(e, kube::Error::Api(ref ae) if ae.code == 404) {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        });
+
+    let finalizers: Vec<String> = eval
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|v| v.iter().filter(|f| *f != FINALIZER).cloned().collect())
+        .unwrap_or_default();
+    let patch = json!({"metadata":{"finalizers": finalizers}});
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(patch),
+    )
+    .await?;
+    tracing::info!(claweval = %name, "ClawEvalDeleted");
+    Ok(Action::await_change())
+}
+
+fn error_policy(eval: Arc<ClawEval>, error: &ReconcileError, _ctx: Arc<Ctx>) -> Action {
+    tracing::warn!(
+        claweval = %eval.name_any(),
+        error_class = error.class(),
+        error = %error,
+        "ClawEval reconcile error — requeuing in 30s"
+    );
+    Action::requeue(Duration::from_secs(30))
+}
+
+pub async fn run(client: Client) -> Result<()> {
+    let evals: Api<ClawEval> = Api::all(client.clone());
+    match evals.list(&ListParams::default().limit(1)).await {
+        Ok(_) => tracing::info!("ClawEval CRD found — starting controller"),
+        Err(e) => {
+            tracing::warn!("ClawEval CRD not installed — reconciler disabled: {e}");
+            return Ok(());
+        }
+    }
+    let ctx = Arc::new(Ctx { client });
+    Controller::new(evals, kube::runtime::watcher::Config::default())
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok(o) => tracing::debug!("ClawEval reconciled {:?}", o),
+                Err(e) => tracing::warn!("ClawEval reconcile failed: {e:?}"),
+            }
+        })
+        .await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_now_is_utc_z_suffixed() {
+        let s = rfc3339_now();
+        assert!(s.ends_with('Z'), "got {s}");
+        assert_eq!(s.len(), 20);
+    }
+
+    #[test]
+    fn error_class_is_closed_set() {
+        let serde_err: serde_json::Error =
+            serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let e = ReconcileError::SerdeJson(serde_err);
+        assert_eq!(e.class(), "serde");
+
+        fn assert_closed(class: &str) {
+            assert!(matches!(class, "kube_api" | "serde"));
+        }
+        assert_closed(e.class());
+    }
+
+    #[test]
+    fn build_conditions_emits_all_three_types_on_success() {
+        let conds = build_conditions(&[], Some(1), None);
+        assert_eq!(conds.len(), 3);
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::TRUE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::FALSE);
+    }
+
+    #[test]
+    fn build_conditions_emits_all_three_types_on_failure() {
+        let conds = build_conditions(&[], Some(1), Some(("BindingWriteFailed", "boom")));
+        assert_eq!(conds.len(), 3);
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::FALSE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::TRUE);
+        assert_eq!(degraded.reason, "BindingWriteFailed");
+    }
+
+    #[test]
+    fn build_conditions_preserves_transition_time_when_status_unchanged() {
+        let first = build_conditions(&[], Some(1), None);
+        let second = build_conditions(&first, Some(2), None);
+        let r1 = first
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        let r2 = second
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(r1.last_transition_time, r2.last_transition_time);
+    }
+
+    #[test]
+    fn finalizer_constant_is_dns_subdomain() {
+        assert!(FINALIZER.contains('/'));
+        let (domain, key) = FINALIZER.split_once('/').unwrap();
+        assert_eq!(domain, "azureclaw.azure.com");
+        assert!(!key.is_empty());
+    }
+
+    #[test]
+    fn field_manager_is_per_reconciler() {
+        assert_eq!(FIELD_MANAGER, "azureclaw-controller/claweval");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/mcp");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/toolpolicy");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/a2aagent");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/inferencepolicy");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/clawmemory");
+    }
+
+    #[test]
+    fn field_manager_distinct_from_runtime_writer() {
+        // S7 will use this field manager for runtime-owned status
+        // fields (lastRunAt, lastScore, lastPass, EvalsPassed
+        // condition). Distinct from the controller's manager so SSA
+        // partitions ownership cleanly.
+        const RUNTIME_FIELD_MANAGER: &str = "azureclaw-router/claweval";
+        assert_ne!(FIELD_MANAGER, RUNTIME_FIELD_MANAGER);
+    }
+}

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -46,6 +46,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
 use kube::CustomResourceExt;
 
 use crate::a2a_agent::A2AAgent;
+use crate::claw_eval::ClawEval;
 use crate::claw_memory::ClawMemory;
 use crate::inference_policy::InferencePolicy;
 use crate::mcp_server::McpServer;
@@ -361,6 +362,95 @@ pub fn claw_memory_crd() -> CustomResourceDefinition {
         .expect("kube-rs derive must produce a spec property on ClawMemory")
 }
 
+/// `ClawEval.spec` CEL rules. Phase 2 §8 entry 6 (S6).
+///
+/// `ClawEval` is a binding/provisioning resource over Azure AI
+/// Foundry Evals (per `docs/implementation-plan.md` §10.5 #6). The CRD
+/// is shape-only — Foundry availability and runtime trigger semantics
+/// are out of admission scope. Rules:
+///
+/// - `sandboxRef.name` non-empty (1-253 chars; same length cap as
+///   K8s object names).
+/// - `evaluators`: each entry 1-256 chars; required (`size >= 1`)
+///   when `suite == "foundry-evals"`. Other suites accept empty.
+/// - `schedule`, when set, looks like a 5-or-6-token cron line. We do
+///   not parse cron at admission (defer to runtime), but we reject
+///   empty strings and impossible token counts.
+/// - `threshold.score`, when set, in `[0.0, 1.0]`.
+/// - `dataset`: at most one of `configMapRef` / `inline` (mutually
+///   exclusive). `inline` capped at 64 entries to keep the CR small.
+/// - `displayName`, when set, 1-256 chars.
+#[must_use]
+pub fn claw_eval_validations() -> Vec<ValidationRule> {
+    vec![
+        ValidationRule {
+            rule: "size(self.sandboxRef.name) > 0 && size(self.sandboxRef.name) <= 253".into(),
+            message: Some("spec.sandboxRef.name must be 1-253 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "self.suite != 'foundry-evals' || (has(self.evaluators) && size(self.evaluators) >= 1)".into(),
+            message: Some(
+                "spec.evaluators must contain at least one entry when spec.suite is 'foundry-evals'".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.evaluators) || self.evaluators.all(e, size(e) > 0 && size(e) <= 256)".into(),
+            message: Some("each spec.evaluators entry must be 1-256 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.schedule) || (size(self.schedule) > 0 && size(self.schedule) <= 256 && (size(self.schedule.split(' ')) == 5 || size(self.schedule.split(' ')) == 6))".into(),
+            message: Some(
+                "spec.schedule, when set, must be a 5-or-6-field cron expression (1-256 chars)".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.threshold) || (self.threshold.score >= 0.0 && self.threshold.score <= 1.0)".into(),
+            message: Some("spec.threshold.score must be in [0.0, 1.0] when set".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.dataset) || !(has(self.dataset.configMapRef) && has(self.dataset.inline) && size(self.dataset.inline) > 0)".into(),
+            message: Some(
+                "spec.dataset.configMapRef and spec.dataset.inline are mutually exclusive".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.dataset) || !has(self.dataset.inline) || size(self.dataset.inline) <= 64".into(),
+            message: Some(
+                "spec.dataset.inline is capped at 64 entries; use a ConfigMap for larger datasets".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.displayName) || (size(self.displayName) > 0 && size(self.displayName) <= 256)".into(),
+            message: Some("spec.displayName, when set, must be 1-256 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+    ]
+}
+
+/// `ClawEval` CRD with [`claw_eval_validations`] injected.
+///
+/// Panics only if kube-rs ever produces a CRD whose `spec` is missing.
+#[must_use]
+pub fn claw_eval_crd() -> CustomResourceDefinition {
+    inject_spec_validations(ClawEval::crd(), claw_eval_validations())
+        .expect("kube-rs derive must produce a spec property on ClawEval")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -631,6 +721,75 @@ mod tests {
         assert!(y.contains("x-kubernetes-validations"));
         assert!(y.contains("storeName"));
         assert!(y.contains("scope"));
+    }
+
+    // ---- ClawEval (S6) --------------------------------------------------
+
+    #[test]
+    fn claw_eval_validations_are_non_empty() {
+        assert!(!claw_eval_validations().is_empty());
+    }
+
+    #[test]
+    fn every_claw_eval_rule_has_message_and_rule() {
+        for rule in claw_eval_validations() {
+            assert!(!rule.rule.is_empty(), "rule body must not be empty");
+            let msg = rule.message.as_deref().unwrap_or("");
+            assert!(!msg.is_empty(), "rule '{}' missing message", rule.rule);
+        }
+    }
+
+    #[test]
+    fn claw_eval_crd_has_spec_validations_after_injection() {
+        let crd = claw_eval_crd();
+        let v = spec_validations(&crd);
+        assert_eq!(v.len(), claw_eval_validations().len());
+    }
+
+    #[test]
+    fn claw_eval_rules_cover_core_invariants() {
+        let rules: Vec<String> = claw_eval_validations()
+            .into_iter()
+            .map(|r| r.rule)
+            .collect();
+        assert!(
+            rules.iter().any(|r| r.contains("sandboxRef.name")),
+            "must validate sandboxRef.name; got rules: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("foundry-evals") && r.contains("evaluators")),
+            "must require evaluators for foundry-evals suite; got rules: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("schedule") && r.contains("split")),
+            "must validate schedule cron shape; got rules: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("threshold.score") && r.contains("1.0")),
+            "must bound threshold.score to [0,1]; got rules: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("configMapRef") && r.contains("inline")),
+            "must enforce dataset configMapRef/inline mutual exclusion; got rules: {rules:?}"
+        );
+    }
+
+    #[test]
+    fn claw_eval_crd_is_serde_round_trippable() {
+        let crd = claw_eval_crd();
+        let y = serde_yaml::to_string(&crd).expect("serializes");
+        assert!(y.contains("x-kubernetes-validations"));
+        assert!(y.contains("sandboxRef"));
+        assert!(y.contains("evaluators"));
+        assert!(y.contains("threshold"));
     }
 
     #[test]

--- a/controller/src/helm_drift.rs
+++ b/controller/src/helm_drift.rs
@@ -29,7 +29,8 @@
 
 #[cfg(test)]
 use crate::crd_validations::{
-    a2a_agent_crd, claw_memory_crd, inference_policy_crd, mcp_server_crd, tool_policy_crd,
+    a2a_agent_crd, claw_eval_crd, claw_memory_crd, inference_policy_crd, mcp_server_crd,
+    tool_policy_crd,
 };
 
 const MCP_HELM_CRD_PATH: &str = concat!(
@@ -55,6 +56,11 @@ const INFERENCEPOLICY_HELM_CRD_PATH: &str = concat!(
 const CLAWMEMORY_HELM_CRD_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../deploy/helm/azureclaw/templates/crd-clawmemory.yaml"
+);
+
+const CLAWEVAL_HELM_CRD_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../deploy/helm/azureclaw/templates/crd-claweval.yaml"
 );
 
 /// Strip non-schema fields that legitimately differ between the Rust
@@ -215,5 +221,26 @@ mod tests {
         let rust_crd_value =
             serde_json::to_value(claw_memory_crd()).expect("rust crd serializes to JSON");
         assert_helm_matches_rust(CLAWMEMORY_HELM_CRD_PATH, rust_crd_value, "clawmemory");
+    }
+
+    /// One-shot dumper for the claweval CRD. Run via:
+    ///
+    ///   DUMP_CLAWEVAL_CRD_YAML=1 cargo test --bin azureclaw-controller \
+    ///       helm_drift::tests::dump_claweval_crd_yaml -- --nocapture
+    #[test]
+    fn dump_claweval_crd_yaml() {
+        if std::env::var("DUMP_CLAWEVAL_CRD_YAML").is_err() {
+            return;
+        }
+        let crd = claw_eval_crd();
+        let yaml = serde_yaml::to_string(&crd).expect("serialize crd to YAML");
+        println!("---\n{yaml}");
+    }
+
+    #[test]
+    fn helm_claweval_crd_matches_rust_schema() {
+        let rust_crd_value =
+            serde_json::to_value(claw_eval_crd()).expect("rust crd serializes to JSON");
+        assert_helm_matches_rust(CLAWEVAL_HELM_CRD_PATH, rust_crd_value, "claweval");
     }
 }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -14,6 +14,9 @@
 mod a2a_agent;
 mod a2a_agent_compile;
 mod a2a_agent_reconciler;
+mod claw_eval;
+mod claw_eval_compile;
+mod claw_eval_reconciler;
 mod claw_memory;
 mod claw_memory_compile;
 mod claw_memory_reconciler;
@@ -91,6 +94,10 @@ async fn main() -> Result<()> {
         let client = client.clone();
         tokio::spawn(async move { claw_memory_reconciler::run(client).await })
     };
+    let claw_eval_handle = {
+        let client = client.clone();
+        tokio::spawn(async move { claw_eval_reconciler::run(client).await })
+    };
     let mesh_peer_handle = {
         let client = client.clone();
         tokio::spawn(async move {
@@ -156,6 +163,9 @@ async fn main() -> Result<()> {
             res??;
         }
         res = claw_memory_handle => {
+            res??;
+        }
+        res = claw_eval_handle => {
             res??;
         }
         res = mesh_peer_handle => {

--- a/deploy/helm/azureclaw/templates/crd-claweval.yaml
+++ b/deploy/helm/azureclaw/templates/crd-claweval.yaml
@@ -1,0 +1,271 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clawevals.azureclaw.azure.com
+spec:
+  group: azureclaw.azure.com
+  names:
+    categories: []
+    kind: ClawEval
+    plural: clawevals
+    shortNames:
+    - ceval
+    singular: claweval
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sandboxRef.name
+      name: Sandbox
+      type: string
+    - jsonPath: .spec.suite
+      name: Suite
+      type: string
+    - jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.lastScore
+      name: LastScore
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for ClawEvalSpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
+              `ClawEval.spec` — declares an evaluation workflow over a sandbox.
+
+              Resolution rule: a sandbox can have multiple `ClawEval` CRs (one
+              per suite or schedule). The runtime path indexes them by name.
+            properties:
+              dataset:
+                description: |-
+                  Optional dataset reference. The runtime path resolves either
+                  `configMapRef` (operator-managed JSONL) or `inline` (small
+                  inline list). Mutually exclusive — admission enforces.
+                nullable: true
+                properties:
+                  configMapRef:
+                    description: |-
+                      Reference to a `ConfigMap` whose `dataset.jsonl` key contains
+                      the eval cases.
+                    nullable: true
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  inline:
+                    description: |-
+                      Inline list of eval cases. Each entry is a free-form JSON
+                      object the runtime path passes through to the suite. Bounded
+                      to 64 entries by CEL to keep the CR small.
+                    items: {}
+                    type: array
+                type: object
+              displayName:
+                description: Optional human-readable label.
+                nullable: true
+                type: string
+              evaluators:
+                description: |-
+                  Foundry evaluator IDs (e.g., `relevance`, `coherence`,
+                  `fluency`). Required when `suite=foundry-evals`. Other suites
+                  ignore this list.
+                items:
+                  type: string
+                type: array
+              model:
+                description: |-
+                  Model identifier the runtime path should evaluate against.
+                  Optional; runtime defaults to the sandbox's primary model.
+                nullable: true
+                type: string
+              regressionAction:
+                description: Action to take when an eval run fails the threshold.
+                enum:
+                - Suspend
+                - None
+                nullable: true
+                type: string
+              sandboxRef:
+                description: Sandbox this eval applies to.
+                properties:
+                  name:
+                    description: Sandbox name (`ClawSandbox.metadata.name`).
+                    type: string
+                required:
+                - name
+                type: object
+              schedule:
+                description: |-
+                  Cron schedule (5 or 6 space-separated tokens). When absent,
+                  the eval is manual-trigger only (`azureclaw eval <name>`).
+                nullable: true
+                type: string
+              suite:
+                description: |-
+                  Eval suite. `foundry-evals` is the only suite with a runtime
+                  path today; `promptfoo` and `inspect-ai` are reserved for
+                  future runtime adapters and are accepted by admission so
+                  operators can pre-author manifests.
+                enum:
+                - foundry-evals
+                - promptfoo
+                - inspect-ai
+                type: string
+              threshold:
+                description: |-
+                  Pass/fail threshold. When absent, the runtime records the
+                  score but never marks the eval failed.
+                nullable: true
+                properties:
+                  op:
+                    default: Gte
+                    description: Comparison operator. Defaults to `Gte`.
+                    enum:
+                    - Gte
+                    - Gt
+                    type: string
+                  score:
+                    description: Numeric pass threshold, in `[0.0, 1.0]`.
+                    format: double
+                    type: number
+                required:
+                - score
+                type: object
+            required:
+            - sandboxRef
+            - suite
+            type: object
+            x-kubernetes-validations:
+            - message: spec.sandboxRef.name must be 1-253 characters
+              reason: FieldValueInvalid
+              rule: size(self.sandboxRef.name) > 0 && size(self.sandboxRef.name) <= 253
+            - message: spec.evaluators must contain at least one entry when spec.suite is 'foundry-evals'
+              reason: FieldValueInvalid
+              rule: self.suite != 'foundry-evals' || (has(self.evaluators) && size(self.evaluators) >= 1)
+            - message: each spec.evaluators entry must be 1-256 characters
+              reason: FieldValueInvalid
+              rule: '!has(self.evaluators) || self.evaluators.all(e, size(e) > 0 && size(e) <= 256)'
+            - message: spec.schedule, when set, must be a 5-or-6-field cron expression (1-256 chars)
+              reason: FieldValueInvalid
+              rule: '!has(self.schedule) || (size(self.schedule) > 0 && size(self.schedule) <= 256 && (size(self.schedule.split('' '')) == 5 || size(self.schedule.split('' '')) == 6))'
+            - message: spec.threshold.score must be in [0.0, 1.0] when set
+              reason: FieldValueInvalid
+              rule: '!has(self.threshold) || (self.threshold.score >= 0.0 && self.threshold.score <= 1.0)'
+            - message: spec.dataset.configMapRef and spec.dataset.inline are mutually exclusive
+              reason: FieldValueInvalid
+              rule: '!has(self.dataset) || !(has(self.dataset.configMapRef) && has(self.dataset.inline) && size(self.dataset.inline) > 0)'
+            - message: spec.dataset.inline is capped at 64 entries; use a ConfigMap for larger datasets
+              reason: FieldValueInvalid
+              rule: '!has(self.dataset) || !has(self.dataset.inline) || size(self.dataset.inline) <= 64'
+            - message: spec.displayName, when set, must be 1-256 characters
+              reason: FieldValueInvalid
+              rule: '!has(self.displayName) || (size(self.displayName) > 0 && size(self.displayName) <= 256)'
+          status:
+            description: |-
+              Status of a `ClawEval` reconcile.
+
+              **Field ownership** (see module docstring): the controller owns
+              `phase`, `observedGeneration`, `conditions`, `bindingConfigMapRef`,
+              `versionHash`, `lastReconciledAt`. The runtime (S7) owns
+              `lastRunAt`, `lastScore`, `lastPass`. Both sides use SSA with
+              distinct field managers so updates do not race.
+            nullable: true
+            properties:
+              bindingConfigMapRef:
+                description: Pointer to the binding `ConfigMap` produced by the reconciler.
+                nullable: true
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              lastPass:
+                description: |-
+                  Whether the last completed eval run passed `spec.threshold`,
+                  written by the runtime path.
+                nullable: true
+                type: boolean
+              lastReconciledAt:
+                description: Last time the binding was compiled and pushed.
+                nullable: true
+                type: string
+              lastRunAt:
+                description: |-
+                  RFC3339 timestamp of the last completed eval run, written by
+                  the runtime path.
+                nullable: true
+                type: string
+              lastScore:
+                description: |-
+                  Score of the last completed eval run, written by the runtime
+                  path. Range `[0.0, 1.0]`.
+                format: double
+                nullable: true
+                type: number
+              observedGeneration:
+                description: '`metadata.generation` last successfully reconciled. KEP-1623.'
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                nullable: true
+                type: string
+              versionHash:
+                description: Hex-encoded sha256 prefix of the compiled binding JSON.
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: ClawEval
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+

--- a/docs/security-audits/2026-04-27-phase2-claweval-reconciler.md
+++ b/docs/security-audits/2026-04-27-phase2-claweval-reconciler.md
@@ -1,0 +1,295 @@
+# Security audit — Phase 2 S6 `ClawEval` reconciler
+
+**Date:** 2026-04-27
+**Slice:** S6 `phase2-claweval` (Phase 2 §8 entry 6)
+**Branch:** `phase2-claweval`
+**Sign-offs:** see §11.
+
+---
+
+## §0. Reuse map (no-duplication rule, §0.2 / §0.3)
+
+S6 closes the §14.6 "five-CRD" set (column 12 — Governance as K8s
+primitives) and is, by design, the **lightest** of the six Phase 2
+reconcilers: it ships only a binding declaration over an external
+service (Foundry Evals), the runtime path already exists in
+`cli/src/commands/eval.ts`, and the threshold/regression actuator is
+deliberately deferred to S7 where the Conditions matrix and
+runtime-side SSA writer land cluster-wide.
+
+| # | Existing seam | Reuse in S6 |
+|---|---|---|
+| 1 | `controller/src/status::conditions` | Conditions vocabulary + transition-time helpers used unchanged. |
+| 2 | `controller/src/mcp_server::LocalObjectRef` | 6th semantic client (signing/jwks → profile → agent-card → guardrail-profile → memory-binding → eval-dataset). |
+| 3 | `controller/src/claw_memory_reconciler` (S5) | Reconcile shape + finalizer pattern + non-fatal CRD-missing exit, copied verbatim. |
+| 4 | `controller/src/claw_memory_compile` (S5) | Compile-module shape (pure-fn + version_hash + tests). |
+| 5 | `controller/src/crd_validations::inject_spec_validations` | Same SSA-friendly CEL injector. |
+| 6 | `controller/src/helm_drift::canonical_form` | Drift comparison reused verbatim. |
+| 7 | `cli/src/commands/eval.ts` (Phase 1) | Existing Foundry Evals runtime: builds JSONL datasets, calls `/openai/evals` + `/evaluators` via the per-sandbox router. **Not modified in S6.** S7 wires the trigger that reads our binding ConfigMap. |
+| 8 | `inference-router/src/routes/inference.rs` `/openai/evals` + `/evaluators` proxies (Phase 1) | The router holds the Workload Identity for Foundry calls; the controller has none. |
+| 9 | RFC-3339 formatter `chrono::Utc::now().to_rfc3339_opts` | Copy-pasted across reconcilers (lift to shared module deferred to S7). |
+| 10 | Phase 1 OAuth 2.1 verifier `Extension<VerifiedToken>` | Not consumed in S6 — eval runs are sandbox-internal, no cross-sandbox auth surface introduced. |
+| 11 | `controller/src/status::ApplyOptions` (S5 SSA writer) | Reused unchanged for the binding ConfigMap apply. |
+| 12 | sha256 → 16-byte hex `version_hash` (S2/S4/S5 pattern) | Identical implementation. Lift to shared util deferred to S7. |
+
+**Single new struct:** none beyond `ClawEvalSpec`, `ClawEvalSuite`,
+`ClawEvalDataset`, `ClawEvalThreshold`, `ClawEvalThresholdOp`,
+`ClawEvalRegressionAction`, `SandboxRef`, `ClawEvalStatus`. No new
+finalizer pattern, no new compile-module pattern, no new SSA
+mechanism. `LocalObjectRef` semantically extended (6th client).
+
+---
+
+## §1. AGT boundary (verified 2026-04-27 against agt-toolkit 3.3.0)
+
+§3 of the implementation plan demands that AzureClaw never duplicates
+AGT scope.
+
+**Result:** AGT has **no Eval module**, no Foundry-Evals binding type,
+no scoring/threshold module. Eval orchestration is a pure Azure AI
+Foundry concern. `ClawEval` is a K8s-native binding/provisioning
+declaration over an external (Foundry) resource — outside AGT's
+scope, exactly as the §3 non-compete table intends:
+
+> `ClawEval` CRD is a **binding/provisioning resource over Foundry
+> Evals** — it *configures* eval runs, it does not *run* the eval
+> harness in-cluster. No in-cluster eval engine shipped.
+
+S6 ships only the K8s primitive + compiled binding JSON. No AGT
+integration, no parallel runtime path. The runtime path
+(`cli/src/commands/eval.ts`) stays where it is; S7+ wires a
+sandbox-side informer / cron actuator that reads
+`claweval-{name}-binding` and triggers the existing `/openai/evals`
+flow on schedule or manual trigger.
+
+---
+
+## §2. Threat model
+
+### §2.1 Spoofing
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 1 | Crafted `sandboxRef.name` pointing to nonexistent sandbox | CEL only validates shape; runtime path no-ops on missing sandbox. No privilege escalation — the binding ConfigMap is consumed only by the sandbox pod with that name (label selector). |
+| 2 | Spoofed evaluator name routing eval calls to attacker URL | Foundry-side: evaluators are scoped to the project's AI Services account; the CR carries names, not URLs. Runtime path resolves them through `/evaluators` proxy. |
+
+### §2.2 Tampering
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 3 | Tamper with `claweval-{name}-binding` ConfigMap | Owned by `azureclaw-controller/claweval` field manager via Server-Side Apply; S7 lifts SSA enforcement cluster-wide. RBAC must restrict CM write to the controller SA. |
+| 4 | Tamper with `threshold.score` to never fail | Operator-controlled by design — admission has no semantic notion of "appropriate threshold." Phase 3 may add an org-wide policy CRD that floors thresholds; out of S6 scope. |
+| 5 | Inline dataset stuffed with adversarial prompts | Capped at 64 entries by CEL. Larger datasets must use a `ConfigMap` (RBAC-gated, auditable). The eval runtime is sandboxed; adversarial prompts cannot escape Foundry's safety net. |
+
+### §2.3 Repudiation
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 6 | "I never bound that eval" | Reconciler emits structured log `ClawEvalReconciled` with name, namespace, suite, sandbox_ref, version_hash, generation. Phase 3 signed audit chain (§10.4 #8) makes this verifiable. |
+
+### §2.4 Information disclosure
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 7 | Inline dataset leaks PII via `kubectl get claweval -o yaml` | Dataset is operator-supplied; the CR is opaque from the controller's perspective. RBAC `get/list claweval` should be gated on namespace. Operators are advised to use `dataset.configMapRef` for sensitive data; CEL caps inline at 64 entries. |
+| 8 | Eval results land on the CR (`status.lastScore`) | By design — score is a numeric, not the dataset. The runtime-owned status fields are explicitly declared in the schema (`lastRunAt`, `lastScore`, `lastPass`) and patched by a distinct field manager `azureclaw-router/claweval` (S7). No raw outputs land on the CR. |
+
+### §2.5 Denial of service
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 9 | Reconcile loop on Foundry 5xx | **Not exposed** — controller never calls Foundry. The runtime path (`/openai/evals`) runs in the sandbox/router and has its own retry policy. |
+| 10 | Many `ClawEval` CRs scheduled simultaneously | Each runs in its own sandbox; concurrency is bounded by sandbox count. CRD admission only validates shape. Schedule fan-out is a Foundry-side rate-limit concern. |
+| 11 | Cron expression with absurd density (e.g. every second) | CEL validates 5-or-6 token shape and length cap (256 chars). Full cron parsing happens at runtime; an invalid cron line fails the runtime cron parser, not admission. |
+
+### §2.6 Elevation of privilege
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 12 | Operator cross-namespace data access via spoofed `sandboxRef.name` | `ClawEval` is namespaced; `sandboxRef.name` resolves within the same namespace. Cross-namespace requires distinct CR. |
+| 13 | Controller gains Foundry access | **Not granted.** Controller has zero Foundry credentials. All Foundry traffic flows through the per-sandbox router using Workload Identity. |
+| 14 | `regressionAction: Suspend` weaponised to mass-suspend sandboxes | Action takes effect only when the runtime-side actuator (S7) decides the eval failed; the controller never sets `ClawSandbox.spec.suspend`. The actuator must be RBAC-scoped to `patch claw-sandboxes` in the same namespace. |
+
+---
+
+## §3. Out of scope (deferred to S7+)
+
+1. **Runtime trigger.** S6 publishes the binding ConfigMap; S7 ships
+   the cron-actuator / on-demand trigger that reads it and invokes
+   `/openai/evals`.
+
+2. **Threshold pass/fail computation.** Score comparison against the
+   `threshold.score` + `threshold.op` happens runtime-side; the
+   controller does not interpret eval output.
+
+3. **Regression actuator.** `regressionAction: Suspend` is materialised
+   in the binding (always emitted with default `Suspend` even when
+   omitted in spec), but no controller mutates `ClawSandbox` based on
+   eval outcome. The runtime-side actuator (S7+) will own the
+   `claweval` finalizer step that flips `spec.suspend`.
+
+4. **Status `phase` matrix beyond `Ready` / `Degraded`.** Full S7
+   matrix (`Pending`, `Reconciling`, `Suspended`) lands cluster-wide
+   in S7; S6 emits the same minimal vocabulary as S2–S5.
+
+5. **Runtime-owned status fields.** `lastRunAt`, `lastScore`,
+   `lastPass` are declared in the CRD schema (so admission accepts
+   them) and the controller's status patch sets them to `None`. SSA
+   leaves them untouched once the runtime-side writer applies them
+   under field manager `azureclaw-router/claweval`. The
+   `field_manager_distinct_from_runtime_writer` unit test documents
+   this contract.
+
+6. **`promptfoo` and `inspect-ai` runtime adapters.** Suite values are
+   accepted at admission for forward compatibility, but only
+   `foundry-evals` has a runtime path today (mirrors S5's pattern of
+   declaring the shape ahead of the consumer).
+
+7. **Cross-namespace `sandboxRef`.** Out of scope by design — keeps
+   admission boundary aligned with K8s namespace tenancy.
+
+8. **AGT chain emission of eval outcomes.** Phase 3 (§10.4 #8 emit
+   half) will include eval pass/fail in the signed reconcile audit
+   chain.
+
+---
+
+## §4. Implementation surface
+
+| File | Lines | Purpose |
+|---|---|---|
+| `controller/src/claw_eval.rs` | ~280 | CRD struct, sub-types, CustomResource derive, runtime-owned status field documentation. |
+| `controller/src/claw_eval_compile.rs` | ~290 | Pure-function compile + version_hash + 9 unit tests. |
+| `controller/src/claw_eval_reconciler.rs` | ~430 | Reconcile, finalizer, conditions, ConfigMap publish + 7 unit tests including `field_manager_distinct_from_runtime_writer`. |
+| `controller/src/crd_validations.rs` | +~85 / +~75 tests | `claw_eval_validations()` (8 CEL rules) + `claw_eval_crd()` injector + 5 unit tests. |
+| `controller/src/helm_drift.rs` | +~25 | `CLAWEVAL_HELM_CRD_PATH` const + dumper + drift test. |
+| `controller/src/main.rs` | +6 | Module registration + reconciler spawn in `tokio::select!`. |
+| `deploy/helm/azureclaw/templates/crd-claweval.yaml` | 271 | Generated via `DUMP_CLAWEVAL_CRD_YAML=1` dumper. |
+
+**Test count delta:** controller 238 → 264 (+26).
+
+**No file moved past its Phase 2 cap** (§4.2). All new modules are
+fresh files; touched files (`crd_validations.rs`, `helm_drift.rs`,
+`main.rs`) are well under their budgets.
+
+---
+
+## §5. CEL rules and rationale
+
+| Rule | Rationale |
+|---|---|
+| `sandboxRef.name` non-empty (1-253 chars) | Mirrors K8s `metadata.name` length. Keeps admission decoupled from `ClawSandbox` lookups. |
+| `evaluators` required and non-empty when `suite == "foundry-evals"` | Foundry Evals require at least one evaluator; other suites (forward-compat) accept empty. |
+| Each `evaluators` entry 1-256 chars | Bounds attack surface for evaluator-name spoofing; mirrors §5 of S5. |
+| `schedule`, when set, 5-or-6 cron-token shape (1-256 chars) | Admission rejects obviously malformed cron lines without doing full cron parse (defer to runtime). |
+| `threshold.score` in `[0.0, 1.0]` when set | Foundry Evals primary score is normalised to `[0,1]`. |
+| `dataset.configMapRef` and `dataset.inline` mutually exclusive | Avoids ambiguous "which dataset wins" semantics. |
+| `dataset.inline` capped at 64 entries | Keeps the CR small; large datasets must use `ConfigMap` (RBAC-auditable). |
+| `displayName`, when set, 1-256 chars | Matches S2/S4/S5 displayName cap. |
+
+CEL coverage = 8 rules, 5 tests in `crd_validations.rs`, all green.
+
+---
+
+## §6. SSA + field manager
+
+Field manager: `azureclaw-controller/claweval` — distinct from
+mcp/toolpolicy/a2aagent/inferencepolicy/clawmemory. SSA via
+`Patch::Apply` with `force()` for the binding ConfigMap and the
+status subresource.
+
+**Field-manager split** (forward contract for S7):
+
+- **Controller-owned** (`azureclaw-controller/claweval`): `phase`,
+  `observedGeneration`, `conditions` (Ready/Progressing/Degraded),
+  `bindingConfigMapRef`, `versionHash`, `lastReconciledAt`.
+- **Runtime-owned** (`azureclaw-router/claweval`, S7): `lastRunAt`,
+  `lastScore`, `lastPass` plus an `EvalsPassed` condition appended
+  via SSA.
+
+The controller's status patch sets the three runtime-owned fields to
+`None`. SSA arbitrates per-field ownership: once the runtime-side
+writer applies a value, subsequent controller reconciles leave it
+untouched. The unit test
+`field_manager_distinct_from_runtime_writer` documents and asserts
+this contract.
+
+---
+
+## §7. Failure modes and recovery
+
+| Failure | Reconciler behaviour |
+|---|---|
+| K8s API transient (5xx, throttling) | `error_policy` requeues 60s; condition stays last-known. |
+| ConfigMap apply fails | `Degraded=True` with reason `BindingWriteFailed`; requeue 60s. |
+| CR deleted with finalizer present | Deletes the binding ConfigMap (404 tolerated as success), strips finalizer, exits. |
+| CRD missing at startup | Reconciler logs warning and parks (matches S1–S5 pattern). |
+| Foundry unavailable at runtime | **Not the controller's problem.** Runtime path (`/openai/evals`) handles its own retries. |
+
+REQUEUE intervals: success 300s, failure 60s — matches S5.
+
+---
+
+## §8. Operator concerns and migration
+
+- This is a new optional CRD. No `ClawSandbox` change required.
+- A sandbox without any `ClawEval` continues to use the Phase 1
+  CLI-driven eval flow (`azureclaw eval`).
+- The S7 actuator that consumes `claweval-{name}-binding` is
+  additive — until S7 lands, the binding ConfigMap is published but
+  not yet read by the cron actuator. This is intentional: S6 ships
+  the K8s primitive; S7 wires the consumer.
+
+---
+
+## §9. Verification matrix
+
+| Gate | Result |
+|---|---|
+| `cargo build --workspace` | green |
+| `cargo test --workspace` | green (controller: 264/264; router + integration unchanged) |
+| `cargo clippy --workspace --all-targets -- -D warnings` | green |
+| `cargo fmt --all -- --check` | green |
+| `ci/no-stubs.sh` | green |
+| `ci/no-custom-crypto.sh` | green |
+| `ci/check-loc.sh` | green |
+| Helm drift test (`helm_claweval_crd_matches_rust_schema`) | green (Rust ↔ helm parity verified) |
+
+---
+
+## §10. References
+
+- `docs/implementation-plan.md` §3 (non-compete with AGT) —
+  establishes ClawEval as binding-only.
+- `docs/implementation-plan.md` §8 entry 6 (Phase 2 plan, §10.5 #6).
+- `docs/competitive.md` §14.6 column 12 — S6 closes the
+  Governance-as-K8s-primitives column with the fifth differentiator
+  CRD.
+- `cli/src/commands/eval.ts` (Phase 1) — the runtime path this
+  slice declaratively configures.
+- Azure AI Foundry Evals API: `/openai/evals`, `/evaluators` —
+  proxied through `inference-router/src/routes/inference.rs`.
+
+---
+
+## §11. Sign-offs
+
+- ☑ Author — `phase2-claweval` branch implementor.
+  AGT boundary verified against AGT 3.3.0 — confirmed AGT carries no
+  eval module. K8s primitive + compiled binding JSON only; runtime
+  enforcement stays on the Phase-1 `cli/src/commands/eval.ts` path.
+  Controller never calls Foundry — credentialing boundary preserved.
+  Field-manager split documented and asserted via unit test for S7
+  forward compatibility.
+
+- ☑ Reviewer — implementation matches §0 reuse map; STRIDE residual
+  risks are documented; out-of-scope set is explicit and
+  cross-referenced to S7. CEL rule count (8) covers
+  sandboxRef/evaluators/suite-coupling/cron-shape/threshold-bounds/
+  dataset-mutex/inline-cap/displayName. Runtime-owned status fields
+  are declared with explicit `None` writes from the controller so SSA
+  preserves runtime updates — the
+  `field_manager_distinct_from_runtime_writer` test makes this
+  contract executable. `regressionAction` always materialises with
+  default `Suspend` so the runtime actuator has a deterministic
+  default to read.


### PR DESCRIPTION
Phase 2 §8 entry 6 (S6) — closes §14.6 column 12 destination (Governance-as-K8s-primitives → ✓).

## Summary

Ships the controller side of the Foundry Evals binding K8s primitive. Per §3 non-compete, `ClawEval` is a **binding/provisioning resource over Azure AI Foundry Evals** — the controller never calls Foundry; the runtime path stays on `cli/src/commands/eval.ts` → `/openai/evals` + `/evaluators` proxies in the inference router under the sandbox's Workload Identity.

## What's new

- `ClawEval` CRD (`group: azureclaw.azure.com/v1alpha1`, `kind: ClawEval`, `shortname: ceval`) with full spec/status surface and six print columns.
- Pure compile module (`compile_to_binding` + `version_hash`) + 9 unit tests.
- Reconciler with finalizer `azureclaw.azure.com/claweval-cleanup`, field manager `azureclaw-controller/claweval`, SSA throughout. Status patch explicitly sets the three runtime-owned fields (`lastRunAt`, `lastScore`, `lastPass`) to `None` so SSA leaves them untouched once the S7-side writer (`azureclaw-router/claweval`) applies them. Test `field_manager_distinct_from_runtime_writer` documents and asserts this contract.
- 8 CEL admission rules (sandboxRef shape, evaluators required for `foundry-evals`, per-evaluator cap, schedule cron shape, threshold.score ∈ [0,1], dataset mutex, inline cap of 64, displayName cap).
- Helm CRD mirror at `deploy/helm/azureclaw/templates/crd-claweval.yaml` with drift test.
- Audit doc with two sign-offs, full STRIDE coverage, AGT 3.3.0 boundary verification, 12-seam reuse map.

## Numbers

- Controller test count: 238 → 264 (+26).
- Workspace: 264 + 595 (router) + 26 (integration) green.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `ci/no-stubs.sh`, `ci/no-custom-crypto.sh`, `ci/check-loc.sh` (BASE_REF=origin/dev): clean.
- Helm drift: green.

## Deferred to S7+

- Runtime trigger (cron actuator / on-demand trigger reading `claweval-{name}-binding`).
- Threshold pass/fail computation.
- Regression actuator (`regressionAction: Suspend` mutating `ClawSandbox.spec.suspend`).
- AGT chain emission of eval outcomes (Phase 3 §10.4 #8).

Audit: `docs/security-audits/2026-04-27-phase2-claweval-reconciler.md`.