### PR TITLE
phase2-migrate-mode-switch: `azureclaw migrate` mode-switch CLI (Phase 2 S9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,83 @@ floor compare-and-block, model-preference selection).
 - The runtime gate `inference-router::routes::inference_policy::check`
   (Phase 1) is **not modified in this slice**.
 
+### S9.1 `phase2-migrate-mode-switch` — `azureclaw migrate` mode-switch CLI
+
+Operator-facing tool to flip a ClawSandbox between the four
+upstream-compatibility modes that S8 (#57) shipped on the controller
+side. The CLI surface that drives day-zero adoption: take an existing
+upstream `sigs.k8s.io/agent-sandbox` Sandbox and bolt AzureClaw
+governance on without rewriting the YAML.
+
+**Real workflow this unlocks:**
+
+```bash
+# operator already has an upstream Sandbox CR called 'legacy-agent';
+# wraps it with AzureClaw governance:
+$ azureclaw migrate to-overlay legacy --upstream-ref legacy-agent
+  legacy: native → overlay (upstream sandbox 'legacy-agent')
+  ✓ patched
+
+# later: drop the upstream, return to native AzureClaw
+$ azureclaw migrate from-overlay legacy
+  legacy: overlay → native
+  ✓ patched
+```
+
+**Subcommands shipped:**
+
+- `azureclaw migrate to-overlay <name> --upstream-ref <upstream>` —
+  flip to OverlayMode (governance overlay only; upstream owns the Pod).
+- `azureclaw migrate from-overlay <name>` — revert to native AzureClaw
+  (controller resumes Pod / Service / NetworkPolicy ownership).
+- `azureclaw migrate to-translate <name>` — SandboxClaim translate mode.
+- `azureclaw migrate to-observe <name>` — status-mirror mode.
+- `azureclaw migrate to-native <name>` — alias for native (`off`).
+
+All five accept `--namespace`, `--dry-run`, `--format human|json`.
+
+**Reuse-first design (§0.2 #11):**
+
+- Single thin wrapper around `kubectl patch --type=merge`. No new
+  CRD field, no controller change, no admission hook. The OverlayMode
+  reconciler logic landed in S8; this is the operator-facing tool that
+  drives it.
+- Pure helpers (`validateMode`, `buildModePatch`, `readCurrentMode`,
+  `summariseTransition`, `modeDisplay`) are unit-testable without a
+  cluster — fully exercised by the 22 new vitest cases.
+- JSON merge patch (RFC 7396) with explicit `null` for
+  `upstreamSandboxRef` removal — guards against the controller's
+  `Option<LocalObjectRef>::skip_serializing_if` semantic stranding a
+  stale ref. Asserted directly in tests.
+- Exit codes: `0` on success / no-op, `1` on kubectl failure, `2`
+  on validation failure (so a CI gate can distinguish "operator typo"
+  from "infrastructure problem").
+
+**Pre-flight + transition summary:** before applying, the orchestrator
+runs `kubectl get clawsandbox <name> -o json`, reads the current mode
++ ref, and prints `current → target` (e.g. `native → overlay (upstream
+sandbox 'legacy-agent')`). If the sandbox is already in the target
+state, the orchestrator skips the patch entirely and reports it as a
+no-op — JSON output sets `noop: true` for scripting.
+
+**Out of scope (S9.2 — separate PR):**
+
+- `azureclaw migrate from-kagent` — Solo.io kagent CR → ClawSandbox
+  translator (heavier; needs upstream kagent shape mapping).
+- Real `azureclaw convert` — YAML translator from upstream
+  agent-sandbox shapes (currently a Phase 0 exit-3 skeleton).
+- `azureclaw migrate verify` — validates that an OverlayMode sandbox
+  is in sync with its upstream Sandbox (needs upstream CRD informer;
+  Phase 3 candidate).
+
+**Surface:** `cli/src/commands/migrate.ts` (~330 LOC), single new
+file. `cli/src/cli.ts` adds one import + one `addCommand`.
+22 vitest cases. CLI workspace 315 → 337 (+22). tsc + lint + vitest +
+ci/no-stubs + ci/no-custom-crypto + ci/check-loc all green with
+`BASE_REF=origin/dev`.
+
+**Audit:** `docs/security-audits/2026-04-28-phase2-migrate-mode-switch.md`.
+
 ### S11.1 `phase2-attest-baseline` — drift-aware `--baseline` diff
 
 Outcome-shaped follow-up to S11. Turns `azureclaw attest` from a

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -21,6 +21,7 @@ import { pairCommand } from "./commands/pair.js";
 import { convertCommand } from "./commands/convert.js";
 import { a2aCommand } from "./commands/a2a.js";
 import { attestCommand } from "./commands/attest.js";
+import { migrateCommand } from "./commands/migrate.js";
 
 export function createCli(): Command {
   const program = new Command();
@@ -64,6 +65,7 @@ export function createCli(): Command {
   // Interop
   program.addCommand(convertCommand());
   program.addCommand(a2aCommand());
+  program.addCommand(migrateCommand());
 
   // Attestation (Phase 2 read surface; signing lands in Phase 3)
   program.addCommand(attestCommand());

--- a/cli/src/commands/migrate.test.ts
+++ b/cli/src/commands/migrate.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { __test, MIGRATE_MODES } from "./migrate.js";
+
+describe("migrateCommand — validateMode", () => {
+  it("accepts each known mode without an upstreamRef (except overlay)", () => {
+    for (const m of MIGRATE_MODES) {
+      if (m === "overlay") continue;
+      expect(__test.validateMode(m, undefined)).toEqual([]);
+    }
+  });
+
+  it("requires --upstream-ref for overlay", () => {
+    const errs = __test.validateMode("overlay", undefined);
+    expect(errs.length).toBe(1);
+    expect(errs[0]).toContain("upstream-ref");
+  });
+
+  it("accepts overlay with a non-empty upstreamRef", () => {
+    expect(__test.validateMode("overlay", "legacy-agent")).toEqual([]);
+  });
+
+  it("rejects --upstream-ref for non-overlay modes", () => {
+    const errs = __test.validateMode("translate", "stray");
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0]).toContain("only meaningful for 'overlay'");
+  });
+
+  it("rejects empty-string upstreamRef even for overlay", () => {
+    const errs = __test.validateMode("overlay", "");
+    // Both 'required' and 'non-empty' fire — we just need a clear error.
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.join(" ")).toMatch(/upstream-ref/);
+  });
+
+  it("rejects unknown mode strings", () => {
+    // Cast through unknown to bypass the literal-type guard at the test edge.
+    const errs = __test.validateMode("bogus" as unknown as "overlay", undefined);
+    expect(errs[0]).toContain("invalid mode");
+  });
+});
+
+describe("migrateCommand — buildModePatch", () => {
+  it("emits sigsAgentSandbox + null upstreamSandboxRef for native", () => {
+    expect(__test.buildModePatch("off", undefined)).toEqual({
+      spec: {
+        upstreamCompatibility: {
+          sigsAgentSandbox: "off",
+          upstreamSandboxRef: null,
+        },
+      },
+    });
+  });
+
+  it("emits the upstream ref object for overlay", () => {
+    expect(__test.buildModePatch("overlay", "legacy-agent")).toEqual({
+      spec: {
+        upstreamCompatibility: {
+          sigsAgentSandbox: "overlay",
+          upstreamSandboxRef: { name: "legacy-agent" },
+        },
+      },
+    });
+  });
+
+  it("ignores upstreamRef for translate/observe (sets it to null)", () => {
+    for (const m of ["translate", "observe"] as const) {
+      const p = __test.buildModePatch(m, "should-be-ignored");
+      expect(p.spec.upstreamCompatibility.upstreamSandboxRef).toBeNull();
+      expect(p.spec.upstreamCompatibility.sigsAgentSandbox).toBe(m);
+    }
+  });
+
+  it("uses null (not undefined) for upstreamSandboxRef removal — RFC 7396", () => {
+    // JSON merge patch (RFC 7396) deletes a field on `null`. Undefined
+    // would JSON-stringify to a missing key, leaving a stale value
+    // behind on the server. This test guards that semantic.
+    const patch = __test.buildModePatch("off", undefined);
+    expect(JSON.stringify(patch)).toContain('"upstreamSandboxRef":null');
+  });
+});
+
+describe("migrateCommand — readCurrentMode", () => {
+  it("defaults to off + null when spec is missing", () => {
+    expect(__test.readCurrentMode(undefined)).toEqual({ mode: "off", upstreamRef: null });
+    expect(__test.readCurrentMode({})).toEqual({ mode: "off", upstreamRef: null });
+  });
+
+  it("reads overlay + upstream ref", () => {
+    expect(
+      __test.readCurrentMode({
+        upstreamCompatibility: {
+          sigsAgentSandbox: "overlay",
+          upstreamSandboxRef: { name: "legacy" },
+        },
+      }),
+    ).toEqual({ mode: "overlay", upstreamRef: "legacy" });
+  });
+
+  it("falls back to off on unknown mode strings", () => {
+    expect(
+      __test.readCurrentMode({
+        upstreamCompatibility: { sigsAgentSandbox: "bogus" },
+      }),
+    ).toEqual({ mode: "off", upstreamRef: null });
+  });
+
+  it("ignores upstreamSandboxRef when mode is not overlay", () => {
+    // The CRD doc says the field is *ignored* outside overlay; the
+    // reader still surfaces it (so noop detection sees stale refs)
+    // but the controller will not act on it.
+    const out = __test.readCurrentMode({
+      upstreamCompatibility: {
+        sigsAgentSandbox: "translate",
+        upstreamSandboxRef: { name: "stray" },
+      },
+    });
+    expect(out.mode).toBe("translate");
+    expect(out.upstreamRef).toBe("stray");
+  });
+});
+
+describe("migrateCommand — summariseTransition", () => {
+  it("flags noop when mode + ref unchanged", () => {
+    const out = __test.summariseTransition(
+      { mode: "off", upstreamRef: null },
+      { mode: "off", upstreamRef: undefined },
+    );
+    expect(out.noop).toBe(true);
+    expect(out.message).toContain("native");
+    expect(out.message).toContain("already in target state");
+  });
+
+  it("flags noop for matching overlay+ref", () => {
+    const out = __test.summariseTransition(
+      { mode: "overlay", upstreamRef: "legacy" },
+      { mode: "overlay", upstreamRef: "legacy" },
+    );
+    expect(out.noop).toBe(true);
+  });
+
+  it("detects ref-only change (overlay → overlay with new upstream)", () => {
+    const out = __test.summariseTransition(
+      { mode: "overlay", upstreamRef: "v1" },
+      { mode: "overlay", upstreamRef: "v2" },
+    );
+    expect(out.noop).toBe(false);
+    expect(out.message).toContain("'v2'");
+  });
+
+  it("renders 'native → overlay' for the canonical adoption story", () => {
+    const out = __test.summariseTransition(
+      { mode: "off", upstreamRef: null },
+      { mode: "overlay", upstreamRef: "legacy" },
+    );
+    expect(out.noop).toBe(false);
+    expect(out.message).toBe("native → overlay (upstream sandbox 'legacy')");
+  });
+
+  it("renders 'overlay → native' for the rollback story", () => {
+    const out = __test.summariseTransition(
+      { mode: "overlay", upstreamRef: "legacy" },
+      { mode: "off", upstreamRef: undefined },
+    );
+    expect(out.message).toBe("overlay → native");
+  });
+});
+
+describe("migrateCommand — modeDisplay", () => {
+  it("renders 'off' as 'native'", () => {
+    expect(__test.modeDisplay("off")).toBe("native");
+  });
+
+  it("passes through other modes verbatim", () => {
+    expect(__test.modeDisplay("overlay")).toBe("overlay");
+    expect(__test.modeDisplay("translate")).toBe("translate");
+    expect(__test.modeDisplay("observe")).toBe("observe");
+  });
+
+  it("renders null/undefined as 'native' (matches default)", () => {
+    expect(__test.modeDisplay(null)).toBe("native");
+    expect(__test.modeDisplay(undefined)).toBe("native");
+  });
+});

--- a/cli/src/commands/migrate.ts
+++ b/cli/src/commands/migrate.ts
@@ -1,0 +1,394 @@
+// Phase 2 S9.1 — `azureclaw migrate` mode-switch CLI subcommand.
+//
+// Operator-facing tool to flip a `ClawSandbox` between the four
+// upstream-compatibility modes shipped by S8 (controller-side
+// OverlayMode / TranslateMode / ObserveMode + the default Native /
+// "off" mode). The command is a thin wrapper around `kubectl patch`:
+// pure helpers compute a JSON merge patch and a human transition
+// summary; the orchestrator pre-fetches the current spec, prints a
+// before/after, and applies the patch.
+//
+// Real workflow this unlocks (the day-zero adoption story discussed
+// in S11.1):
+//
+//   # operator already has an upstream sigs.k8s.io/agent-sandbox
+//   # `Sandbox` CR called `legacy-agent`; wants to bolt AzureClaw
+//   # governance on without rewriting it:
+//   $ kubectl apply -f legacy-clawsandbox.yaml      # native by default
+//   $ azureclaw migrate to-overlay legacy --upstream-ref legacy-agent
+//   ✓ legacy: native → overlay (upstream sandbox 'legacy-agent')
+//
+//   # later: customer wants pure AzureClaw, drop the upstream
+//   $ azureclaw migrate from-overlay legacy
+//   ✓ legacy: overlay → native
+//
+// **No new CRD field, no controller change.** The OverlayMode
+// reconciler logic landed in S8 (PR #57); this slice ships the
+// operator-facing command that drives it. Reuse-first by design.
+//
+// Sub-slice S9.2 (separate PR) ships `migrate from-kagent` (kagent CR
+// → ClawSandbox translator) + a real `azureclaw convert` (YAML
+// translator from upstream agent-sandbox shapes). Those are heavier
+// translators; this slice keeps the surface tight on mode-switch.
+
+import { Command } from "commander";
+import chalk from "chalk";
+
+/** The four upstream-compatibility modes the controller accepts.
+ *  Keep in sync with `controller/src/crd.rs`
+ *  `UpstreamCompatibilityConfig.sigs_agent_sandbox` doc comment. */
+export const MIGRATE_MODES = ["off", "observe", "translate", "overlay"] as const;
+export type MigrateMode = (typeof MIGRATE_MODES)[number];
+
+/** Display name for a mode — what the operator sees in transition
+ *  summaries. "off" reads better as "native" since that's how the
+ *  product positions the default. */
+export function modeDisplay(m: MigrateMode | null | undefined): string {
+  if (!m || m === "off") return "native";
+  return m;
+}
+
+/** Validates a mode-switch request before any kubectl call.
+ *  Returns an array of human-readable error strings; empty array
+ *  means valid. */
+export function validateMode(
+  mode: MigrateMode,
+  upstreamRef: string | undefined,
+): string[] {
+  const errs: string[] = [];
+  if (!MIGRATE_MODES.includes(mode)) {
+    errs.push(
+      `invalid mode '${mode}'; expected one of: ${MIGRATE_MODES.join(", ")}`,
+    );
+  }
+  if (mode === "overlay" && !upstreamRef) {
+    errs.push(
+      "--upstream-ref <name> is required for 'overlay' mode " +
+        "(the upstream sigs.k8s.io/agent-sandbox CR that owns the Pod)",
+    );
+  }
+  if (mode !== "overlay" && upstreamRef) {
+    errs.push(
+      `--upstream-ref is only meaningful for 'overlay' mode (got mode='${mode}')`,
+    );
+  }
+  if (upstreamRef !== undefined && upstreamRef.length === 0) {
+    errs.push("--upstream-ref must be a non-empty name");
+  }
+  return errs;
+}
+
+/** Builds the JSON merge patch that flips the sandbox to `mode`.
+ *  Pure — no IO. The patch always sets `sigsAgentSandbox` so the
+ *  controller's pre-flight sees a deterministic value, and it
+ *  *removes* `upstreamSandboxRef` (sets to `null`) when leaving
+ *  overlay mode so a stale ref cannot strand the sandbox.
+ *
+ *  Shape (always rooted at `spec.upstreamCompatibility`):
+ *
+ *    overlay:    { sigsAgentSandbox: "overlay",   upstreamSandboxRef: { name } }
+ *    translate:  { sigsAgentSandbox: "translate", upstreamSandboxRef: null }
+ *    observe:    { sigsAgentSandbox: "observe",   upstreamSandboxRef: null }
+ *    off:        { sigsAgentSandbox: "off",       upstreamSandboxRef: null }
+ *
+ *  JSON merge patch (RFC 7396) treats `null` as "delete the field",
+ *  which matches the controller's `Option<LocalObjectRef>`
+ *  `skip_serializing_if = "Option::is_none"` round-trip semantics. */
+export function buildModePatch(
+  mode: MigrateMode,
+  upstreamRef: string | undefined,
+): { spec: { upstreamCompatibility: Record<string, unknown> } } {
+  const upstreamCompatibility: Record<string, unknown> = {
+    sigsAgentSandbox: mode,
+    upstreamSandboxRef: mode === "overlay" ? { name: upstreamRef } : null,
+  };
+  return { spec: { upstreamCompatibility } };
+}
+
+interface CurrentMode {
+  mode: MigrateMode;
+  upstreamRef: string | null;
+}
+
+/** Reads the relevant fields off the current ClawSandbox spec.
+ *  Defaults match the controller: missing config is "off" mode. */
+export function readCurrentMode(spec: unknown): CurrentMode {
+  const s = spec as Record<string, unknown> | undefined;
+  const uc = s?.upstreamCompatibility as Record<string, unknown> | undefined;
+  const rawMode = uc?.sigsAgentSandbox;
+  const mode: MigrateMode =
+    typeof rawMode === "string" && (MIGRATE_MODES as readonly string[]).includes(rawMode)
+      ? (rawMode as MigrateMode)
+      : "off";
+  const ref = uc?.upstreamSandboxRef as Record<string, unknown> | undefined;
+  const upstreamRef = typeof ref?.name === "string" ? (ref.name as string) : null;
+  return { mode, upstreamRef };
+}
+
+/** Describes the transition in human terms. Returns the message and
+ *  a `noop` flag so the orchestrator can skip the kubectl call. */
+export function summariseTransition(
+  current: CurrentMode,
+  target: { mode: MigrateMode; upstreamRef: string | undefined },
+): { message: string; noop: boolean } {
+  const cur = modeDisplay(current.mode);
+  const tgt = modeDisplay(target.mode);
+  const refSuffix = target.upstreamRef
+    ? ` (upstream sandbox '${target.upstreamRef}')`
+    : "";
+
+  const sameMode = current.mode === target.mode;
+  const sameRef =
+    (current.upstreamRef ?? null) === (target.upstreamRef ?? null);
+  if (sameMode && sameRef) {
+    return {
+      message: `${cur} mode${refSuffix} (already in target state)`,
+      noop: true,
+    };
+  }
+  return { message: `${cur} → ${tgt}${refSuffix}`, noop: false };
+}
+
+async function runPatch(
+  name: string,
+  namespace: string,
+  patch: object,
+): Promise<void> {
+  const { execa } = await import("execa");
+  await execa(
+    "kubectl",
+    [
+      "patch",
+      "clawsandbox",
+      name,
+      "-n",
+      namespace,
+      "--type=merge",
+      "-p",
+      JSON.stringify(patch),
+    ],
+    { stdio: "pipe" },
+  );
+}
+
+async function fetchCurrentSpec(
+  name: string,
+  namespace: string,
+): Promise<unknown> {
+  const { execa } = await import("execa");
+  const { stdout } = await execa(
+    "kubectl",
+    ["get", "clawsandbox", name, "-n", namespace, "-o", "json"],
+    { stdio: "pipe" },
+  );
+  const cr = JSON.parse(stdout) as { spec?: unknown };
+  return cr.spec;
+}
+
+interface ActionOptions {
+  namespace: string;
+  dryRun: boolean;
+  format: "human" | "json";
+}
+
+async function runMigrate(
+  name: string,
+  target: { mode: MigrateMode; upstreamRef: string | undefined },
+  opts: ActionOptions,
+): Promise<void> {
+  const errs = validateMode(target.mode, target.upstreamRef);
+  if (errs.length > 0) {
+    process.stderr.write(chalk.red(errs.map((e) => `✗ ${e}`).join("\n") + "\n"));
+    process.exit(2);
+  }
+
+  const patch = buildModePatch(target.mode, target.upstreamRef);
+
+  if (opts.dryRun) {
+    if (opts.format === "json") {
+      console.log(JSON.stringify({ patch, dryRun: true }, null, 2));
+    } else {
+      console.log(chalk.bold("DRY RUN — patch that would be applied:"));
+      console.log(JSON.stringify(patch, null, 2));
+      console.log(chalk.dim(`\nApply with: azureclaw migrate ... (omit --dry-run)`));
+    }
+    return;
+  }
+
+  let current: CurrentMode;
+  try {
+    const spec = await fetchCurrentSpec(name, opts.namespace);
+    current = readCurrentMode(spec);
+  } catch (err) {
+    process.stderr.write(
+      chalk.red(`✗ failed to read sandbox '${name}' in '${opts.namespace}': `) +
+        ((err as Error).message ?? String(err)) +
+        "\n",
+    );
+    process.exit(1);
+  }
+
+  const transition = summariseTransition(current, target);
+
+  if (opts.format === "json") {
+    console.log(
+      JSON.stringify(
+        {
+          sandbox: name,
+          namespace: opts.namespace,
+          before: { mode: current.mode, upstreamRef: current.upstreamRef },
+          after: { mode: target.mode, upstreamRef: target.upstreamRef ?? null },
+          noop: transition.noop,
+          patch: transition.noop ? null : patch,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(chalk.bold(`\n  ${name}: `) + transition.message);
+  }
+
+  if (transition.noop) return;
+
+  try {
+    await runPatch(name, opts.namespace, patch);
+    if (opts.format !== "json") {
+      console.log(chalk.green(`  ✓ patched`));
+      console.log(chalk.dim(`  controller will reconcile the new mode shortly`));
+    }
+  } catch (err) {
+    process.stderr.write(
+      chalk.red(`✗ kubectl patch failed: `) +
+        ((err as Error).message ?? String(err)) +
+        "\n",
+    );
+    process.exit(1);
+  }
+}
+
+function commonOptions(cmd: Command): Command {
+  return cmd
+    .option(
+      "-n, --namespace <ns>",
+      "Namespace where the ClawSandbox CR lives",
+      "azureclaw-system",
+    )
+    .option(
+      "--dry-run",
+      "Print the JSON merge patch without applying",
+      false,
+    )
+    .option(
+      "--format <fmt>",
+      "Output format: 'human' (default) or 'json'",
+      "human",
+    );
+}
+
+export function migrateCommand(): Command {
+  const cmd = new Command("migrate")
+    .description(
+      "Switch a ClawSandbox between upstream-compatibility modes " +
+        "(native / overlay / translate / observe). Wraps a kubectl " +
+        "patch with validation, before/after summary, and dry-run.",
+    );
+
+  commonOptions(
+    cmd
+      .command("to-overlay <name>")
+      .description(
+        "Flip to overlay mode: AzureClaw provides governance overlay " +
+          "(namespace, NetworkPolicy, ConfigMaps); upstream sigs.k8s.io/" +
+          "agent-sandbox CR owns the Pod. Requires --upstream-ref.",
+      )
+      .requiredOption(
+        "--upstream-ref <name>",
+        "Name of the upstream Sandbox CR in the same namespace",
+      ),
+  ).action(
+    async (
+      name: string,
+      options: {
+        namespace: string;
+        dryRun: boolean;
+        format: string;
+        upstreamRef: string;
+      },
+    ) => {
+      await runMigrate(
+        name,
+        { mode: "overlay", upstreamRef: options.upstreamRef },
+        {
+          namespace: options.namespace,
+          dryRun: options.dryRun,
+          format: options.format === "json" ? "json" : "human",
+        },
+      );
+    },
+  );
+
+  commonOptions(
+    cmd
+      .command("from-overlay <name>")
+      .description(
+        "Leave overlay mode and revert to native AzureClaw " +
+          "(controller resumes Pod / Service / NetworkPolicy ownership).",
+      ),
+  ).action(
+    async (
+      name: string,
+      options: { namespace: string; dryRun: boolean; format: string },
+    ) => {
+      await runMigrate(
+        name,
+        { mode: "off", upstreamRef: undefined },
+        {
+          namespace: options.namespace,
+          dryRun: options.dryRun,
+          format: options.format === "json" ? "json" : "human",
+        },
+      );
+    },
+  );
+
+  for (const m of ["translate", "observe", "native"] as const) {
+    const subMode: MigrateMode = m === "native" ? "off" : m;
+    commonOptions(
+      cmd
+        .command(`to-${m} <name>`)
+        .description(
+          m === "translate"
+            ? "Accept upstream SandboxClaim semantics on inbound (P1 schema-only)."
+            : m === "observe"
+              ? "Mirror status of an upstream Sandbox CR; no overlay."
+              : "Reset to default native mode (AzureClaw owns the workload).",
+        ),
+    ).action(
+      async (
+        name: string,
+        options: { namespace: string; dryRun: boolean; format: string },
+      ) => {
+        await runMigrate(
+          name,
+          { mode: subMode, upstreamRef: undefined },
+          {
+            namespace: options.namespace,
+            dryRun: options.dryRun,
+            format: options.format === "json" ? "json" : "human",
+          },
+        );
+      },
+    );
+  }
+
+  return cmd;
+}
+
+export const __test = {
+  validateMode,
+  buildModePatch,
+  readCurrentMode,
+  summariseTransition,
+  modeDisplay,
+};

--- a/docs/security-audits/2026-04-28-phase2-migrate-mode-switch.md
+++ b/docs/security-audits/2026-04-28-phase2-migrate-mode-switch.md
@@ -1,0 +1,204 @@
+# Phase 2 — `phase2-migrate-mode-switch` security audit (2026-04-28)
+
+## §0 Reuse map (§0.2 #11)
+
+- **No new CRD field.** Targets the existing
+  `spec.upstreamCompatibility.{sigsAgentSandbox, upstreamSandboxRef}`
+  fields shipped in S8 (#57).
+- **No controller change.** The OverlayMode reconciler logic — the
+  pre-flight that requires `upstreamSandboxRef` when
+  `sigsAgentSandbox == "overlay"` and the deployment-block skip — all
+  landed in S8. This slice is the operator-facing tool that drives
+  the existing reconciler path.
+- **No new dependency.** `commander` + `chalk` + `execa` already in
+  the CLI for every other command.
+- **`kubectl patch --type=merge`** is the standard mutation primitive
+  used elsewhere in the CLI (`add`, `credentials`); no new transport.
+- **Mode literals** (`off / observe / translate / overlay`) and field
+  names (`sigsAgentSandbox`, `upstreamSandboxRef`) sourced from
+  `controller/src/crd.rs` `UpstreamCompatibilityConfig` doc comment
+  (lines 104-134) — the single source of truth.
+
+## §1 AGT boundary
+
+Read+patch surface only on the `ClawSandbox` CR; AGT is not in the
+loop. The patched fields drive the controller's reconcile path; the
+controller itself emits AGT receipts (Phase 3). No AGT change in
+this slice.
+
+## §2 STRIDE
+
+| Threat | Mitigation |
+|---|---|
+| **Spoofing** — operator patches a sandbox they don't own | Patch is gated by the caller's kubeconfig RBAC (same as `kubectl patch`). No bypass. |
+| **Tampering** — operator strands a sandbox in an inconsistent state | Three guards: (1) `validateMode` rejects bad combinations client-side (e.g., `--upstream-ref` for non-overlay; missing `--upstream-ref` for overlay). (2) JSON merge patch always sets *both* `sigsAgentSandbox` and `upstreamSandboxRef` (the latter to `null` when leaving overlay) so a stale ref cannot survive a mode flip. (3) The controller's existing pre-flight (S8) `degrade!`s the sandbox if `overlay` is set without a ref — the CLI cannot create a half-applied state the controller would accept. |
+| **Repudiation** | `kubectl patch` is auditable via the cluster's audit log + the SSA `managedFields` map. The next `azureclaw attest` call surfaces the new manager (`kubectl-patch` or whatever the operator's kubeconfig name is) under `fieldOwners`. |
+| **Information disclosure** | No secret material printed. Patch contents printed only under `--dry-run` or `--format json` and contain only mode + upstream-ref name (operator-supplied input). |
+| **Denial of service** | Single `kubectl get` + single `kubectl patch` per invocation. No loops, no informers, no watches. Bounded. |
+| **Elevation of privilege** | The CLI cannot grant itself permissions it does not have. `kubectl patch` requires `patch` on `clawsandboxes.azureclaw.azure.com`; cluster admins gate this via RBAC. |
+
+## §3 Out of scope (S9.2 / Phase 3)
+
+- `azureclaw migrate from-kagent` — Solo.io kagent CR → ClawSandbox
+  translator. Needs the upstream kagent CRD shape; separate PR.
+- Real `azureclaw convert` — YAML translator from upstream
+  `sigs.k8s.io/agent-sandbox` shapes. Currently a Phase 0 exit-3
+  skeleton; S9.2 implements it.
+- `azureclaw migrate verify <name>` — checks that an OverlayMode
+  sandbox is consistent with its upstream Sandbox CR. Requires an
+  upstream CRD informer; deferred to a future slice.
+- Multi-cluster or fleet mode (`migrate --all` / `--cluster-config-dir`)
+  — not in scope for Phase 2; the right primitive to layer on top is
+  in place (the per-sandbox command is idempotent + JSON-output capable).
+
+## §4 Implementation surface
+
+`cli/src/commands/migrate.ts` (~330 LOC, single new file):
+
+- `MIGRATE_MODES` — the four mode literals from the CRD doc.
+- `validateMode(mode, upstreamRef)` — pure; returns array of human
+  errors. Called before any `kubectl` invocation.
+- `buildModePatch(mode, upstreamRef)` — pure; returns the JSON merge
+  patch. Always emits both fields; uses `null` (RFC 7396 delete) for
+  `upstreamSandboxRef` when leaving overlay.
+- `readCurrentMode(spec)` — pure; reads the two fields off a
+  ClawSandbox spec, defaulting missing/unknown to `off + null`.
+- `summariseTransition(current, target)` — pure; returns
+  `{message, noop}` so the orchestrator can skip a no-op patch.
+- `modeDisplay(mode)` — pure; renders `off` as `native` for human
+  output (matches product positioning).
+- `runPatch / fetchCurrentSpec` — execa-only orchestration.
+- `runMigrate(name, target, opts)` — top-level orchestrator.
+- `migrateCommand()` — Commander factory with five subcommands
+  (`to-overlay`, `from-overlay`, `to-translate`, `to-observe`,
+  `to-native`). `to-overlay` uses `requiredOption` for
+  `--upstream-ref` (Commander pre-validates).
+- `__test` named export exposing the five pure helpers.
+
+`cli/src/commands/migrate.test.ts` — 22 vitest cases.
+
+`cli/src/cli.ts` — one import + one `addCommand` under the existing
+"Interop" section (alongside `convert` and `a2a`).
+
+## §5 Field semantics
+
+The patch is always rooted at `spec.upstreamCompatibility` and always
+contains both fields:
+
+```
+overlay:    { sigsAgentSandbox: "overlay",   upstreamSandboxRef: { name } }
+translate:  { sigsAgentSandbox: "translate", upstreamSandboxRef: null }
+observe:    { sigsAgentSandbox: "observe",   upstreamSandboxRef: null }
+off:        { sigsAgentSandbox: "off",       upstreamSandboxRef: null }
+```
+
+JSON merge patch (RFC 7396) interprets `null` as "delete the field"
+on the server side, which matches the controller's
+`Option<LocalObjectRef>::skip_serializing_if = "Option::is_none"`
+round-trip semantic. Asserted directly in tests
+(`buildModePatch — uses null (not undefined) for upstreamSandboxRef
+removal — RFC 7396`).
+
+## §6 SSA + reconciler skip
+
+Uses JSON merge patch (`--type=merge`), not server-side apply, for
+two reasons:
+
+1. **Field ownership semantics.** The CLI is invoked ad-hoc by an
+   operator; we want the patch attributed to the operator's kubeconfig
+   manager (e.g. `kubectl-patch` or the user's name), not to a
+   long-lived field manager. The next `azureclaw attest` run
+   (S11/S11.1) will surface this under `fieldOwners`, and an
+   `--baseline` diff will flag it as `fieldOwnerAdded` — which is
+   exactly the change-control signal we want.
+2. **Atomicity.** Both fields ship in one patch object so the server
+   either accepts both or rejects both; there is no window where a
+   sandbox could be in `overlay` mode without a ref (which the
+   controller would `degrade!` anyway, but client-side prevention is
+   cheaper than server-side rejection).
+
+The controller's existing reconcile path (S8) handles the new spec
+without modification.
+
+## §7 Failure modes
+
+| Failure | Behaviour |
+|---|---|
+| `--upstream-ref` missing for `to-overlay` | Commander `requiredOption` rejects; exits non-zero before any kubectl call. |
+| `--upstream-ref` passed to non-overlay subcommand | `validateMode` flags it; CLI prints red `✗` and exits **2**. |
+| Empty-string `--upstream-ref` for `to-overlay` | `validateMode` flags it; exits **2**. |
+| Sandbox CR not found at `kubectl get` time | execa rejects; CLI prints red error + exits **1**. |
+| `kubectl patch` fails (RBAC, network) | execa rejects; CLI prints red error + exits **1**. |
+| Sandbox already in target state | Pre-flight detects no-op; CLI prints `(already in target state)` + exits **0** without applying. JSON output sets `noop: true`. |
+| `--dry-run` | Prints the JSON merge patch + advisory line; no kubectl call. Exits **0**. |
+| Unknown mode value in current sandbox spec | `readCurrentMode` defaults to `off`; transition is summarised against the default (the controller would `degrade!` the original anyway, so the operator's mental model is "we're recovering from a bad state"). |
+
+## §8 Test surface
+
+`cli/src/commands/migrate.test.ts` — 22 vitest cases:
+
+- 6 × validateMode (every known mode, overlay-needs-ref, ref-on-non-
+  overlay rejected, empty-ref rejected, unknown-mode rejected, etc.)
+- 4 × buildModePatch (native shape, overlay shape, translate/observe
+  ignore-but-null, RFC 7396 null-not-undefined invariant)
+- 4 × readCurrentMode (defaults, overlay round-trip, unknown-mode
+  fallback, stale ref preserved for noop detection)
+- 5 × summariseTransition (noop variants, ref-only change, the two
+  canonical user stories `native → overlay` and `overlay → native`)
+- 3 × modeDisplay (off → native, passthrough, null/undefined → native)
+
+CLI workspace test count: 315 → **337** (+22). vitest + `tsc --noEmit`
++ oxlint all green.
+
+End-to-end smoke verified manually:
+- `node dist/index.js migrate --help` lists all five subcommands.
+- `node dist/index.js migrate to-overlay demo --upstream-ref legacy
+  --dry-run` prints the expected JSON merge patch.
+- `node dist/index.js migrate to-overlay demo --dry-run` (without
+  ref) is rejected by Commander before any code runs.
+
+## §9 Verify-don't-guess (§0.2 #10)
+
+- **Mode literals + field names** read from `controller/src/crd.rs:104-126`
+  (`UpstreamCompatibilityConfig.sigs_agent_sandbox` doc comment +
+  `upstream_sandbox_ref` field).
+- **JSON merge patch semantics** verified against RFC 7396: `null`
+  values delete the corresponding key. The Rust controller's
+  `Option<...>::skip_serializing_if = "Option::is_none"` round-trip
+  matches this — when the server applies a `null`, the field
+  disappears from the persisted object, which deserialises back as
+  `None` on the controller. Tested directly via the
+  `'"upstreamSandboxRef":null'` assertion.
+- **`requiredOption` ordering vs custom validation.** Commander.js
+  validates `requiredOption` *before* the action handler runs; our
+  `validateMode` runs inside the handler and is a defense-in-depth
+  check (e.g. for an empty-string ref that satisfies `requiredOption`
+  but is operationally invalid).
+
+## §10 Ops surface
+
+```
+# Day-zero adoption: wrap an upstream sigs.k8s.io/agent-sandbox CR
+azureclaw migrate to-overlay legacy --upstream-ref legacy-agent
+
+# Inspect what would change without applying
+azureclaw migrate to-overlay legacy --upstream-ref legacy-agent --dry-run
+
+# Switch back to pure AzureClaw (controller resumes Pod ownership)
+azureclaw migrate from-overlay legacy
+
+# Status-only mirror (no overlay, no Pod ownership)
+azureclaw migrate to-observe legacy
+
+# JSON output for CI / scripts
+azureclaw migrate to-overlay legacy --upstream-ref legacy-agent --format json
+```
+
+Pairs with `azureclaw attest <name> --baseline <approved.json>`
+(S11.1) for change control: capture the baseline before the migrate,
+diff after.
+
+## §11 Sign-offs
+
+- **Author / dev:** AzureClaw Phase 2 implementer (this PR).
+- **Reviewer:** to be filled at PR review.


### PR DESCRIPTION
Operator-facing tool to flip a ClawSandbox between the four upstream-compatibility modes that S8 (#57) shipped on the controller side. Drives the **day-zero adoption** story: take an existing upstream `sigs.k8s.io/agent-sandbox` Sandbox and bolt AzureClaw governance on without rewriting the YAML.

## Real workflow this unlocks

```bash
# operator already has an upstream Sandbox CR called 'legacy-agent';
# wraps it with AzureClaw governance:
$ azureclaw migrate to-overlay legacy --upstream-ref legacy-agent
  legacy: native → overlay (upstream sandbox 'legacy-agent')
  ✓ patched

# later: drop the upstream, return to native AzureClaw
$ azureclaw migrate from-overlay legacy
  legacy: overlay → native
  ✓ patched
```

## Subcommands

| Command | Effect |
|---|---|
| `migrate to-overlay <name> --upstream-ref <upstream>` | OverlayMode (governance overlay only; upstream owns Pod) |
| `migrate from-overlay <name>` | Revert to native (controller resumes Pod ownership) |
| `migrate to-translate <name>` | SandboxClaim translate mode |
| `migrate to-observe <name>` | Status-mirror mode |
| `migrate to-native <name>` | Alias for native (`off`) |

All five accept `--namespace`, `--dry-run`, `--format human|json`.

## Reuse-first (§0.2 #11)

- **No new CRD field, no controller change.** OverlayMode reconciler logic shipped in S8 (#57); this is the operator-facing tool that drives it.
- **Pure helpers** (`validateMode`, `buildModePatch`, `readCurrentMode`, `summariseTransition`, `modeDisplay`) — unit-testable without a cluster.
- **JSON merge patch (RFC 7396)** with explicit `null` for `upstreamSandboxRef` removal — matches `Option<...>::skip_serializing_if` round-trip on the controller side. Asserted directly in tests.

## Exit codes (CI-friendly)

- `0` — success or no-op (already in target state)
- `1` — kubectl failure (RBAC, network, missing CR)
- `2` — validation failure (operator typo: missing `--upstream-ref`, ref on wrong subcommand, etc.)

## Pre-flight transition summary

Before applying, the orchestrator runs `kubectl get clawsandbox <name>` and prints `current → target`. If already in the target state, it skips the patch as a no-op (`JSON: { noop: true }`).

## Out of scope (S9.2 — follow-up PR)

- `azureclaw migrate from-kagent` (Solo.io kagent CR → ClawSandbox translator)
- Real `azureclaw convert` YAML translator (currently exit-3 skeleton)
- `migrate verify <name>` (consistency check against upstream Sandbox CR)

## Verification

- `cd cli && npx tsc --noEmit` ✅
- `cd cli && npm test` — **337 passed** | 2 skipped (was 315+2; +22 from this slice) ✅
- `cd cli && npm run lint` ✅ (preexisting warnings only)
- `BASE_REF=origin/dev bash ci/no-stubs.sh` ✅
- `BASE_REF=origin/dev bash ci/no-custom-crypto.sh` ✅
- `BASE_REF=origin/dev bash ci/check-loc.sh` ✅
- End-to-end smoke: `node dist/index.js migrate to-overlay demo --upstream-ref legacy --dry-run` prints the expected JSON merge patch.

Phase 2 progress on dev after merge: ✅ S1 #51, S2 #52, S3 #53, S4 #54, S5 #55, S6 #56, S8 #57, S11 #59, S11.1 #61, **S9.1 (this PR)** — 10 of ~14 slices.