### PR TITLE
phase2-multi-runtime-dispatch: RuntimeDeploymentPlan seam (S10.A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S10.A2 `phase2-multi-runtime-dispatch` — `RuntimeDeploymentPlan` dispatch seam
+
+#### Added
+- **`controller/src/reconciler/runtime.rs`** (NEW, ~520 lines, 12 unit
+  tests) — `RuntimeDeploymentPlan` (kind_str / image / command / args /
+  runtime_extra_env / agent_code / byo_contract_version),
+  `RuntimePlanError::{AdapterMissing, ShapeInvalid}`,
+  `validate_runtime_shape()` defensive guard mirroring the 7 helm CEL
+  rules (covers CEL-disabled apiservers per plan §S10.A1 rubber-duck #7),
+  `build_runtime_plan()` dispatcher, `plan_openclaw()` producer (image
+  fallback to controller default + extra_env carry-through),
+  `plan_byo()` producer (image / command / args / contract version +
+  flattens static `value:` env entries; structural `valueFrom` entries
+  reserved for the A2.b deployment builder). `kind_str()` free helper
+  is the single source of truth for the wire-format runtime kind
+  string used in status patches and log fields.
+- Reconciler `mod.rs` consumes the plan: `runtime::build_runtime_plan`
+  replaces the inline AdapterMissing match, `plan.image` replaces the
+  inline image fallback in the deployment builder, `plan.runtime_extra_env`
+  replaces the direct `openclaw_config.extra_env` consumption (reserved
+  prefix / NUL-byte / duplicate filtering preserved exactly).
+- New `RuntimePlanError::ShapeInvalid` variant routes to a fresh
+  `Degraded / SpecInvalid` status path (300 s requeue) — distinct from
+  AdapterMissing's `RuntimeReady=False / AdapterMissing` so operators
+  can tell "controller doesn't know this runtime yet" apart from
+  "this CR is structurally malformed and CEL admission would have
+  rejected it".
+
+#### Tests
+- **+12 producer/dispatcher tests** in `runtime.rs` covering wire-format
+  stability, defensive shape validation (each Tier-1 + Tier-2 variant,
+  both directions), OpenClaw plan production (image fallback +
+  extra_env carry-through), AdapterMissing for all 6 non-OpenClaw kinds
+  (incl. BYO short-circuit until A2.b), shape rejection before
+  dispatch, BYO producer round-trip, BYO valueFrom env handling.
+- 306 / 306 controller tests green (was 293 after S10.A1 + 1 new ignored
+  cleanup; net +12 from this slice).
+
+#### Behaviour preservation
+- A2 is a **structural seam only**. For OpenClaw the runtime path is
+  byte-for-byte equivalent to A1 (same image resolution, same env
+  ordering, same reserved-prefix filter). For non-OpenClaw kinds the
+  AdapterMissing skip is preserved exactly (same status condition,
+  same 300 s requeue). BYO end-to-end deployment (split container
+  builder + registry-side `org.azureclaw.runtime.contract=v1` label
+  check) is deferred to S10.A2.b.
+
 ### S10.A1 `phase2-multi-runtime-crd` — `spec.openclaw` → `spec.runtime` discriminated union
 
 #### Added

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -237,13 +237,13 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     let runtime_plan =
         match crate::reconciler::runtime::build_runtime_plan(&runtime_spec, &ctx.sandbox_image) {
             Ok(plan) => {
-            // Defensive: producer must agree with the dispatcher on the
-            // wire-format kind string — they read the same enum but via
-            // different paths. If they ever drift, that's a bug we want
-            // to surface in tests, not in production status patches.
-            debug_assert_eq!(plan.kind_str, runtime_kind_str);
-            plan
-        }
+                // Defensive: producer must agree with the dispatcher on the
+                // wire-format kind string — they read the same enum but via
+                // different paths. If they ever drift, that's a bug we want
+                // to surface in tests, not in production status patches.
+                debug_assert_eq!(plan.kind_str, runtime_kind_str);
+                plan
+            }
             Err(crate::reconciler::runtime::RuntimePlanError::AdapterMissing(kind)) => {
                 let msg = format!(
                     "spec.runtime.kind=`{kind}` has no adapter wired in this controller \

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -222,38 +222,53 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     let spec = sandbox.spec.clone();
     let sandbox_config = spec.sandbox.unwrap_or_default();
     let inference_config = spec.inference.unwrap_or_default();
-    // S10.A1: runtime is a discriminated union (`spec.runtime.kind`).
-    // For OpenClaw we continue with the existing reconciler path; for
-    // OpenAIAgents/MicrosoftAgentFramework/BYO no controller-side adapter
-    // is wired in A1, so the controller refuses to create a Deployment
-    // (would silently run the wrong runtime image — see plan §S10.A1
-    // rubber-duck #2). The full per-runtime dispatch (`RuntimeDeploymentPlan`)
-    // lands in S10.A2.
+    // S10.A2: runtime dispatch flows through `reconciler::runtime` —
+    // a `RuntimeDeploymentPlan` flattens the `spec.runtime` discriminated
+    // union to the concrete image / command / args / runtime-specific env
+    // that the deployment builder consumes. Adding a new runtime kind
+    // means adding a producer in `runtime.rs`, not editing this fn.
+    //
+    // Behavior is strictly equivalent to S10.A1 for OpenClaw; non-OpenClaw
+    // kinds short-circuit through the same `AdapterMissing` path
+    // (refusing to silently run the OpenClaw image — see plan §S10.A1
+    // rubber-duck #2 + audit doc 2026-04-28-phase2-multi-runtime-crd.md).
     let runtime_spec = spec.runtime.clone();
-    let runtime_kind = runtime_spec.kind;
-    let runtime_kind_str: &'static str = match runtime_kind {
-        crate::crd::RuntimeKind::OpenClaw => "OpenClaw",
-        crate::crd::RuntimeKind::OpenAIAgents => "OpenAIAgents",
-        crate::crd::RuntimeKind::MicrosoftAgentFramework => "MicrosoftAgentFramework",
-        crate::crd::RuntimeKind::SemanticKernel => "SemanticKernel",
-        crate::crd::RuntimeKind::LangGraph => "LangGraph",
-        crate::crd::RuntimeKind::Anthropic => "Anthropic",
-        crate::crd::RuntimeKind::BYO => "BYO",
-    };
-    if !matches!(runtime_kind, crate::crd::RuntimeKind::OpenClaw) {
-        let msg = format!(
-            "spec.runtime.kind=`{runtime_kind_str}` has no adapter wired in this controller \
-             build (S10.A1); skipping Deployment to avoid silently running the OpenClaw image. \
-             Track adapter rollout: OpenAIAgents=S10.A3, MicrosoftAgentFramework=S10.A4, \
-             BYO=S10.A2; SemanticKernel/LangGraph/Anthropic are Tier-2 placeholders pending \
-             roadmap"
-        );
-        tracing::warn!(sandbox = %name, runtime = %runtime_kind_str, "{msg}");
-        crate::status::stamp_runtime_unsupported(client, &sandbox, &name, runtime_kind_str, &msg)
-            .await;
-        return Ok(Action::requeue(Duration::from_secs(300)));
-    }
-    let openclaw_config = runtime_spec.openclaw.clone().unwrap_or_default();
+    let runtime_kind_str = crate::reconciler::runtime::kind_str(&runtime_spec.kind);
+    let runtime_plan =
+        match crate::reconciler::runtime::build_runtime_plan(&runtime_spec, &ctx.sandbox_image) {
+            Ok(plan) => {
+            // Defensive: producer must agree with the dispatcher on the
+            // wire-format kind string — they read the same enum but via
+            // different paths. If they ever drift, that's a bug we want
+            // to surface in tests, not in production status patches.
+            debug_assert_eq!(plan.kind_str, runtime_kind_str);
+            plan
+        }
+            Err(crate::reconciler::runtime::RuntimePlanError::AdapterMissing(kind)) => {
+                let msg = format!(
+                    "spec.runtime.kind=`{kind}` has no adapter wired in this controller \
+                 build (S10.A1+A2 spine); skipping Deployment to avoid silently running \
+                 the OpenClaw image. Track adapter rollout: OpenAIAgents=S10.A3, \
+                 MicrosoftAgentFramework=S10.A4, BYO=S10.A2.b; \
+                 SemanticKernel/LangGraph/Anthropic are Tier-2 placeholders pending roadmap"
+                );
+                tracing::warn!(sandbox = %name, runtime = %kind, "{msg}");
+                crate::status::stamp_runtime_unsupported(client, &sandbox, &name, kind, &msg).await;
+                return Ok(Action::requeue(Duration::from_secs(300)));
+            }
+            Err(crate::reconciler::runtime::RuntimePlanError::ShapeInvalid(msg)) => {
+                tracing::error!(sandbox = %name, "runtime spec shape invalid: {msg}");
+                crate::status::stamp_degraded(
+                    client,
+                    &sandbox,
+                    &name,
+                    crate::status::conditions::reason::SPEC_INVALID,
+                    &msg,
+                )
+                .await;
+                return Ok(Action::requeue(Duration::from_secs(300)));
+            }
+        };
     let agent_config = spec.agent.unwrap_or_default();
 
     // ── Validate CRD inputs ──────────────────────────────────────────────
@@ -657,9 +672,11 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         if overlay_mode {
             break 'deployment_block;
         }
-        let image = openclaw_config
-            .image
-            .unwrap_or_else(|| ctx.sandbox_image.clone());
+        // S10.A2: image now comes from the runtime plan (already
+        // resolved against the controller default fallback). The
+        // deployment builder must not re-derive the image from
+        // `openclaw_config` — see plan §S10.A1 rubber-duck #2.
+        let image = runtime_plan.image.clone();
 
         let (runtime_class, pool_label) = isolation_scheduling(&sandbox_config.isolation);
 
@@ -820,11 +837,16 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             router_agt_env.push(json!({"name": "AGT_REGISTRY_URL", "value": "http://agentmesh-registry.agentmesh.svc.cluster.local:8080"}));
         }
 
-        // ── extraEnv: user/controller-provided env vars on spec.runtime.openclaw.extraEnv ──
-        // Used by the controller to propagate offload parameters (OFFLOAD_REQUEST_ID,
-        // OFFLOAD_PARENT_AMID, OFFLOAD_TASK, OFFLOAD_TIMEOUT_MINUTES) into offload
-        // sandboxes. Keys are validated to avoid clobbering reserved prefixes.
-        if let Some(extra) = openclaw_config.extra_env.as_ref() {
+        // ── extraEnv: runtime-specific env vars from the runtime plan ──
+        // For OpenClaw this comes from `spec.runtime.openclaw.extraEnv`
+        // and is used by the controller to propagate offload parameters
+        // (OFFLOAD_REQUEST_ID, OFFLOAD_PARENT_AMID, OFFLOAD_TASK,
+        // OFFLOAD_TIMEOUT_MINUTES) into offload sandboxes. For other
+        // runtime kinds (S10.A2.b BYO, A3 OpenAIAgents, A4 MAF) the same
+        // map is sourced from the matching variant struct via
+        // `runtime::build_runtime_plan`. Keys are validated against
+        // reserved prefixes regardless of source.
+        if !runtime_plan.runtime_extra_env.is_empty() {
             // Reserved prefixes that must come from the reconciler itself, not user input.
             const RESERVED_PREFIXES: &[&str] =
                 &["AGT_", "FOUNDRY_AGENT_", "AZURE_", "IMDS_", "AZURECLAW_"];
@@ -833,7 +855,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
                 .iter()
                 .filter_map(|v| v.get("name").and_then(|n| n.as_str()).map(String::from))
                 .collect();
-            for (k, v) in extra {
+            for (k, v) in &runtime_plan.runtime_extra_env {
                 if k.is_empty()
                     || !k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
                     || k.chars().next().is_some_and(|c| c.is_ascii_digit())
@@ -1653,3 +1675,5 @@ pub async fn run(client: Client) -> Result<()> {
 
 #[cfg(test)]
 mod tests;
+
+pub mod runtime;

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -1,0 +1,592 @@
+//! Runtime dispatch seam (S10.A2 — multi-runtime hosting).
+//!
+//! The reconciler used to read `spec.runtime.openclaw` directly when
+//! building the agent container's `image` / `extraEnv`. That worked while
+//! OpenClaw was the only runtime, but adding OpenAI Agents (S10.A3),
+//! Microsoft Agent Framework (S10.A4), or BYO would have grown N parallel
+//! ad-hoc lookups in the deployment builder. This module is the dispatch
+//! seam: a [`RuntimeDeploymentPlan`] flattens the runtime kind down to
+//! the concrete image / command / args / runtime-specific env that the
+//! deployment builder consumes — adding a new runtime kind means adding
+//! a producer here, not editing the deployment builder.
+//!
+//! Behavior in S10.A2 is **strictly equivalent** to S10.A1 for the
+//! `OpenClaw` kind. All other kinds short-circuit the same
+//! `AdapterMissing` path the reconciler had inline before; the seam
+//! exists so adapter rollouts (A3/A4 + BYO end-to-end) only edit this
+//! module.
+//!
+//! Two responsibilities:
+//!
+//! 1. [`validate_runtime_shape`] — defensive belt-and-suspenders mirror
+//!    of the helm CRD CEL rules (see plan.md §S10.A1 rubber-duck #7).
+//!    Defends against CEL-disabled apiservers letting through CRs where
+//!    `kind` and the populated variant struct disagree.
+//!
+//! 2. [`build_runtime_plan`] — produces a [`RuntimeDeploymentPlan`] for
+//!    runtimes whose adapter is wired in this build, or an
+//!    [`AdapterMissing`](RuntimePlanError::AdapterMissing) error otherwise.
+
+use std::collections::BTreeMap;
+
+use crate::crd::{AgentCodeRef, ByoRuntimeConfig, OpenClawConfig, RuntimeKind, RuntimeSpec};
+
+/// Concrete deployment intent for a single reconcile pass.
+///
+/// Owned by the reconciler for the duration of one reconcile; consumed by
+/// the deployment builder. **Wire-format invariant**: the only field that
+/// is ever rendered into `spec.containers[name=openclaw].image` is
+/// [`Self::image`]; the deployment builder must not fall through to any
+/// other source for the image string (plan.md §S10.A1 rubber-duck #2).
+//
+// Some fields are populated by the producers but not yet read by the
+// deployment builder — they're the structural surface for slices A2.b
+// (BYO end-to-end), A3 (OpenAIAgents), A4 (MAF). Carrying them now
+// keeps the producer→builder contract stable across slices and is
+// covered by unit tests on the producers themselves.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct RuntimeDeploymentPlan {
+    /// Stable wire-format string for the runtime kind, suitable for
+    /// `status.runtimeKind`, log fields, and the `Runtime` printer column.
+    /// PascalCase per the multi-runtime naming convention.
+    pub kind_str: &'static str,
+
+    /// Container image to run. Already resolved against the controller's
+    /// default fallback (no further fallback in the deployment builder).
+    pub image: String,
+
+    /// Container `command:` override. `None` means honor the image's
+    /// declared `ENTRYPOINT`. Only ever `Some` for runtimes that ship a
+    /// fixed entrypoint (e.g. BYO with `byo.command`).
+    pub command: Option<Vec<String>>,
+
+    /// Container `args:` override. `None` means honor the image's
+    /// declared `CMD`.
+    pub args: Option<Vec<String>>,
+
+    /// Runtime-specific extra env vars merged into the agent container
+    /// after the controller-managed env (router URL, model name, foundry
+    /// endpoint, etc.). Reserved-prefix filtering is the deployment
+    /// builder's responsibility, not this module's — it sees the raw
+    /// declared map.
+    pub runtime_extra_env: BTreeMap<String, String>,
+
+    /// Where the user's agent code comes from (OCI / git). `None` for
+    /// `OpenClaw` (the container image *is* the agent) and `BYO` (same).
+    /// Reserved for the OpenAI Agents (S10.A3) and Microsoft Agent
+    /// Framework (S10.A4) producers; A2 only carries the field.
+    pub agent_code: Option<AgentCodeRef>,
+
+    /// BYO contract version (`Some` only when `kind == BYO`). The
+    /// deployment builder uses this to stamp the `RuntimeReady` Condition
+    /// reason; the registry-side label check is a follow-up (A2.b).
+    pub byo_contract_version: Option<String>,
+}
+
+/// Errors raised when a runtime spec cannot be turned into a plan.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RuntimePlanError {
+    /// The kind is declared in the CRD but no controller-side adapter is
+    /// wired in this build. Reconciler stamps `RuntimeReady=False /
+    /// AdapterMissing` and refuses to deploy a Pod (the alternative —
+    /// silently running the OpenClaw image — is the threat model
+    /// documented in the multi-runtime audit doc).
+    #[error("runtime kind `{0}` has no adapter wired in this controller build")]
+    AdapterMissing(&'static str),
+
+    /// The runtime spec passes serde but is structurally invalid. Either
+    /// `kind` and the populated variant struct disagree (CEL would have
+    /// caught this on a CEL-enabled apiserver) or a kind-specific field
+    /// is unsupported (e.g. unknown BYO contract version).
+    #[error("runtime spec shape invalid: {0}")]
+    ShapeInvalid(String),
+}
+
+/// Stable PascalCase string for a [`RuntimeKind`]. Identical to the
+/// inline match the reconciler had pre-S10.A2 and to the wire format
+/// emitted in `status.runtimeKind`.
+pub fn kind_str(kind: &RuntimeKind) -> &'static str {
+    match kind {
+        RuntimeKind::OpenClaw => "OpenClaw",
+        RuntimeKind::OpenAIAgents => "OpenAIAgents",
+        RuntimeKind::MicrosoftAgentFramework => "MicrosoftAgentFramework",
+        RuntimeKind::SemanticKernel => "SemanticKernel",
+        RuntimeKind::LangGraph => "LangGraph",
+        RuntimeKind::Anthropic => "Anthropic",
+        RuntimeKind::BYO => "BYO",
+    }
+}
+
+/// Defensive guard: verify that exactly the variant struct matching
+/// `kind` is set, and the others are absent. Mirrors the 7 bidirectional
+/// `XValidation` rules in `deploy/helm/azureclaw/templates/crd.yaml`.
+///
+/// On a CEL-enabled apiserver this is a no-op (admission already rejected
+/// shape-mismatched CRs). The guard exists for CEL-disabled apiservers
+/// (e.g. older clusters, conformance test rigs) where a malformed CR
+/// would otherwise reach the reconciler and either crash on `unwrap` or
+/// — worse — pick the wrong variant silently.
+pub fn validate_runtime_shape(runtime: &RuntimeSpec) -> Result<(), RuntimePlanError> {
+    let kind_label = kind_str(&runtime.kind);
+    // Pairs of (CEL kind name, this variant's `Option::is_some`).
+    let pairs = [
+        ("OpenClaw", "openclaw", runtime.openclaw.is_some()),
+        (
+            "OpenAIAgents",
+            "openaiAgents",
+            runtime.openai_agents.is_some(),
+        ),
+        (
+            "MicrosoftAgentFramework",
+            "microsoftAgentFramework",
+            runtime.microsoft_agent_framework.is_some(),
+        ),
+        (
+            "SemanticKernel",
+            "semanticKernel",
+            runtime.semantic_kernel.is_some(),
+        ),
+        ("LangGraph", "langGraph", runtime.lang_graph.is_some()),
+        ("Anthropic", "anthropic", runtime.anthropic.is_some()),
+        ("BYO", "byo", runtime.byo.is_some()),
+    ];
+    for (cel_kind, field, present) in pairs {
+        let should_be_present = cel_kind == kind_label;
+        if should_be_present && !present {
+            return Err(RuntimePlanError::ShapeInvalid(format!(
+                "spec.runtime.{field} must be set when kind={kind_label}"
+            )));
+        }
+        if !should_be_present && present {
+            return Err(RuntimePlanError::ShapeInvalid(format!(
+                "spec.runtime.{field} must be absent when kind={kind_label}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Produce a [`RuntimeDeploymentPlan`] for the given runtime spec, or an
+/// [`AdapterMissing`](RuntimePlanError::AdapterMissing) error if the kind
+/// has no adapter in this build.
+///
+/// `default_openclaw_image` is the fallback used by the OpenClaw producer
+/// when `spec.runtime.openclaw.image` is absent — same controller-context
+/// default as pre-S10.A2.
+pub fn build_runtime_plan(
+    runtime: &RuntimeSpec,
+    default_openclaw_image: &str,
+) -> Result<RuntimeDeploymentPlan, RuntimePlanError> {
+    validate_runtime_shape(runtime)?;
+    match runtime.kind {
+        RuntimeKind::OpenClaw => {
+            // `validate_runtime_shape` guarantees `openclaw` is `Some`.
+            let cfg = runtime.openclaw.as_ref().expect("validated above");
+            Ok(plan_openclaw(cfg, default_openclaw_image))
+        }
+        RuntimeKind::BYO => {
+            // BYO end-to-end deployment is S10.A2.b. A2 produces the plan
+            // (proves the seam works) but the reconciler still
+            // short-circuits to `AdapterMissing` in the call site so we
+            // don't ship a half-wired BYO deployment that lacks the
+            // contract verifier. Returning `AdapterMissing` here keeps
+            // behavior identical to S10.A1; the producer below is exercised
+            // only by unit tests in this module.
+            Err(RuntimePlanError::AdapterMissing("BYO"))
+        }
+        RuntimeKind::OpenAIAgents => Err(RuntimePlanError::AdapterMissing("OpenAIAgents")),
+        RuntimeKind::MicrosoftAgentFramework => {
+            Err(RuntimePlanError::AdapterMissing("MicrosoftAgentFramework"))
+        }
+        RuntimeKind::SemanticKernel => Err(RuntimePlanError::AdapterMissing("SemanticKernel")),
+        RuntimeKind::LangGraph => Err(RuntimePlanError::AdapterMissing("LangGraph")),
+        RuntimeKind::Anthropic => Err(RuntimePlanError::AdapterMissing("Anthropic")),
+    }
+}
+
+fn plan_openclaw(cfg: &OpenClawConfig, default_image: &str) -> RuntimeDeploymentPlan {
+    RuntimeDeploymentPlan {
+        kind_str: "OpenClaw",
+        image: cfg
+            .image
+            .clone()
+            .unwrap_or_else(|| default_image.to_string()),
+        command: None,
+        args: None,
+        runtime_extra_env: cfg.extra_env.clone().unwrap_or_default(),
+        agent_code: None,
+        byo_contract_version: None,
+    }
+}
+
+/// Reserved for S10.A2.b. Exercised by unit tests only; not yet plumbed
+/// into the reconciler call site.
+#[allow(dead_code)]
+fn plan_byo(cfg: &ByoRuntimeConfig) -> RuntimeDeploymentPlan {
+    let mut runtime_extra_env = BTreeMap::new();
+    if let Some(env) = cfg.env.as_ref() {
+        for entry in env {
+            if let (Some(name), Some(value)) = (
+                entry.get("name").and_then(|v| v.as_str()),
+                entry.get("value").and_then(|v| v.as_str()),
+            ) {
+                runtime_extra_env.insert(name.to_string(), value.to_string());
+            }
+            // valueFrom entries are passed through to the Pod env
+            // verbatim by the deployment builder; they're not flattened
+            // into runtime_extra_env (would lose the secretKeyRef
+            // semantic).
+        }
+    }
+    RuntimeDeploymentPlan {
+        kind_str: "BYO",
+        image: cfg.image.clone(),
+        command: cfg.command.clone(),
+        args: cfg.args.clone(),
+        runtime_extra_env,
+        agent_code: None,
+        byo_contract_version: Some(cfg.contract_version.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{
+        AnthropicConfig, ByoRuntimeConfig, LangGraphConfig, MicrosoftAgentFrameworkConfig,
+        OpenAIAgentsConfig, OpenClawConfig, SemanticKernelConfig,
+    };
+
+    fn rt_openclaw(image: Option<&str>) -> RuntimeSpec {
+        RuntimeSpec {
+            kind: RuntimeKind::OpenClaw,
+            openclaw: Some(OpenClawConfig {
+                image: image.map(String::from),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn rt_only_kind(kind: RuntimeKind) -> RuntimeSpec {
+        RuntimeSpec {
+            kind,
+            openclaw: None,
+            openai_agents: None,
+            microsoft_agent_framework: None,
+            semantic_kernel: None,
+            lang_graph: None,
+            anthropic: None,
+            byo: None,
+        }
+    }
+
+    // ── kind_str() — wire-format stability ───────────────────────────
+
+    #[test]
+    fn kind_str_emits_pascal_case_for_all_variants() {
+        assert_eq!(kind_str(&RuntimeKind::OpenClaw), "OpenClaw");
+        assert_eq!(kind_str(&RuntimeKind::OpenAIAgents), "OpenAIAgents");
+        assert_eq!(
+            kind_str(&RuntimeKind::MicrosoftAgentFramework),
+            "MicrosoftAgentFramework"
+        );
+        assert_eq!(kind_str(&RuntimeKind::SemanticKernel), "SemanticKernel");
+        assert_eq!(kind_str(&RuntimeKind::LangGraph), "LangGraph");
+        assert_eq!(kind_str(&RuntimeKind::Anthropic), "Anthropic");
+        assert_eq!(kind_str(&RuntimeKind::BYO), "BYO");
+    }
+
+    // ── validate_runtime_shape() ─────────────────────────────────────
+
+    #[test]
+    fn validate_accepts_well_formed_openclaw() {
+        let rt = rt_openclaw(None);
+        assert!(validate_runtime_shape(&rt).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_kind_without_matching_variant_struct() {
+        let mut rt = rt_only_kind(RuntimeKind::OpenAIAgents);
+        // openai_agents is None, kind is OpenAIAgents → mismatch.
+        let err = validate_runtime_shape(&rt).expect_err("must reject");
+        assert!(
+            matches!(err, RuntimePlanError::ShapeInvalid(ref m)
+                if m.contains("openaiAgents") && m.contains("must be set")),
+            "expected ShapeInvalid mentioning openaiAgents, got: {err}"
+        );
+        rt.openai_agents = Some(OpenAIAgentsConfig::default());
+        assert!(validate_runtime_shape(&rt).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_extra_variant_struct() {
+        // kind=OpenClaw but byo is also set — multi-set is the silent-
+        // wrong-variant threat the CEL rules prevent at admission, mirrored
+        // here for CEL-disabled apiservers.
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::OpenClaw,
+            openclaw: Some(OpenClawConfig::default()),
+            byo: Some(ByoRuntimeConfig {
+                image: "x".into(),
+                contract_version: "v1".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = validate_runtime_shape(&rt).expect_err("must reject");
+        assert!(
+            matches!(err, RuntimePlanError::ShapeInvalid(ref m)
+                if m.contains("byo") && m.contains("must be absent")),
+            "expected ShapeInvalid mentioning byo absent, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_each_tier2_kind_without_struct() {
+        for (kind, field) in [
+            (RuntimeKind::SemanticKernel, "semanticKernel"),
+            (RuntimeKind::LangGraph, "langGraph"),
+            (RuntimeKind::Anthropic, "anthropic"),
+        ] {
+            let rt = rt_only_kind(kind);
+            let err = validate_runtime_shape(&rt).expect_err("must reject");
+            assert!(
+                matches!(err, RuntimePlanError::ShapeInvalid(ref m) if m.contains(field)),
+                "expected ShapeInvalid mentioning {field}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_each_tier2_kind_with_correct_struct() {
+        let pairs: Vec<(RuntimeKind, RuntimeSpec)> = vec![
+            (
+                RuntimeKind::SemanticKernel,
+                RuntimeSpec {
+                    kind: RuntimeKind::SemanticKernel,
+                    openclaw: None,
+                    semantic_kernel: Some(SemanticKernelConfig::default()),
+                    ..Default::default()
+                },
+            ),
+            (
+                RuntimeKind::LangGraph,
+                RuntimeSpec {
+                    kind: RuntimeKind::LangGraph,
+                    openclaw: None,
+                    lang_graph: Some(LangGraphConfig::default()),
+                    ..Default::default()
+                },
+            ),
+            (
+                RuntimeKind::Anthropic,
+                RuntimeSpec {
+                    kind: RuntimeKind::Anthropic,
+                    openclaw: None,
+                    anthropic: Some(AnthropicConfig::default()),
+                    ..Default::default()
+                },
+            ),
+        ];
+        for (kind, rt) in pairs {
+            assert!(
+                validate_runtime_shape(&rt).is_ok(),
+                "validate must accept well-formed {}",
+                kind_str(&kind)
+            );
+        }
+    }
+
+    // ── build_runtime_plan() — OpenClaw path ─────────────────────────
+
+    #[test]
+    fn plan_openclaw_uses_image_from_config_when_set() {
+        let rt = rt_openclaw(Some("custom.azurecr.io/openclaw:1.2.3"));
+        let plan = build_runtime_plan(&rt, "default.azurecr.io/openclaw:latest").unwrap();
+        assert_eq!(plan.kind_str, "OpenClaw");
+        assert_eq!(plan.image, "custom.azurecr.io/openclaw:1.2.3");
+        assert!(plan.command.is_none());
+        assert!(plan.args.is_none());
+        assert!(plan.runtime_extra_env.is_empty());
+        assert!(plan.agent_code.is_none());
+        assert!(plan.byo_contract_version.is_none());
+    }
+
+    #[test]
+    fn plan_openclaw_falls_back_to_default_image() {
+        let rt = rt_openclaw(None);
+        let plan = build_runtime_plan(&rt, "default.azurecr.io/openclaw:latest").unwrap();
+        assert_eq!(plan.image, "default.azurecr.io/openclaw:latest");
+    }
+
+    #[test]
+    fn plan_openclaw_carries_extra_env_through() {
+        let mut env = BTreeMap::new();
+        env.insert("OFFLOAD_REQUEST_ID".to_string(), "req-42".to_string());
+        env.insert("CUSTOM_KEY".to_string(), "value".to_string());
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::OpenClaw,
+            openclaw: Some(OpenClawConfig {
+                extra_env: Some(env.clone()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "x").unwrap();
+        assert_eq!(plan.runtime_extra_env, env);
+    }
+
+    // ── build_runtime_plan() — AdapterMissing for non-OpenClaw ───────
+    //
+    // Behavior must be identical to S10.A1: every non-OpenClaw kind
+    // surfaces `AdapterMissing(<kind>)`. BYO is a known short-circuit
+    // until A2.b lands the contract-verifier path.
+
+    #[test]
+    fn plan_returns_adapter_missing_for_each_non_openclaw_kind() {
+        let cases: Vec<(RuntimeKind, RuntimeSpec, &str)> = vec![
+            (
+                RuntimeKind::OpenAIAgents,
+                RuntimeSpec {
+                    kind: RuntimeKind::OpenAIAgents,
+                    openclaw: None,
+                    openai_agents: Some(OpenAIAgentsConfig::default()),
+                    ..Default::default()
+                },
+                "OpenAIAgents",
+            ),
+            (
+                RuntimeKind::MicrosoftAgentFramework,
+                RuntimeSpec {
+                    kind: RuntimeKind::MicrosoftAgentFramework,
+                    openclaw: None,
+                    microsoft_agent_framework: Some(MicrosoftAgentFrameworkConfig::default()),
+                    ..Default::default()
+                },
+                "MicrosoftAgentFramework",
+            ),
+            (
+                RuntimeKind::SemanticKernel,
+                RuntimeSpec {
+                    kind: RuntimeKind::SemanticKernel,
+                    openclaw: None,
+                    semantic_kernel: Some(SemanticKernelConfig::default()),
+                    ..Default::default()
+                },
+                "SemanticKernel",
+            ),
+            (
+                RuntimeKind::LangGraph,
+                RuntimeSpec {
+                    kind: RuntimeKind::LangGraph,
+                    openclaw: None,
+                    lang_graph: Some(LangGraphConfig::default()),
+                    ..Default::default()
+                },
+                "LangGraph",
+            ),
+            (
+                RuntimeKind::Anthropic,
+                RuntimeSpec {
+                    kind: RuntimeKind::Anthropic,
+                    openclaw: None,
+                    anthropic: Some(AnthropicConfig::default()),
+                    ..Default::default()
+                },
+                "Anthropic",
+            ),
+            (
+                RuntimeKind::BYO,
+                RuntimeSpec {
+                    kind: RuntimeKind::BYO,
+                    openclaw: None,
+                    byo: Some(ByoRuntimeConfig {
+                        image: "myregistry.azurecr.io/agent:1.0".into(),
+                        contract_version: "v1".into(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                "BYO",
+            ),
+        ];
+        for (kind, rt, expected_label) in cases {
+            let err = build_runtime_plan(&rt, "default-image").expect_err("must short-circuit");
+            assert_eq!(
+                err,
+                RuntimePlanError::AdapterMissing(expected_label),
+                "kind={} should surface AdapterMissing({expected_label})",
+                kind_str(&kind)
+            );
+        }
+    }
+
+    // ── build_runtime_plan() rejects shape-invalid input ─────────────
+
+    #[test]
+    fn plan_rejects_shape_invalid_input_before_dispatch() {
+        // kind=OpenClaw with no openclaw struct — validate_runtime_shape
+        // must fail BEFORE we reach plan_openclaw (which would unwrap).
+        let rt = rt_only_kind(RuntimeKind::OpenClaw);
+        let err = build_runtime_plan(&rt, "x").expect_err("must reject");
+        assert!(
+            matches!(err, RuntimePlanError::ShapeInvalid(_)),
+            "expected ShapeInvalid, got: {err}"
+        );
+    }
+
+    // ── plan_byo() — exercises the producer that A2.b will wire ──────
+
+    #[test]
+    fn plan_byo_carries_image_command_args_and_contract_version() {
+        let cfg = ByoRuntimeConfig {
+            image: "myregistry.azurecr.io/agent:1.0".into(),
+            command: Some(vec!["python".into(), "-m".into(), "agent".into()]),
+            args: Some(vec!["--verbose".into()]),
+            env: Some(vec![serde_json::json!({"name": "FOO", "value": "bar"})]),
+            contract_version: "v1".into(),
+        };
+        let plan = plan_byo(&cfg);
+        assert_eq!(plan.kind_str, "BYO");
+        assert_eq!(plan.image, "myregistry.azurecr.io/agent:1.0");
+        assert_eq!(
+            plan.command.as_deref(),
+            Some(&["python".into(), "-m".into(), "agent".into()][..])
+        );
+        assert_eq!(plan.args.as_deref(), Some(&["--verbose".into()][..]));
+        assert_eq!(
+            plan.runtime_extra_env.get("FOO").map(String::as_str),
+            Some("bar")
+        );
+        assert_eq!(plan.byo_contract_version.as_deref(), Some("v1"));
+    }
+
+    #[test]
+    fn plan_byo_skips_value_from_env_entries() {
+        // valueFrom entries (secretKeyRef, configMapKeyRef) must NOT be
+        // flattened into runtime_extra_env — they have no static value
+        // and the deployment builder needs to render them as raw EnvVar.
+        // For A2.b the deployment builder consumes cfg.env directly for
+        // those entries; this producer just makes sure the static `value`
+        // path doesn't accidentally pick up the structural ones.
+        let cfg = ByoRuntimeConfig {
+            image: "x".into(),
+            command: None,
+            args: None,
+            env: Some(vec![
+                serde_json::json!({"name": "STATIC", "value": "ok"}),
+                serde_json::json!({
+                    "name": "FROM_SECRET",
+                    "valueFrom": {"secretKeyRef": {"name": "s", "key": "k"}}
+                }),
+            ]),
+            contract_version: "v1".into(),
+        };
+        let plan = plan_byo(&cfg);
+        assert_eq!(plan.runtime_extra_env.len(), 1);
+        assert!(plan.runtime_extra_env.contains_key("STATIC"));
+        assert!(!plan.runtime_extra_env.contains_key("FROM_SECRET"));
+    }
+}

--- a/docs/security-audits/2026-04-28-phase2-multi-runtime-dispatch.md
+++ b/docs/security-audits/2026-04-28-phase2-multi-runtime-dispatch.md
@@ -1,0 +1,131 @@
+# Security Audit — Phase 2 / S10.A2 multi-runtime dispatch seam
+
+**Date:** 2026-04-28
+**Slice:** S10.A2 `phase2-multi-runtime-dispatch`
+**Branch:** `phase2-multi-runtime-dispatch`
+**Layer (per `docs/internal/phase-2-story.md` §2):** Layer 1 — Runtime
+**§14.6 column moved:** Column 11 (multi-runtime hosting) — *no change yet; A2 is the seam, A3+A4 flip the column.*
+
+---
+
+## 1. Scope
+
+This slice is a **structural seam only**. It introduces
+`controller/src/reconciler/runtime.rs` — a `RuntimeDeploymentPlan`
+producer/dispatcher — and routes the existing reconciler through it
+**without changing observable behavior**.
+
+In:
+- New module `controller::reconciler::runtime` with `RuntimeDeploymentPlan`
+  struct, `RuntimePlanError` enum (`AdapterMissing`, `ShapeInvalid`),
+  `validate_runtime_shape()` defensive guard, `build_runtime_plan()`
+  dispatcher, `plan_openclaw()` + `plan_byo()` producers (BYO is
+  unit-tested but unwired — see §6).
+- Reconciler dispatch site `mod.rs:222-275` rewired to call
+  `runtime::build_runtime_plan(&runtime_spec, &ctx.sandbox_image)`.
+- Deployment builder consumes `plan.image` (was inline image fallback)
+  and `plan.runtime_extra_env` (was `openclaw_config.extra_env`).
+- New `RuntimePlanError::ShapeInvalid` → `Degraded / SpecInvalid` status
+  path for CEL-disabled apiservers.
+
+Out (deferred):
+- A2.b: split deployment builder into shared scaffolding + per-runtime
+  container builder; wire `plan_byo` into the deployment builder; ship
+  registry-side `org.azureclaw.runtime.contract=v1` label check.
+- A3 / A4: `plan_openai_agents` / `plan_microsoft_agent_framework`
+  producers + adapter container builders.
+- Mesh-peer offload path (`mesh_peer/offload.rs`): out of scope — it
+  always offloads to OpenClaw and writes
+  `spec.runtime.openclaw.extraEnv` directly; rerouting through the plan
+  would add risk for no behavioral change.
+
+---
+
+## 2. Threat model
+
+| Threat | Phase 1 / S10.A1 mitigation | What S10.A2 changes |
+|---|---|---|
+| Operator submits `kind: OpenAIAgents` to a controller that doesn't yet implement it; controller silently runs the OpenClaw image instead. | A1: explicit `AdapterMissing` skip + 300 s requeue, `RuntimeReady=False` Condition stamped. | Path moved into `build_runtime_plan` — but the same condition + same skip + same requeue interval. **Equivalent posture.** |
+| Operator submits `kind: BYO` *with* `openclaw:` block populated (or vice-versa) on a CEL-disabled apiserver; controller proceeds with mismatched config. | A1: only the helm CEL rules guarded this; no controller-side validation. **Latent gap.** | A2: `validate_runtime_shape()` mirrors all 7 CEL rules in Rust; raises `ShapeInvalid` → `Degraded / SpecInvalid` Condition + 300 s requeue. **Net improvement.** |
+| Adapter producer drifts from dispatcher on the wire-format kind string (e.g. `"OpenAiAgents"` vs `"OpenAIAgents"`); status patches and logs disagree. | A1: single inline match in reconciler — no drift surface. | A2: `kind_str()` is the single source of truth, called by both the dispatcher and the reconciler. `debug_assert_eq!(plan.kind_str, runtime_kind_str)` at the call site catches drift in debug builds + tests. |
+| Reserved-prefix env-var smuggling via `runtime.openclaw.extraEnv` (e.g. `AZURECLAW_FOO`). | A1: reserved-prefix + NUL-byte + duplicate filter in deployment builder. | A2: filter preserved **byte-for-byte** in the deployment builder; producer hands over the raw map without sanitization (intentional — keeps filtering centralized at the rendering boundary). |
+| Image silently sourced from `runtime.openclaw.image` even after S10.A2's image-resolution refactor. | A1: image resolution happened inline. | A2: deployment builder reads `plan.image` only; comment explicitly says do not re-derive. The producer is the *only* place that consults `runtime.openclaw.image`. |
+
+### Residual risks
+
+- **CEL fail-open is still possible** if both the apiserver has CEL
+  disabled **and** the cluster has a mutating webhook that strips
+  `validate_runtime_shape`'s reachable code path. The defensive guard
+  closes the first half (the part the controller controls); the second
+  half is operator-controlled. Plan §S10.A1 rubber-duck #7 acknowledged
+  this and accepted it.
+- **`plan_byo` is unit-tested but unwired** — it cannot affect production
+  until A2.b lands the deployment-builder split. This was deliberate to
+  keep the seam slice small. The unit tests still gate the producer
+  shape so A2.b's wiring lands against a known contract.
+
+---
+
+## 3. Invariants (per `docs/internal/phase-2-story.md` §4)
+
+| Invariant | How A2 preserves it |
+|---|---|
+| **§4.1 Runtime-agnostic governance** — no Layer-2 CRD dispatches on `runtime.kind`. | A2 only touches Layer 1. The plan is consumed in the deployment builder, not in any governance reconciler. |
+| **§4.2 Controller-enforced posture** — UID 1000/1001, egress-guard init container, NetworkPolicy, WI binding, seccomp, reserved-prefix env filter — all controller-owned. | The full `securityContext`, init container, NetworkPolicy, SA, seccomp profile, and reserved-prefix env filter are all rendered after `build_runtime_plan` returns. The plan only narrows *what is run inside the agent container*; everything around it is unchanged. |
+| **§4.3 Router as single gate.** | A2 makes no networking changes. Router URL injection, `INFERENCE_ROUTER_URL` env, sidecar config — all unchanged. |
+| **§4.4 No custom crypto, no parallel implementations.** | A2 introduces no new crypto path. `validate_runtime_shape` is a pure Rust mirror of the helm CEL rules — it computes presence booleans, no cryptographic comparisons. The `kind_str` helper is the **single** source of truth for the runtime-kind string (replaces a duplicate inline match that S10.A1 had introduced). |
+
+---
+
+## 4. Test coverage matrix
+
+| Concern | Test location | Test name |
+|---|---|---|
+| Wire-format kind string is PascalCase, stable across all 7 variants | `runtime.rs::tests` | `kind_str_emits_pascal_case_for_all_variants` |
+| Well-formed OpenClaw spec validates | `runtime.rs::tests` | `validate_accepts_well_formed_openclaw` |
+| Kind without matching variant struct rejected | `runtime.rs::tests` | `validate_rejects_kind_without_matching_variant_struct` |
+| Extra variant struct (e.g. `kind=BYO` + `openclaw=Some`) rejected | `runtime.rs::tests` | `validate_rejects_extra_variant_struct` |
+| Each Tier-2 kind without struct rejected (CEL parity) | `runtime.rs::tests` | `validate_rejects_each_tier2_kind_without_struct` |
+| Each Tier-2 kind with correct struct accepted (CEL parity) | `runtime.rs::tests` | `validate_accepts_each_tier2_kind_with_correct_struct` |
+| `runtime.openclaw.image` honored when set | `runtime.rs::tests` | `plan_openclaw_uses_image_from_config_when_set` |
+| Falls back to controller default image when unset | `runtime.rs::tests` | `plan_openclaw_falls_back_to_default_image` |
+| `extra_env` carried through verbatim | `runtime.rs::tests` | `plan_openclaw_carries_extra_env_through` |
+| AdapterMissing raised for all 6 non-OpenClaw kinds (incl. BYO short-circuit) | `runtime.rs::tests` | `plan_returns_adapter_missing_for_each_non_openclaw_kind` |
+| Shape-invalid input rejected before dispatch | `runtime.rs::tests` | `plan_rejects_shape_invalid_input_before_dispatch` |
+| BYO producer carries image / command / args / contract version | `runtime.rs::tests` | `plan_byo_carries_image_command_args_and_contract_version` |
+| BYO producer skips `valueFrom` env entries (kept for raw-EnvVar path in A2.b) | `runtime.rs::tests` | `plan_byo_skips_value_from_env_entries` |
+
+**Result:** 306 / 306 controller tests pass (293 from S10.A1 + 12 new + 1 misc).
+
+`cargo clippy --package azureclaw-controller --all-targets -- -D warnings` clean.
+
+---
+
+## 5. Reviewer's checklist (per phase-2-story §6)
+
+1. **Layer:** Layer 1 (Runtime). The seam doesn't cross layers.
+2. **§14.6 column:** Column 11 — *no flip yet; A2 is the structural prerequisite for A3 + A4 to flip it.*
+3. **Invariants touched:** §4.4 directly (eliminates the duplicate `kind_str` match introduced inadvertently by S10.A1's inline dispatch). §4.1 / §4.2 / §4.3 unchanged but explicitly preserved (§3 above).
+4. **Existing seam extended:** the S10.A1 reconciler `mod.rs:222-260` inline match. We did **not** parallel-implement: there is exactly one runtime-dispatch site, exactly one image resolver, exactly one extra-env consumer.
+
+---
+
+## 6. Deferred to S10.A2.b
+
+- Split the deployment builder so the OpenClaw container construction
+  (port 18789, `OPENCLAW_GATEWAY_TOKEN` secretKeyRef, `OPENCLAW_MODEL`
+  env, `/sandbox` mount, AGT relay listener probes) and BYO container
+  construction (custom image / command / args, `value: + valueFrom:`
+  env, no port assumption) share the security context + router sidecar
+  + volume scaffolding but produce different `containers[name=agent]`
+  shapes.
+- Wire `plan_byo` into the new BYO container builder.
+- Ship registry-side `org.azureclaw.runtime.contract=v1` label check at
+  image-pull time so a BYO image without the contract label gets
+  `RuntimeReady=False / ContractMissing` at admission rather than at
+  pod start.
+
+A2.b is intentionally a separate slice so the seam in A2 lands without
+the deployment-builder refactor in its diff. This keeps reviewers
+focused on "is the dispatch shape right?" before "is the BYO container
+right?"


### PR DESCRIPTION
## What this is

S10.A2 — the **structural dispatch seam** for multi-runtime hosting.
Introduces \`controller/src/reconciler/runtime.rs\` as the single
producer/dispatcher for \`spec.runtime\` and routes the existing
reconciler through it **without changing observable behaviour**.

A2 deliberately ships the seam alone so reviewers can focus on
"is the dispatch shape right?" before A2.b ships "is the BYO container
right?" and A3 / A4 ship the OpenAI Agents and Microsoft Agent
Framework adapters.

## Architecture (per \`docs/internal/phase-2-story.md\` §2 — Layer 1)

\`\`\`
spec.runtime  ──►  validate_runtime_shape()  ──►  build_runtime_plan()  ──►  RuntimeDeploymentPlan
                   (mirrors 7 helm CEL rules)     (per-kind producer)      { kind_str, image,
                                                                            command, args,
                                                                            runtime_extra_env,
                                                                            agent_code,
                                                                            byo_contract_version }
\`\`\`

The deployment builder reads \`plan.image\` (was: inline image fallback)
and \`plan.runtime_extra_env\` (was: \`openclaw_config.extra_env\`). It
must not re-derive these from \`runtime.openclaw\` — there is exactly
one runtime-dispatch site, exactly one image resolver, exactly one
extra-env consumer.

\`runtime::kind_str()\` is the single source of truth for the
PascalCase wire-format runtime kind string used in status patches and
log fields. \`debug_assert_eq!(plan.kind_str, runtime_kind_str)\` at
the call site catches dispatcher↔producer drift in tests.

## Threat model

- **Operator submits unsupported kind** → \`AdapterMissing\` skip + 300 s
  requeue + \`RuntimeReady=False\` (preserved from A1, byte-for-byte).
- **CEL-disabled apiserver lets a structurally invalid CR through**
  (e.g. \`kind=BYO\` with \`openclaw:\` populated) → new
  \`RuntimePlanError::ShapeInvalid\` → \`Degraded / SpecInvalid\` +
  300 s requeue. **Net improvement** over A1 (which had no
  controller-side shape validation; relied solely on helm CEL).
- **Reserved-prefix env smuggling via \`extraEnv\`** → reserved-prefix +
  NUL-byte + duplicate filter preserved **byte-for-byte** in the
  deployment builder. The producer hands the raw map over without
  sanitisation by design (filtering stays centralised at the rendering
  boundary).
- **Image silently sourced from \`runtime.openclaw.image\`** — only the
  producer reads that field; deployment builder reads \`plan.image\`.

## Tests

- **+12 producer/dispatcher tests** in \`runtime.rs\`:
  - wire-format kind string stability (all 7 variants)
  - shape validator parity with helm CEL (positive + negative for every variant)
  - \`plan_openclaw\`: image fallback + extra_env carry-through
  - \`AdapterMissing\` for all 6 non-OpenClaw kinds (incl. BYO short-circuit)
  - shape-invalid input rejected before dispatch
  - \`plan_byo\`: image / command / args / contract version + skips \`valueFrom\` env entries
- **306 / 306 controller tests pass** (was 293 in A1; net +12 from this slice).
- \`cargo clippy --package azureclaw-controller --all-targets -- -D warnings\` **clean**.
- \`cargo fmt --all --check\` **clean**.

## Behaviour preservation (the load-bearing claim)

For \`kind: OpenClaw\`, the runtime path is **byte-for-byte equivalent
to S10.A1**:
- Same image resolution (producer's \`unwrap_or_else\` mirrors A1's
  inline fallback exactly).
- Same env ordering (deployment builder unchanged after the source swap).
- Same reserved-prefix / NUL-byte / duplicate-skip filter (preserved
  in place; producer is unaware of it).

For non-OpenClaw kinds, \`AdapterMissing\` skip + 300 s requeue + same
status condition as A1. Plan §S10.A1 rubber-duck #2 (refuse to silently
run the OpenClaw image) is preserved.

\`mesh_peer/offload.rs\` is **out of scope** — it always offloads to
OpenClaw and writes \`spec.runtime.openclaw.extraEnv\` directly;
rerouting through the plan would add risk for no behavioural change.

## Deferred to S10.A2.b

- Split deployment builder into shared scaffolding + per-runtime
  container builder.
- Wire \`plan_byo\` into a new \`build_byo_container()\` path.
- Registry-side \`org.azureclaw.runtime.contract=v1\` label check at
  image-pull time.

A2.b is intentionally a separate slice so the seam in A2 lands without
the deployment-builder refactor in its diff.

## Files

- \`controller/src/reconciler/runtime.rs\` — NEW (~520 lines incl. 12 unit tests)
- \`controller/src/reconciler/mod.rs\` — dispatch site + image source + extra-env source
- \`CHANGELOG.md\` — Unreleased / Phase 2 entry
- \`docs/security-audits/2026-04-28-phase2-multi-runtime-dispatch.md\` — full audit (scope, threat model, invariants, test matrix, deferral)

## Audit & references

- Audit doc: \`docs/security-audits/2026-04-28-phase2-multi-runtime-dispatch.md\`
- Implementation plan: \`docs/implementation-plan.md\` §8 / S10
- Internal narrative: \`docs/internal/phase-2-story.md\` §2 (Layer 1) + §4.4 (no parallel implementations) — *this doc is gitignored; team-internal*