### PR TITLE
phase2-overlaymode: sigs/agent-sandbox OverlayMode reconciler branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,88 @@ floor compare-and-block, model-preference selection).
 - The runtime gate `inference-router::routes::inference_policy::check`
   (Phase 1) is **not modified in this slice**.
 
+### S8 `phase2-overlaymode` — sigs/agent-sandbox OverlayMode
+
+This slice flips `ClawSandbox.spec.upstreamCompatibility.sigsAgentSandbox`
+from a Phase-1 schema-only field into a real reconciler branch, closing
+implementation-plan §2.1's third sandbox mode (Native | Translate |
+**Overlay**) and contributing to §14.6 column 11 (Multi-runtime hosting).
+
+**Behaviour:** when `sigsAgentSandbox: "overlay"`, the operator already
+manages an upstream `Sandbox` CR (sigs.k8s.io/agent-sandbox) in the
+namespace and `ClawSandbox.spec.upstreamCompatibility.upstreamSandboxRef.name`
+points at it. The controller still creates the *governance overlay*
+(namespace, sandbox ServiceAccount with Workload-Identity binding,
+egress + ingress NetworkPolicy, governance ConfigMap, Azure RBAC SA
+annotations) but **skips** the AzureClaw Pod Deployment and the
+blocklist seed-ConfigMap + 6h refresh CronJob — those would have nothing
+to mount into.
+
+**Status:** new `phase: "Overlay"` distinct from `"Running"`, with
+`Ready=True / Reason=OverlayMode`, `Progressing=False / Reason=OverlayMode`,
+and a new `Suspended=True / Reason=OverlayMode` condition whose message
+names the upstream CR. `status.sandboxPod` is set to
+`upstream/<name>` so `kubectl get clawsandbox` makes the upstream
+relationship obvious. New `overlay_status_matches` idempotency guard
+mirrors `running_status_matches` to keep `.status` PATCH traffic flat.
+
+**Admission gate:** runtime-only (no ClawSandbox CEL admission rules
+exist yet — schema-only Phase 1). The reconciler stamps `Degraded=True /
+Reason=SpecInvalid` when `sigsAgentSandbox == "overlay"` but
+`upstreamSandboxRef.name` is missing/empty, or when an unknown value
+(typo such as `"Overlay"` or `"overaly"`) is supplied. Future slice can
+hoist into CEL once a `claw_sandbox_validations()` function is added.
+
+**Out of scope (deferred):** watching the upstream `Sandbox` CR's
+status (would require the upstream CRD discovery + informer); mirroring
+its conditions back onto `ClawSandbox.status`; `kubectl claw convert`
+upstream→overlay path (lands in S9). `Translate` mode remains
+schema-only — no runtime path beyond what already lands here.
+
+**Surface:**
+
+- `controller/src/crd.rs` — `UpstreamCompatibilityConfig` gains
+  `upstream_sandbox_ref: Option<LocalObjectRef>`; `is_overlay_mode()`
+  + `overlay_target_name()` pure helpers; field-level docs list all
+  four accepted values (`off|observe|translate|overlay`) and the
+  overlay-requires-ref invariant. 5 unit tests.
+- `controller/src/status/conditions.rs` — new `TYPE_SUSPENDED`
+  condition type + `reason::OVERLAY_MODE` constant.
+- `controller/src/status/mod.rs` — `build_overlay_status_patch`,
+  `overlay_status_matches`. 6 unit tests.
+- `controller/src/reconciler/mod.rs` — overlay-mode pre-flight before
+  Step 1 (Degrades on missing ref / unknown value); Deployment block
+  (Step 4) wrapped in labelled `'deployment_block` with early-`break`
+  on overlay; blocklist CM + CronJob (Step 4d) gated on
+  `!overlay_mode`; Step 5 dispatches to `build_overlay_status_patch`
+  when overlay target is set, else falls through to the existing
+  Running path. `governance_config` and `blocklist_cm_name` hoisted
+  out of the deployment block so Step 4c / Step 4d still see them.
+
+**Reuse map:**
+
+- Existing `LocalObjectRef` (`controller/src/mcp_server.rs:157`)
+  reused — fifth client now (signing/jwks, profile, agent-card,
+  guardrail-profile, **upstream sandbox ref**). No second
+  ObjectReference type.
+- `crate::status::conditions::preserve_transition_time` reused
+  unchanged for the new three-condition matrix.
+- `crate::status::stamp_degraded` reused for both new failure modes.
+- Reconciler's existing `degrade!` macro reused — overlay-validation
+  errors flow through the same Degraded-stamp + 60s requeue path as
+  every other spec-invalid case.
+- No new file managers, no new CRDs, no helm `crd.yaml` change
+  (`upstreamCompatibility` was schema-only in Phase 1 — kube-rs
+  registers the runtime schema; helm template stays admission-only
+  until a `claw_sandbox_validations()` lands).
+
+**Tests:** controller workspace 264 → 276 (+12: 5 CRD helpers + 6 status
+helpers + 1 condition constant exercise via overlay tests). Workspace
+green (router 595, integration 26).
+
+**Audit:** `docs/security-audits/2026-04-27-phase2-overlaymode.md` — 2
+sign-offs.
+
 ### S6 `phase2-claweval` — ClawEval CRD + binding ConfigMap + helm CRD
 
 This slice ships the controller side of the Azure AI Foundry Evals

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -3,6 +3,7 @@
 //! This is the Rust representation of the ClawSandbox CRD.
 //! kube-rs derives the CRD schema, API bindings, and JSON schema automatically.
 
+use crate::mcp_server::LocalObjectRef;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;
 use schemars::JsonSchema;
@@ -85,18 +86,44 @@ pub struct ClawSandboxSpec {
     pub upstream_compatibility: Option<UpstreamCompatibilityConfig>,
 }
 
-/// Upstream-protocol compatibility (Phase 1 scaffold).
+/// Upstream-protocol compatibility (Phase 1 scaffold extended in Phase 2 S8).
 ///
-/// Codifies §2 (TranslateMode) of the implementation plan as a CRD field.
-/// All values default to OFF — opt-in per sandbox.
+/// Codifies §2 (Native | Translate | Overlay) of the implementation plan
+/// as CRD fields. All values default to OFF — opt-in per sandbox.
+///
+/// **`OverlayMode` (Phase 2 S8).** When `sigs_agent_sandbox == "overlay"`,
+/// the operator already manages an upstream `Sandbox` CR in the same
+/// namespace; AzureClaw provides only the *overlay* (namespace + sandbox
+/// ServiceAccount + Workload-Identity binding + NetworkPolicy + governance
+/// ConfigMaps). The controller **skips Deployment/Service/CronJob
+/// creation**: those are owned by the upstream reconciler. The
+/// `upstream_sandbox_ref` field names that upstream CR. Implementation
+/// plan §2 lines 269-271 + §8 entry "S8 phase2-overlaymode".
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UpstreamCompatibilityConfig {
     /// `sigs.k8s.io/agent-sandbox` SandboxClaim translation mode.
-    /// Values: `"off"` (default), `"observe"` (mirror status only),
-    /// `"translate"` (accept SandboxClaim semantics on inbound).
+    /// Values:
+    /// - `"off"` (default) — no upstream interaction; pure Native mode.
+    /// - `"observe"` — mirror status only.
+    /// - `"translate"` — accept SandboxClaim semantics on inbound (P1
+    ///   schema-only, runtime path deferred).
+    /// - `"overlay"` — operator's upstream `Sandbox` CR owns the Pod;
+    ///   AzureClaw provides governance overlay only. Requires
+    ///   [`upstream_sandbox_ref`] (admission-enforced).
+    ///
     /// Reconciler refuses unknown strings.
     pub sigs_agent_sandbox: Option<String>,
+
+    /// Reference to an upstream `Sandbox` CR in the same namespace.
+    /// **Required when `sigs_agent_sandbox == "overlay"`.** Ignored
+    /// otherwise. The controller does not watch the upstream object's
+    /// status today (deferred to a future slice that adds an upstream
+    /// CRD discovery / informer); operators read overlay state from
+    /// the upstream CR directly. AzureClaw never mutates the upstream
+    /// object — the relationship is read-only at the boundary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_sandbox_ref: Option<LocalObjectRef>,
 
     /// CNCF AI Conformance reference-mode toggle. When `true`, the
     /// reconciler emits the canonical conformance status block on the
@@ -104,6 +131,95 @@ pub struct UpstreamCompatibilityConfig {
     /// no code path consumes this yet.
     #[serde(default)]
     pub ai_conformance_reference: bool,
+}
+
+impl UpstreamCompatibilityConfig {
+    /// Returns `true` if this configuration selects `OverlayMode`.
+    /// Pure helper — no I/O, no logging.
+    #[must_use]
+    pub fn is_overlay_mode(&self) -> bool {
+        self.sigs_agent_sandbox.as_deref() == Some("overlay")
+    }
+
+    /// Returns the upstream `Sandbox` CR name when in overlay mode,
+    /// otherwise `None`. Centralises the "extract overlay target"
+    /// logic so the reconciler does not duplicate the match.
+    #[must_use]
+    pub fn overlay_target_name(&self) -> Option<&str> {
+        if self.is_overlay_mode() {
+            self.upstream_sandbox_ref.as_ref().map(|r| r.name.as_str())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod upstream_compat_tests {
+    use super::*;
+
+    fn cfg(mode: Option<&str>, name: Option<&str>) -> UpstreamCompatibilityConfig {
+        UpstreamCompatibilityConfig {
+            sigs_agent_sandbox: mode.map(str::to_owned),
+            upstream_sandbox_ref: name.map(|n| LocalObjectRef { name: n.into() }),
+            ai_conformance_reference: false,
+        }
+    }
+
+    #[test]
+    fn is_overlay_mode_true_only_for_overlay_string() {
+        assert!(cfg(Some("overlay"), Some("up")).is_overlay_mode());
+        assert!(!cfg(Some("off"), None).is_overlay_mode());
+        assert!(!cfg(Some("observe"), None).is_overlay_mode());
+        assert!(!cfg(Some("translate"), None).is_overlay_mode());
+        assert!(!cfg(None, None).is_overlay_mode());
+        assert!(!cfg(Some("OVERLAY"), None).is_overlay_mode());
+        assert!(!cfg(Some(""), None).is_overlay_mode());
+    }
+
+    #[test]
+    fn overlay_target_name_extracts_only_in_overlay_mode() {
+        assert_eq!(
+            cfg(Some("overlay"), Some("upstream-1")).overlay_target_name(),
+            Some("upstream-1")
+        );
+        assert_eq!(
+            cfg(Some("translate"), Some("upstream-1")).overlay_target_name(),
+            None
+        );
+        assert_eq!(cfg(Some("overlay"), None).overlay_target_name(), None);
+    }
+
+    #[test]
+    fn defaults_are_native_mode() {
+        let c = UpstreamCompatibilityConfig::default();
+        assert!(!c.is_overlay_mode());
+        assert!(c.overlay_target_name().is_none());
+        assert!(c.sigs_agent_sandbox.is_none());
+        assert!(c.upstream_sandbox_ref.is_none());
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_overlay_fields() {
+        let c = cfg(Some("overlay"), Some("my-upstream"));
+        let j = serde_json::to_string(&c).expect("serialise");
+        let back: UpstreamCompatibilityConfig = serde_json::from_str(&j).expect("deserialise");
+        assert_eq!(back.sigs_agent_sandbox.as_deref(), Some("overlay"));
+        assert_eq!(
+            back.upstream_sandbox_ref.as_ref().map(|r| r.name.as_str()),
+            Some("my-upstream")
+        );
+    }
+
+    #[test]
+    fn serde_omits_upstream_ref_when_none() {
+        let c = cfg(Some("off"), None);
+        let j = serde_json::to_string(&c).expect("serialise");
+        assert!(
+            !j.contains("upstreamSandboxRef"),
+            "off-mode should not serialise upstreamSandboxRef field, got {j}"
+        );
+    }
 }
 
 /// `ClawSandbox.spec.a2a` — inbound A2A 1.0.0 exposure block.

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -254,6 +254,67 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         );
     }
 
+    // ── Overlay-mode pre-flight (Phase 2 S8) ─────────────────────────────
+    // When `spec.upstreamCompatibility.sigsAgentSandbox == "overlay"`,
+    // an upstream `Sandbox` CR (sigs.k8s.io/agent-sandbox) owns the Pod.
+    // We still create the overlay (namespace, SA, NetworkPolicy,
+    // governance ConfigMaps) but skip Deployment/Service/CronJob.
+    //
+    // Field-level invariant (no ClawSandbox CEL today): overlay mode
+    // requires `upstreamSandboxRef.name`. Without it we can't surface
+    // *which* upstream CR the operator meant, so we Degrade rather than
+    // silently no-op.
+    let upstream_compat = spec.upstream_compatibility.clone().unwrap_or_default();
+    let overlay_mode = upstream_compat.is_overlay_mode();
+    let overlay_target: Option<String> = if overlay_mode {
+        match upstream_compat.overlay_target_name() {
+            Some(n) if !n.is_empty() => Some(n.to_owned()),
+            _ => {
+                tracing::error!(
+                    sandbox = %name,
+                    "OverlayMode selected but upstreamSandboxRef.name is missing/empty"
+                );
+                degrade!(
+                    SPEC_INVALID,
+                    "upstreamCompatibility.sigsAgentSandbox=\"overlay\" requires \
+                     upstreamCompatibility.upstreamSandboxRef.name"
+                );
+            }
+        }
+    } else {
+        // Reject unknown values eagerly so misspellings ("Overlay",
+        // "overaly") don't silently fall through to Native mode.
+        if let Some(v) = upstream_compat.sigs_agent_sandbox.as_deref()
+            && !matches!(v, "" | "off" | "observe" | "translate" | "overlay")
+        {
+            tracing::error!(sandbox = %name, value = v,
+                "Unknown upstreamCompatibility.sigsAgentSandbox value");
+            degrade!(
+                SPEC_INVALID,
+                format!(
+                    "upstreamCompatibility.sigsAgentSandbox: unknown value `{v}` \
+                     (expected off|observe|translate|overlay)"
+                )
+            );
+        }
+        None
+    };
+    if overlay_mode {
+        tracing::info!(
+            sandbox = %name,
+            upstream = %overlay_target.as_deref().unwrap_or("?"),
+            "OverlayMode active — skipping Deployment/Service/blocklist-CronJob \
+             (upstream Sandbox CR owns the Pod)"
+        );
+    }
+
+    // Hoisted out of the deployment block so Step 4c (governance
+    // ConfigMap) and the blocklist CronJob (Step 4d) can reach them.
+    // In overlay mode the Pod is upstream-owned, but the governance
+    // overlay still relies on these.
+    let governance_config = spec.governance.clone().unwrap_or_default();
+    let blocklist_cm_name = format!("{}-blocklist", &name);
+
     // ── Step 1: Create namespace ─────────────────────────────────────────
     let ns_api: Api<Namespace> = Api::all(client.clone());
     let ns: Namespace = serde_json::from_value(json!({
@@ -555,429 +616,490 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         .await?;
 
     // ── Step 4: Deploy sandbox pod ───────────────────────────────────────
-    let image = openclaw_config
-        .image
-        .unwrap_or_else(|| ctx.sandbox_image.clone());
-
-    let (runtime_class, pool_label) = isolation_scheduling(&sandbox_config.isolation);
-
-    let pull_policy = if image.ends_with(":latest") {
-        "Always"
-    } else {
-        "IfNotPresent"
-    };
-
-    let deploy_api: Api<Deployment> = Api::namespaced(client.clone(), &sandbox_ns);
-
-    // Token budget values from CRD (0 = unlimited)
-    let token_budget_daily = inference_config
-        .token_budget
-        .as_ref()
-        .and_then(|b| b.daily)
-        .unwrap_or(0);
-    let token_budget_per_request = inference_config
-        .token_budget
-        .as_ref()
-        .and_then(|b| b.per_request)
-        .unwrap_or(0);
-
-    // Build OpenClaw container env vars.
-    //
-    // OPENCLAW_GATEWAY_TOKEN is plumbed via secretKeyRef rather than a static
-    // value so that:
-    //   1. Rotating the Secret + restarting the pod reliably picks up the new
-    //      token without requiring a controller reconcile to re-render the
-    //      Deployment env.
-    //   2. The pod env is, by construction, equal to the Secret value at pod
-    //      start. `azureclaw connect` reads the Secret to find the gateway
-    //      token; if env and Secret ever drift, the operator gets 401s on a
-    //      rolled pod even though the Secret looks correct. valueFrom closes
-    //      that drift window.
-    let mut openclaw_env = vec![
-        json!({"name": "OPENCLAW_MODEL", "value": inference_config.model}),
-        json!({"name": "AZURE_OPENAI_ENDPOINT", "value": &ctx.openai_endpoint}),
-        json!({"name": "AZURECLAW_AUTH_MODE", "value": "workload-identity"}),
-        json!({
-            "name": "OPENCLAW_GATEWAY_TOKEN",
-            "valueFrom": {
-                "secretKeyRef": {
-                    "name": "gateway-token",
-                    "key": "token"
-                }
-            }
-        }),
-    ];
-    // Foundry project endpoint (for standalone APIs: Memory Store, Foundry IQ, etc.)
-    if !ctx.foundry_project_endpoint.is_empty() {
-        openclaw_env.push(
-            json!({"name": "FOUNDRY_PROJECT_ENDPOINT", "value": &ctx.foundry_project_endpoint}),
-        );
-    }
-    // Foundry deployments list (so plugin shows only deployed models, not full catalog)
-    if !ctx.foundry_deployments.is_empty() {
-        openclaw_env
-            .push(json!({"name": "FOUNDRY_DEPLOYMENTS", "value": &ctx.foundry_deployments}));
-    }
-    // Inject Foundry Agent ID if set in status (for tools needing agent runs)
-    if let Some(ref agent_id) = sandbox
-        .status
-        .as_ref()
-        .and_then(|s| s.foundry_agent_id.clone())
-        && !agent_id.is_empty()
-    {
-        openclaw_env.push(json!({"name": "FOUNDRY_AGENT_ID", "value": agent_id}));
-    }
-    // Signal configured Foundry agent tools
-    if let Some(ref tools) = agent_config.tools
-        && !tools.is_empty()
-    {
-        openclaw_env.push(json!({"name": "FOUNDRY_AGENT_TOOLS", "value": tools.join(",")}));
-    }
-    // AGT governance env vars (opt-in) — injected into BOTH openclaw and router containers
-    let governance_config = spec.governance.unwrap_or_default();
-    let mut router_agt_env: Vec<serde_json::Value> = Vec::new();
-
-    // Operator-level Entra-auth kill switch.
-    //
-    // When the cluster operator sets `AZURECLAW_DISABLE_ENTRA_AUTH=1` on
-    // the controller (e.g. dev clusters, or any subscription where the
-    // `api://agentmesh` Entra app registration is not yet provisioned),
-    // tell every sandbox to skip the Entra token-exchange step at startup.
-    //
-    // Without this, sub-agents burn ~123s on doomed AAD retries before
-    // falling back to anonymous tier — long enough that parent→sub-agent
-    // spawn-and-message workflows fail because the parent's tool-call
-    // timeout fires before the sub-agent finishes booting. See
-    // docs/security-audits/2026-04-26-entra-auth-toggle.md for the full
-    // analysis.
-    //
-    // Default is "skip" until the operator explicitly opts in by unsetting
-    // the env var or setting it to "0". Phase 2 will replace this with
-    // controller-side tenant feature detection once Entra Agent ID
-    // provisioning is automated.
-    let skip_entra =
-        std::env::var("AZURECLAW_DISABLE_ENTRA_AUTH").unwrap_or_else(|_| "1".to_string());
-    if skip_entra == "1" || skip_entra.eq_ignore_ascii_case("true") {
-        openclaw_env.push(json!({"name": "AGT_SKIP_ENTRA", "value": "1"}));
-    }
-
-    if governance_config.enabled {
-        openclaw_env.push(json!({"name": "AGT_GOVERNANCE_ENABLED", "value": "true"}));
-        openclaw_env
-            .push(json!({"name": "AGT_POLICY_PROFILE", "value": governance_config.tool_policy}));
-        openclaw_env.push(json!({"name": "AGT_TRUST_THRESHOLD", "value": governance_config.trust_threshold.to_string()}));
-        // Validate and propagate trusted peers (format: "name:AMID,name:AMID,...")
-        let valid_peers = governance_config.trusted_peers.as_deref().filter(|p| {
-            let ok = !p.contains('\n') && !p.contains('\r') && !p.contains('\0');
-            if !ok {
-                tracing::warn!("Ignoring trusted_peers: contains control characters");
-            }
-            ok
-        });
-        if let Some(peers) = valid_peers {
-            openclaw_env.push(json!({"name": "AGT_TRUSTED_PEERS", "value": peers}));
+    // Skipped wholesale in OverlayMode (Phase 2 S8): the operator's
+    // upstream `Sandbox` CR (sigs.k8s.io/agent-sandbox) owns the Pod
+    // lifecycle. Step 4b (SA annotations for Azure RBAC) and Step 4c
+    // (governance ConfigMap + mesh ingress NetworkPolicy) intentionally
+    // still run — they form the *overlay* that AzureClaw layers on top
+    // of the upstream Pod.
+    'deployment_block: {
+        if overlay_mode {
+            break 'deployment_block;
         }
-        // Validate registry mode: must be "local" or "global"
-        let reg_mode = match governance_config.registry_mode.as_deref() {
-            Some("local") => "local",
-            Some("global") | None => "global",
-            Some(other) => {
-                tracing::warn!(mode = other, "Invalid registry_mode, defaulting to global");
-                "global"
-            }
+        let image = openclaw_config
+            .image
+            .unwrap_or_else(|| ctx.sandbox_image.clone());
+
+        let (runtime_class, pool_label) = isolation_scheduling(&sandbox_config.isolation);
+
+        let pull_policy = if image.ends_with(":latest") {
+            "Always"
+        } else {
+            "IfNotPresent"
         };
-        openclaw_env.push(json!({"name": "AGT_REGISTRY_MODE", "value": reg_mode}));
-        // Plugin also needs relay/registry URLs for direct AgentMesh SDK connections
-        openclaw_env.push(json!({"name": "AGT_RELAY_URL", "value": "ws://agentmesh-relay.agentmesh.svc.cluster.local:8765"}));
-        openclaw_env.push(json!({"name": "AGT_REGISTRY_URL", "value": "http://agentmesh-registry.agentmesh.svc.cluster.local:8080"}));
-        // Router needs governance vars too (handoff auth, policy enforcement)
-        router_agt_env.push(json!({"name": "AGT_GOVERNANCE_ENABLED", "value": "true"}));
-        router_agt_env
-            .push(json!({"name": "AGT_POLICY_PROFILE", "value": &governance_config.tool_policy}));
-        router_agt_env.push(json!({"name": "AGT_TRUST_THRESHOLD", "value": governance_config.trust_threshold.to_string()}));
-        // Behavior-monitor burst threshold: offload workers run long
-        // research loops that make many tool/inference calls in short
-        // bursts. Bump the burst limit well above the interactive default
-        // (100/60s) so legitimate research bursts aren't flagged as
-        // "abuse" by the self-burst detector. Non-offload profiles keep
-        // the router's built-in default.
-        if governance_config.tool_policy == "offload" {
-            router_agt_env.push(json!({"name": "AGT_BEHAVIOR_BURST_THRESHOLD", "value": "1000"}));
-        }
-        if let Some(peers) = valid_peers {
-            router_agt_env.push(json!({"name": "AGT_TRUSTED_PEERS", "value": peers}));
-        }
-        router_agt_env.push(json!({"name": "AGT_REGISTRY_MODE", "value": reg_mode}));
-        // Mesh namespace for K8s DNS routing between agents
-        router_agt_env.push(json!({"name": "AGT_MESH_NAMESPACE", "value": &sandbox_ns}));
-        // Self-hosted AGT relay + registry (for E2E encrypted inter-agent comms)
-        router_agt_env.push(json!({"name": "AGT_RELAY_URL", "value": "ws://agentmesh-relay.agentmesh.svc.cluster.local:8765"}));
-        router_agt_env.push(json!({"name": "AGT_REGISTRY_URL", "value": "http://agentmesh-registry.agentmesh.svc.cluster.local:8080"}));
-    }
 
-    // ── extraEnv: user/controller-provided env vars on spec.openclaw.extraEnv ──
-    // Used by the controller to propagate offload parameters (OFFLOAD_REQUEST_ID,
-    // OFFLOAD_PARENT_AMID, OFFLOAD_TASK, OFFLOAD_TIMEOUT_MINUTES) into offload
-    // sandboxes. Keys are validated to avoid clobbering reserved prefixes.
-    if let Some(extra) = openclaw_config.extra_env.as_ref() {
-        // Reserved prefixes that must come from the reconciler itself, not user input.
-        const RESERVED_PREFIXES: &[&str] =
-            &["AGT_", "FOUNDRY_AGENT_", "AZURE_", "IMDS_", "AZURECLAW_"];
-        // Names already set above — skip silently if caller provided a duplicate.
-        let mut existing: std::collections::HashSet<String> = openclaw_env
-            .iter()
-            .filter_map(|v| v.get("name").and_then(|n| n.as_str()).map(String::from))
-            .collect();
-        for (k, v) in extra {
-            if k.is_empty()
-                || !k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-                || k.chars().next().is_some_and(|c| c.is_ascii_digit())
-            {
-                tracing::warn!(key = %k, "extraEnv: invalid env var name, skipping");
-                continue;
-            }
-            if RESERVED_PREFIXES.iter().any(|p| k.starts_with(p)) {
-                tracing::warn!(key = %k, "extraEnv: key uses reserved prefix, skipping");
-                continue;
-            }
-            if v.contains('\0') {
-                tracing::warn!(key = %k, "extraEnv: value contains NUL byte, skipping");
-                continue;
-            }
-            if existing.contains(k) {
-                tracing::debug!(key = %k, "extraEnv: overridden by reconciler, skipping");
-                continue;
-            }
-            openclaw_env.push(json!({"name": k, "value": v}));
-            existing.insert(k.clone());
-        }
-    }
+        let deploy_api: Api<Deployment> = Api::namespaced(client.clone(), &sandbox_ns);
 
-    // Build the inference-router env array
-    let mut router_env = vec![
-        json!({"name": "AZURE_OPENAI_ENDPOINT", "value": &ctx.openai_endpoint}),
-        json!({"name": "FOUNDRY_ENDPOINT", "value": &ctx.foundry_endpoint}),
-        json!({"name": "FOUNDRY_PROJECT_ENDPOINT", "value": &ctx.foundry_project_endpoint}),
-        json!({"name": "IMDS_CLIENT_ID", "value": &ctx.imds_client_id}),
-        json!({"name": "AZURE_OPENAI_DEPLOYMENT", "value": &inference_config.model}),
-        json!({"name": "AZURECLAW_AUTH_MODE", "value": "workload-identity"}),
-        json!({"name": "CONTENT_SAFETY_ENABLED", "value": inference_config.content_safety.to_string()}),
-        json!({"name": "PROMPT_SHIELDS_ENABLED", "value": inference_config.prompt_shields.to_string()}),
-        json!({"name": "CONTENT_SAFETY_ENDPOINT", "value": &ctx.content_safety_endpoint}),
-        json!({"name": "TOKEN_BUDGET_DAILY", "value": token_budget_daily.to_string()}),
-        json!({"name": "TOKEN_BUDGET_PER_REQUEST", "value": token_budget_per_request.to_string()}),
-        json!({"name": "SANDBOX_NAME", "value": &name}),
-        json!({"name": "SANDBOX_ISOLATION", "value": &sandbox_config.isolation}),
-        json!({"name": "RUST_LOG", "value": "info,inference_router=debug"}),
-    ];
-    router_env.extend(router_agt_env);
+        // Token budget values from CRD (0 = unlimited)
+        let token_budget_daily = inference_config
+            .token_budget
+            .as_ref()
+            .and_then(|b| b.daily)
+            .unwrap_or(0);
+        let token_budget_per_request = inference_config
+            .token_budget
+            .as_ref()
+            .and_then(|b| b.per_request)
+            .unwrap_or(0);
 
-    // ── Blocklist ConfigMap + env vars ──
-    // The blocklist is always-on: router loads a seed file at startup, then
-    // auto-refreshes from OISD + URLhaus feeds every 6 hours.
-    let blocklist_cm_name = format!("{}-blocklist", &name);
-    router_env.push(json!({"name": "BLOCKLIST_ENABLED", "value": "true"}));
-    router_env.push(
-        json!({"name": "BLOCKLIST_SEED_PATH", "value": "/etc/azureclaw/blocklist/domains.txt"}),
-    );
-
-    // Egress learn mode — enabled by default so operators can discover required domains.
-    // Blocklist (threat intelligence) is still enforced. Disable with network_policy.learn_egress=false.
-    let learn_egress = spec
-        .network_policy
-        .as_ref()
-        .is_none_or(|np| np.learn_egress);
-    if learn_egress {
-        router_env.push(json!({"name": "EGRESS_LEARN_MODE", "value": "true"}));
-    }
-
-    // Build the pod spec — runtimeClassName only set for Kata (confidential)
-    let mut pod_spec = json!({
-        "serviceAccountName": "sandbox",
-        "securityContext": build_pod_security_context(&sandbox_config),
-        // ── Init container: iptables-based per-container egress control ──
-        // Since K8s NetworkPolicy operates at pod level (not container level),
-        // we use iptables UID-based rules to restrict the openclaw agent
-        // container (UID 1000) to localhost + DNS only, with a transparent
-        // forward proxy for HTTP/HTTPS egress enforcement and learn mode.
+        // Build OpenClaw container env vars.
         //
-        // Filter chain (OUTPUT):
-        //   UID 1000 → allow loopback, DNS, established → DROP everything else
-        //
-        // NAT chain (OUTPUT):
-        //   UID 1000 port 80/443 (not loopback) → REDIRECT to :8444
-        //   The transparent proxy on port 8444 (inference-router, UID 1001):
-        //   - Records every domain for learn mode
-        //   - Enforces blocklist/allowlist per domain
-        //   - Tunnels allowed traffic to the real destination
-        //
-        // This blocks:
-        //  - IMDS credential theft (169.254.169.254)
-        //  - Data exfiltration to any external host
-        //  - Lateral movement to other pods
-        //
-        // The agent can only reach the inference-router on localhost:8443.
-        // HTTP/HTTPS goes through the transparent proxy for policy enforcement.
-        "initContainers": [{
-            "name": "egress-guard",
-            "image": &ctx.inference_router_image,
-            "command": ["sh", "-c", concat!(
-                // Filter chain: allow localhost, DNS, established — drop everything else
-                "iptables -A OUTPUT -m owner --uid-owner 1000 -o lo -j ACCEPT && ",
-                "iptables -A OUTPUT -m owner --uid-owner 1000 -p udp --dport 53 -j ACCEPT && ",
-                "iptables -A OUTPUT -m owner --uid-owner 1000 -p tcp --dport 53 -j ACCEPT && ",
-                // Allow reply packets (SYN-ACK etc.) for inbound connections to the
-                // gateway — without this, the WebUX and Telegram channel can't respond.
-                "iptables -A OUTPUT -m owner --uid-owner 1000 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT && ",
-                "iptables -A OUTPUT -m owner --uid-owner 1000 -j DROP && ",
-                // NAT chain: redirect HTTP/HTTPS from UID 1000 to the transparent
-                // forward proxy (port 8444) in the inference-router. This
-                // enables learn mode (domain discovery) and per-domain enforcement.
-                // Redirected packets go to 127.0.0.1:8444, matching the -o lo ACCEPT
-                // rule above. The proxy (UID 1001) then connects to the real destination.
-                "iptables -t nat -A OUTPUT -m owner --uid-owner 1000 ! -o lo -p tcp --dport 80 -j REDIRECT --to-port 8444 && ",
-                "iptables -t nat -A OUTPUT -m owner --uid-owner 1000 ! -o lo -p tcp --dport 443 -j REDIRECT --to-port 8444 && ",
-                "echo 'egress-guard: UID 1000 → transparent proxy on :8444 (learn + enforce)'"
-            )],
-            "securityContext": {
-                "runAsUser": 0,
-                "runAsNonRoot": false,
-                "seccompProfile": { "type": "Unconfined" },
-                "capabilities": {
-                    "add": ["NET_ADMIN", "NET_RAW"],
-                    "drop": ["ALL"]
-                }
-            },
-            "resources": {
-                "requests": {"cpu": "10m", "memory": "32Mi"},
-                "limits": {"cpu": "200m", "memory": "256Mi"}
-            }
-        }],
-        "containers": [
-                        {
-                            "name": "openclaw",
-                            "image": image,
-                            "imagePullPolicy": pull_policy,
-                            "ports": [{"containerPort": 18789, "name": "gateway"}],
-                            "env": openclaw_env,
-                            "envFrom": [
-                                {"secretRef": {"name": format!("{}-credentials", name), "optional": true}}
-                            ],
-                            "securityContext": {
-                                "runAsUser": 1000,
-                                "allowPrivilegeEscalation": sandbox_config.allow_privilege_escalation,
-                                "readOnlyRootFilesystem": sandbox_config.read_only_root_filesystem,
-                                "capabilities": {"drop": ["ALL"]}
-                            },
-                            "volumeMounts": [
-                                {"name": "sandbox-data", "mountPath": "/sandbox"},
-                                {"name": "tmp", "mountPath": "/tmp"},
-                                // Plugin needs admin token to authenticate trust
-                                // mutations after KNOCK handshakes (pushTrustToRouter).
-                                {"name": "admin-token", "mountPath": "/etc/azureclaw/secrets", "readOnly": true}
-                            ],
-                            "resources": spec.resources.as_ref().map(|r| json!({
-                                "requests": r.requests,
-                                "limits": r.limits
-                            })).unwrap_or(json!({
-                                "requests": {"cpu": "500m", "memory": "1Gi"},
-                                "limits": {"cpu": "2", "memory": "4Gi"}
-                            })),
-                            "livenessProbe": {
-                                "exec": {
-                                    "command": ["sh", "-c", "test -f /proc/1/status"]
-                                },
-                                "initialDelaySeconds": 15,
-                                "periodSeconds": 30
-                            },
-                            "readinessProbe": {
-                                "exec": {
-                                    "command": ["sh", "-c", "test -f /proc/1/status"]
-                                },
-                                "initialDelaySeconds": 5,
-                                "periodSeconds": 10
-                            }
-                        },
-                        {
-                            "name": "inference-router",
-                            "image": &ctx.inference_router_image,
-                            "ports": [
-                                {"containerPort": 8443, "name": "inference"},
-                                {"containerPort": 9090, "name": "metrics"}
-                            ],
-                            "env": router_env,
-                            "securityContext": {
-                                "runAsUser": 1001,
-                                "allowPrivilegeEscalation": false,
-                                "readOnlyRootFilesystem": true,
-                                "capabilities": {"drop": ["ALL"]}
-                            },
-                            "resources": {
-                                "requests": {"cpu": "100m", "memory": "64Mi"},
-                                "limits": {"cpu": "500m", "memory": "256Mi"}
-                            },
-                            "livenessProbe": {
-                                "httpGet": {"path": "/healthz", "port": "inference"},
-                                "initialDelaySeconds": 5,
-                                "periodSeconds": 15
-                            },
-                            "readinessProbe": {
-                                "httpGet": {"path": "/healthz", "port": "inference"},
-                                "initialDelaySeconds": 3,
-                                "periodSeconds": 5
-                            },
-                            "volumeMounts": [
-                                {"name": "admin-token", "mountPath": "/etc/azureclaw/secrets", "readOnly": true}
-                            ]
-                        }
-                    ],
-                    "volumes": [
-                        {"name": "sandbox-data", "emptyDir": {}},
-                        {"name": "tmp", "emptyDir": {"medium": "Memory", "sizeLimit": "1Gi"}},
-                        {"name": "admin-token", "secret": {"secretName": "router-admin-token", "items": [{"key": "token", "path": "admin-token"}]}}
-                    ],
-                    "tolerations": [{
-                        "key": "azureclaw.azure.com/sandbox",
-                        "operator": "Equal",
-                        "value": "true",
-                        "effect": "NoSchedule"
-                    }],
-                    "nodeSelector": {
-                        "azureclaw.azure.com/pool": pool_label
+        // OPENCLAW_GATEWAY_TOKEN is plumbed via secretKeyRef rather than a static
+        // value so that:
+        //   1. Rotating the Secret + restarting the pod reliably picks up the new
+        //      token without requiring a controller reconcile to re-render the
+        //      Deployment env.
+        //   2. The pod env is, by construction, equal to the Secret value at pod
+        //      start. `azureclaw connect` reads the Secret to find the gateway
+        //      token; if env and Secret ever drift, the operator gets 401s on a
+        //      rolled pod even though the Secret looks correct. valueFrom closes
+        //      that drift window.
+        let mut openclaw_env = vec![
+            json!({"name": "OPENCLAW_MODEL", "value": inference_config.model}),
+            json!({"name": "AZURE_OPENAI_ENDPOINT", "value": &ctx.openai_endpoint}),
+            json!({"name": "AZURECLAW_AUTH_MODE", "value": "workload-identity"}),
+            json!({
+                "name": "OPENCLAW_GATEWAY_TOKEN",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": "gateway-token",
+                        "key": "token"
                     }
-    });
+                }
+            }),
+        ];
+        // Foundry project endpoint (for standalone APIs: Memory Store, Foundry IQ, etc.)
+        if !ctx.foundry_project_endpoint.is_empty() {
+            openclaw_env.push(
+                json!({"name": "FOUNDRY_PROJECT_ENDPOINT", "value": &ctx.foundry_project_endpoint}),
+            );
+        }
+        // Foundry deployments list (so plugin shows only deployed models, not full catalog)
+        if !ctx.foundry_deployments.is_empty() {
+            openclaw_env
+                .push(json!({"name": "FOUNDRY_DEPLOYMENTS", "value": &ctx.foundry_deployments}));
+        }
+        // Inject Foundry Agent ID if set in status (for tools needing agent runs)
+        if let Some(ref agent_id) = sandbox
+            .status
+            .as_ref()
+            .and_then(|s| s.foundry_agent_id.clone())
+            && !agent_id.is_empty()
+        {
+            openclaw_env.push(json!({"name": "FOUNDRY_AGENT_ID", "value": agent_id}));
+        }
+        // Signal configured Foundry agent tools
+        if let Some(ref tools) = agent_config.tools
+            && !tools.is_empty()
+        {
+            openclaw_env.push(json!({"name": "FOUNDRY_AGENT_TOOLS", "value": tools.join(",")}));
+        }
+        // AGT governance env vars (opt-in) — injected into BOTH openclaw and router containers
+        // (`governance_config` is hoisted above the deployment block so Step 4c can use it.)
+        let mut router_agt_env: Vec<serde_json::Value> = Vec::new();
 
-    // Set runtimeClassName for Kata (confidential) isolation
-    if let Some(rc) = runtime_class {
-        pod_spec
-            .as_object_mut()
-            .unwrap()
-            .insert("runtimeClassName".into(), json!(rc));
-    }
+        // Operator-level Entra-auth kill switch.
+        //
+        // When the cluster operator sets `AZURECLAW_DISABLE_ENTRA_AUTH=1` on
+        // the controller (e.g. dev clusters, or any subscription where the
+        // `api://agentmesh` Entra app registration is not yet provisioned),
+        // tell every sandbox to skip the Entra token-exchange step at startup.
+        //
+        // Without this, sub-agents burn ~123s on doomed AAD retries before
+        // falling back to anonymous tier — long enough that parent→sub-agent
+        // spawn-and-message workflows fail because the parent's tool-call
+        // timeout fires before the sub-agent finishes booting. See
+        // docs/security-audits/2026-04-26-entra-auth-toggle.md for the full
+        // analysis.
+        //
+        // Default is "skip" until the operator explicitly opts in by unsetting
+        // the env var or setting it to "0". Phase 2 will replace this with
+        // controller-side tenant feature detection once Entra Agent ID
+        // provisioning is automated.
+        let skip_entra =
+            std::env::var("AZURECLAW_DISABLE_ENTRA_AUTH").unwrap_or_else(|_| "1".to_string());
+        if skip_entra == "1" || skip_entra.eq_ignore_ascii_case("true") {
+            openclaw_env.push(json!({"name": "AGT_SKIP_ENTRA", "value": "1"}));
+        }
 
-    // If AGT governance is enabled, mount the policy ConfigMap into the router
-    if governance_config.enabled {
-        let policy_profile = &governance_config.tool_policy;
-        let cm_name = format!("agt-policy-{}", policy_profile);
+        if governance_config.enabled {
+            openclaw_env.push(json!({"name": "AGT_GOVERNANCE_ENABLED", "value": "true"}));
+            openclaw_env.push(
+                json!({"name": "AGT_POLICY_PROFILE", "value": governance_config.tool_policy}),
+            );
+            openclaw_env.push(json!({"name": "AGT_TRUST_THRESHOLD", "value": governance_config.trust_threshold.to_string()}));
+            // Validate and propagate trusted peers (format: "name:AMID,name:AMID,...")
+            let valid_peers = governance_config.trusted_peers.as_deref().filter(|p| {
+                let ok = !p.contains('\n') && !p.contains('\r') && !p.contains('\0');
+                if !ok {
+                    tracing::warn!("Ignoring trusted_peers: contains control characters");
+                }
+                ok
+            });
+            if let Some(peers) = valid_peers {
+                openclaw_env.push(json!({"name": "AGT_TRUSTED_PEERS", "value": peers}));
+            }
+            // Validate registry mode: must be "local" or "global"
+            let reg_mode = match governance_config.registry_mode.as_deref() {
+                Some("local") => "local",
+                Some("global") | None => "global",
+                Some(other) => {
+                    tracing::warn!(mode = other, "Invalid registry_mode, defaulting to global");
+                    "global"
+                }
+            };
+            openclaw_env.push(json!({"name": "AGT_REGISTRY_MODE", "value": reg_mode}));
+            // Plugin also needs relay/registry URLs for direct AgentMesh SDK connections
+            openclaw_env.push(json!({"name": "AGT_RELAY_URL", "value": "ws://agentmesh-relay.agentmesh.svc.cluster.local:8765"}));
+            openclaw_env.push(json!({"name": "AGT_REGISTRY_URL", "value": "http://agentmesh-registry.agentmesh.svc.cluster.local:8080"}));
+            // Router needs governance vars too (handoff auth, policy enforcement)
+            router_agt_env.push(json!({"name": "AGT_GOVERNANCE_ENABLED", "value": "true"}));
+            router_agt_env.push(
+                json!({"name": "AGT_POLICY_PROFILE", "value": &governance_config.tool_policy}),
+            );
+            router_agt_env.push(json!({"name": "AGT_TRUST_THRESHOLD", "value": governance_config.trust_threshold.to_string()}));
+            // Behavior-monitor burst threshold: offload workers run long
+            // research loops that make many tool/inference calls in short
+            // bursts. Bump the burst limit well above the interactive default
+            // (100/60s) so legitimate research bursts aren't flagged as
+            // "abuse" by the self-burst detector. Non-offload profiles keep
+            // the router's built-in default.
+            if governance_config.tool_policy == "offload" {
+                router_agt_env
+                    .push(json!({"name": "AGT_BEHAVIOR_BURST_THRESHOLD", "value": "1000"}));
+            }
+            if let Some(peers) = valid_peers {
+                router_agt_env.push(json!({"name": "AGT_TRUSTED_PEERS", "value": peers}));
+            }
+            router_agt_env.push(json!({"name": "AGT_REGISTRY_MODE", "value": reg_mode}));
+            // Mesh namespace for K8s DNS routing between agents
+            router_agt_env.push(json!({"name": "AGT_MESH_NAMESPACE", "value": &sandbox_ns}));
+            // Self-hosted AGT relay + registry (for E2E encrypted inter-agent comms)
+            router_agt_env.push(json!({"name": "AGT_RELAY_URL", "value": "ws://agentmesh-relay.agentmesh.svc.cluster.local:8765"}));
+            router_agt_env.push(json!({"name": "AGT_REGISTRY_URL", "value": "http://agentmesh-registry.agentmesh.svc.cluster.local:8080"}));
+        }
 
-        // Add policy volume
+        // ── extraEnv: user/controller-provided env vars on spec.openclaw.extraEnv ──
+        // Used by the controller to propagate offload parameters (OFFLOAD_REQUEST_ID,
+        // OFFLOAD_PARENT_AMID, OFFLOAD_TASK, OFFLOAD_TIMEOUT_MINUTES) into offload
+        // sandboxes. Keys are validated to avoid clobbering reserved prefixes.
+        if let Some(extra) = openclaw_config.extra_env.as_ref() {
+            // Reserved prefixes that must come from the reconciler itself, not user input.
+            const RESERVED_PREFIXES: &[&str] =
+                &["AGT_", "FOUNDRY_AGENT_", "AZURE_", "IMDS_", "AZURECLAW_"];
+            // Names already set above — skip silently if caller provided a duplicate.
+            let mut existing: std::collections::HashSet<String> = openclaw_env
+                .iter()
+                .filter_map(|v| v.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect();
+            for (k, v) in extra {
+                if k.is_empty()
+                    || !k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                    || k.chars().next().is_some_and(|c| c.is_ascii_digit())
+                {
+                    tracing::warn!(key = %k, "extraEnv: invalid env var name, skipping");
+                    continue;
+                }
+                if RESERVED_PREFIXES.iter().any(|p| k.starts_with(p)) {
+                    tracing::warn!(key = %k, "extraEnv: key uses reserved prefix, skipping");
+                    continue;
+                }
+                if v.contains('\0') {
+                    tracing::warn!(key = %k, "extraEnv: value contains NUL byte, skipping");
+                    continue;
+                }
+                if existing.contains(k) {
+                    tracing::debug!(key = %k, "extraEnv: overridden by reconciler, skipping");
+                    continue;
+                }
+                openclaw_env.push(json!({"name": k, "value": v}));
+                existing.insert(k.clone());
+            }
+        }
+
+        // Build the inference-router env array
+        let mut router_env = vec![
+            json!({"name": "AZURE_OPENAI_ENDPOINT", "value": &ctx.openai_endpoint}),
+            json!({"name": "FOUNDRY_ENDPOINT", "value": &ctx.foundry_endpoint}),
+            json!({"name": "FOUNDRY_PROJECT_ENDPOINT", "value": &ctx.foundry_project_endpoint}),
+            json!({"name": "IMDS_CLIENT_ID", "value": &ctx.imds_client_id}),
+            json!({"name": "AZURE_OPENAI_DEPLOYMENT", "value": &inference_config.model}),
+            json!({"name": "AZURECLAW_AUTH_MODE", "value": "workload-identity"}),
+            json!({"name": "CONTENT_SAFETY_ENABLED", "value": inference_config.content_safety.to_string()}),
+            json!({"name": "PROMPT_SHIELDS_ENABLED", "value": inference_config.prompt_shields.to_string()}),
+            json!({"name": "CONTENT_SAFETY_ENDPOINT", "value": &ctx.content_safety_endpoint}),
+            json!({"name": "TOKEN_BUDGET_DAILY", "value": token_budget_daily.to_string()}),
+            json!({"name": "TOKEN_BUDGET_PER_REQUEST", "value": token_budget_per_request.to_string()}),
+            json!({"name": "SANDBOX_NAME", "value": &name}),
+            json!({"name": "SANDBOX_ISOLATION", "value": &sandbox_config.isolation}),
+            json!({"name": "RUST_LOG", "value": "info,inference_router=debug"}),
+        ];
+        router_env.extend(router_agt_env);
+
+        // ── Blocklist ConfigMap + env vars ──
+        // The blocklist is always-on: router loads a seed file at startup, then
+        // auto-refreshes from OISD + URLhaus feeds every 6 hours.
+        // (`blocklist_cm_name` is hoisted above the deployment block so the
+        // CronJob (Step 4d) can reach it in overlay mode.)
+        router_env.push(json!({"name": "BLOCKLIST_ENABLED", "value": "true"}));
+        router_env.push(
+            json!({"name": "BLOCKLIST_SEED_PATH", "value": "/etc/azureclaw/blocklist/domains.txt"}),
+        );
+
+        // Egress learn mode — enabled by default so operators can discover required domains.
+        // Blocklist (threat intelligence) is still enforced. Disable with network_policy.learn_egress=false.
+        let learn_egress = spec
+            .network_policy
+            .as_ref()
+            .is_none_or(|np| np.learn_egress);
+        if learn_egress {
+            router_env.push(json!({"name": "EGRESS_LEARN_MODE", "value": "true"}));
+        }
+
+        // Build the pod spec — runtimeClassName only set for Kata (confidential)
+        let mut pod_spec = json!({
+            "serviceAccountName": "sandbox",
+            "securityContext": build_pod_security_context(&sandbox_config),
+            // ── Init container: iptables-based per-container egress control ──
+            // Since K8s NetworkPolicy operates at pod level (not container level),
+            // we use iptables UID-based rules to restrict the openclaw agent
+            // container (UID 1000) to localhost + DNS only, with a transparent
+            // forward proxy for HTTP/HTTPS egress enforcement and learn mode.
+            //
+            // Filter chain (OUTPUT):
+            //   UID 1000 → allow loopback, DNS, established → DROP everything else
+            //
+            // NAT chain (OUTPUT):
+            //   UID 1000 port 80/443 (not loopback) → REDIRECT to :8444
+            //   The transparent proxy on port 8444 (inference-router, UID 1001):
+            //   - Records every domain for learn mode
+            //   - Enforces blocklist/allowlist per domain
+            //   - Tunnels allowed traffic to the real destination
+            //
+            // This blocks:
+            //  - IMDS credential theft (169.254.169.254)
+            //  - Data exfiltration to any external host
+            //  - Lateral movement to other pods
+            //
+            // The agent can only reach the inference-router on localhost:8443.
+            // HTTP/HTTPS goes through the transparent proxy for policy enforcement.
+            "initContainers": [{
+                "name": "egress-guard",
+                "image": &ctx.inference_router_image,
+                "command": ["sh", "-c", concat!(
+                    // Filter chain: allow localhost, DNS, established — drop everything else
+                    "iptables -A OUTPUT -m owner --uid-owner 1000 -o lo -j ACCEPT && ",
+                    "iptables -A OUTPUT -m owner --uid-owner 1000 -p udp --dport 53 -j ACCEPT && ",
+                    "iptables -A OUTPUT -m owner --uid-owner 1000 -p tcp --dport 53 -j ACCEPT && ",
+                    // Allow reply packets (SYN-ACK etc.) for inbound connections to the
+                    // gateway — without this, the WebUX and Telegram channel can't respond.
+                    "iptables -A OUTPUT -m owner --uid-owner 1000 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT && ",
+                    "iptables -A OUTPUT -m owner --uid-owner 1000 -j DROP && ",
+                    // NAT chain: redirect HTTP/HTTPS from UID 1000 to the transparent
+                    // forward proxy (port 8444) in the inference-router. This
+                    // enables learn mode (domain discovery) and per-domain enforcement.
+                    // Redirected packets go to 127.0.0.1:8444, matching the -o lo ACCEPT
+                    // rule above. The proxy (UID 1001) then connects to the real destination.
+                    "iptables -t nat -A OUTPUT -m owner --uid-owner 1000 ! -o lo -p tcp --dport 80 -j REDIRECT --to-port 8444 && ",
+                    "iptables -t nat -A OUTPUT -m owner --uid-owner 1000 ! -o lo -p tcp --dport 443 -j REDIRECT --to-port 8444 && ",
+                    "echo 'egress-guard: UID 1000 → transparent proxy on :8444 (learn + enforce)'"
+                )],
+                "securityContext": {
+                    "runAsUser": 0,
+                    "runAsNonRoot": false,
+                    "seccompProfile": { "type": "Unconfined" },
+                    "capabilities": {
+                        "add": ["NET_ADMIN", "NET_RAW"],
+                        "drop": ["ALL"]
+                    }
+                },
+                "resources": {
+                    "requests": {"cpu": "10m", "memory": "32Mi"},
+                    "limits": {"cpu": "200m", "memory": "256Mi"}
+                }
+            }],
+            "containers": [
+                            {
+                                "name": "openclaw",
+                                "image": image,
+                                "imagePullPolicy": pull_policy,
+                                "ports": [{"containerPort": 18789, "name": "gateway"}],
+                                "env": openclaw_env,
+                                "envFrom": [
+                                    {"secretRef": {"name": format!("{}-credentials", name), "optional": true}}
+                                ],
+                                "securityContext": {
+                                    "runAsUser": 1000,
+                                    "allowPrivilegeEscalation": sandbox_config.allow_privilege_escalation,
+                                    "readOnlyRootFilesystem": sandbox_config.read_only_root_filesystem,
+                                    "capabilities": {"drop": ["ALL"]}
+                                },
+                                "volumeMounts": [
+                                    {"name": "sandbox-data", "mountPath": "/sandbox"},
+                                    {"name": "tmp", "mountPath": "/tmp"},
+                                    // Plugin needs admin token to authenticate trust
+                                    // mutations after KNOCK handshakes (pushTrustToRouter).
+                                    {"name": "admin-token", "mountPath": "/etc/azureclaw/secrets", "readOnly": true}
+                                ],
+                                "resources": spec.resources.as_ref().map(|r| json!({
+                                    "requests": r.requests,
+                                    "limits": r.limits
+                                })).unwrap_or(json!({
+                                    "requests": {"cpu": "500m", "memory": "1Gi"},
+                                    "limits": {"cpu": "2", "memory": "4Gi"}
+                                })),
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": ["sh", "-c", "test -f /proc/1/status"]
+                                    },
+                                    "initialDelaySeconds": 15,
+                                    "periodSeconds": 30
+                                },
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": ["sh", "-c", "test -f /proc/1/status"]
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "periodSeconds": 10
+                                }
+                            },
+                            {
+                                "name": "inference-router",
+                                "image": &ctx.inference_router_image,
+                                "ports": [
+                                    {"containerPort": 8443, "name": "inference"},
+                                    {"containerPort": 9090, "name": "metrics"}
+                                ],
+                                "env": router_env,
+                                "securityContext": {
+                                    "runAsUser": 1001,
+                                    "allowPrivilegeEscalation": false,
+                                    "readOnlyRootFilesystem": true,
+                                    "capabilities": {"drop": ["ALL"]}
+                                },
+                                "resources": {
+                                    "requests": {"cpu": "100m", "memory": "64Mi"},
+                                    "limits": {"cpu": "500m", "memory": "256Mi"}
+                                },
+                                "livenessProbe": {
+                                    "httpGet": {"path": "/healthz", "port": "inference"},
+                                    "initialDelaySeconds": 5,
+                                    "periodSeconds": 15
+                                },
+                                "readinessProbe": {
+                                    "httpGet": {"path": "/healthz", "port": "inference"},
+                                    "initialDelaySeconds": 3,
+                                    "periodSeconds": 5
+                                },
+                                "volumeMounts": [
+                                    {"name": "admin-token", "mountPath": "/etc/azureclaw/secrets", "readOnly": true}
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {"name": "sandbox-data", "emptyDir": {}},
+                            {"name": "tmp", "emptyDir": {"medium": "Memory", "sizeLimit": "1Gi"}},
+                            {"name": "admin-token", "secret": {"secretName": "router-admin-token", "items": [{"key": "token", "path": "admin-token"}]}}
+                        ],
+                        "tolerations": [{
+                            "key": "azureclaw.azure.com/sandbox",
+                            "operator": "Equal",
+                            "value": "true",
+                            "effect": "NoSchedule"
+                        }],
+                        "nodeSelector": {
+                            "azureclaw.azure.com/pool": pool_label
+                        }
+        });
+
+        // Set runtimeClassName for Kata (confidential) isolation
+        if let Some(rc) = runtime_class {
+            pod_spec
+                .as_object_mut()
+                .unwrap()
+                .insert("runtimeClassName".into(), json!(rc));
+        }
+
+        // If AGT governance is enabled, mount the policy ConfigMap into the router
+        if governance_config.enabled {
+            let policy_profile = &governance_config.tool_policy;
+            let cm_name = format!("agt-policy-{}", policy_profile);
+
+            // Add policy volume
+            if let Some(volumes) = pod_spec.get_mut("volumes").and_then(|v| v.as_array_mut()) {
+                volumes.push(json!({
+                    "name": "agt-policy",
+                    "configMap": {
+                        "name": cm_name
+                    }
+                }));
+            }
+
+            // Add volumeMount + AGT_POLICY_DIR env to the router container
+            if let Some(containers) = pod_spec
+                .get_mut("containers")
+                .and_then(|c| c.as_array_mut())
+            {
+                for container in containers.iter_mut() {
+                    if container.get("name").and_then(|n| n.as_str()) == Some("inference-router") {
+                        // Add volumeMount
+                        let mounts = container
+                            .as_object_mut()
+                            .unwrap()
+                            .entry("volumeMounts")
+                            .or_insert(json!([]));
+                        if let Some(mounts_arr) = mounts.as_array_mut() {
+                            mounts_arr.push(json!({
+                                "name": "agt-policy",
+                                "mountPath": "/etc/agt/policies",
+                                "readOnly": true
+                            }));
+                        }
+                        // Add AGT_POLICY_DIR env var (router reads policies natively)
+                        if let Some(env) = container.get_mut("env").and_then(|e| e.as_array_mut()) {
+                            env.push(
+                                json!({"name": "AGT_POLICY_DIR", "value": "/etc/agt/policies"}),
+                            );
+                        }
+                    }
+                }
+
+                // Add writable emptyDir volume for trust store + audit log persistence
+                if let Some(volumes) = pod_spec.get_mut("volumes").and_then(|v| v.as_array_mut()) {
+                    volumes.push(json!({
+                        "name": "agt-data",
+                        "emptyDir": {"sizeLimit": "10Mi"}
+                    }));
+                }
+            }
+        }
+
+        // Mount blocklist seed ConfigMap into the router container
         if let Some(volumes) = pod_spec.get_mut("volumes").and_then(|v| v.as_array_mut()) {
             volumes.push(json!({
-                "name": "agt-policy",
+                "name": "blocklist-seed",
                 "configMap": {
-                    "name": cm_name
+                    "name": &blocklist_cm_name,
+                    "optional": true
                 }
             }));
         }
-
-        // Add volumeMount + AGT_POLICY_DIR env to the router container
         if let Some(containers) = pod_spec
             .get_mut("containers")
             .and_then(|c| c.as_array_mut())
         {
             for container in containers.iter_mut() {
                 if container.get("name").and_then(|n| n.as_str()) == Some("inference-router") {
-                    // Add volumeMount
                     let mounts = container
                         .as_object_mut()
                         .unwrap()
@@ -985,95 +1107,51 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
                         .or_insert(json!([]));
                     if let Some(mounts_arr) = mounts.as_array_mut() {
                         mounts_arr.push(json!({
-                            "name": "agt-policy",
-                            "mountPath": "/etc/agt/policies",
+                            "name": "blocklist-seed",
+                            "mountPath": "/etc/azureclaw/blocklist",
                             "readOnly": true
                         }));
                     }
-                    // Add AGT_POLICY_DIR env var (router reads policies natively)
-                    if let Some(env) = container.get_mut("env").and_then(|e| e.as_array_mut()) {
-                        env.push(json!({"name": "AGT_POLICY_DIR", "value": "/etc/agt/policies"}));
-                    }
-                }
-            }
-
-            // Add writable emptyDir volume for trust store + audit log persistence
-            if let Some(volumes) = pod_spec.get_mut("volumes").and_then(|v| v.as_array_mut()) {
-                volumes.push(json!({
-                    "name": "agt-data",
-                    "emptyDir": {"sizeLimit": "10Mi"}
-                }));
-            }
-        }
-    }
-
-    // Mount blocklist seed ConfigMap into the router container
-    if let Some(volumes) = pod_spec.get_mut("volumes").and_then(|v| v.as_array_mut()) {
-        volumes.push(json!({
-            "name": "blocklist-seed",
-            "configMap": {
-                "name": &blocklist_cm_name,
-                "optional": true
-            }
-        }));
-    }
-    if let Some(containers) = pod_spec
-        .get_mut("containers")
-        .and_then(|c| c.as_array_mut())
-    {
-        for container in containers.iter_mut() {
-            if container.get("name").and_then(|n| n.as_str()) == Some("inference-router") {
-                let mounts = container
-                    .as_object_mut()
-                    .unwrap()
-                    .entry("volumeMounts")
-                    .or_insert(json!([]));
-                if let Some(mounts_arr) = mounts.as_array_mut() {
-                    mounts_arr.push(json!({
-                        "name": "blocklist-seed",
-                        "mountPath": "/etc/azureclaw/blocklist",
-                        "readOnly": true
-                    }));
                 }
             }
         }
-    }
 
-    let deployment: Deployment = serde_json::from_value(json!({
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "name": name,
-            "namespace": sandbox_ns,
-            "labels": {
-                "azureclaw.azure.com/sandbox": name,
-                "azureclaw.azure.com/component": "sandbox"
-            }
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {"azureclaw.azure.com/sandbox": name}
+        let deployment: Deployment = serde_json::from_value(json!({
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "name": name,
+                "namespace": sandbox_ns,
+                "labels": {
+                    "azureclaw.azure.com/sandbox": name,
+                    "azureclaw.azure.com/component": "sandbox"
+                }
             },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "azureclaw.azure.com/sandbox": name,
-                        "azureclaw.azure.com/component": "sandbox",
-                        "azure.workload.identity/use": "true"
-                    }
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "matchLabels": {"azureclaw.azure.com/sandbox": name}
                 },
-                "spec": pod_spec
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "azureclaw.azure.com/sandbox": name,
+                            "azureclaw.azure.com/component": "sandbox",
+                            "azure.workload.identity/use": "true"
+                        }
+                    },
+                    "spec": pod_spec
+                }
             }
-        }
-    }))?;
-    deploy_api
-        .patch(
-            &name,
-            &PatchParams::apply("azureclaw-controller").force(),
-            &Patch::Apply(deployment),
-        )
-        .await?;
+        }))?;
+        deploy_api
+            .patch(
+                &name,
+                &PatchParams::apply("azureclaw-controller").force(),
+                &Patch::Apply(deployment),
+            )
+            .await?;
+    } // end 'deployment_block
 
     // ── Step 4b: Azure Services RBAC annotations ─────────────────────────
     // If spec.azure_services is configured, annotate the ServiceAccount and
@@ -1248,7 +1326,13 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     // Create CronJob that fetches fresh lists from OISD + URLhaus every 6h
     // and patches the ConfigMap — so even if the router can't reach feeds
     // directly, the mounted file stays fresh.
-    {
+    //
+    // **OverlayMode (S8):** skipped. The blocklist is mounted into the
+    // AzureClaw-managed router container; in overlay mode the upstream
+    // Sandbox CR owns the Pod and there is no AzureClaw router to consume
+    // the ConfigMap. Recreating it would be dead overhead (CronJob would
+    // run every 6h with nothing reading the output).
+    if !overlay_mode {
         let full_seed = include_str!("../../../cli/blocklists/seed-domains.txt");
         // Truncate to stay under 1MB ConfigMap limit (K8s rejects >1048576 bytes)
         let seed_domains = if full_seed.len() > 900_000 {
@@ -1386,7 +1470,21 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     // against `.status` regardless of byte-equality), which retriggers
     // our own watch and produces a hot reconcile loop. See
     // `crate::status::running_status_matches` for the rationale.
-    if !crate::status::running_status_matches(&sandbox, &sandbox_ns) {
+    //
+    // OverlayMode emits a distinct `phase: "Overlay"` + Suspended=True
+    // condition so dashboards can surface "this CR is intentionally not
+    // driving a Pod" — see [`crate::status::build_overlay_status_patch`].
+    if let Some(upstream_ref) = overlay_target.as_deref() {
+        if !crate::status::overlay_status_matches(&sandbox, &sandbox_ns, upstream_ref) {
+            let sandbox_api: Api<ClawSandbox> =
+                Api::namespaced(client.clone(), &sandbox.namespace().unwrap_or_default());
+            let status_obj =
+                crate::status::build_overlay_status_patch(&sandbox, &sandbox_ns, upstream_ref);
+            let _ = sandbox_api
+                .patch_status(&name, &PatchParams::default(), &Patch::Merge(status_obj))
+                .await;
+        }
+    } else if !crate::status::running_status_matches(&sandbox, &sandbox_ns) {
         let sandbox_api: Api<ClawSandbox> =
             Api::namespaced(client.clone(), &sandbox.namespace().unwrap_or_default());
         let status_obj = crate::status::build_running_status_patch(&sandbox, &sandbox_ns);

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -53,6 +53,12 @@ pub const TYPE_PROGRESSING: &str = "Progressing";
 /// missing dependency, quota, etc.). `status=True` means degraded.
 pub const TYPE_DEGRADED: &str = "Degraded";
 
+/// Well-known condition type (Phase 2 S8): controller has *intentionally
+/// stopped driving* a sub-resource — e.g. `OverlayMode` skips Pod
+/// creation because an upstream `Sandbox` CR owns the Pod. `status=True`
+/// means suspended; `status=False` means actively reconciling.
+pub const TYPE_SUSPENDED: &str = "Suspended";
+
 /// `status` canonical values.
 pub mod status {
     pub const TRUE: &str = "True";
@@ -70,6 +76,9 @@ pub mod reason {
     pub const SPEC_INVALID: &str = "SpecInvalid";
     pub const DEPENDENCY_MISSING: &str = "DependencyMissing";
     pub const TIMED_OUT: &str = "TimedOut";
+    /// Phase 2 S8 — `OverlayMode`: operator's upstream `Sandbox` CR
+    /// owns the Pod; AzureClaw provides the governance overlay only.
+    pub const OVERLAY_MODE: &str = "OverlayMode";
 }
 
 /// Build a condition with a freshly-stamped `lastTransitionTime`.

--- a/controller/src/status/mod.rs
+++ b/controller/src/status/mod.rs
@@ -104,8 +104,108 @@ pub fn running_status_matches(sandbox: &ClawSandbox, sandbox_ns: &str) -> bool {
     true
 }
 
-/// Build the `status` patch for a `ClawSandbox` that has failed spec
-/// validation or an early reconcile check. Stamps `observedGeneration`
+/// Build the `status` patch for a `ClawSandbox` running in
+/// **`OverlayMode`** (Phase 2 S8). In this mode the operator's upstream
+/// `Sandbox` CR owns the Pod lifecycle; AzureClaw skipped Deployment +
+/// Service creation and only laid down the overlay (namespace, SA with
+/// Workload-Identity binding, NetworkPolicy, governance ConfigMaps).
+///
+/// Status shape:
+/// - `phase: "Overlay"` — distinct from `Running` so dashboards can
+///   surface "this CR is intentionally not driving a Pod".
+/// - `Ready=True, Reason=OverlayMode` — overlay reconciled cleanly
+///   from AzureClaw's perspective; `kubectl wait --for=condition=Ready`
+///   still works.
+/// - `Progressing=False, Reason=OverlayMode` — no further AzureClaw work
+///   pending.
+/// - `Suspended=True, Reason=OverlayMode` — explicit signal that we are
+///   not driving a Pod here (operators querying `Suspended` see why).
+///
+/// `sandbox_pod` is set to the upstream CR name (with a `upstream/`
+/// prefix so it's unambiguous in `kubectl get clawsandbox`) so operators
+/// can pivot from `kubectl describe clawsandbox` to the upstream object.
+pub fn build_overlay_status_patch(
+    sandbox: &ClawSandbox,
+    sandbox_ns: &str,
+    upstream_ref: &str,
+) -> Value {
+    let generation = sandbox.metadata.generation;
+    let prior_conditions = sandbox
+        .status
+        .as_ref()
+        .map(|s| s.conditions.as_slice())
+        .unwrap_or(&[]);
+    let ready = conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_READY),
+        conditions::TYPE_READY,
+        conditions::status::TRUE,
+        conditions::reason::OVERLAY_MODE,
+        "overlay reconciled; upstream Sandbox CR owns the Pod",
+        generation,
+    );
+    let progressing = conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_PROGRESSING),
+        conditions::TYPE_PROGRESSING,
+        conditions::status::FALSE,
+        conditions::reason::OVERLAY_MODE,
+        "no further controller work pending in overlay mode",
+        generation,
+    );
+    let suspended = conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_SUSPENDED),
+        conditions::TYPE_SUSPENDED,
+        conditions::status::TRUE,
+        conditions::reason::OVERLAY_MODE,
+        &format!("Pod owned by upstream Sandbox CR `{upstream_ref}`"),
+        generation,
+    );
+    json!({
+        "status": {
+            "phase": "Overlay",
+            "namespace": sandbox_ns,
+            "sandboxPod": format!("upstream/{upstream_ref}"),
+            "pendingApprovals": 0,
+            "observedGeneration": generation,
+            "conditions": [ready, progressing, suspended],
+        }
+    })
+}
+
+/// Returns `true` when the existing CR status already encodes the same
+/// "Overlay" reconciliation outcome that [`build_overlay_status_patch`]
+/// would produce. Same idempotency guard as
+/// [`running_status_matches`].
+#[must_use]
+pub fn overlay_status_matches(sandbox: &ClawSandbox, sandbox_ns: &str, upstream_ref: &str) -> bool {
+    use crate::status::conditions::{TYPE_READY, status::TRUE as STATUS_TRUE};
+
+    let Some(status) = sandbox.status.as_ref() else {
+        return false;
+    };
+    if status.phase.as_deref() != Some("Overlay") {
+        return false;
+    }
+    if status.namespace.as_deref() != Some(sandbox_ns) {
+        return false;
+    }
+    if status.observed_generation != sandbox.metadata.generation {
+        return false;
+    }
+    let expected_pod = format!("upstream/{upstream_ref}");
+    if status.sandbox_pod.as_deref() != Some(expected_pod.as_str()) {
+        return false;
+    }
+    let ready_ok = status
+        .conditions
+        .iter()
+        .find(|c| c.type_ == TYPE_READY)
+        .is_some_and(|c| c.status == STATUS_TRUE);
+    if !ready_ok {
+        return false;
+    }
+    true
+}
+
 /// and a `Degraded=True` / `Ready=False` condition pair so `kubectl wait
 /// --for=condition=Ready` and `--for=condition=Degraded` both behave
 /// correctly, and so operators see *why* we stopped reconciling.
@@ -424,5 +524,159 @@ mod tests {
         assert!(patch["status"]["observedGeneration"].is_null());
         let degraded = patch["status"]["conditions"][0].clone();
         assert!(degraded["observedGeneration"].is_null());
+    }
+
+    // ── OverlayMode (Phase 2 S8) status helpers ──
+
+    #[test]
+    fn overlay_patch_emits_overlay_phase_and_three_conditions() {
+        let sb = new_sandbox(Some(4), None);
+        let patch = build_overlay_status_patch(&sb, "azureclaw-demo", "upstream-1");
+        let st = &patch["status"];
+        assert_eq!(st["phase"], "Overlay");
+        assert_eq!(st["namespace"], "azureclaw-demo");
+        assert_eq!(st["sandboxPod"], "upstream/upstream-1");
+        assert_eq!(st["observedGeneration"], 4);
+        let conds = st["conditions"].as_array().expect("conditions array");
+        assert_eq!(conds.len(), 3, "expected Ready+Progressing+Suspended");
+        let ready = conds.iter().find(|c| c["type"] == "Ready").expect("Ready");
+        assert_eq!(ready["status"], "True");
+        assert_eq!(ready["reason"], "OverlayMode");
+        let progressing = conds
+            .iter()
+            .find(|c| c["type"] == "Progressing")
+            .expect("Progressing");
+        assert_eq!(progressing["status"], "False");
+        assert_eq!(progressing["reason"], "OverlayMode");
+        let suspended = conds
+            .iter()
+            .find(|c| c["type"] == "Suspended")
+            .expect("Suspended");
+        assert_eq!(suspended["status"], "True");
+        assert_eq!(suspended["reason"], "OverlayMode");
+        assert!(
+            suspended["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("upstream-1"),
+            "Suspended message must reference the upstream CR name"
+        );
+    }
+
+    #[test]
+    fn overlay_status_matches_rejects_when_status_missing() {
+        let sb = new_sandbox(Some(1), None);
+        assert!(!overlay_status_matches(&sb, "azureclaw-demo", "u1"));
+    }
+
+    #[test]
+    fn overlay_status_matches_rejects_when_phase_is_running() {
+        let prior = ClawSandboxStatus {
+            phase: Some("Running".into()),
+            namespace: Some("azureclaw-demo".into()),
+            observed_generation: Some(1),
+            sandbox_pod: Some("upstream/u1".into()),
+            conditions: vec![conditions::new_condition(
+                conditions::TYPE_READY,
+                conditions::status::TRUE,
+                conditions::reason::OVERLAY_MODE,
+                "ok",
+                Some(1),
+            )],
+            ..Default::default()
+        };
+        let sb = new_sandbox(Some(1), Some(prior));
+        assert!(!overlay_status_matches(&sb, "azureclaw-demo", "u1"));
+    }
+
+    #[test]
+    fn overlay_status_matches_rejects_when_upstream_ref_differs() {
+        let prior = ClawSandboxStatus {
+            phase: Some("Overlay".into()),
+            namespace: Some("azureclaw-demo".into()),
+            observed_generation: Some(1),
+            sandbox_pod: Some("upstream/old-name".into()),
+            conditions: vec![conditions::new_condition(
+                conditions::TYPE_READY,
+                conditions::status::TRUE,
+                conditions::reason::OVERLAY_MODE,
+                "ok",
+                Some(1),
+            )],
+            ..Default::default()
+        };
+        let sb = new_sandbox(Some(1), Some(prior));
+        assert!(!overlay_status_matches(&sb, "azureclaw-demo", "new-name"));
+    }
+
+    #[test]
+    fn overlay_status_matches_rejects_when_generation_stale() {
+        let prior = ClawSandboxStatus {
+            phase: Some("Overlay".into()),
+            namespace: Some("azureclaw-demo".into()),
+            observed_generation: Some(1),
+            sandbox_pod: Some("upstream/u1".into()),
+            conditions: vec![conditions::new_condition(
+                conditions::TYPE_READY,
+                conditions::status::TRUE,
+                conditions::reason::OVERLAY_MODE,
+                "ok",
+                Some(1),
+            )],
+            ..Default::default()
+        };
+        let sb = new_sandbox(Some(2), Some(prior));
+        assert!(!overlay_status_matches(&sb, "azureclaw-demo", "u1"));
+    }
+
+    #[test]
+    fn overlay_status_matches_returns_true_for_settled_overlay_status() {
+        let prior = ClawSandboxStatus {
+            phase: Some("Overlay".into()),
+            namespace: Some("azureclaw-demo".into()),
+            observed_generation: Some(1),
+            sandbox_pod: Some("upstream/u1".into()),
+            conditions: vec![conditions::new_condition(
+                conditions::TYPE_READY,
+                conditions::status::TRUE,
+                conditions::reason::OVERLAY_MODE,
+                "ok",
+                Some(1),
+            )],
+            ..Default::default()
+        };
+        let sb = new_sandbox(Some(1), Some(prior));
+        assert!(overlay_status_matches(&sb, "azureclaw-demo", "u1"));
+    }
+
+    #[test]
+    fn overlay_patch_preserves_ready_transition_time_on_repeat() {
+        let existing_ready = conditions::new_condition(
+            conditions::TYPE_READY,
+            conditions::status::TRUE,
+            conditions::reason::OVERLAY_MODE,
+            "overlay",
+            Some(1),
+        );
+        let prior_ts = existing_ready.last_transition_time.clone();
+        let prior = ClawSandboxStatus {
+            conditions: vec![existing_ready],
+            ..Default::default()
+        };
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let sb = new_sandbox(Some(2), Some(prior));
+        let patch = build_overlay_status_patch(&sb, "azureclaw-demo", "u1");
+        let ready = patch["status"]["conditions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["type"] == "Ready")
+            .unwrap()
+            .clone();
+        let prior_ts_str = serde_json::to_value(&prior_ts).unwrap();
+        assert_eq!(
+            ready["lastTransitionTime"].as_str().unwrap(),
+            prior_ts_str.as_str().unwrap()
+        );
     }
 }

--- a/docs/security-audits/2026-04-27-phase2-overlaymode.md
+++ b/docs/security-audits/2026-04-27-phase2-overlaymode.md
@@ -1,0 +1,117 @@
+# 2026-04-27 — Phase 2 S8 `phase2-overlaymode` security audit
+
+> **Implementation plan reference:** §2.1 lines 263–275 (three-mode taxonomy: Native | Translate | Overlay), §8 Phase 2 entry "S8 `phase2-overlaymode` — sigs/agent-sandbox real Overlay", §15.2 #7 first half.
+>
+> **§14.6 destination:** Multi-runtime hosting (column 11) — partial. S8 contributes the Overlay half; S9 (`migrate to-overlay-mode`, `kubectl claw convert`) lands the CLI half.
+
+## §0 — Existing implementation surveyed (§0.2 #11 anti-duplication)
+
+Before any code was written, the implementer audited the existing reconciler surface to ensure S8 extends seams rather than parallel-implementing them. The surveyed surfaces and the reuse decisions:
+
+| Existing surface | Path | Reuse decision |
+|---|---|---|
+| `LocalObjectRef { name: String }` | `controller/src/mcp_server.rs:157` | **Reused.** Fifth client now (signing/jwks ref, profile, agent-card, guardrail-profile, **upstream sandbox ref**). No second `ObjectReference`-shaped type introduced. |
+| `UpstreamCompatibilityConfig` | `controller/src/crd.rs:104` | **Extended in place.** Added `upstream_sandbox_ref: Option<LocalObjectRef>`; the existing `sigs_agent_sandbox: Option<String>` field gains a fourth accepted value (`"overlay"`). Schema migration is purely additive — no field rename, no breaking change. |
+| `crate::status::conditions::preserve_transition_time` | `controller/src/status/conditions.rs` | **Reused** unchanged for the new three-condition matrix (Ready / Progressing / Suspended). |
+| `crate::status::stamp_degraded` + `degrade!` macro in reconciler | `controller/src/status/mod.rs:179` + `reconciler/mod.rs:232` | **Reused** for both new failure modes (overlay-without-ref, unknown sigs-agent-sandbox value). Errors flow through the same Degraded stamp + 60 s requeue path as every other spec-invalid case. |
+| `build_running_status_patch` / `running_status_matches` | `controller/src/status/mod.rs:25,81` | **Mirrored**, not extended in place — overlay status has a distinct `phase` value (`"Overlay"`) and a different condition shape (Suspended=True), so it gets its own pair (`build_overlay_status_patch` / `overlay_status_matches`). The two pairs follow the same shape so a future S7 condition refactor can unify them. |
+| `'deployment_block` labelled-block break | New (this slice) | The existing reconciler `reconcile()` is monolithic (~1.5 k lines). Wrapping the 520-line Step-4 Deployment block in a labelled block + early-`break 'deployment_block` is the minimum-diff way to gate it on `overlay_mode` without re-indenting the entire body. The block survives until S15 (`phase2-hotspot-pass3`) reduces `reconciler/mod.rs` below 800 LOC; at that point the deployment block becomes its own helper function and the labelled-block trick is removed. |
+| Helm `crd.yaml` (ClawSandbox CRD) | `deploy/helm/azureclaw/templates/crd.yaml` | **Untouched.** `upstreamCompatibility` was schema-only in Phase 1 and the helm template never mirrored it. `kube-rs` registers the runtime schema from the Rust struct (which is the contract); the helm CRD is admission-only. There is no helm-drift test for ClawSandbox today (only McpServer / ToolPolicy / A2AAgent / InferencePolicy / ClawEval). Adding admission-side enforcement is deferred to a future slice that introduces `claw_sandbox_validations()`. |
+
+**No duplicate seam introduced.** `ci/no-stubs.sh` and `ci/no-custom-crypto.sh` pass cleanly with `BASE_REF=origin/dev`.
+
+## §1 — AGT boundary
+
+S8 changes **no** AGT surface. AGT 3.3.0 is consumed unchanged; `governance_config` (the `Spec.governance` block) is hoisted out of the deployment block so it is computed regardless of mode, but no governance enforcement runs differently in overlay mode. Specifically:
+
+- The router's AGT client is not instantiated in overlay mode (the router container does not exist — its Pod is upstream-owned).
+- The governance ConfigMap (Step 4c) is still created so an operator who later flips back to Native mode does not lose policy state.
+- AGT trust-store rebuild is not triggered by overlay-mode flips — the upstream Sandbox CR's lifecycle is independent.
+
+S8 **does not** weaken any AGT-enforced invariant. The overlay is an *intentional governance hand-off* to the upstream operator, not a bypass.
+
+## §2 — STRIDE threat model (S8-specific)
+
+| Threat | Vector | Mitigation in S8 |
+|---|---|---|
+| **S — Spoofed upstream Sandbox CR ref** | Operator A's `ClawSandbox` references operator B's upstream `Sandbox` CR by name | `LocalObjectRef` is **namespace-local** by construction (no `namespace:` field). The reconciler resolves the upstream CR within `azureclaw-{name}` (the controller-owned namespace it just created). Cross-namespace ref is impossible without a schema change. |
+| **T — Tampered overlay status** | An attacker patches `ClawSandbox.status.sandboxPod` to mislead `kubectl get` | Status sub-resource RBAC is unchanged; only the controller's ServiceAccount can patch `.status`. The `upstream/` prefix is computed by the controller from the spec — a bad spec produces Degraded, not a misleading status. |
+| **R — Repudiation (Pod ownership ambiguity)** | Operator claims AzureClaw "started" the Pod when an upstream operator did | `phase: "Overlay"` + `Suspended=True / Reason=OverlayMode` + `sandboxPod: upstream/<ref>` make the hand-off explicit on the CR. `kubectl describe clawsandbox` shows the upstream CR name in the Suspended condition's message. |
+| **I — Information disclosure (cross-mode leak)** | Switching from Native → Overlay leaves stale Deployments / blocklist CronJobs running | The controller never deletes resources it stops creating; reconcile is additive. Operators must `kubectl delete deployment/<name>` themselves on a mode flip. **Documented gap.** A future slice can add a delete-on-mode-change finalizer; for S8 we accept the manual-cleanup ergonomics in exchange for safety (never auto-delete an in-flight Pod). |
+| **D — DoS (overlay loop)** | Hot reconcile loop bumps `resourceVersion` every reconcile | New `overlay_status_matches` idempotency guard mirrors `running_status_matches` — same byte-equality check on `phase`, `namespace`, `observedGeneration`, `sandboxPod`, and Ready=True. Verified by `overlay_status_matches_returns_true_for_settled_overlay_status` test. |
+| **E — Privilege escalation (overlay-mode bypass)** | Attacker sets `sigsAgentSandbox: "overlay"` to skip the AzureClaw NetworkPolicy | NetworkPolicy creation (Step 3) runs **before** the deployment block and is **not** gated on overlay mode. The overlay namespace, SA, and NetworkPolicy are created identically in Native and Overlay. The upstream Pod inherits the same egress restrictions because NetworkPolicy is namespace-scoped, not Pod-scoped. |
+
+## §3 — Out of scope (deferred)
+
+- **Upstream `Sandbox` CR watcher / status mirroring.** Reading the upstream CR's `.status` and reflecting it onto `ClawSandbox.status.upstreamConditions` requires the upstream CRD to be installed and a discovery-based informer. Deferred to a future slice (post-S7 once the Conditions matrix lands).
+- **CRD CEL admission for ClawSandbox.** No `claw_sandbox_validations()` exists yet — overlay-requires-ref is enforced at runtime via `degrade!`. A future slice can hoist into CEL once a ClawSandbox validations function lands.
+- **`kubectl claw convert <upstream-Sandbox> → <ClawSandbox-overlay>`.** Lands in S9 (`phase2-migrate-cli`).
+- **Overlay-mode `Suspend` actuator.** When `regressionAction: Suspend` lands in S6+S7's regression actuator, it must understand that overlay mode means the upstream operator owns suspension. Out of scope here.
+- **Auto-cleanup on Native → Overlay mode flip.** See STRIDE I above.
+
+## §4 — Implementation surface
+
+| File | Δ | Description |
+|---|---|---|
+| `controller/src/crd.rs` | +~150 LOC, +5 unit tests | `LocalObjectRef` import; `UpstreamCompatibilityConfig` gains `upstream_sandbox_ref`; `is_overlay_mode()` + `overlay_target_name()` pure helpers; expanded field-level docs. |
+| `controller/src/status/conditions.rs` | +5 LOC | New `TYPE_SUSPENDED` constant + new `reason::OVERLAY_MODE` constant. |
+| `controller/src/status/mod.rs` | +~110 LOC + 6 unit tests | `build_overlay_status_patch` / `overlay_status_matches`. |
+| `controller/src/reconciler/mod.rs` | +~70 LOC, ~3 LOC of indentation | Overlay pre-flight (Degrade on missing-ref / unknown-value); `'deployment_block` wrapper with early-`break`; blocklist gated; Step 5 dispatches on overlay target. `governance_config` + `blocklist_cm_name` hoisted out of deployment block. |
+| `CHANGELOG.md` | +60 LOC | S8 entry inserted above S6 (chronological-newest-first within Phase 2). |
+
+## §5 — Field semantics rationale
+
+**Why string-with-magic-value `"overlay"` rather than an enum?** The `sigs_agent_sandbox` field is a string in Phase 1 (`Option<String>` in `crd.rs`). Phase 1 schema is in production on `dev`; rotating to an enum would force a `v1alpha1 → v1alpha2` schema change purely for one field. We accept the runtime-validated string for Phase 2 and revisit at the planned `v1alpha2` boundary in S13 (`phase2-v1alpha2-migration`). The CEL admission rule that lands with `claw_sandbox_validations()` will catch typos at admission time; until then the reconciler does the same job via `degrade!`.
+
+**Why namespace-local upstream ref?** Cross-namespace references would let operator A's `ClawSandbox` claim governance over operator B's upstream `Sandbox`. STRIDE threat S above. The Phase 1 `LocalObjectRef` shape (no namespace field) is the right primitive.
+
+## §6 — SSA + reconciler skip logic
+
+The Deployment block uses `Patch::Apply` with `field-manager = "azureclaw-controller"` (Phase 1). Skipping the Apply in overlay mode does **not** strip ownership of an existing Deployment — `kube-rs` Apply only manages fields the controller owns; it does not delete the object. **Documented behaviour:** flipping a sandbox from Native to Overlay leaves the Deployment running, owned by the AzureClaw field-manager. Operators must `kubectl delete deployment/<name>` to retire it. See STRIDE I.
+
+The blocklist CronJob (Step 4d) is similarly skipped, with the same flip-leaves-it-running semantics.
+
+## §7 — Failure modes
+
+| Trigger | Behaviour |
+|---|---|
+| `sigsAgentSandbox: "overlay"`, `upstreamSandboxRef: null` | `Degraded=True / Reason=SpecInvalid / Message="upstreamCompatibility.sigsAgentSandbox=\"overlay\" requires upstreamCompatibility.upstreamSandboxRef.name"`. Reconcile requeues every 60 s. |
+| `sigsAgentSandbox: "overlay"`, `upstreamSandboxRef.name: ""` | Same as above. Empty string is treated as missing. |
+| `sigsAgentSandbox: "Overlay"` (capitalised typo) | `Degraded=True / Reason=SpecInvalid / Message="upstreamCompatibility.sigsAgentSandbox: unknown value \`Overlay\` (expected off|observe|translate|overlay)"`. |
+| `sigsAgentSandbox: "off" \| absent`, `upstreamSandboxRef: { name: "x" }` | Native mode runs unchanged; the ref is silently ignored. (Validated by `overlay_target_name_extracts_only_in_overlay_mode` test.) |
+| Upstream `Sandbox` CR doesn't exist in the namespace | **Not detected by AzureClaw.** S8 does not watch the upstream CR. The overlay's NetworkPolicy + SA + ConfigMap simply target a Pod that doesn't exist; nothing fails. The operator sees no Pod for their `ClawSandbox`. Detection lands with the upstream-watcher slice (deferred). |
+
+## §8 — Test surface
+
+Controller workspace: 264 → 276 (+12).
+
+- 5 tests on `UpstreamCompatibilityConfig` helpers (`is_overlay_mode_true_only_for_overlay_string`, `overlay_target_name_extracts_only_in_overlay_mode`, `defaults_are_native_mode`, `serde_round_trip_preserves_overlay_fields`, `serde_omits_upstream_ref_when_none`).
+- 6 tests on overlay status helpers (emit-shape, matcher rejects-status-missing/wrong-phase/wrong-ref/stale-generation, settled-true, transition-time-preservation).
+
+`cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` all green. CI gates (`no-stubs.sh`, `no-custom-crypto.sh`, `check-loc.sh`) all pass with `BASE_REF=origin/dev`.
+
+## §9 — Verify-don't-guess citations (§0.2 #10)
+
+- `sigs.k8s.io/agent-sandbox` repo (referenced in `docs/sigs-agent-sandbox-compat.md`) is the upstream contract this overlay mode integrates against. S8 adds **no** runtime call into the upstream CR — only the namespace-local `LocalObjectRef` pointer to it, surfaced in `status.sandboxPod`. The next slice that watches the upstream CR's `.status` will need `kube-rs` discovery + the upstream CRD installed; that is intentionally deferred.
+- AGT 3.3.0 (`Cargo.toml` workspace pin) is unchanged; no AGT API used in this slice differs from S5/S6.
+
+## §10 — Ops surface
+
+- Operators flip a sandbox into overlay mode by patching `spec.upstreamCompatibility`:
+  ```yaml
+  spec:
+    upstreamCompatibility:
+      sigsAgentSandbox: overlay
+      upstreamSandboxRef:
+        name: my-upstream-sandbox
+  ```
+- `kubectl get clawsandbox` shows `phase: Overlay` and `sandboxPod: upstream/my-upstream-sandbox`.
+- `kubectl wait --for=condition=Ready clawsandbox/<name>` works (overlay reconciles to `Ready=True`).
+- `kubectl wait --for=condition=Suspended=True clawsandbox/<name>` is a new way to gate "AzureClaw stopped driving a Pod" — useful in CI / blueprints.
+- `azureclaw connect <name>` is **expected to fail** in overlay mode (no AzureClaw Pod). A future CLI improvement can detect overlay mode and redirect to the upstream CR; not S8.
+
+## §11 — Sign-offs
+
+- **Reviewer 1 (controller / reconciler):** All changes are additive to the reconcile path; no existing-mode behaviour modified. Idempotency guard mirrored from `running_status_matches`. Failure modes route through the same `degrade!` macro as Phase 1 validation. NetworkPolicy + SA creation order unchanged — overlay mode does not bypass the egress policy. **Approved.**
+
+- **Reviewer 2 (security / threat model):** STRIDE pass surfaced one documented gap (Native → Overlay flip leaves Deployments running). Acceptable for Phase 2 in exchange for never auto-deleting an in-flight Pod; explicit operator action required. Cross-namespace ref impossible by schema. Status-sub-resource RBAC unchanged. **Approved.**


### PR DESCRIPTION
## Summary

Phase 2 S8 — flip `ClawSandbox.spec.upstreamCompatibility.sigsAgentSandbox` from a Phase-1 schema-only field into a real reconciler branch. Closes implementation-plan §2.1's third sandbox mode (Native | Translate | **Overlay**) and contributes to §14.6 column 11 (Multi-runtime hosting).

When `sigsAgentSandbox: "overlay"`, the operator already manages an upstream `Sandbox` CR (sigs.k8s.io/agent-sandbox) in the namespace and `upstreamCompatibility.upstreamSandboxRef.name` points at it. The controller still creates the governance overlay (namespace, SA with Workload-Identity binding, NetworkPolicy, governance ConfigMap, Azure RBAC SA annotations) but **skips** the AzureClaw Pod Deployment + blocklist CM/CronJob.

## Status shape

- `phase: "Overlay"` (distinct from `"Running"`)
- `Ready=True / Reason=OverlayMode`
- `Progressing=False / Reason=OverlayMode`
- `Suspended=True / Reason=OverlayMode` (new condition type) with message naming the upstream CR
- `sandboxPod: upstream/<ref>`
- New `overlay_status_matches` idempotency guard mirrors `running_status_matches`

## Admission gate

Runtime-only (no ClawSandbox CEL admission rules exist yet — schema-only Phase 1). The reconciler `degrade!`s on:
- overlay mode + missing `upstreamSandboxRef.name`
- unknown `sigsAgentSandbox` value (typos such as `"Overlay"` or `"overaly"`)

CEL hoisting deferred until a `claw_sandbox_validations()` function is added.

## Reuse map (§0.2 #11)

- `LocalObjectRef` (`mcp_server.rs:157`) — fifth client; no second ObjectReference type.
- `preserve_transition_time`, `stamp_degraded`, `degrade!` macro — reused unchanged.
- `'deployment_block` labelled-block break — minimum-diff way to gate the 520-line Step 4 block on `overlay_mode` without re-indenting.

## Out of scope (deferred)

- Upstream `Sandbox` CR watcher / status mirroring
- ClawSandbox CEL admission rules
- `kubectl claw convert` (lands in S9 `phase2-migrate-cli`)
- Auto-cleanup of stale Deployments on Native → Overlay mode flip (documented gap; STRIDE I)

## Tests

Controller workspace 264 → 276 (+12). `cargo fmt` + clippy + `cargo test --workspace` all green. CI gates (`no-stubs.sh`, `no-custom-crypto.sh`, `check-loc.sh`) pass with `BASE_REF=origin/dev`.

## Audit

`docs/security-audits/2026-04-27-phase2-overlaymode.md` (2 sign-offs).