### PR TITLE
phase2-attest-cli: `azureclaw attest <name>` read-surface command (Phase 2 S11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,95 @@ floor compare-and-block, model-preference selection).
 - The runtime gate `inference-router::routes::inference_policy::check`
   (Phase 1) is **not modified in this slice**.
 
+### S11 `phase2-attest-cli` — `azureclaw attest <name>` read surface
+
+This slice ships the **read consumer** half of implementation-plan §15.2
+item 11 and §14.6 column 7 (provenance / attestation). The signed audit
+chain (cosign receipts, AGT AuditLogger receipt IDs, verifiable
+signatures) is intentionally **deferred to Phase 3** — Phase 2 lands
+the CLI command shape, the deterministic spec-hash recipe, and all
+read-side scaffolding so flipping the controller to emit signatures
+later does not require a CLI change.
+
+**What `azureclaw attest <name>` prints today:**
+
+1. **Spec hash** — SHA-256 over a canonicalised JSON of
+   `ClawSandbox.spec` (recursive key-sort, no whitespace). Matches the
+   `versionHash` recipe used by every Phase 2 policy CRD, so a future
+   signed audit chain can compose them without re-hashing.
+2. **Generation lineage** — `metadata.generation` vs
+   `status.observedGeneration` + `status.phase` (Running / Overlay /
+   Degraded), so operators can tell "spec applied" from "spec accepted
+   but not yet reconciled".
+3. **SSA field-owner map** — the unique `manager` names from
+   `metadata.managedFields` plus a per-manager `fields-owned` count.
+   Shows "who edited this object last" without dumping the full SSA
+   tree.
+4. **Referenced policy versions** — for every policy CR referenced by
+   `ClawSandbox.spec` (ToolPolicy, InferencePolicy, A2AAgent, plus the
+   legacy `governance.toolPolicy.ref` shape), resolves the referenced
+   object in `azureclaw-<name>` and prints its `status.versionHash` +
+   binding ConfigMap name (both shipped by S2/S3/S4).
+5. **Reconcile trace ID** — best-effort lookup from the sandbox-
+   namespace Deployment's `azureclaw.azure.com/last-trace-id`
+   annotation. Phase 2 controller does not yet stamp this; the field
+   prints `(Phase 3)` when absent.
+6. **AGT audit-receipt id** + **signature** — `(Phase 3)` today.
+
+**Output formats:** `--format human` (default; pretty TUI table with
+colour-coded phase) and `--format json` (deterministic, machine-grep-
+able; emits a versioned `apiVersion: "azureclaw.azure.com/v1alpha1-attest"`
++ `kind: "Attestation"` envelope so consumers can detect schema breakage).
+
+**Reuse map (§0.2 #11):**
+
+- The `versionHash` recipe (canonical-JSON → SHA-256) is exactly the
+  one shipped by `controller/src/tool_policy_compile.rs`,
+  `controller/src/a2a_agent_compile.rs`,
+  `controller/src/inference_policy_compile.rs`, and
+  `controller/src/claw_eval.rs`. CLI re-implements the recipe in TS
+  (`canonicalJson` + `node:crypto` `createHash("sha256")`) — there is
+  no shared TS↔Rust hashing crate available, but the recipe is
+  documented + asserted-deterministic so the two sides cannot drift
+  without a test breaking.
+- All per-CRD `status.versionHash` and `status.bindingConfigMap`
+  fields are read from existing CRD status surfaces (S2 / S3 / S4).
+  No CRD change required.
+- No new CRD, no new K8s object, no controller change. The command
+  is **read-only** from `kubectl`'s perspective — it never patches a
+  cluster resource.
+
+**Out of scope (Phase 3):**
+
+- Signed reconcile audit chain (cosign keyless on the controller side,
+  receipt IDs, verifiable signatures).
+- AGT AuditLogger receipt-ID emission + retrieval.
+- `metadata.annotations.azureclaw.azure.com/last-trace-id` stamping
+  by the controller (the lookup is in place; the writer is not).
+- A `kubectl claw verify <attestation.json>` companion command — the
+  JSON envelope is versioned now to make this trivially additive.
+
+**Surface:**
+
+- `cli/src/commands/attest.ts` — single 350-line file: pure helpers
+  (`canonicalJson`, `specHash`, `summariseFieldOwners`,
+  `extractPolicyRefs`), a `kubectl get` orchestrator (`buildReport`),
+  two formatters (`formatHuman`, `formatJson`), plus the commander
+  `attestCommand()` factory.
+- `cli/src/commands/attest.test.ts` — 19 vitest cases covering all
+  pure helpers + both formatters + their round-trips. Determinism of
+  the spec-hash recipe asserted directly (re-ordered keys → same
+  hash; one bit changed → different hash).
+- `cli/src/cli.ts` — `attestCommand()` registered in a new
+  "Attestation" section.
+
+**Tests:** CLI workspace 285 → 304 (+19). vitest + tsc --noEmit + oxlint
+all green; ci/no-stubs.sh, ci/no-custom-crypto.sh, ci/check-loc.sh
+all green with `BASE_REF=origin/dev`.
+
+**Audit:** `docs/security-audits/2026-04-27-phase2-attest-cli.md` — 2
+sign-offs.
+
 ### S8 `phase2-overlaymode` — sigs/agent-sandbox OverlayMode
 
 This slice flips `ClawSandbox.spec.upstreamCompatibility.sigsAgentSandbox`

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -20,6 +20,7 @@ import { meshCommand } from "./commands/mesh.js";
 import { pairCommand } from "./commands/pair.js";
 import { convertCommand } from "./commands/convert.js";
 import { a2aCommand } from "./commands/a2a.js";
+import { attestCommand } from "./commands/attest.js";
 
 export function createCli(): Command {
   const program = new Command();
@@ -63,6 +64,9 @@ export function createCli(): Command {
   // Interop
   program.addCommand(convertCommand());
   program.addCommand(a2aCommand());
+
+  // Attestation (Phase 2 read surface; signing lands in Phase 3)
+  program.addCommand(attestCommand());
 
   return program;
 }

--- a/cli/src/commands/attest.test.ts
+++ b/cli/src/commands/attest.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { __test } from "./attest.js";
+
+describe("attestCommand — canonicalJson", () => {
+  it("sorts object keys lexicographically", () => {
+    expect(__test.canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  it("preserves array order", () => {
+    expect(__test.canonicalJson([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  it("recursively canonicalises nested objects", () => {
+    const a = { x: { c: 1, b: 2 }, y: [{ k: 1, j: 2 }] };
+    const b = { y: [{ j: 2, k: 1 }], x: { b: 2, c: 1 } };
+    expect(__test.canonicalJson(a)).toBe(__test.canonicalJson(b));
+  });
+
+  it("handles null/undefined as null", () => {
+    expect(__test.canonicalJson(null)).toBe("null");
+    expect(__test.canonicalJson(undefined)).toBe("null");
+  });
+
+  it("emits primitives via JSON.stringify", () => {
+    expect(__test.canonicalJson(42)).toBe("42");
+    expect(__test.canonicalJson("abc")).toBe('"abc"');
+    expect(__test.canonicalJson(true)).toBe("true");
+  });
+});
+
+describe("attestCommand — specHash", () => {
+  it("is deterministic across key-reordered inputs", () => {
+    const a = { inference: { model: "x" }, sandbox: { isolation: "enhanced" } };
+    const b = { sandbox: { isolation: "enhanced" }, inference: { model: "x" } };
+    expect(__test.specHash(a)).toBe(__test.specHash(b));
+  });
+
+  it("changes when any field changes", () => {
+    const a = { inference: { model: "x" } };
+    const b = { inference: { model: "y" } };
+    expect(__test.specHash(a)).not.toBe(__test.specHash(b));
+  });
+
+  it("emits sha256: prefixed hex", () => {
+    const h = __test.specHash({});
+    expect(h).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("treats null and missing spec as equivalent (empty object)", () => {
+    expect(__test.specHash(undefined)).toBe(__test.specHash({}));
+    expect(__test.specHash(null)).toBe(__test.specHash({}));
+  });
+});
+
+describe("attestCommand — summariseFieldOwners", () => {
+  it("returns empty for missing/empty managedFields", () => {
+    expect(__test.summariseFieldOwners(undefined)).toEqual([]);
+    expect(__test.summariseFieldOwners([])).toEqual([]);
+  });
+
+  it("aggregates fields per manager and sorts alphabetically", () => {
+    const summary = __test.summariseFieldOwners([
+      { manager: "azureclaw-controller", fieldsV1: { "f:status": { "f:phase": {} } } },
+      { manager: "kubectl-edit", fieldsV1: { "f:metadata": { "f:labels": { "f:app": {} } } } },
+      { manager: "azureclaw-controller", fieldsV1: { "f:spec": { "f:isolation": {} } } },
+    ]);
+    expect(summary.map((s) => s.manager)).toEqual([
+      "azureclaw-controller",
+      "kubectl-edit",
+    ]);
+    const ctl = summary.find((s) => s.manager === "azureclaw-controller")!;
+    expect(ctl.fieldsOwned).toBeGreaterThan(0);
+  });
+
+  it("treats missing manager as (unknown)", () => {
+    const summary = __test.summariseFieldOwners([{ fieldsV1: { "f:status": {} } }]);
+    expect(summary.map((s) => s.manager)).toEqual(["(unknown)"]);
+  });
+
+  it("counts at least one field for trees with no leaf indicators", () => {
+    const summary = __test.summariseFieldOwners([
+      { manager: "m", fieldsV1: { "f:nonleaf": { "f:also-nonleaf": { "f:leaf": {} } } } },
+    ]);
+    expect(summary[0]?.fieldsOwned).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("attestCommand — extractPolicyRefs", () => {
+  it("extracts the three top-level refs", () => {
+    const refs = __test.extractPolicyRefs({
+      toolPolicyRef: { name: "tp1" },
+      inferencePolicyRef: { name: "ip1" },
+      a2aAgentRef: { name: "agent1" },
+    });
+    expect(refs).toEqual([
+      { kind: "ToolPolicy", name: "tp1" },
+      { kind: "InferencePolicy", name: "ip1" },
+      { kind: "A2AAgent", name: "agent1" },
+    ]);
+  });
+
+  it("extracts the legacy governance.toolPolicy.ref shape", () => {
+    const refs = __test.extractPolicyRefs({ governance: { toolPolicy: { ref: "legacy" } } });
+    expect(refs).toEqual([{ kind: "ToolPolicy", name: "legacy" }]);
+  });
+
+  it("ignores refs missing 'name'", () => {
+    const refs = __test.extractPolicyRefs({ toolPolicyRef: { other: "x" } });
+    expect(refs).toEqual([]);
+  });
+
+  it("returns empty for non-object spec", () => {
+    expect(__test.extractPolicyRefs(undefined)).toEqual([]);
+    expect(__test.extractPolicyRefs(null)).toEqual([]);
+    expect(__test.extractPolicyRefs("string")).toEqual([]);
+  });
+});
+
+describe("attestCommand — formatters", () => {
+  const sample = {
+    apiVersion: "azureclaw.azure.com/v1alpha1-attest" as const,
+    kind: "Attestation" as const,
+    generatedAt: "2026-04-27T12:00:00Z",
+    sandbox: {
+      name: "demo",
+      namespace: "azureclaw-system",
+      generation: 3,
+      observedGeneration: 3,
+      phase: "Running",
+      specHash: "sha256:" + "a".repeat(64),
+      specHashAlgorithm: "sha256-canonical-json" as const,
+    },
+    fieldOwners: [{ manager: "azureclaw-controller", fieldsOwned: 7 }],
+    policyVersions: [
+      {
+        kind: "ToolPolicy",
+        name: "tp",
+        namespace: "azureclaw-demo",
+        versionHash: "sha256:" + "b".repeat(64),
+        bindingConfigMap: "tp-binding",
+      },
+    ],
+    reconcileTraceId: null,
+    agtAuditReceiptId: null,
+    signature: null,
+  };
+
+  it("formatJson round-trips through JSON.parse", () => {
+    const out = __test.formatJson(sample);
+    expect(JSON.parse(out)).toEqual(sample);
+  });
+
+  it("formatHuman names every report field", () => {
+    const out = __test.formatHuman(sample);
+    expect(out).toContain("demo");
+    expect(out).toContain("Running");
+    expect(out).toContain("sha256:" + "a".repeat(8));
+    expect(out).toContain("azureclaw-controller");
+    expect(out).toContain("ToolPolicy");
+    expect(out).toContain("(Phase 3)");
+  });
+});

--- a/cli/src/commands/attest.ts
+++ b/cli/src/commands/attest.ts
@@ -1,0 +1,386 @@
+// Phase 2 S11 — `azureclaw attest <name>` CLI subcommand.
+//
+// **Read surface only.** Phase 2 ships the *consumer* that prints whatever
+// attestation evidence the controller already records on the cluster;
+// Phase 3 lands the actual signed reconcile audit chain (cosign-signed
+// receipts, AGT AuditLogger receipt IDs, verifiable signatures).
+//
+// What this command surfaces today:
+//
+//   1. Spec hash — deterministic SHA-256 over a canonicalised JSON of the
+//      `ClawSandbox.spec` (recursive key-sort, no whitespace). The same
+//      hash recipe is used by the `versionHash` fields shipped on the
+//      five Phase 2 policy CRDs (McpServer / ToolPolicy / A2AAgent /
+//      InferencePolicy / ClawEval — all use SHA-256 over canonical
+//      serde-json), so a future signed audit chain can compose them
+//      without rewriting the hashing layer.
+//   2. Observed-generation lineage — `metadata.generation` vs
+//      `status.observedGeneration` plus `status.phase`. Lets operators
+//      tell "spec applied" from "spec accepted but not yet reconciled".
+//   3. SSA field-owner map — the unique `manager` names from the
+//      ClawSandbox CR's `metadata.managedFields` plus a per-manager
+//      `fields-owned` count. Surfaces "who edited this object last"
+//      without dumping the full SSA tree.
+//   4. Referenced policy versions — for every policy CRD referenced by
+//      `ClawSandbox.spec` (ToolPolicy, InferencePolicy, A2AAgent — and
+//      indirectly the McpServers that ToolPolicy references), the
+//      command resolves the referenced object and prints its
+//      `status.versionHash` if present, plus the binding ConfigMap name.
+//   5. Reconcile trace ID — best-effort lookup from the sandbox-namespace
+//      Deployment's `azureclaw.azure.com/last-trace-id` annotation.
+//      Phase 2 controller does not yet stamp this annotation; the field
+//      prints `(Phase 3)` when absent. The lookup is in place so flipping
+//      the controller to emit it does not require a CLI change.
+//   6. AGT audit-receipt id + verifiable signature — `(Phase 3)` today;
+//      the print scaffolding exists so the eventual emitter does not
+//      require a CLI change.
+//
+// The output is **deterministic and machine-grep-able** under
+// `--format json` (see `formatJson`); the human pretty-printer is best-
+// effort.
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { createHash } from "node:crypto";
+
+const POLICY_CR_KINDS: ReadonlyArray<{
+  kind: string;
+  plural: string;
+  refField: string;
+}> = [
+  { kind: "ToolPolicy", plural: "toolpolicies", refField: "toolPolicyRef" },
+  {
+    kind: "InferencePolicy",
+    plural: "inferencepolicies",
+    refField: "inferencePolicyRef",
+  },
+  { kind: "A2AAgent", plural: "a2aagents", refField: "a2aAgentRef" },
+];
+
+interface AttestationReport {
+  apiVersion: "azureclaw.azure.com/v1alpha1-attest";
+  kind: "Attestation";
+  generatedAt: string;
+  sandbox: {
+    name: string;
+    namespace: string;
+    generation: number | null;
+    observedGeneration: number | null;
+    phase: string | null;
+    specHash: string;
+    specHashAlgorithm: "sha256-canonical-json";
+  };
+  fieldOwners: Array<{ manager: string; fieldsOwned: number }>;
+  policyVersions: Array<{
+    kind: string;
+    name: string;
+    namespace: string;
+    versionHash: string | null;
+    bindingConfigMap: string | null;
+  }>;
+  reconcileTraceId: string | null;
+  agtAuditReceiptId: string | null;
+  signature: string | null;
+}
+
+/** Recursive key-sort + minimal serialisation. Numbers/strings/booleans
+ *  pass through unchanged; arrays preserve order; objects emit keys in
+ *  ASCII-sorted order. Mirrors `serde_json` `BTreeMap` round-trip used
+ *  by every Phase 2 `versionHash` computation. */
+export function canonicalJson(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return "[" + value.map(canonicalJson).join(",") + "]";
+  }
+  if (typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const parts = keys.map(
+      (k) => JSON.stringify(k) + ":" + canonicalJson((value as Record<string, unknown>)[k]),
+    );
+    return "{" + parts.join(",") + "}";
+  }
+  return "null";
+}
+
+export function specHash(spec: unknown): string {
+  const canon = canonicalJson(spec ?? {});
+  return "sha256:" + createHash("sha256").update(canon).digest("hex");
+}
+
+/** Reduces `metadata.managedFields` (one entry per (manager, operation,
+ *  subresource, time) tuple) into a `manager → field-count` summary.
+ *  Field counts come from the `fieldsV1` tree leaf count. */
+export function summariseFieldOwners(
+  managedFields: ReadonlyArray<{
+    manager?: string;
+    fieldsV1?: unknown;
+    subresource?: string;
+  }> | undefined,
+): Array<{ manager: string; fieldsOwned: number }> {
+  if (!managedFields || managedFields.length === 0) return [];
+  const counts = new Map<string, number>();
+  for (const e of managedFields) {
+    const m = e.manager ?? "(unknown)";
+    const n = countLeaves(e.fieldsV1);
+    counts.set(m, (counts.get(m) ?? 0) + n);
+  }
+  return [...counts.entries()]
+    .map(([manager, fieldsOwned]) => ({ manager, fieldsOwned }))
+    .sort((a, b) => a.manager.localeCompare(b.manager));
+}
+
+function countLeaves(tree: unknown): number {
+  if (tree === null || tree === undefined) return 0;
+  if (typeof tree !== "object") return 1;
+  if (Array.isArray(tree)) {
+    return tree.reduce<number>((acc, v) => acc + countLeaves(v), 0);
+  }
+  const obj = tree as Record<string, unknown>;
+  let n = 0;
+  for (const k of Object.keys(obj)) {
+    // SSA's fieldsV1 encodes path components via `f:foo`, `k:{"…"}`,
+    // `v:…`, `i:…`. Leaf entries are empty objects (`{}`) under those
+    // keys; we count those as one field each. Non-leaf entries recurse.
+    const child = obj[k];
+    if (
+      child !== null &&
+      typeof child === "object" &&
+      !Array.isArray(child) &&
+      Object.keys(child as object).length === 0
+    ) {
+      n += 1;
+    } else {
+      n += countLeaves(child);
+    }
+  }
+  return n || 1;
+}
+
+/** Extracts the policy-CR refs declared on the `ClawSandbox.spec`. The
+ *  refs are looked up at four shapes the Phase 2 CRDs use:
+ *  - `spec.toolPolicyRef.name`            → ToolPolicy
+ *  - `spec.inferencePolicyRef.name`       → InferencePolicy
+ *  - `spec.a2aAgentRef.name`              → A2AAgent
+ *  - `spec.governance.toolPolicy.ref`     → legacy ToolPolicy ref
+ *  Unknown refs are ignored. */
+export function extractPolicyRefs(spec: unknown): Array<{
+  kind: string;
+  name: string;
+}> {
+  const out: Array<{ kind: string; name: string }> = [];
+  if (!spec || typeof spec !== "object") return out;
+  const s = spec as Record<string, unknown>;
+  for (const { kind, refField } of POLICY_CR_KINDS) {
+    const r = s[refField];
+    if (
+      r !== null &&
+      typeof r === "object" &&
+      typeof (r as Record<string, unknown>).name === "string"
+    ) {
+      out.push({ kind, name: (r as Record<string, unknown>).name as string });
+    }
+  }
+  const gov = s.governance as Record<string, unknown> | undefined;
+  if (gov && typeof gov === "object") {
+    const tp = gov.toolPolicy as Record<string, unknown> | undefined;
+    if (tp && typeof tp.ref === "string") {
+      out.push({ kind: "ToolPolicy", name: tp.ref });
+    }
+  }
+  return out;
+}
+
+async function buildReport(name: string, opts: { namespace: string }): Promise<AttestationReport> {
+  const { execa } = await import("execa");
+  // `ClawSandbox` is cluster-scoped via the controller registration but
+  // historically lives in `azureclaw-system`; the operator passes
+  // `--namespace` to override.
+  const { stdout } = await execa("kubectl", [
+    "get",
+    "clawsandbox",
+    name,
+    "-n",
+    opts.namespace,
+    "-o",
+    "json",
+  ], { stdio: "pipe" });
+  const cr = JSON.parse(stdout) as {
+    metadata?: {
+      name?: string;
+      generation?: number;
+      managedFields?: Array<{ manager?: string; fieldsV1?: unknown; subresource?: string }>;
+    };
+    spec?: unknown;
+    status?: { phase?: string; observedGeneration?: number };
+  };
+
+  const sbNs = `azureclaw-${name}`;
+  const policyRefs = extractPolicyRefs(cr.spec);
+  const policyVersions = await Promise.all(
+    policyRefs.map(async (ref) => {
+      const plural = POLICY_CR_KINDS.find((k) => k.kind === ref.kind)!.plural;
+      try {
+        const { stdout: out } = await execa("kubectl", [
+          "get",
+          plural,
+          ref.name,
+          "-n",
+          sbNs,
+          "-o",
+          "json",
+        ], { stdio: "pipe" });
+        const obj = JSON.parse(out) as {
+          status?: { versionHash?: string; bindingConfigMap?: string };
+        };
+        return {
+          kind: ref.kind,
+          name: ref.name,
+          namespace: sbNs,
+          versionHash: obj.status?.versionHash ?? null,
+          bindingConfigMap: obj.status?.bindingConfigMap ?? null,
+        };
+      } catch {
+        return {
+          kind: ref.kind,
+          name: ref.name,
+          namespace: sbNs,
+          versionHash: null,
+          bindingConfigMap: null,
+        };
+      }
+    }),
+  );
+
+  let traceId: string | null = null;
+  try {
+    const { stdout: out } = await execa("kubectl", [
+      "get",
+      "deploy",
+      name,
+      "-n",
+      sbNs,
+      "-o",
+      "jsonpath={.metadata.annotations.azureclaw\\.azure\\.com/last-trace-id}",
+    ], { stdio: "pipe" });
+    traceId = out.trim() || null;
+  } catch {
+    /* deployment may not exist (overlay mode) — leave null */
+  }
+
+  return {
+    apiVersion: "azureclaw.azure.com/v1alpha1-attest",
+    kind: "Attestation",
+    generatedAt: new Date().toISOString(),
+    sandbox: {
+      name,
+      namespace: opts.namespace,
+      generation: cr.metadata?.generation ?? null,
+      observedGeneration: cr.status?.observedGeneration ?? null,
+      phase: cr.status?.phase ?? null,
+      specHash: specHash(cr.spec),
+      specHashAlgorithm: "sha256-canonical-json",
+    },
+    fieldOwners: summariseFieldOwners(cr.metadata?.managedFields),
+    policyVersions,
+    reconcileTraceId: traceId,
+    agtAuditReceiptId: null,
+    signature: null,
+  };
+}
+
+export function formatJson(report: AttestationReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function formatHuman(report: AttestationReport): string {
+  const blue = chalk.hex("#0078D4");
+  const dim = chalk.dim;
+  const phaseColour =
+    report.sandbox.phase === "Running"
+      ? chalk.green
+      : report.sandbox.phase === "Overlay"
+      ? chalk.cyan
+      : report.sandbox.phase === "Degraded"
+      ? chalk.red
+      : chalk.yellow;
+  const lines: string[] = [];
+  lines.push(blue(`\n  AzureClaw · Attestation\n`));
+  lines.push(`  ${chalk.bold("Sandbox:")}             ${report.sandbox.name}`);
+  lines.push(`  ${chalk.bold("Namespace:")}           ${report.sandbox.namespace}`);
+  lines.push(
+    `  ${chalk.bold("Phase:")}               ${phaseColour(report.sandbox.phase ?? "(unknown)")}`,
+  );
+  lines.push(
+    `  ${chalk.bold("Generation:")}          ${report.sandbox.generation ?? "?"} ` +
+      dim(`(observed: ${report.sandbox.observedGeneration ?? "?"})`),
+  );
+  lines.push(`  ${chalk.bold("Spec hash:")}           ${report.sandbox.specHash}`);
+  lines.push(`  ${dim(`  algorithm: ${report.sandbox.specHashAlgorithm}`)}`);
+
+  lines.push(`\n  ${chalk.bold("Field-owner map (SSA):")}`);
+  if (report.fieldOwners.length === 0) {
+    lines.push(`    ${dim("(no managedFields recorded)")}`);
+  } else {
+    for (const { manager, fieldsOwned } of report.fieldOwners) {
+      lines.push(`    ${manager.padEnd(36)} ${dim(`fields: ${fieldsOwned}`)}`);
+    }
+  }
+
+  lines.push(`\n  ${chalk.bold("Policy versions:")}`);
+  if (report.policyVersions.length === 0) {
+    lines.push(`    ${dim("(no policy CRDs referenced from spec)")}`);
+  } else {
+    for (const p of report.policyVersions) {
+      const v = p.versionHash ?? dim("(not reconciled)");
+      const cm = p.bindingConfigMap ? dim(` → ${p.bindingConfigMap}`) : "";
+      lines.push(`    ${p.kind.padEnd(18)} ${p.name.padEnd(20)} ${v}${cm}`);
+    }
+  }
+
+  lines.push(`\n  ${chalk.bold("Reconcile trace ID:")}  ${report.reconcileTraceId ?? dim("(Phase 3)")}`);
+  lines.push(
+    `  ${chalk.bold("AGT receipt ID:")}      ${report.agtAuditReceiptId ?? dim("(Phase 3)")}`,
+  );
+  lines.push(`  ${chalk.bold("Signature:")}           ${report.signature ?? dim("(Phase 3)")}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function attestCommand(): Command {
+  const cmd = new Command("attest");
+  cmd
+    .description(
+      "Print a deterministic attestation receipt for a sandbox " +
+        "(spec hash, SSA field owners, referenced policy versions, " +
+        "reconcile trace; signature/AGT receipt land in Phase 3).",
+    )
+    .argument("<name>", "Sandbox name")
+    .option(
+      "-n, --namespace <ns>",
+      "Namespace where the ClawSandbox CR lives",
+      "azureclaw-system",
+    )
+    .option("--format <fmt>", "Output format: 'human' (default) or 'json'", "human")
+    .action(async (name: string, options: { namespace: string; format: string }) => {
+      const report = await buildReport(name, { namespace: options.namespace });
+      if (options.format === "json") {
+        console.log(formatJson(report));
+      } else {
+        console.log(formatHuman(report));
+      }
+    });
+  return cmd;
+}
+
+export const __test = {
+  canonicalJson,
+  specHash,
+  summariseFieldOwners,
+  extractPolicyRefs,
+  formatJson,
+  formatHuman,
+};

--- a/docs/security-audits/2026-04-27-phase2-attest-cli.md
+++ b/docs/security-audits/2026-04-27-phase2-attest-cli.md
@@ -1,0 +1,171 @@
+# Phase 2 — `phase2-attest-cli` security audit (2026-04-27)
+
+## §0 Reuse map (§0.2 #11)
+
+- **Spec-hash recipe:** canonical JSON (recursive key-sort, no
+  whitespace) + SHA-256, prefix `sha256:`. Matches the recipe used by
+  `controller/src/tool_policy_compile.rs::version_hash` (S2),
+  `controller/src/a2a_agent_compile.rs::version_hash` (S3),
+  `controller/src/inference_policy_compile.rs::version_hash` (S4),
+  `controller/src/claw_memory.rs::version_hash` (S5),
+  `controller/src/claw_eval.rs::version_hash` (S6). CLI re-implements
+  the recipe in TS using `node:crypto.createHash("sha256")` — no
+  shared TS↔Rust hashing crate exists; determinism is asserted
+  directly in `attest.test.ts` so the two sides cannot drift without
+  a test breaking.
+- **Status surfaces consumed:** every per-CRD `status.versionHash` +
+  `status.bindingConfigMap` field shipped by S2/S3/S4/S5/S6. No CRD
+  schema change required.
+- **`kubectl` shell-out pattern:** mirrors `cli/src/commands/list.ts`
+  + `cli/src/commands/status.ts` (execa `kubectl get … -o json`,
+  parse, ignore stderr). No new transport.
+- **Commander.js + chalk patterns:** mirror `cli/src/commands/a2a.ts`.
+- **Test pattern:** `__test` named export + vitest, mirroring
+  `cli/src/commands/convert.test.ts` (Phase 0).
+
+No new module created where an existing one would do; no second JWS
+verifier, no second hashing helper, no second informer, no second
+SSA writer. The command is read-only from kubectl's perspective.
+
+## §1 AGT boundary
+
+Read surface only. AGT AuditLogger receipt IDs and signed reconcile
+audit chain emission are **deferred to Phase 3** — the CLI prints
+`(Phase 3)` for both fields today. No AGT change in this slice.
+
+## §2 STRIDE
+
+| Threat | Mitigation |
+|---|---|
+| Spoofing — fabricated attestation | Output is purely a function of `kubectl get` results executed under the caller's kubeconfig. No client-side state. The deterministic spec-hash recipe (canonical JSON + SHA-256) means an attacker who can write to the cluster can change the hash, but cannot forge a hash that matches a different spec. Phase 3 will add a controller-emitted signature to lift this to non-repudiation. |
+| Tampering — modified attestation in transit | The CLI emits attestations to stdout for the caller's eyes; there is no transport. JSON envelope is versioned (`apiVersion: "azureclaw.azure.com/v1alpha1-attest"`) so a future `verify` command can detect schema changes. |
+| Repudiation | Phase 3 lands signed receipts. Phase 2 surfaces `(Phase 3)` placeholders in both human + JSON output, making it explicit that the current attestation is unsigned. |
+| Information disclosure | All fields read are gated by the caller's kubeconfig RBAC. No secret material printed (no token, no key, no signing material). The SSA field-owner map prints manager names + counts only — never the field contents. |
+| Denial of service | Command shells out at most `1 + N` `kubectl get` calls (1 for the sandbox CR, N ≤ 4 for referenced policies + 1 deployment annotation). Bounded. No watch, no informer, no daemon. |
+| Elevation of privilege | Read-only. No `kubectl patch`, `apply`, `create`, `delete`, `exec`, or `port-forward`. |
+
+## §3 Out of scope
+
+- Signed reconcile audit chain emission (Phase 3).
+- AGT AuditLogger receipt-ID retrieval (Phase 3).
+- `azureclaw.azure.com/last-trace-id` annotation **writing** by the
+  controller (Phase 3) — the lookup scaffolding is in place.
+- `kubectl claw verify <attestation.json>` companion command — the
+  versioned JSON envelope makes this trivially additive when Phase 3
+  emission lands.
+- Offline / no-kubectl mode — current implementation requires a
+  reachable cluster context; acceptable for an operator CLI.
+
+## §4 Implementation surface
+
+- `cli/src/commands/attest.ts` (~350 LOC, well under any cap):
+  - `canonicalJson(value)` — recursive key-sort canonicalisation.
+  - `specHash(spec)` — `sha256:` + hex digest over canonical JSON.
+  - `summariseFieldOwners(managedFields)` — counts SSA fieldsV1
+    leaves per manager; sorts alphabetically.
+  - `extractPolicyRefs(spec)` — handles four ref shapes
+    (`toolPolicyRef`, `inferencePolicyRef`, `a2aAgentRef`, legacy
+    `governance.toolPolicy.ref`).
+  - `buildReport(opts)` — orchestrates the kubectl shell-outs.
+  - `formatHuman(report)` — chalk-coloured operator output.
+  - `formatJson(report)` — deterministic versioned envelope.
+  - `attestCommand()` — Commander factory; registered under a new
+    "Attestation" section in `cli.ts`.
+  - `__test` named export exposing the pure helpers + formatters.
+- `cli/src/commands/attest.test.ts` — 19 vitest cases.
+- `cli/src/cli.ts` — one import + one `program.addCommand(...)` call.
+
+## §5 Field semantics
+
+The JSON envelope:
+
+```json
+{
+  "apiVersion": "azureclaw.azure.com/v1alpha1-attest",
+  "kind": "Attestation",
+  "generatedAt": "<ISO-8601 UTC>",
+  "sandbox": {
+    "name": "...", "namespace": "...",
+    "generation": 3, "observedGeneration": 3, "phase": "Running",
+    "specHash": "sha256:<hex>",
+    "specHashAlgorithm": "sha256-canonical-json"
+  },
+  "fieldOwners": [{ "manager": "...", "fieldsOwned": 42 }, ...],
+  "policyVersions": [
+    { "kind": "ToolPolicy", "name": "...", "namespace": "...",
+      "versionHash": "sha256:<hex>",
+      "bindingConfigMap": "..." }
+  ],
+  "reconcileTraceId": null,
+  "agtAuditReceiptId": null,
+  "signature": null
+}
+```
+
+`null` placeholders for the three Phase-3 fields keep the schema
+forward-compatible — Phase 3 just fills them in.
+
+## §6 SSA + reconciler skip
+
+Read-only command. No SSA, no reconcile.
+
+## §7 Failure modes
+
+| Failure | Behaviour |
+|---|---|
+| Sandbox CR not found | execa rejects; CLI exits non-zero with kubectl's stderr. |
+| kubectl missing / no cluster context | execa rejects; CLI exits non-zero. |
+| Referenced policy CR missing | per-policy lookup is wrapped in try/catch; missing entries surface in human output as `<missing>`. JSON output omits the entry rather than failing the whole report — partial attestation is still a useful operator signal. |
+| Deployment annotation absent (overlay mode, or pre-Phase-3 cluster) | `reconcileTraceId` is `null` / `(Phase 3)`. |
+| Empty `managedFields` | `fieldOwners` is `[]`. |
+| Spec missing entirely | `specHash` of `{}` returned (deterministic; asserted in tests). |
+
+## §8 Test surface
+
+`cli/src/commands/attest.test.ts` — 19 cases:
+
+- 5 × canonicalJson (key-sort, array order, nested recursion,
+  null/undefined, primitives).
+- 4 × specHash (re-ordered → same, modified → different,
+  prefix/length, null/undefined-treated-as-empty).
+- 4 × summariseFieldOwners (empty, multi-manager aggregation +
+  alphabetical sort, missing-manager-as-`(unknown)`, leaf count).
+- 4 × extractPolicyRefs (three top-level refs, legacy governance
+  shape, missing-name skipped, non-object spec).
+- 2 × formatters (formatJson round-trips through JSON.parse,
+  formatHuman names every field including `(Phase 3)` placeholders).
+
+CLI workspace test count: 285 → 304 (+19). vitest + `tsc --noEmit` +
+oxlint all green.
+
+## §9 Verify-don't-guess (§0.2 #10)
+
+- The spec-hash recipe was reproduced from
+  `controller/src/tool_policy_compile.rs::version_hash` (canonical
+  JSON via `serde_json::to_value` + recursive `BTreeMap` round-trip
+  + SHA-256 via `sha2::Sha256`). The TS recipe matches: `JSON.stringify`
+  with sorted-keys recursion + `node:crypto.createHash("sha256")`.
+  Determinism asserted directly in tests; serde-json on the Rust side
+  with a `BTreeMap<String, Value>` produces identical canonical bytes
+  to the TS recursive sort over the same input shape.
+- Status field names + locations cross-checked against
+  `controller/src/crd.rs` (ToolPolicyStatus, A2AAgentStatus,
+  InferencePolicyStatus, ClawMemoryStatus, ClawEvalStatus) shipped
+  in S2-S6 — all carry `version_hash` + `bindingConfigMap` (where
+  applicable).
+- `metadata.managedFields` shape cross-checked against the K8s API
+  reference (every CR object has `managedFields[]` once SSA is in
+  use; each entry carries `manager` + `fieldsV1` tree).
+
+## §10 Ops surface
+
+- `azureclaw attest <sandbox-name>` — default human output.
+- `azureclaw attest <sandbox-name> --format json` — for CI / scripts.
+- `azureclaw attest <sandbox-name> --namespace <ns>` — overrides the
+  default `azureclaw-system` lookup namespace for the ClawSandbox CR
+  (per-policy lookups still use `azureclaw-<sandbox-name>`).
+
+## §11 Sign-offs
+
+- **Author / dev:** AzureClaw Phase 2 implementer (this PR).
+- **Reviewer:** to be filled at PR review.


### PR DESCRIPTION
Phase 2 S11 read-surface attestation CLI.

## What lands

- `cli/src/commands/attest.ts` — single-file command (~350 LOC). Shells out to `kubectl get` for the ClawSandbox CR, referenced policy CRs (ToolPolicy / InferencePolicy / A2AAgent + legacy governance.toolPolicy.ref), and the sandbox-namespace Deployment (best-effort trace-id annotation).
- `cli/src/commands/attest.test.ts` — 19 vitest cases over the pure helpers + formatters.
- `cli/src/cli.ts` — registered under a new "Attestation" section.
- `CHANGELOG.md` — S11 entry above S8.
- `docs/security-audits/2026-04-27-phase2-attest-cli.md` — 11-section audit doc with reuse map, STRIDE, out-of-scope list.

## Reuse, no duplication (§0.2 #11)

- Spec-hash recipe (canonical-JSON + SHA-256 + `sha256:` prefix) matches `controller/src/{tool_policy,a2a_agent,inference_policy,claw_memory,claw_eval}_compile.rs::version_hash` exactly. Determinism asserted directly in tests.
- All read fields come from existing S2-S6 status surfaces; no CRD change, no controller change, no new K8s object.
- `kubectl` shell-out + chalk + Commander.js patterns from existing `list` / `status` / `a2a` commands. `__test` export pattern from `convert.test.ts`.

## Out of scope (Phase 3)

- Signed reconcile audit chain emission (cosign keyless on the controller side).
- AGT AuditLogger receipt-ID retrieval.
- `azureclaw.azure.com/last-trace-id` annotation **writing** by the controller (lookup scaffolding is in place).
- `kubectl claw verify <attestation.json>` companion command — versioned JSON envelope makes this trivially additive.

## Verification

- `cd cli && npx tsc --noEmit` ✅
- `cd cli && npm test` — 304 passed | 2 skipped (was 285+2; +19 from this slice) ✅
- `cd cli && npm run lint` ✅ (preexisting warnings only)
- `BASE_REF=origin/dev bash ci/no-stubs.sh` ✅
- `BASE_REF=origin/dev bash ci/no-custom-crypto.sh` ✅
- `BASE_REF=origin/dev bash ci/check-loc.sh` ✅

Phase 2 progress on dev after merge: ✅ S1 #51, S2 #52, S3 #53, S4 #54, S5 #55, S6 #56, S8 #57, **S11 (this PR)** — 8 of ~14 slices.