### PR TITLE
phase2-migrate-from-kagent: ship `azureclaw migrate from-kagent` (S9.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,116 @@ floor compare-and-block, model-preference selection).
 - The runtime gate `inference-router::routes::inference_policy::check`
   (Phase 1) is **not modified in this slice**.
 
+### S9.3 `phase2-migrate-from-kagent` — `azureclaw migrate from-kagent` translator
+
+Operator-facing one-shot translator from a kagent.dev/v1alpha2 `Agent` CR
+into an AzureClaw resource bundle:
+
+- **ClawSandbox** (always) — name + namespace + labels + provenance
+  annotations preserved; `spec.openclaw.image` from `spec.byo.deployment.image`
+  for BYO agents (`--image` override required for Declarative agents that
+  use the kagent ADK runtime); `spec.sandbox.network.allowedDomains` →
+  `spec.networkPolicy.allowedEndpoints`; deployment-level `env` projected
+  to `spec.openclaw.extraEnv` (last-literal-wins, `valueFrom` dropped + warned).
+- **InferencePolicy** — emitted only when `spec.declarative.modelConfig`
+  is set; carries the kagent ModelConfig name as a provenance annotation
+  (`azureclaw.azure.com/kagent-model-config`). Inference *enforcement* is
+  not migrated — that needs an equivalent AzureClaw `InferencePolicy`
+  hand-authored separately.
+- **ToolPolicy** — one per `(McpServer, toolName)` pair. `requireApproval`
+  list maps to `spec.approval.mode = "always"`. Empty `toolNames` emits
+  one wildcard ToolPolicy with a warning. `type: Agent` tools are dropped
+  with warning (no agent-as-tool support). `headersFrom` and
+  `allowedHeaders` are dropped with warning.
+
+**Hard-fails on lossy translation by default**; `--allow-lossy` waives.
+Same exit-code grammar as S9.2 (`convert`): 0 ok, 2 invalid input, 4 lossy
+refused. `--dry-run` still applies the lossy gate (silently dropping a
+network allowlist or `requireApproval` list is a governance regression
+even for a "preview").
+
+Lossy fields explicitly catalogued and warned:
+
+- `spec.skills.{refs,gitRefs,initContainer}` — needs S12 `policy-learn-oci`.
+- `spec.declarative.{systemMessage,systemMessageFrom,promptTemplate,runtime,
+  stream,executeCodeBlocks,memory,context,a2aConfig}` — kagent-ADK-specific.
+- `spec.{byo,declarative}.deployment.{tolerations,affinity,nodeSelector,
+  volumes,volumeMounts,imagePullSecrets,imagePullPolicy,securityContext,
+  podSecurityContext,serviceAccountName,serviceAccountConfig,replicas}` —
+  controller-managed in AzureClaw.
+- `spec.allowedNamespaces` — Gateway-API cross-namespace pattern not modeled.
+- `spec.sandbox.network.allowedDomains` wildcards — passed through
+  verbatim with a warning (ClawSandbox `EndpointConfig.host` wildcard
+  semantics are not documented; operators must verify).
+- `spec.byo.deployment.{cmd,args}` — not exposed by ClawSandbox.
+- env entries with `valueFrom`.
+
+Aspirational mappings explicitly **rejected** during pre-implementation
+critique:
+
+- `ClawAgentIdentity` — does not exist as a CRD (Phase 4 per
+  `docs/internal/internal-boundaries.md:28`); the implementation plan
+  line 210 mentioning it is overridden by repo reality per slice rule
+  §0.2#7 (no aspirational emit).
+- `McpServer` auto-emission — we cannot reconstruct MCP server endpoints
+  from a kagent `TypedReference`; ToolPolicies carry the original
+  reference as a provenance annotation
+  (`azureclaw.azure.com/kagent-tool-ref`) and operators are warned that
+  an equivalent AzureClaw `McpServer` must already exist.
+- `InferencePolicy` enforcement from `modelConfig` — kagent ModelConfig
+  is a separate CRD; we preserve only provenance, not behaviour.
+
+**Subcommand:** `azureclaw migrate from-kagent <input-yaml-or-stdin>`
+with `--allow-lossy`, `--namespace`, `--isolation`, `--image`,
+`--out-dir`, `--force`, `--format yaml|json`, `--dry-run`.
+
+**Output:**
+
+- `--format yaml` (default) — multi-doc YAML stream on stdout, deterministic
+  ordering: ClawSandbox, InferencePolicy, ToolPolicies (sorted by name).
+- `--format json` — single Kubernetes `v1.List` object on stdout (pipes
+  cleanly to `kubectl apply -f -`).
+- `--out-dir <dir>` — splits the bundle into `<kind>-<name>.yaml` files;
+  refuses to overwrite existing files unless `--force`.
+
+**Implementation:**
+
+- `cli/src/migrate/from_kagent.ts` — pure translator, ~720 LOC. Helpers
+  (`sanitizeDnsName`, `hashSuffix`, `generateToolPolicyName`,
+  `cleanMetadata`, `envArrayToMap`, `projectDescription`, `translate`)
+  exposed via `__test`. No I/O.
+- `cli/src/commands/migrate.ts` — adds the `from-kagent` subcommand with
+  argparse, stdin support, multi-doc rejection, dry-run, `--out-dir`
+  with collision detection.
+- 53 new vitest cases covering: DNS sanitisation edge cases, hash
+  determinism + collision distinguishability, env projection (last-wins,
+  `valueFrom`, prior-literal-purge), description truncation, input
+  gating (apiVersion / kind / spec.type / metadata.name / BYO image),
+  ClawSandbox label and annotation injection, sandbox-label conflict
+  rejection, namespace override warning, declarative no-image
+  non-runnability, declarative `--image` escape hatch, `InferencePolicy`
+  conditional emit, ToolPolicy fan-out, approval-list mapping, wildcard
+  tool emission, McpServer name validation, agent-as-tool drop, deterministic
+  bundle ordering, toolName dedupe, headersFrom and allowedHeaders warnings,
+  every Declarative-only and deployment-level lossy field, networking
+  projection, wildcard domain warning, BYO clean happy-path, env
+  projection in BYO context.
+
+CLI test count: 382 → **435** (+53).
+
+Upstream kagent CRD shape verified directly against
+`kagent-dev/kagent @ 90212ab go/api/v1alpha2/agent_types.go` via
+GitHub MCP. Target CRD shapes verified directly against
+`controller/src/{crd.rs, inference_policy.rs, tool_policy.rs}`.
+
+Closes §15.2 #8 ("kagent migration tool"). Day-1 use case: an operator
+running kagent declarative agents adopts AzureClaw governance by running
+`azureclaw migrate from-kagent agent.yaml --image my/runtime:v1
+--allow-lossy | kubectl apply -f -`, then hand-edits the emitted
+ClawSandbox to set `spec.inference.{provider,endpoint,model}` per their
+ModelConfig and creates an AzureClaw `McpServer` for each kagent
+McpServer reference.
+
 ### S9.2 `phase2-convert-translator` — real `azureclaw convert` translator
 
 Phase 0 shipped `azureclaw convert` as an exit-3 skeleton to lock in the CLI

--- a/cli/src/commands/migrate.ts
+++ b/cli/src/commands/migrate.ts
@@ -26,13 +26,25 @@
 // reconciler logic landed in S8 (PR #57); this slice ships the
 // operator-facing command that drives it. Reuse-first by design.
 //
-// Sub-slice S9.2 (separate PR) ships `migrate from-kagent` (kagent CR
-// → ClawSandbox translator) + a real `azureclaw convert` (YAML
-// translator from upstream agent-sandbox shapes). Those are heavier
-// translators; this slice keeps the surface tight on mode-switch.
+// Sub-slice S9.2 (PR #63) shipped a real `azureclaw convert` (YAML
+// translator from upstream agent-sandbox shapes).
+//
+// Sub-slice S9.3 (this file's `from-kagent` subcommand) ships the
+// kagent CR → ClawSandbox translator: pure helpers live in
+// `cli/src/migrate/from_kagent.ts`.
 
 import { Command } from "commander";
 import chalk from "chalk";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import yaml from "yaml";
+import {
+  InvalidInputError,
+  type KubeResource,
+  type TranslateOptions,
+  type Warning,
+  translate as translateFromKagent,
+} from "../migrate/from_kagent.js";
 
 /** The four upstream-compatibility modes the controller accepts.
  *  Keep in sync with `controller/src/crd.rs`
@@ -382,7 +394,225 @@ export function migrateCommand(): Command {
     );
   }
 
+  cmd
+    .command("from-kagent <input>")
+    .description(
+      "Translate a kagent.dev/v1alpha2 Agent YAML into an AzureClaw " +
+        "resource bundle (ClawSandbox + InferencePolicy + ToolPolicies). " +
+        "Use '-' to read from stdin. Hard-fails on lossy translation " +
+        "by default; pass --allow-lossy to waive.",
+    )
+    .option(
+      "-n, --namespace <ns>",
+      "Override metadata.namespace on emitted resources (warns on mismatch with input).",
+    )
+    .option(
+      "--isolation <mode>",
+      "ClawSandbox isolation mode: standard | enhanced | confidential (default: enhanced).",
+      "enhanced",
+    )
+    .option(
+      "--image <image>",
+      "Override spec.openclaw.image (required to make Declarative agents runnable; ignored for BYO).",
+    )
+    .option(
+      "--allow-lossy",
+      "Waive the hard-fail on lossy translation. Warnings are still printed to stderr.",
+      false,
+    )
+    .option("--out-dir <dir>", "Write each emitted resource to <dir>/<kind>-<name>.yaml.")
+    .option("--force", "With --out-dir, overwrite existing files.", false)
+    .option(
+      "--format <fmt>",
+      "Output format when writing to stdout: 'yaml' (multi-doc, default) or 'json' (List).",
+      "yaml",
+    )
+    .option("--dry-run", "Print summary + warnings; emit no resources.", false)
+    .action(
+      async (
+        input: string,
+        options: {
+          namespace?: string;
+          isolation: string;
+          image?: string;
+          allowLossy: boolean;
+          outDir?: string;
+          force: boolean;
+          format: string;
+          dryRun: boolean;
+        },
+      ) => {
+        await runFromKagent(input, options);
+      },
+    );
+
   return cmd;
+}
+
+// ---- from-kagent runner ----------------------------------------------------
+
+interface FromKagentOptions {
+  namespace?: string;
+  isolation: string;
+  image?: string;
+  allowLossy: boolean;
+  outDir?: string;
+  force: boolean;
+  format: string;
+  dryRun: boolean;
+}
+
+async function runFromKagent(
+  input: string,
+  options: FromKagentOptions,
+): Promise<void> {
+  const text = await readInput(input);
+  const docs = yaml.parseAllDocuments(text);
+  const nonEmpty = docs.filter((d) => d.contents !== null);
+  if (nonEmpty.length === 0) {
+    process.stderr.write(`error: input contains no YAML documents\n`);
+    process.exit(2);
+  }
+  if (nonEmpty.length > 1) {
+    process.stderr.write(
+      `error: input contains ${nonEmpty.length} YAML documents; from-kagent expects exactly one Agent\n`,
+    );
+    process.exit(2);
+  }
+  const doc = nonEmpty[0]!;
+  if (doc.errors.length > 0) {
+    for (const err of doc.errors) process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+  }
+  const json = doc.toJS();
+
+  const isolation = validateIsolation(options.isolation);
+  const opts: TranslateOptions = {
+    namespace: options.namespace,
+    isolation,
+    image: options.image,
+  };
+
+  let result;
+  try {
+    result = translateFromKagent(json, opts);
+  } catch (e) {
+    if (e instanceof InvalidInputError) {
+      process.stderr.write(`error: ${e.message}\n`);
+      process.exit(2);
+    }
+    throw e;
+  }
+
+  for (const w of result.warnings) printWarning(w);
+
+  const lossy = result.warnings.length > 0;
+  if (lossy && !options.allowLossy) {
+    process.stderr.write(
+      chalk.red(
+        `error: translation is lossy (${result.warnings.length} warnings). Pass --allow-lossy to waive.\n`,
+      ),
+    );
+    process.exit(4);
+  }
+
+  // Summary line for both dry-run and real output.
+  const s = result.summary;
+  process.stderr.write(
+    chalk.gray(
+      `summary: ${s.agentType} agent '${s.namespace}/${s.sandboxName}'; ` +
+        `runnable=${s.runnable}; toolPolicies=${s.toolPolicyCount}; ` +
+        `inferencePolicies=${s.inferencePolicyCount}\n`,
+    ),
+  );
+
+  if (options.dryRun) return;
+
+  if (options.outDir) {
+    await writeBundleToDir(result.resources, options.outDir, options.force);
+    process.stderr.write(
+      chalk.green(`✓ wrote ${result.resources.length} resources to ${options.outDir}\n`),
+    );
+    return;
+  }
+
+  if (options.format === "json") {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          apiVersion: "v1",
+          kind: "List",
+          items: result.resources,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    const docs = result.resources
+      .map((r) => yaml.stringify(r, { lineWidth: 0 }))
+      .join("---\n");
+    process.stdout.write(docs);
+  }
+}
+
+async function readInput(target: string): Promise<string> {
+  if (target === "-") {
+    const chunks: Buffer[] = [];
+    for await (const c of process.stdin) chunks.push(c as Buffer);
+    return Buffer.concat(chunks).toString("utf8");
+  }
+  return readFile(target, "utf8");
+}
+
+function validateIsolation(
+  raw: string,
+): "standard" | "enhanced" | "confidential" {
+  if (raw === "standard" || raw === "enhanced" || raw === "confidential") {
+    return raw;
+  }
+  process.stderr.write(
+    `error: --isolation must be one of standard|enhanced|confidential (got '${raw}')\n`,
+  );
+  process.exit(2);
+}
+
+function printWarning(w: Warning): void {
+  const tag = w.severity === "error" ? chalk.red("✗") : chalk.yellow("!");
+  process.stderr.write(`${tag} ${chalk.cyan(w.path)}: ${w.message}\n`);
+}
+
+async function writeBundleToDir(
+  resources: KubeResource[],
+  dir: string,
+  force: boolean,
+): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  const seen = new Set<string>();
+  for (const r of resources) {
+    const fname = `${r.kind.toLowerCase()}-${r.metadata.name}.yaml`;
+    if (seen.has(fname)) {
+      process.stderr.write(
+        `error: duplicate output filename '${fname}' (kind+name collision)\n`,
+      );
+      process.exit(2);
+    }
+    seen.add(fname);
+    const fpath = path.join(dir, fname);
+    const flag = force ? "w" : "wx";
+    try {
+      await writeFile(fpath, yaml.stringify(r, { lineWidth: 0 }), { flag });
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code === "EEXIST") {
+        process.stderr.write(
+          `error: ${fpath} already exists (use --force to overwrite)\n`,
+        );
+        process.exit(2);
+      }
+      throw e;
+    }
+  }
 }
 
 export const __test = {

--- a/cli/src/migrate/from_kagent.test.ts
+++ b/cli/src/migrate/from_kagent.test.ts
@@ -1,0 +1,714 @@
+// Phase 2 S9.3 — vitest cases for the kagent → AzureClaw translator.
+//
+// Pure-helper coverage. CLI runner I/O is exercised separately via
+// the existing migrate command e2e tests.
+
+import { describe, expect, it } from "vitest";
+import {
+  __test,
+  AZURECLAW_GROUP,
+  AZURECLAW_VERSION,
+  InvalidInputError,
+  KAGENT_API_VERSION,
+  KAGENT_KIND,
+  SANDBOX_LABEL_KEY,
+} from "./from_kagent.js";
+
+const {
+  sanitizeDnsName,
+  hashSuffix,
+  generateToolPolicyName,
+  cleanMetadata,
+  envArrayToMap,
+  projectDescription,
+  translate,
+} = __test;
+
+const baseAgent = {
+  apiVersion: KAGENT_API_VERSION,
+  kind: KAGENT_KIND,
+  metadata: { name: "alice", namespace: "team-a" },
+  spec: {
+    type: "BYO",
+    byo: { deployment: { image: "ghcr.io/example/agent:1.2.3" } },
+  },
+};
+
+// ---- DNS sanitization ------------------------------------------------------
+
+describe("sanitizeDnsName", () => {
+  it("lowercases and replaces non-DNS chars", () => {
+    expect(sanitizeDnsName("MyTool/v2")).toBe("mytool-v2");
+  });
+  it("collapses repeated separators", () => {
+    expect(sanitizeDnsName("a---b")).toBe("a-b");
+  });
+  it("trims leading/trailing dashes", () => {
+    expect(sanitizeDnsName("--abc--")).toBe("abc");
+  });
+  it("falls back to 'x' for empty after sanitization", () => {
+    expect(sanitizeDnsName("---")).toBe("x");
+    expect(sanitizeDnsName("")).toBe("x");
+    expect(sanitizeDnsName("///")).toBe("x");
+  });
+  it("keeps numbers and dashes verbatim", () => {
+    expect(sanitizeDnsName("agent-007-prod")).toBe("agent-007-prod");
+  });
+});
+
+describe("hashSuffix", () => {
+  it("is deterministic", () => {
+    expect(hashSuffix(["a", "b", "c"])).toBe(hashSuffix(["a", "b", "c"]));
+  });
+  it("differs across distinct tuples", () => {
+    expect(hashSuffix(["a", "b"])).not.toBe(hashSuffix(["b", "a"]));
+  });
+  it("returns hex of length 6", () => {
+    expect(hashSuffix(["x"])).toMatch(/^[0-9a-f]{6}$/);
+  });
+});
+
+describe("generateToolPolicyName", () => {
+  it("yields ≤ 63-char DNS-safe names", () => {
+    const n = generateToolPolicyName(
+      "very-long-sandbox-name-that-pushes-the-limit",
+      "mcp-server-with-a-rather-verbose-name",
+      "tool/with/path",
+      0,
+    );
+    expect(n.length).toBeLessThanOrEqual(63);
+    expect(n).toMatch(/^[a-z0-9-]+-[0-9a-f]{6}$/);
+  });
+  it("disambiguates collisions via hash on the unsanitized tuple", () => {
+    const a = generateToolPolicyName("s", "m", "Foo/Bar", 0);
+    const b = generateToolPolicyName("s", "m", "foo-bar", 0);
+    // Both sanitize the prefix to the same DNS form; the hash suffix
+    // on the *unsanitized* input keeps them distinct.
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---- metadata --------------------------------------------------------------
+
+describe("cleanMetadata", () => {
+  it("strips server-managed fields", () => {
+    expect(
+      cleanMetadata({
+        name: "n",
+        namespace: "ns",
+        uid: "abc",
+        resourceVersion: "1",
+        generation: 5,
+        creationTimestamp: "2024-01-01",
+        managedFields: [{ x: 1 }],
+        ownerReferences: [{ name: "o" }],
+        finalizers: ["f"],
+      }),
+    ).toEqual({ name: "n", namespace: "ns" });
+  });
+  it("filters kubectl annotations", () => {
+    const out = cleanMetadata({
+      name: "n",
+      annotations: {
+        "kubectl.kubernetes.io/last-applied-configuration": "{}",
+        "user.example/keep": "yes",
+      },
+    });
+    expect(out.annotations).toEqual({ "user.example/keep": "yes" });
+  });
+  it("returns empty for non-objects", () => {
+    expect(cleanMetadata(null)).toEqual({});
+    expect(cleanMetadata("x")).toEqual({});
+    expect(cleanMetadata(undefined)).toEqual({});
+  });
+});
+
+// ---- env projection --------------------------------------------------------
+
+describe("envArrayToMap", () => {
+  it("projects literal entries last-wins with warning on redefine", () => {
+    const w: ReturnType<typeof translate>["warnings"] = [];
+    const out = envArrayToMap(
+      [
+        { name: "FOO", value: "1" },
+        { name: "BAR", value: "x" },
+        { name: "FOO", value: "2" },
+      ],
+      "spec.env",
+      w,
+    );
+    expect(out).toEqual({ FOO: "2", BAR: "x" });
+    expect(w).toHaveLength(1);
+    expect(w[0]!.message).toMatch(/redefined/);
+  });
+  it("warns and drops valueFrom entries", () => {
+    const w: ReturnType<typeof translate>["warnings"] = [];
+    const out = envArrayToMap(
+      [{ name: "S", valueFrom: { secretKeyRef: { name: "x", key: "k" } } }],
+      "spec.env",
+      w,
+    );
+    expect(out).toEqual({});
+    expect(w[0]!.message).toMatch(/valueFrom/);
+  });
+  it("drops a prior literal when later valueFrom for same name appears", () => {
+    const w: ReturnType<typeof translate>["warnings"] = [];
+    const out = envArrayToMap(
+      [
+        { name: "TOK", value: "abc" },
+        { name: "TOK", valueFrom: { secretKeyRef: { name: "s", key: "k" } } },
+      ],
+      "spec.env",
+      w,
+    );
+    expect(out).toEqual({});
+    expect(w.some((x) => x.message.includes("prior literal dropped"))).toBe(true);
+  });
+});
+
+// ---- description -----------------------------------------------------------
+
+describe("projectDescription", () => {
+  it("passes through small descriptions verbatim", () => {
+    const w: ReturnType<typeof translate>["warnings"] = [];
+    expect(projectDescription("hi", w)).toEqual({ annotation: "hi" });
+    expect(w).toHaveLength(0);
+  });
+  it("truncates and warns when above 4 KiB", () => {
+    const big = "a".repeat(5000);
+    const w: ReturnType<typeof translate>["warnings"] = [];
+    const out = projectDescription(big, w);
+    expect(out.truncated).toBe(true);
+    expect(out.annotation!.length).toBeLessThanOrEqual(4096);
+    expect(w).toHaveLength(1);
+  });
+});
+
+// ---- translate (full) ------------------------------------------------------
+
+describe("translate: input gating", () => {
+  it("rejects wrong apiVersion", () => {
+    expect(() =>
+      translate({ apiVersion: "v1", kind: "Agent", metadata: { name: "a" } }, {}),
+    ).toThrowError(InvalidInputError);
+  });
+  it("rejects wrong kind", () => {
+    expect(() =>
+      translate(
+        { apiVersion: KAGENT_API_VERSION, kind: "Pod", metadata: { name: "a" } },
+        {},
+      ),
+    ).toThrowError(InvalidInputError);
+  });
+  it("rejects missing metadata.name", () => {
+    expect(() =>
+      translate(
+        { apiVersion: KAGENT_API_VERSION, kind: KAGENT_KIND, metadata: {} },
+        {},
+      ),
+    ).toThrowError(/metadata\.name/);
+  });
+  it("rejects unknown spec.type", () => {
+    expect(() =>
+      translate(
+        { ...baseAgent, spec: { type: "Other" } as unknown as typeof baseAgent.spec },
+        {},
+      ),
+    ).toThrowError(/spec\.type/);
+  });
+  it("rejects BYO without image", () => {
+    expect(() =>
+      translate({ ...baseAgent, spec: { type: "BYO", byo: {} } }, {}),
+    ).toThrowError(/byo\.deployment\.image/);
+  });
+});
+
+describe("translate: ClawSandbox basics", () => {
+  it("emits a ClawSandbox with sandbox-label and provenance annotations", () => {
+    const r = translate(baseAgent, {});
+    const cs = r.resources[0]!;
+    expect(cs.kind).toBe("ClawSandbox");
+    expect(cs.apiVersion).toBe(`${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`);
+    expect(cs.metadata.name).toBe("alice");
+    expect(cs.metadata.namespace).toBe("team-a");
+    expect(cs.metadata.labels![SANDBOX_LABEL_KEY]).toBe("alice");
+    expect(cs.metadata.annotations![`${AZURECLAW_GROUP}/migrated-from`]).toBe(
+      `${KAGENT_API_VERSION} ${KAGENT_KIND}`,
+    );
+    expect(cs.metadata.annotations![`${AZURECLAW_GROUP}/kagent-agent`]).toBe(
+      "team-a/alice",
+    );
+    expect((cs.spec.openclaw as { image: string }).image).toBe(
+      "ghcr.io/example/agent:1.2.3",
+    );
+    expect((cs.spec.sandbox as { isolation: string }).isolation).toBe("enhanced");
+  });
+
+  it("honours --isolation override", () => {
+    const r = translate(baseAgent, { isolation: "confidential" });
+    expect(
+      (r.resources[0]!.spec.sandbox as { isolation: string }).isolation,
+    ).toBe("confidential");
+  });
+
+  it("rejects pre-existing conflicting sandbox label", () => {
+    expect(() =>
+      translate(
+        {
+          ...baseAgent,
+          metadata: {
+            ...baseAgent.metadata,
+            labels: { [SANDBOX_LABEL_KEY]: "different" },
+          },
+        },
+        {},
+      ),
+    ).toThrowError(/already set/);
+  });
+
+  it("preserves a pre-existing matching sandbox label", () => {
+    const r = translate(
+      {
+        ...baseAgent,
+        metadata: {
+          ...baseAgent.metadata,
+          labels: { [SANDBOX_LABEL_KEY]: "alice", team: "a" },
+        },
+      },
+      {},
+    );
+    expect(r.resources[0]!.metadata.labels).toMatchObject({
+      team: "a",
+      [SANDBOX_LABEL_KEY]: "alice",
+    });
+  });
+
+  it("warns on namespace override mismatch", () => {
+    const r = translate(baseAgent, { namespace: "other" });
+    expect(r.summary.namespace).toBe("other");
+    expect(
+      r.warnings.some((w) =>
+        w.message.includes("overriding input namespace 'team-a'"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn when --namespace matches input", () => {
+    const r = translate(baseAgent, { namespace: "team-a" });
+    expect(r.warnings.filter((w) => w.path === "metadata.namespace")).toHaveLength(
+      0,
+    );
+  });
+});
+
+describe("translate: Declarative agent runnability", () => {
+  const decl = {
+    apiVersion: KAGENT_API_VERSION,
+    kind: KAGENT_KIND,
+    metadata: { name: "decl", namespace: "ns" },
+    spec: {
+      type: "Declarative",
+      declarative: { runtime: "python", modelConfig: "gpt4-config" },
+    },
+  };
+
+  it("emits a non-runnable ClawSandbox when no image is provided", () => {
+    const r = translate(decl, {});
+    expect(r.summary.runnable).toBe(false);
+    expect(r.resources[0]!.spec.openclaw).toBeUndefined();
+    expect(
+      r.warnings.some((w) => w.message.includes("--image to override")),
+    ).toBe(true);
+  });
+
+  it("uses --image override for Declarative", () => {
+    const r = translate(decl, { image: "myorg/runtime:v1" });
+    expect(r.summary.runnable).toBe(true);
+    expect((r.resources[0]!.spec.openclaw as { image: string }).image).toBe(
+      "myorg/runtime:v1",
+    );
+  });
+
+  it("emits InferencePolicy with provenance annotation when modelConfig is set", () => {
+    const r = translate(decl, { image: "myorg/runtime:v1" });
+    const ip = r.resources.find((x) => x.kind === "InferencePolicy");
+    expect(ip).toBeDefined();
+    expect(ip!.metadata.annotations![`${AZURECLAW_GROUP}/kagent-model-config`]).toBe(
+      "gpt4-config",
+    );
+    expect((ip!.spec.appliesTo as { sandboxName: string }).sandboxName).toBe(
+      "decl",
+    );
+    expect(
+      r.warnings.some((w) => w.path === "spec.declarative.modelConfig"),
+    ).toBe(true);
+  });
+
+  it("does NOT emit InferencePolicy when modelConfig is absent", () => {
+    const noModel = {
+      ...decl,
+      spec: { type: "Declarative", declarative: { runtime: "python" } },
+    };
+    const r = translate(noModel, { image: "x" });
+    expect(r.resources.find((x) => x.kind === "InferencePolicy")).toBeUndefined();
+    expect(r.summary.inferencePolicyCount).toBe(0);
+  });
+});
+
+describe("translate: Tools", () => {
+  const withTools = (tools: unknown[]) => ({
+    apiVersion: KAGENT_API_VERSION,
+    kind: KAGENT_KIND,
+    metadata: { name: "t", namespace: "ns" },
+    spec: { type: "Declarative", declarative: { tools } },
+  });
+
+  it("fans out one ToolPolicy per (mcpServer, toolName)", () => {
+    const r = translate(
+      withTools([
+        {
+          type: "McpServer",
+          mcpServer: { name: "fs", toolNames: ["read", "write"] },
+        },
+      ]),
+      { image: "x" },
+    );
+    const tps = r.resources.filter((x) => x.kind === "ToolPolicy");
+    expect(tps).toHaveLength(2);
+    expect(tps.map((t) => (t.spec.appliesTo as { tool: string }).tool).sort()).toEqual(
+      ["read", "write"],
+    );
+    // governance auto-enabled when at least one ToolPolicy is emitted.
+    expect((r.resources[0]!.spec.governance as { enabled: boolean }).enabled).toBe(
+      true,
+    );
+  });
+
+  it("sets approval.mode='always' only for tools listed in requireApproval", () => {
+    const r = translate(
+      withTools([
+        {
+          type: "McpServer",
+          mcpServer: {
+            name: "git",
+            toolNames: ["status", "push"],
+            requireApproval: ["push"],
+          },
+        },
+      ]),
+      { image: "x" },
+    );
+    const tps = r.resources.filter((x) => x.kind === "ToolPolicy");
+    const push = tps.find((t) => (t.spec.appliesTo as { tool: string }).tool === "push")!;
+    const status = tps.find(
+      (t) => (t.spec.appliesTo as { tool: string }).tool === "status",
+    )!;
+    expect((push.spec.approval as { mode: string }).mode).toBe("always");
+    expect(status.spec.approval).toBeUndefined();
+  });
+
+  it("emits a wildcard ToolPolicy when toolNames is empty and warns", () => {
+    const r = translate(
+      withTools([{ type: "McpServer", mcpServer: { name: "fs" } }]),
+      { image: "x" },
+    );
+    const tps = r.resources.filter((x) => x.kind === "ToolPolicy");
+    expect(tps).toHaveLength(1);
+    expect((tps[0]!.spec.appliesTo as { tool: string }).tool).toBe("*");
+    expect(r.warnings.some((w) => w.message.includes("wildcard"))).toBe(true);
+  });
+
+  it("rejects McpServer tool with missing name", () => {
+    expect(() =>
+      translate(withTools([{ type: "McpServer", mcpServer: {} }]), { image: "x" }),
+    ).toThrowError(/mcpServer\.name/);
+  });
+
+  it("rejects type=Agent with missing agent.name", () => {
+    expect(() =>
+      translate(withTools([{ type: "Agent", agent: {} }]), { image: "x" }),
+    ).toThrowError(/agent.*name/);
+  });
+
+  it("warns and drops type=Agent tools (does not emit ToolPolicy)", () => {
+    const r = translate(
+      withTools([{ type: "Agent", agent: { name: "other-agent" } }]),
+      { image: "x" },
+    );
+    expect(r.resources.filter((x) => x.kind === "ToolPolicy")).toHaveLength(0);
+    expect(
+      r.warnings.some((w) => w.message.includes("agent-as-tool not supported")),
+    ).toBe(true);
+  });
+
+  it("emits ToolPolicies with deterministic name suffix and stable order", () => {
+    const r = translate(
+      withTools([
+        { type: "McpServer", mcpServer: { name: "b", toolNames: ["x"] } },
+        { type: "McpServer", mcpServer: { name: "a", toolNames: ["y"] } },
+      ]),
+      { image: "x" },
+    );
+    const tps = r.resources.filter((x) => x.kind === "ToolPolicy");
+    const names = tps.map((t) => t.metadata.name);
+    expect(names).toEqual([...names].sort());
+  });
+
+  it("dedupes repeated toolNames", () => {
+    const r = translate(
+      withTools([
+        {
+          type: "McpServer",
+          mcpServer: { name: "fs", toolNames: ["read", "read"] },
+        },
+      ]),
+      { image: "x" },
+    );
+    expect(r.resources.filter((x) => x.kind === "ToolPolicy")).toHaveLength(1);
+  });
+
+  it("warns on Tool.headersFrom and mcpServer.allowedHeaders", () => {
+    const r = translate(
+      withTools([
+        {
+          type: "McpServer",
+          mcpServer: {
+            name: "x",
+            toolNames: ["t"],
+            allowedHeaders: ["x-tenant"],
+          },
+          headersFrom: [{ secretRef: { name: "s", key: "k" } }],
+        },
+      ]),
+      { image: "x" },
+    );
+    expect(r.warnings.some((w) => w.path.endsWith(".headersFrom"))).toBe(true);
+    expect(r.warnings.some((w) => w.path.endsWith(".allowedHeaders"))).toBe(true);
+  });
+});
+
+describe("translate: lossy fields", () => {
+  it("warns on spec.skills (refs)", () => {
+    const r = translate(
+      { ...baseAgent, spec: { ...baseAgent.spec, skills: { refs: ["a"] } } },
+      {},
+    );
+    expect(r.warnings.some((w) => w.path === "spec.skills")).toBe(true);
+  });
+  it("warns on spec.allowedNamespaces", () => {
+    const r = translate(
+      { ...baseAgent, spec: { ...baseAgent.spec, allowedNamespaces: { from: "All" } } },
+      {},
+    );
+    expect(r.warnings.some((w) => w.path === "spec.allowedNamespaces")).toBe(true);
+  });
+  it("warns on each declarative-only field", () => {
+    const decl = {
+      apiVersion: KAGENT_API_VERSION,
+      kind: KAGENT_KIND,
+      metadata: { name: "d", namespace: "ns" },
+      spec: {
+        type: "Declarative",
+        declarative: {
+          systemMessage: "hi",
+          systemMessageFrom: { configMapKeyRef: { name: "x", key: "k" } },
+          promptTemplate: { dataSources: [] },
+          runtime: "python",
+          stream: true,
+          executeCodeBlocks: true,
+          memory: { modelConfig: "m" },
+          context: { compaction: {} },
+          a2aConfig: { skills: [] },
+        },
+      },
+    };
+    const r = translate(decl, { image: "x" });
+    const paths = new Set(r.warnings.map((w) => w.path));
+    for (const k of [
+      "spec.declarative.systemMessage",
+      "spec.declarative.systemMessageFrom",
+      "spec.declarative.promptTemplate",
+      "spec.declarative.runtime",
+      "spec.declarative.stream",
+      "spec.declarative.executeCodeBlocks",
+      "spec.declarative.memory",
+      "spec.declarative.context",
+      "spec.declarative.a2aConfig",
+    ]) {
+      expect(paths.has(k)).toBe(true);
+    }
+  });
+
+  it("warns on each unsupported deployment field (BYO)", () => {
+    const r = translate(
+      {
+        ...baseAgent,
+        spec: {
+          type: "BYO",
+          byo: {
+            deployment: {
+              image: "img",
+              replicas: 3,
+              tolerations: [{ key: "x" }],
+              affinity: { nodeAffinity: {} },
+              nodeSelector: { zone: "x" },
+              imagePullPolicy: "Always",
+              imagePullSecrets: [{ name: "s" }],
+              volumes: [{ name: "v", emptyDir: {} }],
+              volumeMounts: [{ name: "v", mountPath: "/x" }],
+              securityContext: {},
+              podSecurityContext: {},
+              serviceAccountName: "sa",
+            },
+          },
+        },
+      },
+      {},
+    );
+    const paths = new Set(r.warnings.map((w) => w.path));
+    for (const k of [
+      "spec.byo.deployment.replicas",
+      "spec.byo.deployment.tolerations",
+      "spec.byo.deployment.affinity",
+      "spec.byo.deployment.nodeSelector",
+      "spec.byo.deployment.imagePullPolicy",
+      "spec.byo.deployment.imagePullSecrets",
+      "spec.byo.deployment.volumes",
+      "spec.byo.deployment.volumeMounts",
+      "spec.byo.deployment.securityContext",
+      "spec.byo.deployment.podSecurityContext",
+      "spec.byo.deployment.serviceAccountName",
+    ]) {
+      expect(paths.has(k)).toBe(true);
+    }
+  });
+});
+
+describe("translate: networking", () => {
+  it("projects allowedDomains into networkPolicy.allowedEndpoints", () => {
+    const r = translate(
+      {
+        ...baseAgent,
+        spec: {
+          ...baseAgent.spec,
+          sandbox: { network: { allowedDomains: ["api.example.com", "db.local"] } },
+        },
+      },
+      {},
+    );
+    const np = r.resources[0]!.spec.networkPolicy as {
+      defaultDeny: boolean;
+      allowedEndpoints: { host: string }[];
+    };
+    expect(np.defaultDeny).toBe(true);
+    expect(np.allowedEndpoints.map((e) => e.host)).toEqual([
+      "api.example.com",
+      "db.local",
+    ]);
+  });
+
+  it("warns on wildcard domains but still passes them through", () => {
+    const r = translate(
+      {
+        ...baseAgent,
+        spec: {
+          ...baseAgent.spec,
+          sandbox: { network: { allowedDomains: ["*.example.com"] } },
+        },
+      },
+      {},
+    );
+    const np = r.resources[0]!.spec.networkPolicy as {
+      allowedEndpoints: { host: string }[];
+    };
+    expect(np.allowedEndpoints[0]!.host).toBe("*.example.com");
+    expect(r.warnings.some((w) => w.message.includes("wildcard"))).toBe(true);
+  });
+});
+
+describe("translate: bundle ordering and JSON shape", () => {
+  it("orders bundle: ClawSandbox, InferencePolicy, ToolPolicies", () => {
+    const r = translate(
+      {
+        apiVersion: KAGENT_API_VERSION,
+        kind: KAGENT_KIND,
+        metadata: { name: "z", namespace: "ns" },
+        spec: {
+          type: "Declarative",
+          declarative: {
+            modelConfig: "m",
+            tools: [
+              { type: "McpServer", mcpServer: { name: "fs", toolNames: ["r"] } },
+            ],
+          },
+        },
+      },
+      { image: "x" },
+    );
+    expect(r.resources.map((x) => x.kind)).toEqual([
+      "ClawSandbox",
+      "InferencePolicy",
+      "ToolPolicy",
+    ]);
+  });
+
+  it("produces a clean BYO happy-path with zero warnings", () => {
+    const r = translate(baseAgent, {});
+    expect(r.warnings).toHaveLength(0);
+    expect(r.summary.runnable).toBe(true);
+  });
+
+  it("preserves env entries on BYO deployment", () => {
+    const r = translate(
+      {
+        ...baseAgent,
+        spec: {
+          type: "BYO",
+          byo: {
+            deployment: {
+              image: "img",
+              env: [
+                { name: "FOO", value: "1" },
+                { name: "BAR", value: "two" },
+              ],
+            },
+          },
+        },
+      },
+      {},
+    );
+    expect((r.resources[0]!.spec.openclaw as { extraEnv: Record<string, string> }).extraEnv).toEqual({
+      FOO: "1",
+      BAR: "two",
+    });
+    expect(r.warnings).toHaveLength(0);
+  });
+});
+
+describe("translate: description handling", () => {
+  it("preserves short descriptions verbatim as annotation", () => {
+    const r = translate(
+      { ...baseAgent, spec: { ...baseAgent.spec, description: "a friendly agent" } },
+      {},
+    );
+    expect(
+      r.resources[0]!.metadata.annotations![`${AZURECLAW_GROUP}/kagent-description`],
+    ).toBe("a friendly agent");
+    expect(r.warnings.filter((w) => w.path === "spec.description")).toHaveLength(0);
+  });
+  it("truncates and warns on huge descriptions", () => {
+    const r = translate(
+      {
+        ...baseAgent,
+        spec: { ...baseAgent.spec, description: "x".repeat(5000) },
+      },
+      {},
+    );
+    expect(
+      r.resources[0]!.metadata.annotations![
+        `${AZURECLAW_GROUP}/kagent-description-truncated`
+      ],
+    ).toBe("true");
+    expect(r.warnings.some((w) => w.path === "spec.description")).toBe(true);
+  });
+});

--- a/cli/src/migrate/from_kagent.ts
+++ b/cli/src/migrate/from_kagent.ts
@@ -1,0 +1,721 @@
+// Phase 2 S9.3 — `azureclaw migrate from-kagent` translator.
+//
+// Pure translator (no I/O). Reads a kagent.dev/v1alpha2 `Agent` YAML
+// document and emits a deterministic AzureClaw resource bundle:
+//
+//   1. ClawSandbox            (always)
+//   2. InferencePolicy        (only if spec.declarative.modelConfig set)
+//   3. ToolPolicy             (one per (mcpServer, toolName) pair)
+//
+// Hard-fails on lossy translation by default; --allow-lossy waives.
+// Mirrors the conventions established by S9.2 (`convert`).
+//
+// Upstream kagent CRD shape verified directly against
+// kagent-dev/kagent @ 90212ab go/api/v1alpha2/agent_types.go.
+//
+// Target CRDs verified directly against:
+//   - controller/src/crd.rs (ClawSandbox)
+//   - controller/src/inference_policy.rs (InferencePolicy)
+//   - controller/src/tool_policy.rs (ToolPolicy)
+//
+// Aspirational mappings explicitly REJECTED per rubber-duck pre-impl pass:
+//   - ClawAgentIdentity (does not exist as a CRD; Phase 4 per
+//     docs/internal/internal-boundaries.md:28). The plan line 210
+//     mentioning it is overridden by repo reality per slice rule §0.2#7.
+//   - McpServer auto-emission (we cannot reconstruct upstream MCP
+//     server endpoints from a `TypedReference`).
+//   - InferencePolicy enforcement from `modelConfig` (kagent ModelConfig
+//     is a separate CRD; we preserve provenance only).
+
+import { createHash } from "node:crypto";
+
+export const KAGENT_API_VERSION = "kagent.dev/v1alpha2";
+export const KAGENT_KIND = "Agent";
+
+export const AZURECLAW_GROUP = "azureclaw.azure.com";
+export const AZURECLAW_VERSION = "v1alpha1";
+export const SANDBOX_LABEL_KEY = `${AZURECLAW_GROUP}/sandbox`;
+
+const PROVENANCE_FROM_KEY = `${AZURECLAW_GROUP}/migrated-from`;
+const PROVENANCE_AGENT_KEY = `${AZURECLAW_GROUP}/kagent-agent`;
+const KAGENT_DESCRIPTION_KEY = `${AZURECLAW_GROUP}/kagent-description`;
+const KAGENT_DESCRIPTION_TRUNCATED_KEY = `${AZURECLAW_GROUP}/kagent-description-truncated`;
+const KAGENT_MODEL_CONFIG_KEY = `${AZURECLAW_GROUP}/kagent-model-config`;
+const KAGENT_TOOL_REF_KEY = `${AZURECLAW_GROUP}/kagent-tool-ref`;
+
+const DESCRIPTION_CAP_BYTES = 4096;
+const DNS_NAME_MAX = 63;
+const HASH_SUFFIX_LEN = 6;
+
+export type Severity = "warn" | "error";
+
+export interface Warning {
+  severity: Severity;
+  message: string;
+  /// Dotted JSON path of the source field (e.g. `spec.declarative.memory`).
+  path: string;
+}
+
+export interface KubeResource {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: Record<string, unknown>;
+}
+
+export interface TranslateOptions {
+  /// Override metadata.namespace.
+  namespace?: string;
+  /// Override sandbox isolation; default `enhanced`.
+  isolation?: "standard" | "enhanced" | "confidential";
+  /// Override the OpenClaw image. Required (or implied) for Declarative
+  /// agents which kagent runs via its own ADK runtime.
+  image?: string;
+}
+
+export interface TranslateResult {
+  warnings: Warning[];
+  resources: KubeResource[];
+  summary: {
+    sandboxName: string;
+    namespace: string;
+    agentType: "Declarative" | "BYO" | "unknown";
+    runnable: boolean;
+    toolPolicyCount: number;
+    inferencePolicyCount: number;
+  };
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+function warn(path: string, message: string): Warning {
+  return { severity: "warn", message, path };
+}
+
+/** Sanitize a free-form identifier into a DNS-1123 label-safe lowercase string. */
+export function sanitizeDnsName(raw: string): string {
+  let s = raw.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
+  s = s.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+  return s.length === 0 ? "x" : s;
+}
+
+export function hashSuffix(parts: readonly string[]): string {
+  const h = createHash("sha256").update(parts.join("\u0000")).digest("hex");
+  return h.slice(0, HASH_SUFFIX_LEN);
+}
+
+/**
+ * Generate a deterministic, DNS-1123-safe ToolPolicy name of length ≤ 63
+ * from the (sandbox, mcpServer, tool, sourceIndex) tuple. Hash is computed
+ * over the *unsanitized* tuple to avoid collisions when two distinct
+ * inputs sanitize identically.
+ */
+export function generateToolPolicyName(
+  sandbox: string,
+  mcpServer: string,
+  tool: string,
+  sourceIndex: number,
+): string {
+  const suffix = `-${hashSuffix([sandbox, mcpServer, tool, String(sourceIndex)])}`;
+  const reserve = suffix.length;
+  const prefix = sanitizeDnsName(`${sandbox}-${mcpServer}-${tool}`);
+  const trimmed = prefix.slice(0, DNS_NAME_MAX - reserve).replace(/-+$/, "");
+  const result = `${trimmed.length === 0 ? "x" : trimmed}${suffix}`;
+  // Ensure we end on alphanumeric (suffix is hex → always alnum).
+  return result;
+}
+
+const SERVER_MANAGED_META_KEYS = new Set([
+  "uid",
+  "resourceVersion",
+  "generation",
+  "creationTimestamp",
+  "deletionTimestamp",
+  "deletionGracePeriodSeconds",
+  "managedFields",
+  "ownerReferences",
+  "finalizers",
+  "selfLink",
+]);
+
+const KUBECTL_ANNOTATION_PREFIXES = ["kubectl.kubernetes.io/"];
+
+function copyLabels(raw: unknown): Record<string, string> | undefined {
+  if (!isObj(raw)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function copyAnnotations(raw: unknown): Record<string, string> | undefined {
+  if (!isObj(raw)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v !== "string") continue;
+    if (KUBECTL_ANNOTATION_PREFIXES.some((p) => k.startsWith(p))) continue;
+    out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Returns a metadata block stripped of server-managed fields. */
+export function cleanMetadata(raw: unknown): {
+  name?: string;
+  namespace?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+} {
+  if (!isObj(raw)) return {};
+  const out: {
+    name?: string;
+    namespace?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  } = {};
+  if (typeof raw.name === "string") out.name = raw.name;
+  if (typeof raw.namespace === "string") out.namespace = raw.namespace;
+  const labels = copyLabels(raw.labels);
+  if (labels) out.labels = labels;
+  const annotations = copyAnnotations(raw.annotations);
+  if (annotations) out.annotations = annotations;
+  // Server-managed keys deliberately dropped (see SERVER_MANAGED_META_KEYS).
+  for (const k of Object.keys(raw)) {
+    if (SERVER_MANAGED_META_KEYS.has(k)) continue;
+  }
+  return out;
+}
+
+/** Order-aware env projection mirroring convert.ts S9.2 semantics. */
+export function envArrayToMap(
+  raw: unknown[],
+  pathPrefix: string,
+  warnings: Warning[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const seenLiteral = new Set<string>();
+  for (let i = 0; i < raw.length; i++) {
+    const entry = raw[i];
+    if (!isObj(entry)) continue;
+    const name = asString(entry.name);
+    if (!name) continue;
+    if (entry.valueFrom !== undefined) {
+      if (out[name] !== undefined) {
+        warnings.push(
+          warn(
+            `${pathPrefix}[${i}]`,
+            `env '${name}': prior literal dropped because later entry uses valueFrom (unsupported)`,
+          ),
+        );
+        delete out[name];
+      } else {
+        warnings.push(
+          warn(
+            `${pathPrefix}[${i}]`,
+            `env '${name}': valueFrom is not supported by ClawSandbox.spec.openclaw.extraEnv (dropped)`,
+          ),
+        );
+      }
+      continue;
+    }
+    if (typeof entry.value !== "string") continue;
+    if (seenLiteral.has(name)) {
+      warnings.push(
+        warn(`${pathPrefix}[${i}]`, `env '${name}' redefined; later value wins`),
+      );
+    }
+    out[name] = entry.value;
+    seenLiteral.add(name);
+  }
+  return out;
+}
+
+// ---- description handling --------------------------------------------------
+
+function projectDescription(
+  description: string | undefined,
+  warnings: Warning[],
+): { annotation?: string; truncated?: boolean } {
+  if (!description) return {};
+  const bytes = Buffer.byteLength(description, "utf8");
+  if (bytes <= DESCRIPTION_CAP_BYTES) {
+    return { annotation: description };
+  }
+  warnings.push(
+    warn(
+      "spec.description",
+      `description ${bytes} bytes > ${DESCRIPTION_CAP_BYTES}; truncated`,
+    ),
+  );
+  // Truncate to byte budget; safe for ASCII, and reasonable for UTF-8
+  // (we may strip a partial char trailer — fine for an annotation).
+  const buf = Buffer.from(description, "utf8").subarray(
+    0,
+    DESCRIPTION_CAP_BYTES,
+  );
+  return { annotation: buf.toString("utf8"), truncated: true };
+}
+
+// ---- core translate --------------------------------------------------------
+
+export function translate(
+  input: unknown,
+  opts: TranslateOptions,
+): TranslateResult {
+  const warnings: Warning[] = [];
+
+  if (!isObj(input)) {
+    throw new InvalidInputError("input is not a YAML mapping");
+  }
+  const apiVersion = asString(input.apiVersion);
+  const kind = asString(input.kind);
+  if (apiVersion !== KAGENT_API_VERSION) {
+    throw new InvalidInputError(
+      `apiVersion '${apiVersion ?? ""}' is not '${KAGENT_API_VERSION}'`,
+    );
+  }
+  if (kind !== KAGENT_KIND) {
+    throw new InvalidInputError(
+      `kind '${kind ?? ""}' is not '${KAGENT_KIND}'`,
+    );
+  }
+
+  const meta = cleanMetadata(input.metadata);
+  const sandboxName = meta.name;
+  if (!sandboxName) {
+    throw new InvalidInputError("metadata.name is required");
+  }
+  const inputNs = meta.namespace ?? "default";
+  const namespace = opts.namespace ?? inputNs;
+  if (opts.namespace && opts.namespace !== inputNs) {
+    warnings.push(
+      warn(
+        "metadata.namespace",
+        `overriding input namespace '${inputNs}' with --namespace '${opts.namespace}'`,
+      ),
+    );
+  }
+
+  const spec = isObj(input.spec) ? input.spec : {};
+  const agentType = asString(spec.type);
+  if (agentType !== "Declarative" && agentType !== "BYO") {
+    throw new InvalidInputError(
+      `spec.type must be 'Declarative' or 'BYO' (got ${agentType ?? "unset"})`,
+    );
+  }
+
+  const description = asString(spec.description);
+  const descProj = projectDescription(description, warnings);
+
+  // ---- ClawSandbox ---------------------------------------------------------
+  const sandboxLabels: Record<string, string> = { ...meta.labels };
+  // Inject deterministic AzureClaw-owned label so emitted ToolPolicies
+  // can match the sandbox via spec.appliesTo.sandboxMatchLabels. Refuse
+  // a conflicting pre-existing value.
+  if (
+    sandboxLabels[SANDBOX_LABEL_KEY] !== undefined &&
+    sandboxLabels[SANDBOX_LABEL_KEY] !== sandboxName
+  ) {
+    throw new InvalidInputError(
+      `metadata.labels['${SANDBOX_LABEL_KEY}'] already set to '${sandboxLabels[SANDBOX_LABEL_KEY]}', conflicts with sandbox name '${sandboxName}'`,
+    );
+  }
+  sandboxLabels[SANDBOX_LABEL_KEY] = sandboxName;
+
+  const sandboxAnns: Record<string, string> = { ...meta.annotations };
+  sandboxAnns[PROVENANCE_FROM_KEY] = `${KAGENT_API_VERSION} ${KAGENT_KIND}`;
+  sandboxAnns[PROVENANCE_AGENT_KEY] = `${inputNs}/${sandboxName}`;
+  if (descProj.annotation) sandboxAnns[KAGENT_DESCRIPTION_KEY] = descProj.annotation;
+  if (descProj.truncated) sandboxAnns[KAGENT_DESCRIPTION_TRUNCATED_KEY] = "true";
+
+  const isolation = opts.isolation ?? "enhanced";
+
+  // Image resolution ---------------------------------------------------------
+  let image: string | undefined;
+  if (agentType === "BYO") {
+    const byo = isObj(spec.byo) ? spec.byo : {};
+    const byoDeploy = isObj(byo.deployment) ? byo.deployment : {};
+    image = asString(byoDeploy.image);
+    if (!image) {
+      throw new InvalidInputError(
+        "spec.byo.deployment.image is required for BYO agents",
+      );
+    }
+    if (byoDeploy.cmd !== undefined) {
+      warnings.push(
+        warn("spec.byo.deployment.cmd", "container cmd override not supported (dropped)"),
+      );
+    }
+    if (Array.isArray(byoDeploy.args) && byoDeploy.args.length > 0) {
+      warnings.push(
+        warn("spec.byo.deployment.args", "container args override not supported (dropped)"),
+      );
+    }
+  } else if (agentType === "Declarative") {
+    if (opts.image) {
+      image = opts.image;
+    } else {
+      warnings.push(
+        warn(
+          "spec.declarative",
+          "Declarative agents use the kagent ADK runtime image; AzureClaw does not bundle that runtime. Pass --image to override; the emitted ClawSandbox is NOT runnable as-is",
+        ),
+      );
+    }
+  }
+
+  // Deployment shared spec ---------------------------------------------------
+  const deploySpec =
+    agentType === "BYO"
+      ? isObj((isObj(spec.byo) ? spec.byo : {}).deployment)
+        ? (isObj((spec.byo as Record<string, unknown>).deployment)
+            ? ((spec.byo as Record<string, unknown>).deployment as Record<string, unknown>)
+            : {})
+        : {}
+      : isObj((isObj(spec.declarative) ? spec.declarative : {}).deployment)
+        ? ((isObj(spec.declarative)
+            ? ((spec.declarative as Record<string, unknown>).deployment as Record<
+                string,
+                unknown
+              >)
+            : {}) as Record<string, unknown>)
+        : {};
+
+  const extraEnv =
+    Array.isArray(deploySpec.env) && deploySpec.env.length > 0
+      ? envArrayToMap(
+          deploySpec.env as unknown[],
+          `spec.${agentType === "BYO" ? "byo" : "declarative"}.deployment.env`,
+          warnings,
+        )
+      : undefined;
+
+  // Lossy deployment fields --------------------------------------------------
+  const deployBase = `spec.${agentType === "BYO" ? "byo" : "declarative"}.deployment`;
+  for (const [k, msg] of [
+    ["replicas", "controller manages Deployment replicas (dropped)"],
+    ["imagePullSecrets", "imagePullSecrets not exposed via ClawSandbox (dropped)"],
+    ["volumes", "pod-level volumes not exposed via ClawSandbox (dropped)"],
+    ["volumeMounts", "container-level volumeMounts not exposed (dropped)"],
+    ["imagePullPolicy", "imagePullPolicy not exposed (dropped)"],
+    ["tolerations", "pod tolerations not exposed via ClawSandbox (dropped)"],
+    ["affinity", "pod affinity not exposed via ClawSandbox (dropped)"],
+    ["nodeSelector", "nodeSelector not exposed via ClawSandbox (dropped)"],
+    ["securityContext", "container securityContext is controller-managed (dropped)"],
+    ["podSecurityContext", "podSecurityContext is controller-managed (dropped)"],
+    ["serviceAccountName", "ServiceAccount is controller-managed (dropped)"],
+    ["serviceAccountConfig", "ServiceAccount config is controller-managed (dropped)"],
+  ] as const) {
+    if (deploySpec[k] !== undefined && deploySpec[k] !== null) {
+      warnings.push(warn(`${deployBase}.${k}`, msg));
+    }
+  }
+
+  // Resources passthrough ----------------------------------------------------
+  let resources: Record<string, unknown> | undefined;
+  if (isObj(deploySpec.resources)) {
+    resources = {};
+    if (deploySpec.resources.requests !== undefined)
+      resources.requests = deploySpec.resources.requests;
+    if (deploySpec.resources.limits !== undefined)
+      resources.limits = deploySpec.resources.limits;
+    if (Object.keys(resources).length === 0) resources = undefined;
+  }
+
+  // Network policy from kagent sandbox.network.allowedDomains ----------------
+  let networkPolicy: Record<string, unknown> | undefined;
+  if (isObj(spec.sandbox)) {
+    const net = isObj(spec.sandbox.network) ? spec.sandbox.network : undefined;
+    const allowed = net && Array.isArray(net.allowedDomains) ? net.allowedDomains : [];
+    const endpoints: { host: string }[] = [];
+    for (let i = 0; i < allowed.length; i++) {
+      const d = allowed[i];
+      if (typeof d !== "string" || d.length === 0) continue;
+      if (d.includes("*")) {
+        warnings.push(
+          warn(
+            `spec.sandbox.network.allowedDomains[${i}]`,
+            `wildcard domain '${d}' has no documented ClawSandbox.networkPolicy semantics; passed through verbatim — verify behaviour before relying on it`,
+          ),
+        );
+      }
+      endpoints.push({ host: d });
+    }
+    if (endpoints.length > 0) {
+      networkPolicy = {
+        defaultDeny: true,
+        approvalRequired: true,
+        allowedEndpoints: endpoints,
+      };
+    }
+  }
+
+  // Other lossy top-level kagent fields --------------------------------------
+  if (Array.isArray(spec.skills) || isObj(spec.skills)) {
+    warnings.push(
+      warn(
+        "spec.skills",
+        "kagent skills (OCI/git refs) are not installed by AzureClaw S9.3; migrated agent may not function without manual remediation",
+      ),
+    );
+  }
+  if (spec.allowedNamespaces !== undefined) {
+    warnings.push(
+      warn(
+        "spec.allowedNamespaces",
+        "Gateway-API cross-namespace pattern not modeled by AzureClaw (dropped)",
+      ),
+    );
+  }
+
+  // Declarative-only lossy fields --------------------------------------------
+  if (agentType === "Declarative" && isObj(spec.declarative)) {
+    const d = spec.declarative;
+    for (const [k, msg] of [
+      ["systemMessage", "system message not modeled by ClawSandbox (use spec.agent.instructions if Foundry agent is configured)"],
+      ["systemMessageFrom", "system message source ref not modeled (dropped)"],
+      ["promptTemplate", "prompt template processing not modeled (dropped)"],
+      ["runtime", "kagent ADK runtime selector (python/go) is not applicable"],
+      ["stream", "stream flag is router-side and not modeled here (dropped)"],
+      ["executeCodeBlocks", "code execution flag not modeled (dropped)"],
+      ["memory", "memory binding is Phase 4 ClawMemory; preserved only as warning"],
+      ["context", "context compaction config not modeled (dropped)"],
+      ["a2aConfig", "A2A skill list not faithfully translatable to ClawSandbox.spec.a2a (dropped)"],
+    ] as const) {
+      if (d[k] !== undefined) warnings.push(warn(`spec.declarative.${k}`, msg));
+    }
+  }
+
+  // ---- ToolPolicies --------------------------------------------------------
+  const toolPolicies: KubeResource[] = [];
+  let governanceEnabled = false;
+
+  const tools = agentType === "Declarative" && isObj(spec.declarative)
+    ? asArray((spec.declarative as Record<string, unknown>).tools)
+    : [];
+
+  for (let i = 0; i < tools.length; i++) {
+    const tool = tools[i];
+    if (!isObj(tool)) continue;
+    const tType = asString(tool.type);
+    const path = `spec.declarative.tools[${i}]`;
+
+    if (tType === "Agent") {
+      if (!isObj(tool.agent) || !asString((tool.agent as Record<string, unknown>).name)) {
+        throw new InvalidInputError(
+          `${path}.agent: 'name' is required for type=Agent`,
+        );
+      }
+      warnings.push(
+        warn(path, "agent-as-tool not supported by AzureClaw ToolPolicy (dropped)"),
+      );
+      continue;
+    }
+    if (tType !== "McpServer") {
+      throw new InvalidInputError(`${path}.type must be 'McpServer' or 'Agent'`);
+    }
+
+    const mcp = isObj(tool.mcpServer) ? tool.mcpServer : undefined;
+    if (!mcp) {
+      throw new InvalidInputError(`${path}.mcpServer is required for type=McpServer`);
+    }
+    const mcpName = asString(mcp.name);
+    if (!mcpName) {
+      throw new InvalidInputError(`${path}.mcpServer.name is required`);
+    }
+
+    if (Array.isArray(tool.headersFrom) && tool.headersFrom.length > 0) {
+      warnings.push(
+        warn(`${path}.headersFrom`, "request-header propagation not modeled by ToolPolicy (dropped)"),
+      );
+    }
+    if (Array.isArray(mcp.allowedHeaders) && mcp.allowedHeaders.length > 0) {
+      warnings.push(
+        warn(
+          `${path}.mcpServer.allowedHeaders`,
+          "allowedHeaders not modeled by ToolPolicy (dropped)",
+        ),
+      );
+    }
+
+    const requireApproval = new Set(
+      asArray(mcp.requireApproval).filter((x): x is string => typeof x === "string"),
+    );
+
+    // Provenance annotation pointing at the original TypedReference.
+    const ref = {
+      apiGroup: asString(mcp.apiGroup) ?? "",
+      kind: asString(mcp.kind) ?? "",
+      name: mcpName,
+    };
+    const refAnn = JSON.stringify(ref);
+
+    // Warn that the referenced McpServer must already exist.
+    warnings.push(
+      warn(
+        `${path}.mcpServer`,
+        `Tool references kagent McpServer '${mcpName}'; AzureClaw will not auto-create it — ensure an equivalent AzureClaw McpServer CR exists`,
+      ),
+    );
+
+    const rawNames = asArray(mcp.toolNames).filter(
+      (x): x is string => typeof x === "string" && x.length > 0,
+    );
+
+    const toolNames = rawNames.length > 0
+      ? Array.from(new Set(rawNames)).sort()
+      : ["*"];
+    if (rawNames.length === 0) {
+      warnings.push(
+        warn(
+          `${path}.mcpServer.toolNames`,
+          "toolNames omitted; emitting one wildcard ToolPolicy (matches all tools from this McpServer)",
+        ),
+      );
+    }
+
+    for (const toolName of toolNames) {
+      const tpName = generateToolPolicyName(sandboxName, mcpName, toolName, i);
+      const requiresApproval =
+        toolName !== "*" && requireApproval.has(toolName);
+
+      const tpSpec: Record<string, unknown> = {
+        appliesTo: {
+          tool: toolName,
+          mcpServer: mcpName,
+          sandboxMatchLabels: { [SANDBOX_LABEL_KEY]: sandboxName },
+        },
+      };
+      if (requiresApproval) {
+        tpSpec.approval = { mode: "always" };
+      }
+
+      toolPolicies.push({
+        apiVersion: `${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`,
+        kind: "ToolPolicy",
+        metadata: {
+          name: tpName,
+          namespace,
+          labels: { [SANDBOX_LABEL_KEY]: sandboxName },
+          annotations: {
+            [PROVENANCE_FROM_KEY]: `${KAGENT_API_VERSION} ${KAGENT_KIND}`,
+            [PROVENANCE_AGENT_KEY]: `${inputNs}/${sandboxName}`,
+            [KAGENT_TOOL_REF_KEY]: refAnn,
+          },
+        },
+        spec: tpSpec,
+      });
+      governanceEnabled = true;
+    }
+  }
+
+  // Stable bundle order: Sandbox, InferencePolicy, ToolPolicies (sorted).
+  toolPolicies.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+
+  // ---- ClawSandbox spec assembly ------------------------------------------
+  const sbSpec: Record<string, unknown> = {
+    sandbox: { isolation },
+  };
+  if (image) sbSpec.openclaw = { image, ...(extraEnv ? { extraEnv } : {}) };
+  else if (extraEnv) sbSpec.openclaw = { extraEnv };
+  if (resources) sbSpec.resources = resources;
+  if (networkPolicy) sbSpec.networkPolicy = networkPolicy;
+  if (governanceEnabled) sbSpec.governance = { enabled: true };
+
+  const clawsandbox: KubeResource = {
+    apiVersion: `${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`,
+    kind: "ClawSandbox",
+    metadata: {
+      name: sandboxName,
+      namespace,
+      labels: sandboxLabels,
+      annotations: sandboxAnns,
+    },
+    spec: sbSpec,
+  };
+
+  // ---- InferencePolicy (provenance-only) ----------------------------------
+  const inferencePolicies: KubeResource[] = [];
+  if (agentType === "Declarative" && isObj(spec.declarative)) {
+    const modelConfig = asString((spec.declarative as Record<string, unknown>).modelConfig);
+    if (modelConfig && modelConfig.length > 0) {
+      warnings.push(
+        warn(
+          "spec.declarative.modelConfig",
+          `kagent ModelConfig '${modelConfig}' is preserved only as an InferencePolicy annotation; AzureClaw inference provider/model are not configured from it`,
+        ),
+      );
+      inferencePolicies.push({
+        apiVersion: `${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`,
+        kind: "InferencePolicy",
+        metadata: {
+          name: `${sandboxName}-inference`,
+          namespace,
+          labels: { [SANDBOX_LABEL_KEY]: sandboxName },
+          annotations: {
+            [PROVENANCE_FROM_KEY]: `${KAGENT_API_VERSION} ${KAGENT_KIND}`,
+            [PROVENANCE_AGENT_KEY]: `${inputNs}/${sandboxName}`,
+            [KAGENT_MODEL_CONFIG_KEY]: modelConfig,
+          },
+        },
+        spec: {
+          appliesTo: { sandboxName },
+        },
+      });
+    }
+  }
+
+  const resourcesOut: KubeResource[] = [
+    clawsandbox,
+    ...inferencePolicies,
+    ...toolPolicies,
+  ];
+
+  return {
+    warnings,
+    resources: resourcesOut,
+    summary: {
+      sandboxName,
+      namespace,
+      agentType,
+      runnable: image !== undefined,
+      toolPolicyCount: toolPolicies.length,
+      inferencePolicyCount: inferencePolicies.length,
+    },
+  };
+}
+
+export class InvalidInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidInputError";
+  }
+}
+
+export const __test = {
+  sanitizeDnsName,
+  hashSuffix,
+  generateToolPolicyName,
+  cleanMetadata,
+  envArrayToMap,
+  projectDescription,
+  translate,
+};

--- a/docs/security-audits/2026-04-28-phase2-migrate-from-kagent.md
+++ b/docs/security-audits/2026-04-28-phase2-migrate-from-kagent.md
@@ -1,0 +1,190 @@
+# Phase 2 S9.3 — `phase2-migrate-from-kagent` security audit
+
+**Status:** Implemented · awaiting merge into `dev`
+**Date:** 2026-04-28
+**Branch:** `phase2-migrate-from-kagent`
+**Scope:** CLI translator only — zero Rust / controller / router changes.
+
+## 1. Slice summary
+
+Adds `azureclaw migrate from-kagent <input>` — a one-shot, pure-CLI
+YAML translator that converts a `kagent.dev/v1alpha2 Agent` CR into an
+AzureClaw resource bundle:
+
+1. `azureclaw.azure.com/v1alpha1 ClawSandbox` (always, one)
+2. `azureclaw.azure.com/v1alpha1 InferencePolicy` (zero or one — only when
+   `spec.declarative.modelConfig` is set; provenance-only mapping)
+3. `azureclaw.azure.com/v1alpha1 ToolPolicy` (zero or more — one per
+   `(McpServer, toolName)` pair)
+
+Closes §15.2 #8 of the implementation plan ("kagent migration tool"). The
+day-1 adoption story is: an operator running kagent declarative agents
+runs `azureclaw migrate from-kagent agent.yaml --image my/runtime:v1
+--allow-lossy | kubectl apply -f -` to produce an AzureClaw resource
+bundle they can apply alongside hand-authored AzureClaw `McpServer` and
+`InferencePolicy` objects.
+
+## 2. Threat model (STRIDE)
+
+| Category | Threat | Mitigation |
+|---|---|---|
+| **Spoofing** | A malicious YAML claims to be a kagent Agent with `kind: Agent` but a fabricated `apiVersion`. | We hard-gate on the exact pair `(apiVersion=kagent.dev/v1alpha2, kind=Agent)`; any deviation → exit 2. |
+| **Spoofing** | A multi-doc YAML smuggles a malicious second resource. | Multi-doc input is rejected → exit 2. |
+| **Tampering** | An operator pre-populates `metadata.labels[azureclaw.azure.com/sandbox]` with a value other than the agent name to silently misroute generated `ToolPolicy.spec.appliesTo.sandboxMatchLabels`. | We refuse a pre-existing conflicting value → exit 2. Test: `rejects pre-existing conflicting sandbox label`. |
+| **Tampering** | A long `spec.description` is used to smuggle a payload that exceeds the K8s 256 KiB metadata budget at apply time, breaking the entire bundle. | `spec.description` is capped at 4 KiB; truncation produces `azureclaw.azure.com/kagent-description-truncated: "true"` and a lossy warning that is gated by `--allow-lossy`. |
+| **Repudiation** | Operator denies that a sandbox was migrated from a kagent Agent. | Every emitted resource carries `azureclaw.azure.com/migrated-from` and `azureclaw.azure.com/kagent-agent` provenance annotations. |
+| **Information disclosure** | An env var with `valueFrom` (Secret reference) is silently materialised into a literal `extraEnv` value, potentially exposing the secret in the migrated YAML. | `valueFrom` env entries are **dropped** with a `warn`. A prior literal entry with the same name is also dropped (no stale value resurrection). |
+| **Information disclosure** | An env var redefinition is silently coalesced, hiding which entry won. | Redefinitions emit a `warn` per shadowed entry. |
+| **Information disclosure** | A description annotation may carry sensitive free text. | Pass-through is bounded (4 KiB) and the field is opt-in (kagent-controlled). |
+| **Denial of service** | An attacker provides a kagent CR with thousands of `toolNames` to inflate ToolPolicy count and exhaust the cluster's CRD budget on apply. | Translator is in-memory only; cluster-side rate-limiting is a `kubectl apply` concern. We deduplicate identical tool names. We bound generated ToolPolicy names at 63 chars (DNS-1123 label). |
+| **Denial of service** | `--out-dir` writes files; an attacker-supplied tool name like `../etc/passwd` walks out of the directory. | All filenames are derived from sanitised, DNS-1123-safe `metadata.name` values; any path separator from input is replaced. Existing files are refused (no overwrite) unless `--force`. |
+| **Elevation of privilege** | A migrated `ClawSandbox` accidentally inherits an over-permissive `securityContext` from the input. | Pod / container `securityContext` from `SharedDeploymentSpec` is **not** projected (controller-managed). Lossy warn surfaced. |
+| **Elevation of privilege** | `serviceAccountName` from the input grants the migrated agent unintended cluster privileges. | `serviceAccountName` is **dropped** with a warn (controller manages the SA). |
+| **Elevation of privilege** | Wildcard egress domain (`*.example.com`) is silently honoured by AzureClaw with surprising semantics. | Detected and warned; emission is allowed but gated by `--allow-lossy`. |
+
+## 3. STRIDE non-issues
+
+- **Tampering of the translator binary**: out of scope — handled by signed
+  release artefacts (Phase 3 cosign-on-admission).
+- **Tampering of the input YAML in flight**: out of scope — the operator
+  is the trust boundary.
+- **Authentication / authorisation of the operator**: this CLI never talks
+  to a cluster (no `kubectl` invocation, no kube context read, no token
+  exchange). It is a pure file → file translator.
+
+## 4. Existing implementation surveyed
+
+Per slice rule §0.2 #7 ("No duplication, no dead code"):
+
+| Existing seam | Path | Reused? | Rationale |
+|---|---|---|---|
+| `convert.ts::cleanMetadata` | `cli/src/commands/convert.ts:104-115` | Concept reused, not imported | The S9.2 helper strips a different field set; this slice needed strict server-managed-key drop (uid, resourceVersion, generation, creationTimestamp, managedFields, ownerReferences, finalizers, …) and KAGENT-specific annotation filtering. Re-implementing in `from_kagent.ts` keeps the CLI commands loosely coupled and avoids over-narrowing the S9.2 helper. |
+| `convert.ts::envArrayToMap` | `cli/src/commands/convert.ts:233-272` | Concept reused, not imported | S9.2 maps Kubernetes `corev1.EnvVar[]` for forward / inverse `Sandbox` translation; S9.3 needs the same semantics for `SharedDeploymentSpec.env`. The pure-helper signatures differ (different `Warning` shape — S9.3 uses `{severity, path, message}` for richer CLI surface), so direct reuse would have introduced an internal `Warning` adapter type. Keeping each translator self-contained minimises the dependency graph between Phase 2 slices. |
+| Commander subcommand registration | `cli/src/commands/migrate.ts:289-` | Reused — `from-kagent` is added as a sibling of `to-overlay`, `from-overlay`, `to-translate`, `to-observe`, `to-native` | Same `migrate` umbrella command. No new top-level command added. |
+| `yaml.parseAllDocuments` + multi-doc rejection idiom | `cli/src/commands/convert.ts:71-85` | Re-applied | Same parser, same `d.contents !== null` non-empty filter, same exit-code grammar. |
+| `ClawSandbox`, `InferencePolicy`, `ToolPolicy` CRD field shapes | `controller/src/crd.rs`, `controller/src/inference_policy.rs`, `controller/src/tool_policy.rs` | Targeted directly — zero divergence | The aspirational mapping table in `docs/sigs-agent-sandbox-compat.md` was *not* used here; we target the *actual* schema, just like S9.2 did for the upstream `Sandbox` translator. |
+| Phase 2 CI scripts (`ci/no-stubs.sh`, `ci/no-custom-crypto.sh`, `ci/check-loc.sh`) | repo root | Reused, ran clean against `origin/dev` | No new stubs, no new crypto (sha256 hash for deterministic name suffixing only — `node:crypto` per existing convention; not security-sensitive). |
+| `chalk`, `commander`, `yaml@2.6.0`, `vitest@3.x` | `cli/package.json` | Reused | No new runtime deps; no new dev deps. |
+
+**No new module created in lieu of extending an existing seam.** The pure
+translator file `cli/src/migrate/from_kagent.ts` is a *peer* of
+`cli/src/commands/convert.ts`, not a parallel implementation: it targets
+a different *input* shape (kagent `Agent`) and a different *output cardinality*
+(multi-resource bundle vs. single-resource translate).
+
+## 5. Aspirational mappings explicitly rejected
+
+| Plan reference | What was rejected | Why |
+|---|---|---|
+| `plan.md:210` mentions emitting `ClawAgentIdentity` | We emit nothing of that kind. | `ClawAgentIdentity` is **Phase 4** per `docs/internal/internal-boundaries.md:28` and `docs/competitive.md:805`. The CRD has no schema in the cluster; emitting it would produce a manifest that fails admission. Plan line 210 is overridden by current repo reality per slice rule §0.2 #7. |
+| Auto-emit `McpServer` for every kagent `Tool.mcpServer` | Not done. | A kagent `TypedReference` has only `(apiGroup, kind, name)`; the upstream MCP server URL, transport, JWKS, and OAuth client are not in the input. We surface the original ref via `azureclaw.azure.com/kagent-tool-ref` annotation and a hard warning that an equivalent AzureClaw `McpServer` must already exist. |
+| Map `spec.declarative.modelConfig` → `InferencePolicy.spec.tokenBudget`/`modelPreference` | Not done. | kagent `ModelConfig` is a separate CRD; we never see its content. The emitted `InferencePolicy` carries only the model-config name as a provenance annotation. The user must hand-author `spec.inference.{provider,endpoint,model}` on the migrated `ClawSandbox` separately. |
+
+## 6. Failure-mode matrix
+
+| Failure mode | Exit code | Surface |
+|---|---|---|
+| Input is not a YAML mapping | 2 | `error: input is not a YAML mapping` |
+| Input is empty | 2 | `error: input contains no YAML documents` |
+| Input has > 1 YAML document | 2 | `error: input contains N YAML documents; from-kagent expects exactly one Agent` |
+| Wrong `apiVersion` | 2 | `error: apiVersion '<v>' is not 'kagent.dev/v1alpha2'` |
+| Wrong `kind` | 2 | `error: kind '<k>' is not 'Agent'` |
+| Missing `metadata.name` | 2 | `error: metadata.name is required` |
+| Unknown `spec.type` | 2 | `error: spec.type must be 'Declarative' or 'BYO' (got <x>)` |
+| BYO without image | 2 | `error: spec.byo.deployment.image is required for BYO agents` |
+| McpServer tool with missing `name` | 2 | `error: spec.declarative.tools[i].mcpServer.name is required` |
+| Tool with missing `mcpServer` (type=McpServer) | 2 | `error: spec.declarative.tools[i].mcpServer is required for type=McpServer` |
+| Tool of type=Agent with missing `agent.name` | 2 | `error: spec.declarative.tools[i].agent: 'name' is required for type=Agent` |
+| Conflicting pre-existing `azureclaw.azure.com/sandbox` label | 2 | `error: metadata.labels['azureclaw.azure.com/sandbox'] already set to '<v>', conflicts with sandbox name '<n>'` |
+| Invalid `--isolation` value | 2 | `error: --isolation must be one of standard\|enhanced\|confidential` |
+| Translation lossy without `--allow-lossy` | 4 | `error: translation is lossy (N warnings). Pass --allow-lossy to waive.` |
+| `--out-dir` file collision | 2 | `error: <path> already exists (use --force to overwrite)` |
+| Two emitted resources collide on filename | 2 | `error: duplicate output filename '<f>' (kind+name collision)` |
+| Successful translation | 0 | resources written to stdout / `--out-dir` |
+
+## 7. CRD round-trip validation
+
+The emitted resources have been validated by inspection against the
+target CRD schemas:
+
+- `ClawSandboxSpec` — `controller/src/crd.rs:28-87`. Every emitted field
+  (`openclaw.image`, `openclaw.extraEnv`, `sandbox.isolation`,
+  `networkPolicy.{defaultDeny, approvalRequired, allowedEndpoints}`,
+  `governance.enabled`, `resources.{requests,limits}`) maps to a
+  documented field with the correct type. No emit references a field
+  that does not exist on the CRD.
+- `InferencePolicySpec` — `controller/src/inference_policy.rs:77-98`.
+  We emit only `appliesTo.sandboxName`. We deliberately do **not**
+  populate `tokenBudget`, `contentSafety`, or `modelPreference` —
+  doing so would require ModelConfig content we don't have.
+- `ToolPolicySpec` — `controller/src/tool_policy.rs:48-65`. We emit
+  `appliesTo.{tool, mcpServer, sandboxMatchLabels}` and conditionally
+  `approval.mode`. We do **not** emit `commerce` or `rateLimit` —
+  kagent has no equivalent fields.
+
+## 8. CI surface
+
+| Gate | Result | Notes |
+|---|---|---|
+| `cd cli && npx tsc --noEmit` | ✓ | clean |
+| `cd cli && npm run lint` (oxlint) | ✓ | clean (0 warnings, 0 errors after fixing 2 useless-fallback-in-spread warnings on `meta.labels`/`meta.annotations`) |
+| `cd cli && npm test` (vitest) | ✓ | 435/437 (2 pre-existing skipped); +53 new cases |
+| `BASE_REF=origin/dev ci/no-stubs.sh` | ✓ | clean |
+| `BASE_REF=origin/dev ci/no-custom-crypto.sh` | ✓ | clean (sha256 hash via `node:crypto` for deterministic name suffixing — pre-existing convention; not a new crypto primitive) |
+| `BASE_REF=origin/dev ci/check-loc.sh` | ✓ | translator 721 LOC; tests 714 LOC |
+| Manual end-to-end smoke (`migrate from-kagent` against a Declarative agent with tools + network) | ✓ | exits 0 with `--allow-lossy --image …`; exits 4 without `--allow-lossy`; YAML round-trip is well-formed multi-doc |
+
+## 9. Test coverage map
+
+53 cases in `cli/src/migrate/from_kagent.test.ts`:
+
+| Group | Cases | Notes |
+|---|---|---|
+| `sanitizeDnsName` | 5 | empty fallback, DNS char map, dash collapse, leading/trailing trim, alnum passthrough |
+| `hashSuffix` | 3 | determinism, distinct tuples, hex-of-length-6 |
+| `generateToolPolicyName` | 2 | ≤ 63 chars, hash distinguishes after-sanitize collisions |
+| `cleanMetadata` | 3 | server-managed strip, kubectl-annotation filter, non-object input |
+| `envArrayToMap` | 3 | last-wins-warn, valueFrom drop+warn, prior-literal-purge |
+| `projectDescription` | 2 | passthrough, truncation+warn |
+| `translate` input gating | 5 | apiVersion / kind / name / type / BYO image |
+| ClawSandbox basics | 6 | label/annotation injection, isolation override, sandbox-label conflict, label preserve, ns mismatch warn, ns match no-warn |
+| Declarative runnability | 4 | non-runnable warn, --image escape hatch, InferencePolicy emit-when-modelConfig, no-emit-when-absent |
+| Tools | 9 | per-(McpServer,tool) fan-out, approval mapping, wildcard emit, missing-name reject, agent-without-name reject, agent-as-tool drop, deterministic order, dedupe, headersFrom + allowedHeaders warns |
+| Lossy fields | 3 | spec.skills, spec.allowedNamespaces, all declarative-only fields |
+| Lossy deployment fields (BYO) | 1 (×11 sub-paths) | replicas, tolerations, affinity, nodeSelector, imagePullPolicy, imagePullSecrets, volumes, volumeMounts, securityContext, podSecurityContext, serviceAccountName |
+| Networking | 2 | passthrough, wildcard warn |
+| Bundle ordering & shape | 3 | order, BYO clean happy-path, env preservation |
+| Description | 2 | small passthrough, large truncation |
+
+## 10. Operational impact
+
+- **No controller change.** The output of this slice is plain YAML; the
+  controller has no awareness of the migration.
+- **No router change.** Same.
+- **No new CRD.** Same.
+- **No admission policy change.** Same.
+- **No image rebuild required.** This is CLI-only; users get the new
+  subcommand by upgrading the `@azure/azureclaw` npm package.
+
+## 11. Open follow-ups (out of scope for this slice)
+
+- **`McpServer` translator** (Phase 2 S1 follow-on). When the operator
+  has the upstream MCP server URL out-of-band, an `azureclaw mcp import`
+  flow could emit an AzureClaw `McpServer` from a kagent `RemoteMCPServer`
+  CR. Tracked under §15.2 #8.
+- **`InferencePolicy` enforcement from `ModelConfig`** (Phase 2 S4
+  follow-on). Reading a kagent `ModelConfig` CR + provider creds and
+  emitting a fully-wired AzureClaw `InferencePolicy.spec.modelPreference`
+  block. Requires a separate `azureclaw migrate import-modelconfig` flow.
+- **`ClawAgentIdentity` mapping** (Phase 4). Once `ClawAgentIdentity`
+  schema lands, kagent `serviceAccountName` and `serviceAccountConfig`
+  could feed a `ClawAgentIdentity` instead of being dropped.
+
+## 12. Sign-off
+
+| Role | Reviewer | Decision |
+|---|---|---|
+| Slice author | Copilot agent (this PR) | implemented, tests + CI green |
+| Pre-implementation rubber-duck critique | rubber-duck agent | 14 findings adopted, 0 deferred |
+| Phase 2 invariants check | this slice | LOC budget ✓, no Rust change ✓, no new CRD ✓, no aspirational emit ✓, audit doc ✓, CHANGELOG ✓, CI scripts ✓ |
+| Final reviewer | _to be assigned on PR_ | pending |


### PR DESCRIPTION
## Slice S9.3 — `phase2-migrate-from-kagent`

Closes §15.2 #8 of the implementation plan ("kagent migration tool").

One-shot YAML translator from a `kagent.dev/v1alpha2 Agent` CR
(verified directly against `kagent-dev/kagent @ 90212ab go/api/v1alpha2/agent_types.go` via GitHub MCP) into an AzureClaw resource bundle.

### Emits

- **`ClawSandbox`** (always) — name + namespace + labels (with the deterministic `azureclaw.azure.com/sandbox` marker that the emitted ToolPolicies match against), BYO image direct or `--image` override for Declarative agents (kagent ADK runtime is not bundled), `spec.sandbox.network.allowedDomains` → `spec.networkPolicy.allowedEndpoints`, deployment-level `env` → `spec.openclaw.extraEnv` (last-literal-wins, `valueFrom` dropped + warned).
- **`InferencePolicy`** (only when `spec.declarative.modelConfig` is set) — provenance-only mapping; carries the kagent ModelConfig name as `azureclaw.azure.com/kagent-model-config` annotation. Inference *enforcement* is **not** migrated.
- **`ToolPolicy`** (one per `(McpServer, toolName)` pair) — `requireApproval` list maps to `spec.approval.mode='always'`; empty `toolNames` emits one wildcard ToolPolicy with a warning; `type: Agent` tools dropped with warning. Original `TypedReference` preserved as `azureclaw.azure.com/kagent-tool-ref` annotation; user is warned that an equivalent AzureClaw `McpServer` must already exist.

### Hard-fail on lossy by default

Same exit-code grammar as S9.2 `convert`: `0` ok, `2` invalid input / wrong kind / multi-doc / collision, `4` lossy refused. `--allow-lossy` waives. `--dry-run` **still** applies the lossy gate.

### Aspirational mappings explicitly REJECTED

Per pre-implementation rubber-duck critique (14 findings adopted, 0 deferred):

- **`ClawAgentIdentity`** — Phase 4 CRD per `docs/internal/internal-boundaries.md:28`; the plan line 210 mentioning it is overridden by repo reality per slice rule §0.2 #7.
- **`McpServer` auto-emission** — we cannot reconstruct upstream MCP endpoints from a kagent `TypedReference`.
- **`InferencePolicy` enforcement from `ModelConfig`** — separate CRD; we keep provenance only.

### Output formats

- `--format yaml` (default) — multi-doc YAML stream, deterministic order: `ClawSandbox`, `InferencePolicy`, `ToolPolicy`s sorted by name.
- `--format json` — single Kubernetes `v1.List` (pipes cleanly to `kubectl apply -f -`).
- `--out-dir <dir>` — splits into `<kind>-<name>.yaml` files; refuses to overwrite unless `--force`.

### Tests

- 53 new vitest cases in `cli/src/migrate/from_kagent.test.ts` covering DNS sanitization edges, hash determinism + collision distinguishability, env projection (last-wins, `valueFrom`, prior-literal-purge), description truncation, every input gate, label conflict rejection, namespace mismatch warn, Declarative non-runnability + escape hatch, conditional InferencePolicy emit, ToolPolicy fan-out + approval mapping + wildcard emission + dedupe + agent-as-tool drop + headersFrom + allowedHeaders warns, all Declarative + deployment-level lossy fields, networking projection + wildcard warn, bundle ordering, BYO clean happy-path.
- CLI workspace: 382 → **435** tests (+53).
- Manual end-to-end smoke: a Declarative agent with one `McpServer` tool (2 toolNames, 1 requireApproval) + a network allowlist round-trips to a 4-resource bundle that exits 0 with `--allow-lossy --image …` and exits 4 without `--allow-lossy`.

### CI

`tsc --noEmit` ✓ · `oxlint` ✓ (clean) · `vitest` 435 ✓ · `ci/no-stubs.sh` ✓ · `ci/no-custom-crypto.sh` ✓ · `ci/check-loc.sh` ✓.

### Audit doc

`docs/security-audits/2026-04-28-phase2-migrate-from-kagent.md` — full 12-section template. STRIDE table (13 threats), reuse map (7 existing seams enumerated, 0 parallel-implementations), aspirational-rejection table, failure-mode matrix, CRD round-trip validation, test coverage map.

### Day-1 use case

```bash
azureclaw migrate from-kagent agent.yaml --image my/runtime:v1 --allow-lossy | kubectl apply -f -
```

Operator running kagent declarative agents adopts AzureClaw governance by piping the bundle into `kubectl apply`, then hand-edits the emitted ClawSandbox to set `spec.inference.{provider,endpoint,model}` per their ModelConfig and creates an AzureClaw `McpServer` for each kagent McpServer reference.

### Phase 2 progress

S1 #51 ✓ · S2 #52 ✓ · S3 #53 ✓ · S4 #54 ✓ · S5 #55 ✓ · S6 #56 ✓ · S8 #57 ✓ · S11 #59 ✓ · S11.1 #61 ✓ · S9.1 #62 ✓ · S9.2 #63 ✓ · **S9.3 (this PR)**

12 of ~14 slices.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>