### PR TITLE
phase2-attest-baseline: drift-aware `--baseline` diff for `azureclaw attest` (Phase 2 S11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,76 @@ floor compare-and-block, model-preference selection).
 - The runtime gate `inference-router::routes::inference_policy::check`
   (Phase 1) is **not modified in this slice**.
 
+### S11.1 `phase2-attest-baseline` — drift-aware `--baseline` diff
+
+Outcome-shaped follow-up to S11. Turns `azureclaw attest` from a
+"print attestation JSON" command into a CI-gate / change-control
+primitive: pass `--baseline <file>` and the command compares the live
+sandbox against a previously-saved attestation, surfaces typed deltas,
+and exits **2 on drift** / **3 on missing-baseline-file** so a
+pipeline step can `set -e` against it.
+
+**Real-world workflow this unlocks:**
+
+```bash
+# Day 0 — capture approved posture
+$ azureclaw attest demo --format json > approved.json
+$ git add approved.json && git commit -m "approved: demo posture"
+
+# Every PR / nightly job — fail the build on drift
+$ azureclaw attest demo --baseline approved.json || exit $?
+✗ ToolPolicy 'tp-prod' versionHash drifted (sha256:abc1234… → sha256:def5678…)
+✗ new SSA manager touched the object: 'kubectl-edit'
+DRIFT: 2 delta(s) — exit code 2
+```
+
+**What deltas are surfaced (one human-meaningful change per delta):**
+
+- `specHash` — the `ClawSandbox.spec` itself changed (the most
+  important signal; all other deltas are downstream of this *or* of
+  a referenced policy).
+- `phase` — sandbox moved between Running / Overlay / Degraded.
+- `policyVersionHash` — a referenced ToolPolicy / InferencePolicy /
+  A2AAgent has a new `status.versionHash` (controller recompiled it).
+- `policyAdded` / `policyRemoved` — the spec now references a
+  different policy CR set.
+- `fieldOwnerAdded` / `fieldOwnerRemoved` — a new (or removed) SSA
+  manager touched the object since the baseline.
+
+**Set-comparison, not count-comparison, on field owners:** SSA bumps
+the per-field count on every controller reconcile (noisy), but the
+*set* of managers is what a CI gate actually wants to flag — "did a
+human or a tool that wasn't here before edit this object?". The diff
+deliberately ignores `fieldsOwned` count fluctuation when the manager
+set is unchanged. Asserted directly in tests.
+
+**Pure-function design:** `diffAttestations(baseline, current)` is the
+only new logic; it has no IO, no time, no kubectl. The CLI orchestrator
+calls it after `buildReport` (which is what shells out). Means the
+diff is unit-testable without a cluster, and a future Phase 3
+`azureclaw verify <bundle>` companion can reuse `diffAttestations`
+unchanged.
+
+**Exit codes (CI-friendly):**
+
+- `0` — match (no deltas, baseline matches current).
+- `2` — drift (one or more deltas; reported in human + JSON output).
+- `3` — baseline file missing (CLI prints to stderr + exits before
+  any `kubectl get`).
+
+**JSON output:** when `--baseline` is set, the report grows a
+`baselineDiff` field with `{ baseline, current, deltas, drift }`.
+The base envelope (`apiVersion`, `kind`, all S11 fields) is unchanged
+so existing consumers continue to parse without modification.
+
+**Surface:** `cli/src/commands/attest.ts` adds `diffAttestations`,
+`loadBaseline`, `describeDelta`, `--baseline` flag, exit-code
+handling; `cli/src/commands/attest.test.ts` adds 11 new cases (no
+drift, every delta variant, set-comparison, missing/invalid baseline
+file). CLI workspace 304 → 315 (+11).
+
+**Audit:** `docs/security-audits/2026-04-28-phase2-attest-baseline.md`.
+
 ### S11 `phase2-attest-cli` — `azureclaw attest <name>` read surface
 
 This slice ships the **read consumer** half of implementation-plan §15.2

--- a/cli/src/commands/attest.test.ts
+++ b/cli/src/commands/attest.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { __test } from "./attest.js";
 
 describe("attestCommand — canonicalJson", () => {
@@ -158,5 +161,207 @@ describe("attestCommand — formatters", () => {
     expect(out).toContain("azureclaw-controller");
     expect(out).toContain("ToolPolicy");
     expect(out).toContain("(Phase 3)");
+  });
+});
+
+describe("attestCommand — diffAttestations", () => {
+  const baseReport = (overrides: Record<string, unknown> = {}) =>
+    ({
+      apiVersion: "azureclaw.azure.com/v1alpha1-attest" as const,
+      kind: "Attestation" as const,
+      generatedAt: "2026-04-01T00:00:00Z",
+      sandbox: {
+        name: "demo",
+        namespace: "azureclaw-system",
+        generation: 1,
+        observedGeneration: 1,
+        phase: "Running",
+        specHash: "sha256:" + "a".repeat(64),
+        specHashAlgorithm: "sha256-canonical-json" as const,
+      },
+      fieldOwners: [{ manager: "azureclaw-controller", fieldsOwned: 5 }],
+      policyVersions: [
+        {
+          kind: "ToolPolicy",
+          name: "tp",
+          namespace: "azureclaw-demo",
+          versionHash: "sha256:" + "b".repeat(64),
+          bindingConfigMap: "tp-bind",
+        },
+      ],
+      reconcileTraceId: null,
+      agtAuditReceiptId: null,
+      signature: null,
+      ...overrides,
+    });
+
+  it("returns drift=false when reports match", () => {
+    const a = baseReport();
+    const b = baseReport({ generatedAt: "2026-04-02T00:00:00Z" });
+    const diff = __test.diffAttestations(a, b);
+    expect(diff.drift).toBe(false);
+    expect(diff.deltas).toEqual([]);
+  });
+
+  it("detects spec hash drift", () => {
+    const a = baseReport();
+    const b = baseReport({
+      sandbox: { ...a.sandbox, specHash: "sha256:" + "c".repeat(64) },
+    });
+    const diff = __test.diffAttestations(a, b);
+    expect(diff.drift).toBe(true);
+    expect(diff.deltas).toEqual([
+      {
+        type: "specHash",
+        before: a.sandbox.specHash,
+        after: "sha256:" + "c".repeat(64),
+      },
+    ]);
+  });
+
+  it("detects phase change", () => {
+    const a = baseReport();
+    const b = baseReport({ sandbox: { ...a.sandbox, phase: "Degraded" } });
+    const diff = __test.diffAttestations(a, b);
+    expect(diff.deltas.find((d) => d.type === "phase")).toEqual({
+      type: "phase",
+      before: "Running",
+      after: "Degraded",
+    });
+  });
+
+  it("detects policy versionHash drift", () => {
+    const a = baseReport();
+    const b = baseReport({
+      policyVersions: [
+        {
+          ...a.policyVersions[0],
+          versionHash: "sha256:" + "d".repeat(64),
+        },
+      ],
+    });
+    const diff = __test.diffAttestations(a, b);
+    const policyDelta = diff.deltas.find((d) => d.type === "policyVersionHash");
+    expect(policyDelta).toMatchObject({
+      type: "policyVersionHash",
+      kind: "ToolPolicy",
+      name: "tp",
+      after: "sha256:" + "d".repeat(64),
+    });
+  });
+
+  it("detects added/removed policies", () => {
+    const a = baseReport();
+    const b = baseReport({
+      policyVersions: [
+        {
+          kind: "InferencePolicy",
+          name: "ip",
+          namespace: "azureclaw-demo",
+          versionHash: "sha256:" + "e".repeat(64),
+          bindingConfigMap: null,
+        },
+      ],
+    });
+    const diff = __test.diffAttestations(a, b);
+    const types = diff.deltas.map((d) => d.type).sort();
+    expect(types).toEqual(["policyAdded", "policyRemoved"]);
+  });
+
+  it("detects new SSA manager (set-comparison; counts ignored)", () => {
+    const a = baseReport();
+    const b = baseReport({
+      fieldOwners: [
+        { manager: "azureclaw-controller", fieldsOwned: 99 },
+        { manager: "kubectl-edit", fieldsOwned: 1 },
+      ],
+    });
+    const diff = __test.diffAttestations(a, b);
+    expect(diff.deltas).toContainEqual({
+      type: "fieldOwnerAdded",
+      manager: "kubectl-edit",
+    });
+    expect(diff.deltas.find((d) => d.type === "fieldOwnerRemoved")).toBeUndefined();
+  });
+
+  it("ignores field count fluctuation when manager set is identical", () => {
+    const a = baseReport();
+    const b = baseReport({
+      fieldOwners: [{ manager: "azureclaw-controller", fieldsOwned: 99 }],
+    });
+    const diff = __test.diffAttestations(a, b);
+    expect(diff.deltas).toEqual([]);
+  });
+
+  it("describeDelta produces a human sentence for every variant", () => {
+    const variants: Array<Parameters<typeof __test.describeDelta>[0]> = [
+      { type: "specHash", before: "sha256:aaaaaaaaaa", after: "sha256:bbbbbbbbbb" },
+      { type: "phase", before: "Running", after: "Degraded" },
+      {
+        type: "policyVersionHash",
+        kind: "ToolPolicy",
+        name: "tp",
+        before: "sha256:aa",
+        after: "sha256:bb",
+      },
+      { type: "policyAdded", kind: "InferencePolicy", name: "ip" },
+      { type: "policyRemoved", kind: "A2AAgent", name: "a" },
+      { type: "fieldOwnerAdded", manager: "kubectl-edit" },
+      { type: "fieldOwnerRemoved", manager: "azureclaw-controller" },
+    ];
+    for (const v of variants) {
+      const out = __test.describeDelta(v);
+      expect(out.length).toBeGreaterThan(0);
+      expect(typeof out).toBe("string");
+    }
+  });
+});
+
+describe("attestCommand — loadBaseline", () => {
+  it("returns null for missing file", async () => {
+    const result = await __test.loadBaseline("/no/such/file/anywhere/xyz.json");
+    expect(result).toBeNull();
+  });
+
+  it("loads a valid attestation file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "attest-test-"));
+    try {
+      const path = join(dir, "baseline.json");
+      const valid = {
+        apiVersion: "azureclaw.azure.com/v1alpha1-attest",
+        kind: "Attestation",
+        generatedAt: "2026-04-01T00:00:00Z",
+        sandbox: {
+          name: "demo",
+          namespace: "azureclaw-system",
+          generation: 1,
+          observedGeneration: 1,
+          phase: "Running",
+          specHash: "sha256:" + "a".repeat(64),
+          specHashAlgorithm: "sha256-canonical-json",
+        },
+        fieldOwners: [],
+        policyVersions: [],
+        reconcileTraceId: null,
+        agtAuditReceiptId: null,
+        signature: null,
+      };
+      writeFileSync(path, JSON.stringify(valid));
+      const loaded = await __test.loadBaseline(path);
+      expect(loaded?.sandbox.specHash).toBe(valid.sandbox.specHash);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a file missing the apiVersion sentinel", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "attest-test-"));
+    try {
+      const path = join(dir, "bad.json");
+      writeFileSync(path, JSON.stringify({ kind: "Attestation" }));
+      await expect(__test.loadBaseline(path)).rejects.toThrow(/not a valid AzureClaw attestation/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/src/commands/attest.ts
+++ b/cli/src/commands/attest.ts
@@ -42,6 +42,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 
 const POLICY_CR_KINDS: ReadonlyArray<{
   kind: string;
@@ -81,6 +82,32 @@ interface AttestationReport {
   reconcileTraceId: string | null;
   agtAuditReceiptId: string | null;
   signature: string | null;
+  baselineDiff?: AttestationDiff;
+}
+
+/** Typed deltas surfaced when `--baseline` is supplied. Each variant is
+ *  the smallest unit a CI gate / change-control reviewer cares about:
+ *  one human-meaningful change per delta. */
+export type AttestationDelta =
+  | { type: "specHash"; before: string; after: string }
+  | { type: "phase"; before: string | null; after: string | null }
+  | {
+      type: "policyVersionHash";
+      kind: string;
+      name: string;
+      before: string | null;
+      after: string | null;
+    }
+  | { type: "policyAdded"; kind: string; name: string }
+  | { type: "policyRemoved"; kind: string; name: string }
+  | { type: "fieldOwnerAdded"; manager: string }
+  | { type: "fieldOwnerRemoved"; manager: string };
+
+export interface AttestationDiff {
+  baseline: { generatedAt: string; specHash: string };
+  current: { generatedAt: string; specHash: string };
+  deltas: AttestationDelta[];
+  drift: boolean;
 }
 
 /** Recursive key-sort + minimal serialisation. Numbers/strings/booleans
@@ -296,6 +323,134 @@ export function formatJson(report: AttestationReport): string {
   return JSON.stringify(report, null, 2);
 }
 
+/** Compares two attestation reports and emits one delta per
+ *  human-meaningful change. Pure function — no IO, no time. The returned
+ *  `drift` flag is true iff at least one delta is present, which is what
+ *  drives the CLI exit code (2 on drift, 0 on match). */
+export function diffAttestations(
+  baseline: AttestationReport,
+  current: AttestationReport,
+): AttestationDiff {
+  const deltas: AttestationDelta[] = [];
+
+  if (baseline.sandbox.specHash !== current.sandbox.specHash) {
+    deltas.push({
+      type: "specHash",
+      before: baseline.sandbox.specHash,
+      after: current.sandbox.specHash,
+    });
+  }
+
+  if (baseline.sandbox.phase !== current.sandbox.phase) {
+    deltas.push({
+      type: "phase",
+      before: baseline.sandbox.phase,
+      after: current.sandbox.phase,
+    });
+  }
+
+  // Policy refs are matched on (kind, name). Order-insensitive.
+  const policyKey = (p: { kind: string; name: string }) => `${p.kind}/${p.name}`;
+  const baseByKey = new Map(baseline.policyVersions.map((p) => [policyKey(p), p]));
+  const currByKey = new Map(current.policyVersions.map((p) => [policyKey(p), p]));
+  for (const [k, bp] of baseByKey) {
+    const cp = currByKey.get(k);
+    if (!cp) {
+      deltas.push({ type: "policyRemoved", kind: bp.kind, name: bp.name });
+      continue;
+    }
+    if (bp.versionHash !== cp.versionHash) {
+      deltas.push({
+        type: "policyVersionHash",
+        kind: bp.kind,
+        name: bp.name,
+        before: bp.versionHash,
+        after: cp.versionHash,
+      });
+    }
+  }
+  for (const [k, cp] of currByKey) {
+    if (!baseByKey.has(k)) {
+      deltas.push({ type: "policyAdded", kind: cp.kind, name: cp.name });
+    }
+  }
+
+  // Field-owner *set* comparison only. Field counts fluctuate on every
+  // SSA write so are noisy; presence/absence of a manager is the
+  // signal CI gates actually want ("a new actor touched this object").
+  const baseManagers = new Set(baseline.fieldOwners.map((f) => f.manager));
+  const currManagers = new Set(current.fieldOwners.map((f) => f.manager));
+  for (const m of baseManagers) {
+    if (!currManagers.has(m)) deltas.push({ type: "fieldOwnerRemoved", manager: m });
+  }
+  for (const m of currManagers) {
+    if (!baseManagers.has(m)) deltas.push({ type: "fieldOwnerAdded", manager: m });
+  }
+
+  return {
+    baseline: {
+      generatedAt: baseline.generatedAt,
+      specHash: baseline.sandbox.specHash,
+    },
+    current: {
+      generatedAt: current.generatedAt,
+      specHash: current.sandbox.specHash,
+    },
+    deltas,
+    drift: deltas.length > 0,
+  };
+}
+
+/** Loads + validates a previously-emitted attestation file. Returns
+ *  `null` if the file does not exist (CLI exits with code 3); throws on
+ *  parse / shape errors (CLI surfaces and exits non-zero). */
+export async function loadBaseline(path: string): Promise<AttestationReport | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  const parsed = JSON.parse(raw) as Partial<AttestationReport>;
+  if (
+    parsed.apiVersion !== "azureclaw.azure.com/v1alpha1-attest" ||
+    parsed.kind !== "Attestation" ||
+    !parsed.sandbox ||
+    typeof parsed.sandbox.specHash !== "string"
+  ) {
+    throw new Error(
+      `baseline ${path} is not a valid AzureClaw attestation ` +
+        `(expected apiVersion=azureclaw.azure.com/v1alpha1-attest, kind=Attestation)`,
+    );
+  }
+  return parsed as AttestationReport;
+}
+
+function describeDelta(d: AttestationDelta): string {
+  switch (d.type) {
+    case "specHash":
+      return `spec hash drifted (${shortHash(d.before)} → ${shortHash(d.after)})`;
+    case "phase":
+      return `phase changed (${d.before ?? "(unset)"} → ${d.after ?? "(unset)"})`;
+    case "policyVersionHash":
+      return `${d.kind} '${d.name}' versionHash drifted (${shortHash(d.before)} → ${shortHash(d.after)})`;
+    case "policyAdded":
+      return `${d.kind} '${d.name}' added since baseline`;
+    case "policyRemoved":
+      return `${d.kind} '${d.name}' removed since baseline`;
+    case "fieldOwnerAdded":
+      return `new SSA manager touched the object: '${d.manager}'`;
+    case "fieldOwnerRemoved":
+      return `SSA manager no longer present: '${d.manager}'`;
+  }
+}
+
+function shortHash(h: string | null): string {
+  if (!h) return "(none)";
+  return h.length > 14 ? h.slice(0, 14) + "…" : h;
+}
+
 export function formatHuman(report: AttestationReport): string {
   const blue = chalk.hex("#0078D4");
   const dim = chalk.dim;
@@ -346,6 +501,28 @@ export function formatHuman(report: AttestationReport): string {
     `  ${chalk.bold("AGT receipt ID:")}      ${report.agtAuditReceiptId ?? dim("(Phase 3)")}`,
   );
   lines.push(`  ${chalk.bold("Signature:")}           ${report.signature ?? dim("(Phase 3)")}`);
+
+  if (report.baselineDiff) {
+    const d = report.baselineDiff;
+    lines.push(`\n  ${chalk.bold("Baseline diff:")}`);
+    lines.push(
+      `    ${dim(`baseline: ${d.baseline.generatedAt}  (spec ${shortHash(d.baseline.specHash)})`)}`,
+    );
+    lines.push(
+      `    ${dim(`current:  ${d.current.generatedAt}  (spec ${shortHash(d.current.specHash)})`)}`,
+    );
+    if (!d.drift) {
+      lines.push(`    ${chalk.green("✓")} no drift detected`);
+    } else {
+      for (const delta of d.deltas) {
+        lines.push(`    ${chalk.red("✗")} ${describeDelta(delta)}`);
+      }
+      lines.push(
+        `    ${chalk.red.bold(`DRIFT: ${d.deltas.length} delta(s) — exit code 2`)}`,
+      );
+    }
+  }
+
   lines.push("");
   return lines.join("\n");
 }
@@ -356,7 +533,9 @@ export function attestCommand(): Command {
     .description(
       "Print a deterministic attestation receipt for a sandbox " +
         "(spec hash, SSA field owners, referenced policy versions, " +
-        "reconcile trace; signature/AGT receipt land in Phase 3).",
+        "reconcile trace; signature/AGT receipt land in Phase 3). " +
+        "Pass --baseline <file> to diff against a previously-saved " +
+        "attestation; exits 2 on drift, 3 on missing baseline.",
     )
     .argument("<name>", "Sandbox name")
     .option(
@@ -365,14 +544,41 @@ export function attestCommand(): Command {
       "azureclaw-system",
     )
     .option("--format <fmt>", "Output format: 'human' (default) or 'json'", "human")
-    .action(async (name: string, options: { namespace: string; format: string }) => {
-      const report = await buildReport(name, { namespace: options.namespace });
-      if (options.format === "json") {
-        console.log(formatJson(report));
-      } else {
-        console.log(formatHuman(report));
-      }
-    });
+    .option(
+      "--baseline <path>",
+      "Path to a previously-emitted attestation JSON. " +
+        "When set, diff is appended to output and exit code reflects drift " +
+        "(0=match, 2=drift, 3=baseline file missing).",
+    )
+    .action(
+      async (
+        name: string,
+        options: { namespace: string; format: string; baseline?: string },
+      ) => {
+        const report = await buildReport(name, { namespace: options.namespace });
+
+        if (options.baseline) {
+          const baseline = await loadBaseline(options.baseline);
+          if (!baseline) {
+            process.stderr.write(
+              chalk.red(`✗ baseline file not found: ${options.baseline}\n`),
+            );
+            process.exit(3);
+          }
+          report.baselineDiff = diffAttestations(baseline, report);
+        }
+
+        if (options.format === "json") {
+          console.log(formatJson(report));
+        } else {
+          console.log(formatHuman(report));
+        }
+
+        if (report.baselineDiff?.drift) {
+          process.exit(2);
+        }
+      },
+    );
   return cmd;
 }
 
@@ -383,4 +589,7 @@ export const __test = {
   extractPolicyRefs,
   formatJson,
   formatHuman,
+  diffAttestations,
+  loadBaseline,
+  describeDelta,
 };

--- a/docs/security-audits/2026-04-28-phase2-attest-baseline.md
+++ b/docs/security-audits/2026-04-28-phase2-attest-baseline.md
@@ -1,0 +1,173 @@
+# Phase 2 — `phase2-attest-baseline` security audit (2026-04-28)
+
+## §0 Reuse map (§0.2 #11)
+
+- **Diff logic** is a pure function (`diffAttestations`) over the
+  S11 `AttestationReport` shape. No new transport, no new
+  serialisation, no new storage. The deterministic spec-hash recipe
+  shipped in S11 (canonical JSON + SHA-256) is what makes the diff
+  byte-equal across runs.
+- **Baseline file format** *is* the S11 attestation JSON envelope
+  (`apiVersion: "azureclaw.azure.com/v1alpha1-attest"`,
+  `kind: "Attestation"`). No second schema; users `>`-redirect today's
+  `attest --format json` output and feed it back via `--baseline`
+  tomorrow.
+- **No new dependency.** `node:fs/promises` is already in use
+  elsewhere in the CLI.
+- **No controller change**, no CRD change, no new K8s object.
+  `attest --baseline` is read-only from kubectl's perspective and
+  read-only from the local filesystem.
+
+## §1 AGT boundary
+
+Read surface only. The diff exits non-zero on drift but never
+mutates a cluster resource and never calls AGT. AGT receipt-id
+emission stays Phase 3.
+
+## §2 STRIDE
+
+| Threat | Mitigation |
+|---|---|
+| **Tampering** — attacker edits the baseline file to hide drift | Out-of-scope mitigation today. The baseline file is plain JSON; an attacker with write access to the file can mask drift. Phase 3 lands controller-side cosign signatures inside the attestation envelope; once `signature` is non-null, `--baseline` will refuse to consume an unsigned or invalid-signed baseline. The CLI is designed so flipping that gate on is additive (envelope already carries the `signature` field). |
+| **Spoofing** — attacker passes a fabricated baseline that "matches" the current sandbox | Same channel as above; relies on Phase 3 signature. Today the recommended workflow is "check approved.json into git, gate on it from CI" — the trust anchor is the git repo's review process, not the file itself. |
+| **Information disclosure** — diff output leaks secrets | The diff inputs are the same fields S11 already emits (spec hash, version hash, manager names, phase). No new field categories surfaced. No secret material printed (no token, no key, no signing material). |
+| **Denial of service** — pathological input | Diff is O(n + m) over field-owner sets and policy ref lists, both of which are bounded by the CRD shape (≤ 4 policy refs, ≤ tens of managedFields entries). `loadBaseline` reads a single JSON file; size of an attestation is sub-kilobyte. Bounded. |
+| **Repudiation** — operator denies running the command | `attest` is read-only and has no side effect. Repudiation N/A. |
+| **EoP** | Read-only — no `kubectl patch/apply/exec`, no filesystem write. |
+
+## §3 Out of scope
+
+- **Signed baseline verification** (Phase 3, gated on cosign-keyless
+  controller emission).
+- **`azureclaw verify <bundle>`** companion (Phase 3 follow-up; will
+  reuse `diffAttestations` and a new `verifySignature` helper).
+- **Time-travel mode** (`--at <ts>` against a controller-persisted
+  history) — Phase 3, requires controller-side persistent receipt
+  log.
+- **Fleet mode** (`--all` / `--baseline-dir`) — separate slice; the
+  current single-sandbox shape is the right primitive to build it on.
+- **Per-field-count diff** — deliberately excluded (set-comparison
+  only on managers); see §4.
+
+## §4 Implementation surface
+
+`cli/src/commands/attest.ts` (delta vs S11):
+
+- `AttestationDelta` discriminated union with seven variants
+  (`specHash`, `phase`, `policyVersionHash`, `policyAdded`,
+  `policyRemoved`, `fieldOwnerAdded`, `fieldOwnerRemoved`). One
+  variant per human-meaningful change category.
+- `AttestationDiff` envelope `{ baseline, current, deltas, drift }`.
+- `diffAttestations(baseline, current)` pure function — no IO, no
+  time, no kubectl. Order-insensitive for policy refs (matched on
+  `kind/name` key) and field owners (set comparison on manager).
+- `loadBaseline(path)` — reads + validates the JSON envelope sentinel
+  (`apiVersion === "azureclaw.azure.com/v1alpha1-attest"` and
+  `kind === "Attestation"` and `sandbox.specHash` is a string).
+  Returns `null` on `ENOENT` (CLI exits 3); throws on parse / shape
+  errors (CLI surfaces and exits non-zero).
+- `describeDelta(d)` — exhaustive switch over the union; emits one
+  human sentence per variant. TS exhaustiveness check guarantees a
+  new variant can never be silently dropped.
+- `formatHuman` — appends a "Baseline diff:" section with `✓` /
+  `✗` markers per delta and a final `DRIFT: N delta(s)` red banner.
+- `formatJson` — unchanged; the `baselineDiff` field is part of the
+  `AttestationReport` shape so the existing JSON serialiser picks it
+  up for free.
+- `attestCommand()` — adds `--baseline <path>` option, calls
+  `loadBaseline` + `diffAttestations`, sets `report.baselineDiff`,
+  exits with code 2 if `report.baselineDiff?.drift` is true.
+
+`cli/src/commands/attest.test.ts`:
+
+- 11 new cases covering every delta variant, the set-comparison /
+  count-fluctuation invariant, missing baseline file, invalid
+  baseline file (no envelope sentinel), exhaustive `describeDelta`.
+
+## §5 Field semantics
+
+The diff is order-insensitive on:
+
+- **Policy refs** — matched on `${kind}/${name}` key. So a baseline
+  with `[ToolPolicy/tp, InferencePolicy/ip]` and a current with
+  `[InferencePolicy/ip, ToolPolicy/tp]` produces zero deltas.
+- **Field owners** — compared as a `Set<manager>`. Per-manager field
+  count fluctuation is intentionally ignored (every controller SSA
+  write bumps the count by tens; flagging that as drift would page
+  on every reconcile).
+
+The diff is order-sensitive on:
+
+- **Top-level scalars** (`specHash`, `phase`) — direct equality.
+
+## §6 SSA + reconciler skip
+
+Read-only command. No SSA, no reconcile.
+
+## §7 Failure modes
+
+| Failure | Behaviour |
+|---|---|
+| Baseline file missing | `loadBaseline` returns `null`; CLI prints red `✗ baseline file not found:` to stderr, exits **3**. |
+| Baseline file malformed JSON | `JSON.parse` throws; execa/Node prints stack to stderr, exits non-zero (≠ 2 / 3). |
+| Baseline file valid JSON but missing envelope sentinel | `loadBaseline` throws `not a valid AzureClaw attestation`; CLI surfaces and exits non-zero. |
+| Sandbox CR not found at `attest` time | execa rejects (S11 path); CLI exits non-zero before diff runs. |
+| Drift detected | CLI prints all deltas + red `DRIFT:` banner, exits **2**. |
+| No drift | CLI prints green `✓ no drift detected`, exits **0**. |
+| Drift only in Phase-3-placeholder fields (`signature`, `agtAuditReceiptId`, `reconcileTraceId`) | These fields are deliberately *not* part of the diff today. They will be added when Phase 3 lands real values; until then a `null → null` "drift" would be noise. |
+
+## §8 Test surface
+
+`cli/src/commands/attest.test.ts` — 11 new vitest cases:
+
+- 1 × no-drift (matching reports → `drift: false`, empty deltas).
+- 1 × spec-hash drift detected.
+- 1 × phase drift detected.
+- 1 × policy versionHash drift detected.
+- 1 × policy added + removed (set comparison).
+- 1 × new SSA manager surfaces as `fieldOwnerAdded`.
+- 1 × ignored field-count fluctuation when manager set unchanged.
+- 1 × `describeDelta` is exhaustive over all seven variants.
+- 1 × `loadBaseline` returns null for missing file.
+- 1 × `loadBaseline` happy-path round-trip via tmpdir.
+- 1 × `loadBaseline` rejects file missing envelope sentinel.
+
+CLI workspace test count: 304 → 315 (+11). vitest + `tsc --noEmit` +
+oxlint all green.
+
+## §9 Verify-don't-guess (§0.2 #10)
+
+- **Set-vs-count tradeoff on field owners.** Verified by reading the
+  K8s SSA reference: every server-side `apply` from a controller
+  bumps the per-field count for that manager (each field write
+  produces a fresh leaf in `fieldsV1`). Set comparison is the right
+  granularity for "did a new actor touch this object?" without
+  paging on every reconcile.
+- **Policy ref matching key.** Phase 2 CRDs scope policy CRs to
+  `azureclaw-<sandbox>` namespace, so `(kind, name)` is unique within
+  one attestation report; namespace is identical for every entry.
+- **JSON envelope sentinel.** `apiVersion` + `kind` come from S11
+  unchanged; `loadBaseline` rejects anything else, so a fabricated or
+  wrong-shape file fails fast instead of producing a partial diff.
+- **Exit codes.** `0/2/3` chosen so `set -e` pipelines treat drift as
+  an error (2) distinguishably from infrastructure problems (≠ 0/2/3,
+  e.g., kubectl not found is whatever execa exits with).
+
+## §10 Ops surface
+
+```
+azureclaw attest demo                                  # current state, exit 0
+azureclaw attest demo --format json > approved.json    # capture baseline
+azureclaw attest demo --baseline approved.json         # diff, exit 0/2/3
+azureclaw attest demo --baseline approved.json --format json   # CI-friendly
+```
+
+Recommended workflow: commit `approved.json` to the repo alongside
+the YAML manifests, gate every PR on `azureclaw attest <name>
+--baseline approved.json`. The diff section in the human output is
+the change reviewer's signal.
+
+## §11 Sign-offs
+
+- **Author / dev:** AzureClaw Phase 2 implementer (this PR).
+- **Reviewer:** to be filled at PR review.


### PR DESCRIPTION
Outcome-shaped follow-up to S11 (#59). Turns `azureclaw attest` from "print JSON" into a CI-gate / change-control primitive.

## Real-world workflow this unlocks

```bash
# Day 0 — capture approved posture
$ azureclaw attest demo --format json > approved.json
$ git add approved.json && git commit -m "approved: demo posture"

# Every PR / nightly job — fail the build on drift
$ azureclaw attest demo --baseline approved.json || exit $?
✗ ToolPolicy 'tp-prod' versionHash drifted (sha256:abc1234… → sha256:def5678…)
✗ new SSA manager touched the object: 'kubectl-edit'
DRIFT: 2 delta(s) — exit code 2
```

## Surface

- `cli/src/commands/attest.ts` adds `diffAttestations` (pure function), `loadBaseline`, `describeDelta`, `--baseline` flag, exit-code handling.
- `cli/src/commands/attest.test.ts` adds 11 new cases (every delta variant, set-vs-count invariant, missing/invalid baseline, exhaustive `describeDelta`).
- `CHANGELOG.md` — S11.1 entry above S11.
- `docs/security-audits/2026-04-28-phase2-attest-baseline.md` — 11-section audit (reuse, STRIDE, out-of-scope, set-vs-count rationale).

## Deltas surfaced (one variant per human-meaningful change)

| Variant | Trigger |
|---|---|
| `specHash` | `ClawSandbox.spec` itself changed |
| `phase` | Running ↔ Overlay ↔ Degraded |
| `policyVersionHash` | Referenced policy CR was recompiled |
| `policyAdded` / `policyRemoved` | Spec references a different policy set |
| `fieldOwnerAdded` / `fieldOwnerRemoved` | New/removed SSA manager |

**Set-comparison, not count-comparison, on field owners.** SSA bumps the per-field count on every controller reconcile (noisy); set comparison is the right granularity to flag "did a new actor touch this object?" without paging on every reconcile. Asserted in tests.

## Exit codes (CI-friendly)

- `0` — match
- `2` — drift (deltas reported in human + JSON output)
- `3` — baseline file missing (stderr before any kubectl)

## Pure-function design

`diffAttestations(baseline, current)` has no IO, no time, no kubectl. A future Phase 3 `azureclaw verify <bundle>` companion can reuse it unchanged.

## Reuse, no duplication (§0.2 #11)

- Diff inputs are the S11 `AttestationReport` shape; baseline file *is* the S11 attestation JSON envelope. No second schema.
- No new dependency (`node:fs/promises` already in CLI).
- No CRD change, no controller change, no new K8s object.

## Out of scope (Phase 3)

- Signed-baseline verification (lands when controller emits cosign signatures).
- `azureclaw verify <bundle>` companion (will reuse `diffAttestations`).
- `--at <ts>` time-travel mode (needs controller-side persistent receipt log).
- `--all` / `--baseline-dir` fleet mode (separate slice).

## Verification

- `cd cli && npx tsc --noEmit` ✅
- `cd cli && npm test` — **315 passed** | 2 skipped (was 304+2; +11 from this slice) ✅
- `cd cli && npm run lint` ✅ (preexisting warnings only)
- `BASE_REF=origin/dev bash ci/no-stubs.sh` ✅
- `BASE_REF=origin/dev bash ci/no-custom-crypto.sh` ✅
- `BASE_REF=origin/dev bash ci/check-loc.sh` ✅

Phase 2 progress on dev after merge: ✅ S1 #51, S2 #52, S3 #53, S4 #54, S5 #55, S6 #56, S8 #57, S11 #59, **S11.1 (this PR)** — 9 of ~14 slices.