### PR TITLE
feat(mesh-plugin): DID canonicalization for AGT identity parity (Phase 3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Rust / Cargo
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,34 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,24 @@
+name: Secret Scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog Secret Scan
+        uses: trufflesecurity/trufflehog@v3.88.26
+        with:
+          extra_args: --only-verified

--- a/mesh-plugin/src/connection.ts
+++ b/mesh-plugin/src/connection.ts
@@ -190,7 +190,8 @@ export class MeshConnection {
 
     console.log(
       `[mesh] Connecting to relay via SDK: ${this.config.relayUrl} ` +
-      `(amid=${this.config.identity.amid}, plaintextPeers=${(this.config.plaintextPeers || []).length})`,
+      `(amid=${this.config.identity.amid}, did=${this.config.identity.did}, ` +
+      `plaintextPeers=${(this.config.plaintextPeers || []).length})`,
     );
 
     await this.client.connect({
@@ -213,7 +214,7 @@ export class MeshConnection {
     }
 
     this.startTransferCleanup();
-    console.log(`[mesh] ✅ Connected — Signal-ready (amid=${this.config.identity.amid.slice(0, 12)}...)`);
+    console.log(`[mesh] ✅ Connected — Signal-ready (amid=${this.config.identity.amid.slice(0, 12)}..., did=${this.config.identity.did})`);
   }
 
   async disconnect(): Promise<void> {

--- a/mesh-plugin/src/did.test.ts
+++ b/mesh-plugin/src/did.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import * as crypto from "node:crypto";
+import {
+  deriveCanonicalDid,
+  parseDid,
+  normalizeDid,
+  isDid,
+  isCanonicalDid,
+  isAmid,
+  classifyAddress,
+} from "./did.js";
+
+describe("deriveCanonicalDid", () => {
+  it("produces did:agentmesh:<16-char-hex> from a 32-byte key", () => {
+    const key = crypto.randomBytes(32);
+    const did = deriveCanonicalDid(key);
+    expect(did).toMatch(/^did:agentmesh:[0-9a-f]{16}$/);
+  });
+
+  it("is deterministic for the same key", () => {
+    const key = crypto.randomBytes(32);
+    expect(deriveCanonicalDid(key)).toBe(deriveCanonicalDid(key));
+  });
+
+  it("produces different DIDs for different keys", () => {
+    const did1 = deriveCanonicalDid(crypto.randomBytes(32));
+    const did2 = deriveCanonicalDid(crypto.randomBytes(32));
+    expect(did1).not.toBe(did2);
+  });
+
+  it("accepts Uint8Array input", () => {
+    const key = new Uint8Array(crypto.randomBytes(32));
+    const did = deriveCanonicalDid(key);
+    expect(did).toMatch(/^did:agentmesh:[0-9a-f]{16}$/);
+  });
+});
+
+describe("parseDid", () => {
+  it("parses canonical did:agentmesh:<fingerprint>", () => {
+    const result = parseDid("did:agentmesh:abcdef0123456789");
+    expect(result).toEqual({
+      original: "did:agentmesh:abcdef0123456789",
+      method: "agentmesh",
+      fingerprint: "abcdef0123456789",
+    });
+  });
+
+  it("parses AGT TS SDK format did:agentmesh:<agentId>:<fingerprint>", () => {
+    const result = parseDid("did:agentmesh:my-agent:abcdef0123456789");
+    expect(result).toEqual({
+      original: "did:agentmesh:my-agent:abcdef0123456789",
+      method: "agentmesh",
+      agentId: "my-agent",
+      fingerprint: "abcdef0123456789",
+    });
+  });
+
+  it("parses AGT Python SDK format did:mesh:<identifier>", () => {
+    const result = parseDid("did:mesh:abc123def456");
+    expect(result).toEqual({
+      original: "did:mesh:abc123def456",
+      method: "mesh",
+      fingerprint: "abc123def456",
+    });
+  });
+
+  it("returns null for non-DID strings", () => {
+    expect(parseDid("not-a-did")).toBeNull();
+    expect(parseDid("amid:something")).toBeNull();
+    expect(parseDid("")).toBeNull();
+  });
+
+  it("returns null for malformed DIDs", () => {
+    expect(parseDid("did:unknown:abc")).toBeNull();
+    expect(parseDid("did:")).toBeNull();
+  });
+});
+
+describe("normalizeDid", () => {
+  it("returns canonical form unchanged", () => {
+    expect(normalizeDid("did:agentmesh:abcdef0123456789")).toBe(
+      "did:agentmesh:abcdef0123456789",
+    );
+  });
+
+  it("strips agentId from AGT TS SDK format", () => {
+    expect(normalizeDid("did:agentmesh:my-agent:abcdef0123456789")).toBe(
+      "did:agentmesh:abcdef0123456789",
+    );
+  });
+
+  it("preserves did:mesh: as-is (different derivation)", () => {
+    expect(normalizeDid("did:mesh:some-id")).toBe("did:mesh:some-id");
+  });
+
+  it("returns non-DID strings unchanged", () => {
+    expect(normalizeDid("not-a-did")).toBe("not-a-did");
+  });
+});
+
+describe("isDid / isCanonicalDid / isAmid", () => {
+  it("isDid recognizes all DID formats", () => {
+    expect(isDid("did:agentmesh:abcdef0123456789")).toBe(true);
+    expect(isDid("did:agentmesh:agent:abcdef0123456789")).toBe(true);
+    expect(isDid("did:mesh:abc123")).toBe(true);
+    expect(isDid("not-a-did")).toBe(false);
+  });
+
+  it("isCanonicalDid only matches did:agentmesh:<16-hex>", () => {
+    expect(isCanonicalDid("did:agentmesh:abcdef0123456789")).toBe(true);
+    expect(isCanonicalDid("did:agentmesh:agent:abcdef0123456789")).toBe(false);
+    expect(isCanonicalDid("did:mesh:abcdef0123456789")).toBe(false);
+    expect(isCanonicalDid("did:agentmesh:short")).toBe(false);
+  });
+
+  it("isAmid matches base58 strings of expected length", () => {
+    expect(isAmid("2NEpo7TZRRrLZSi2U")).toBe(false); // too short
+    expect(isAmid("2NEpo7TZRRrLZSi2U1234567")).toBe(true);
+    expect(isAmid("did:agentmesh:abc")).toBe(false); // has colon
+  });
+});
+
+describe("classifyAddress", () => {
+  it("classifies canonical DID", () => {
+    expect(classifyAddress("did:agentmesh:abcdef0123456789")).toBe("canonical-did");
+  });
+
+  it("classifies non-canonical DID", () => {
+    expect(classifyAddress("did:mesh:something")).toBe("did");
+    expect(classifyAddress("did:agentmesh:agent:abcdef0123456789")).toBe("did");
+  });
+
+  it("classifies AMID", () => {
+    expect(classifyAddress("2NEpo7TZRRrLZSi2U1234567")).toBe("amid");
+  });
+
+  it("classifies unknown", () => {
+    expect(classifyAddress("random")).toBe("unknown");
+    expect(classifyAddress("")).toBe("unknown");
+  });
+});

--- a/mesh-plugin/src/did.ts
+++ b/mesh-plugin/src/did.ts
@@ -1,0 +1,127 @@
+/**
+ * DID canonicalization — deterministic derivation of AGT-compatible DIDs
+ * from Ed25519 signing keys.
+ *
+ * Phase 3 of the AGT migration: adds canonical DID alongside existing AMID
+ * so both identifiers are available during the cutover period.
+ *
+ * Canonical format: `did:agentmesh:<fingerprint>`
+ *   where fingerprint = hex(sha256(raw_ed25519_pub))[:16]
+ *
+ * This is a simplified form of AGT's TS SDK format (`did:agentmesh:<agentId>:<fingerprint>`)
+ * without the agentId segment, since AzureClaw identities are key-derived,
+ * not name-derived. The full form is accepted as input and normalized.
+ *
+ * Accepted input formats (all normalized to canonical on parse):
+ *   - `did:agentmesh:<fingerprint>`           (canonical)
+ *   - `did:agentmesh:<agentId>:<fingerprint>`  (AGT TS SDK)
+ *   - `did:mesh:<identifier>`                  (AGT Python SDK, passthrough)
+ *   - AMID string                              (legacy, requires public key for DID)
+ */
+
+import * as crypto from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Canonical DID derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the canonical DID from a raw Ed25519 signing public key (32 bytes).
+ *
+ * Uses the same hash as AGT's TS SDK (`sha256(pubkey).hex[:16]`) but over
+ * raw key bytes (not SPKI-wrapped), matching AzureClaw's existing identity
+ * module. The fingerprint is self-verifying: anyone with the public key can
+ * recompute it.
+ */
+export function deriveCanonicalDid(signingPublicKey: Buffer | Uint8Array): string {
+  const fingerprint = crypto
+    .createHash("sha256")
+    .update(signingPublicKey)
+    .digest("hex")
+    .slice(0, 16);
+  return `did:agentmesh:${fingerprint}`;
+}
+
+// ---------------------------------------------------------------------------
+// DID parsing and normalization
+// ---------------------------------------------------------------------------
+
+export interface ParsedDid {
+  /** The full DID string in its original form. */
+  original: string;
+  /** DID method (`agentmesh` or `mesh`). */
+  method: "agentmesh" | "mesh";
+  /** The fingerprint segment (last segment for agentmesh, identifier for mesh). */
+  fingerprint: string;
+  /** Optional agentId segment (present in AGT TS SDK `did:agentmesh:<agentId>:<fp>` form). */
+  agentId?: string;
+}
+
+/**
+ * Parse a DID string into its components.
+ * Returns null if the string is not a recognized DID format.
+ */
+export function parseDid(did: string): ParsedDid | null {
+  if (!did.startsWith("did:")) return null;
+
+  // did:agentmesh:<fingerprint> or did:agentmesh:<agentId>:<fingerprint>
+  const agentmeshMatch = did.match(/^did:agentmesh:([^:]+)(?::([^:]+))?$/);
+  if (agentmeshMatch) {
+    const [, first, second] = agentmeshMatch;
+    if (second) {
+      return { original: did, method: "agentmesh", agentId: first, fingerprint: second };
+    }
+    return { original: did, method: "agentmesh", fingerprint: first };
+  }
+
+  // did:mesh:<identifier>
+  const meshMatch = did.match(/^did:mesh:(.+)$/);
+  if (meshMatch) {
+    return { original: did, method: "mesh", fingerprint: meshMatch[1] };
+  }
+
+  return null;
+}
+
+/**
+ * Normalize any recognized DID to the canonical `did:agentmesh:<fingerprint>` form.
+ * For `did:mesh:*` identifiers that aren't hex fingerprints, returns the original
+ * since lossless normalization isn't possible without the public key.
+ */
+export function normalizeDid(did: string): string {
+  const parsed = parseDid(did);
+  if (!parsed) return did;
+
+  if (parsed.method === "agentmesh") {
+    return `did:agentmesh:${parsed.fingerprint}`;
+  }
+
+  // did:mesh: identifiers may use a different derivation, return as-is
+  return did;
+}
+
+/** Check if a string is a DID in any recognized format. */
+export function isDid(value: string): boolean {
+  return parseDid(value) !== null;
+}
+
+/** Check if a string is the canonical `did:agentmesh:<fingerprint>` format. */
+export function isCanonicalDid(value: string): boolean {
+  return /^did:agentmesh:[0-9a-f]{16}$/.test(value);
+}
+
+/** Check if a string looks like a legacy AMID (base58, typically 24-28 chars). */
+export function isAmid(value: string): boolean {
+  return /^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{20,30}$/.test(value);
+}
+
+/**
+ * Determine the type of a peer address string.
+ * Useful for routing decisions during the dual-identity cutover period.
+ */
+export function classifyAddress(address: string): "canonical-did" | "did" | "amid" | "unknown" {
+  if (isCanonicalDid(address)) return "canonical-did";
+  if (isDid(address)) return "did";
+  if (isAmid(address)) return "amid";
+  return "unknown";
+}

--- a/mesh-plugin/src/identity.ts
+++ b/mesh-plugin/src/identity.ts
@@ -16,6 +16,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { Identity, type IdentityData } from "@agentmesh/sdk";
+import { deriveCanonicalDid } from "./did.js";
 
 const IDENTITY_DIR = path.join(os.homedir(), ".azureclaw");
 const IDENTITY_FILE = path.join(IDENTITY_DIR, "identity.json");
@@ -34,6 +35,8 @@ interface MeshIdentityEnvelope {
 export interface MeshIdentity {
   /** AgentMesh ID — derived from the Ed25519 signing public key. */
   amid: string;
+  /** AGT-compatible DID — `did:agentmesh:<fingerprint>`, derived from the same key. */
+  did: string;
   /** Ed25519 signing public key (raw 32 bytes). */
   signingPublicKey: Buffer;
   /** Ed25519 signing private key (raw 32 bytes). */
@@ -127,9 +130,11 @@ function rawFromPrefixedB64(value: string, prefix: string): Buffer {
 
 async function buildFacade(sdkIdentity: Identity): Promise<MeshIdentity> {
   const data = await sdkIdentity.toData();
+  const signingPublicKey = rawFromPrefixedB64(data.signing_public_key, "ed25519:");
   return {
     amid: sdkIdentity.amid,
-    signingPublicKey: rawFromPrefixedB64(data.signing_public_key, "ed25519:"),
+    did: deriveCanonicalDid(signingPublicKey),
+    signingPublicKey,
     signingPrivateKey: rawFromPrefixedB64(data.signing_private_key, "ed25519:"),
     sdkIdentity,
   };


### PR DESCRIPTION
## Summary

Phase 3 of AGT migration: adds deterministic DID derivation alongside existing AMID identifiers, enabling dual-identity operation during the cutover period.

### Changes

- **\did.ts\** (new): Core DID canonicalization module
  - \deriveCanonicalDid()\: derives \did:agentmesh:<fingerprint>\ from Ed25519 public key
  - \parseDid()\: parses canonical, AGT TS SDK, and AGT Python SDK DID formats
  - \
ormalizeDid()\: normalizes any variant to canonical form
  - \classifyAddress()\: identifies whether an address is canonical-did, did, amid, or unknown

- **\identity.ts\**: Extended \MeshIdentity\ interface with computed \did\ field (derived from public key, not persisted)

- **\connection.ts\**: Added DID to connect/disconnect log messages for observability

- **\did.test.ts\**: 20 tests covering all derivation, parsing, normalization, and classification scenarios

### Design decisions

- Canonical format: \did:agentmesh:<hex(sha256(pubkey))[:16]>\ (matches AGT TS SDK fingerprint derivation)
- DID is always computed, never persisted: no identity schema bump needed
- No wire protocol changes: AMID remains the wire identifier for now
- \did:mesh:<uuid>\ (Python SDK) is accepted as input but preserved as-is since normalization requires the public key

### What's next

- Phase 4: Registry cutover (parallel registries, DID-based discovery)
- Phase 5: Relay replacement (AGT transport)
- Phase 6: Cleanup (remove vendor/agentmesh-*)