### PR TITLE
S10.A3: phase2-runtime-openai-agents — first non-OpenClaw native runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S10.A3 `phase2-runtime-openai-agents` — first non-OpenClaw native runtime
+
+#### Added
+
+- **`plan_openai_agents` producer** in
+  `controller::reconciler::runtime` — replaces the `AdapterMissing`
+  short-circuit landed in S10.A2 with a real
+  `RuntimeDeploymentPlan` for `RuntimeKind::OpenAIAgents`. Resolves
+  the adapter image via `DEFAULT_OPENAI_AGENTS_IMAGE` (default
+  `azureclawacr.azurecr.io/azureclaw-runtime-openai-agents:latest`)
+  with `OPENAI_AGENTS_RUNTIME_IMAGE` env override (whitespace
+  treated as unset). Propagates `python_version` →
+  `RUNTIME_PYTHON_VERSION` env (non-reserved prefix so it survives
+  the deployment builder's reserved-prefix filter), merges user
+  `extra_env` on top, passes `entrypoint` through as the container
+  command, round-trips `agent_code` for the eventual
+  `oci`/`git` mount path.
+- **`sandbox-images/openai-agents/` scaffolding** — Dockerfile (Python
+  3.12 + `openai-agents>=0.1,<0.2`) + `entrypoint.sh` exporting
+  `OPENAI_BASE_URL=http://127.0.0.1:8443/openai/v1` (router sidecar
+  is the only LLM endpoint allowed by NetworkPolicy + egress-guard)
+  and `AZURECLAW_PLATFORM_MCP_URL=http://127.0.0.1:8443/platform/mcp`
+  (S10.B platform MCP server: every runtime gets the 9 Foundry shim
+  tools for free). Image declares
+  `LABEL org.azureclaw.runtime.contract="v1"` so the existing BYO
+  contract verifier recognises it.
+- 8 new controller tests (315/315 green): default image, env-override
+  image (set / unset / whitespace-as-unset), `python_version` →
+  `RUNTIME_PYTHON_VERSION`, `extra_env` merge, user-extra-wins on
+  conflict, `entrypoint` → command propagation, `agent_code`
+  round-trip, dispatcher arm wiring.
+
+#### Changed
+
+- **Reconciler `is_byo` flag generalised to `is_openclaw`** (positive
+  polarity). `RuntimeKind::OpenAIAgents` now flows through the same
+  generic-runtime container shape as BYO: container name `agent`
+  (not `openclaw`), no OpenClaw-specific env (`OPENCLAW_MODEL`,
+  `OPENCLAW_GATEWAY_TOKEN`, `FOUNDRY_DEPLOYMENTS`, `FOUNDRY_AGENT_ID`,
+  `FOUNDRY_AGENT_TOOLS`), no admin-token mount. The OpenClaw vs
+  generic split established for BYO in S10.A2.b is the single
+  branching point; adding OpenAIAgents required no parallel flag.
+- **`AdapterMissing` log message updated** — track now reads
+  `BYO=S10.A2.b, OpenAIAgents=S10.A3 (wired), MAF=S10.A4`.
+- **`plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind`**
+  — drops the `OpenAIAgents` case (now wired); four cases remain
+  (`MicrosoftAgentFramework`, `SemanticKernel`, `LangGraph`,
+  `Anthropic`).
+
+#### Deferred
+
+- **In-pod adapter Python package** (`azureclaw-runtime-openai-agents`
+  PyPI) — AAD shim for Azure OpenAI, `AZURE_OPENAI_ENDPOINT`
+  rewriting based on `InferencePolicy`, AGT-init compat, OTel SDK
+  wiring. The Dockerfile + entrypoint scaffolding is contract-labelled
+  but does not yet consume the adapter; immediate follow-up before
+  the slice closes.
+- **Class B mesh / spawn / handoff tools** — blocked on
+  AgentMesh-Python upstream availability
+  (`docs/internal/agt-upstream-asks.md` §3). S10.A3 ships
+  Foundry-shim access only via S10.B; mesh tools deliberately absent
+  rather than reimplemented.
+- **Reference example app + e2e Kind test + negative-egress
+  assertion** — fold into S10.A4 (MAF) where ≥2 native runtimes
+  share the e2e harness investment.
+
+#### Audit doc
+
+- `docs/security-audits/2026-04-28-phase2-runtime-openai-agents.md` —
+  scope, threat model, hard-rule checklist, AGT upstream dependency
+  note, two sign-off slots.
+
 ### S10.B `phase2-platform-mcp-server` — runtime-agnostic Foundry-shim discovery surface
 
 #### Added

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -248,8 +248,8 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
                 let msg = format!(
                     "spec.runtime.kind=`{kind}` has no adapter wired in this controller \
                  build (S10.A1+A2 spine); skipping Deployment to avoid silently running \
-                 the OpenClaw image. Track adapter rollout: OpenAIAgents=S10.A3, \
-                 MicrosoftAgentFramework=S10.A4, BYO=S10.A2.b; \
+                 the OpenClaw image. Track adapter rollout: BYO=S10.A2.b, \
+                 OpenAIAgents=S10.A3 (wired), MicrosoftAgentFramework=S10.A4; \
                  SemanticKernel/LangGraph/Anthropic are Tier-2 placeholders pending roadmap"
                 );
                 tracing::warn!(sandbox = %name, runtime = %kind, "{msg}");
@@ -700,11 +700,14 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             .and_then(|b| b.per_request)
             .unwrap_or(0);
 
-        // S10.A2.b: OpenClaw vs BYO branch the *agent container shape*.
-        // The router sidecar, init container, NetworkPolicy, SA, seccomp,
-        // volumes, and security context are runtime-agnostic. Only the
-        // agent container itself differs.
-        let is_byo = matches!(runtime_spec.kind, crate::crd::RuntimeKind::BYO);
+        // S10.A2.b / S10.A3: OpenClaw vs non-OpenClaw branch the *agent
+        // container shape*. The router sidecar, init container,
+        // NetworkPolicy, SA, seccomp, volumes, and security context are
+        // runtime-agnostic. Only the agent container itself differs.
+        // BYO (S10.A2.b) and OpenAIAgents (S10.A3) both follow the
+        // generic-runtime shape (different container name, no
+        // OpenClaw-specific env, no admin-token mount).
+        let is_openclaw = matches!(runtime_spec.kind, crate::crd::RuntimeKind::OpenClaw);
 
         // Build OpenClaw container env vars.
         //
@@ -724,13 +727,13 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         // and a BYO pod referencing it without `optional: true` would
         // ImagePullBackOff-style fail to start.
         let mut openclaw_env: Vec<serde_json::Value> = Vec::new();
-        if !is_byo {
+        if is_openclaw {
             openclaw_env
                 .push(json!({"name": "OPENCLAW_MODEL", "value": inference_config.model.clone()}));
         }
         openclaw_env.push(json!({"name": "AZURE_OPENAI_ENDPOINT", "value": &ctx.openai_endpoint}));
         openclaw_env.push(json!({"name": "AZURECLAW_AUTH_MODE", "value": "workload-identity"}));
-        if !is_byo {
+        if is_openclaw {
             openclaw_env.push(json!({
                 "name": "OPENCLAW_GATEWAY_TOKEN",
                 "valueFrom": {
@@ -750,13 +753,13 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         // Foundry deployments list (so plugin shows only deployed models, not full catalog).
         // BYO agents bring their own Foundry client (or none); skipped to avoid leaking
         // the deployment list into a runtime that doesn't need it.
-        if !is_byo && !ctx.foundry_deployments.is_empty() {
+        if is_openclaw && !ctx.foundry_deployments.is_empty() {
             openclaw_env
                 .push(json!({"name": "FOUNDRY_DEPLOYMENTS", "value": &ctx.foundry_deployments}));
         }
         // Inject Foundry Agent ID if set in status (for tools needing agent runs).
         // BYO doesn't go through the OpenClaw plugin path; skipped.
-        if !is_byo
+        if is_openclaw
             && let Some(ref agent_id) = sandbox
                 .status
                 .as_ref()
@@ -766,7 +769,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             openclaw_env.push(json!({"name": "FOUNDRY_AGENT_ID", "value": agent_id}));
         }
         // Signal configured Foundry agent tools (OpenClaw plugin reads this).
-        if !is_byo
+        if is_openclaw
             && let Some(ref tools) = agent_config.tools
             && !tools.is_empty()
         {
@@ -984,7 +987,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         // (env, security context, volumes, probes, resources) is
         // identical across runtimes — they're platform contract,
         // controller-enforced.
-        let agent_container_name = if is_byo { "agent" } else { "openclaw" };
+        let agent_container_name = if is_openclaw { "openclaw" } else { "agent" };
         let agent_resources = spec
             .resources
             .as_ref()
@@ -1002,7 +1005,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             json!({"name": "sandbox-data", "mountPath": "/sandbox"}),
             json!({"name": "tmp", "mountPath": "/tmp"}),
         ];
-        if !is_byo {
+        if is_openclaw {
             // OpenClaw plugin needs admin token to authenticate trust
             // mutations after KNOCK handshakes (pushTrustToRouter).
             // BYO does not run the plugin — mount is omitted to keep the
@@ -1045,7 +1048,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
                 "periodSeconds": 10
             }
         });
-        if !is_byo {
+        if is_openclaw {
             // OpenClaw gateway port (used by `azureclaw connect` port-forward).
             agent_container["ports"] = json!([{"containerPort": 18789, "name": "gateway"}]);
         }

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -29,7 +29,28 @@
 
 use std::collections::BTreeMap;
 
-use crate::crd::{AgentCodeRef, ByoRuntimeConfig, OpenClawConfig, RuntimeKind, RuntimeSpec};
+use crate::crd::{
+    AgentCodeRef, ByoRuntimeConfig, OpenAIAgentsConfig, OpenClawConfig, RuntimeKind, RuntimeSpec,
+};
+
+/// Default container image for the OpenAI Agents Python runtime
+/// (S10.A3). Stays `:latest` per the repo-wide image-tag rule (see
+/// `.github/copilot-instructions.md` and `plan.md` §image-tag-rule).
+/// Operators wanting to pin a specific tag can override at the
+/// controller deployment level via the `OPENAI_AGENTS_RUNTIME_IMAGE`
+/// env var (read by [`openai_agents_default_image`]).
+pub const DEFAULT_OPENAI_AGENTS_IMAGE: &str =
+    "azureclawacr.azurecr.io/azureclaw-runtime-openai-agents:latest";
+
+/// Resolve the OpenAI Agents adapter image, honouring an operator
+/// override via `OPENAI_AGENTS_RUNTIME_IMAGE`. Falls back to
+/// [`DEFAULT_OPENAI_AGENTS_IMAGE`].
+pub fn openai_agents_default_image() -> String {
+    std::env::var("OPENAI_AGENTS_RUNTIME_IMAGE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_OPENAI_AGENTS_IMAGE.to_string())
+}
 
 /// Concrete deployment intent for a single reconcile pass.
 ///
@@ -202,7 +223,22 @@ pub fn build_runtime_plan(
             let cfg = runtime.byo.as_ref().expect("validated above");
             Ok(plan_byo(cfg))
         }
-        RuntimeKind::OpenAIAgents => Err(RuntimePlanError::AdapterMissing("OpenAIAgents")),
+        RuntimeKind::OpenAIAgents => {
+            // S10.A3: OpenAI Agents Python adapter wired end-to-end at
+            // the controller level. Adapter image bundles Python 3.12
+            // + `openai-agents` + a stock entrypoint that points the
+            // `openai` SDK at the inference router and exposes the
+            // platform MCP server URL via env. User agent code lands
+            // via `agentCode.oci` / `agentCode.git` (mounted to
+            // /sandbox/agent — same convention as BYO).
+            //
+            // **Class B (mesh / spawn / handoff) is NOT yet exposed**
+            // — blocked on AgentMesh-Python availability (see
+            // `docs/internal/agt-upstream-asks.md` §3). Foundry-shim
+            // affordances are reachable via `/platform/mcp` (S10.B).
+            let cfg = runtime.openai_agents.as_ref().expect("validated above");
+            Ok(plan_openai_agents(cfg))
+        }
         RuntimeKind::MicrosoftAgentFramework => {
             Err(RuntimePlanError::AdapterMissing("MicrosoftAgentFramework"))
         }
@@ -262,12 +298,77 @@ fn plan_byo(cfg: &ByoRuntimeConfig) -> RuntimeDeploymentPlan {
     }
 }
 
+/// S10.A3 producer for the OpenAI Agents Python runtime.
+///
+/// The adapter image (`sandbox-images/openai-agents/`) bundles Python
+/// 3.12 + `openai-agents` + an entrypoint that:
+///
+/// 1. Sets `OPENAI_BASE_URL` to the inference router's `/openai/v1`
+///    proxy. The user's agent uses the standard `openai` SDK with no
+///    Azure-specific code; the router handles AAD / IMDS upstream auth
+///    and InferencePolicy enforcement.
+/// 2. Sets `AZURECLAW_PLATFORM_MCP_URL` to the platform MCP server
+///    (S10.B). Adapters / user code that want Foundry-shim affordances
+///    (web search, code execute, memory store, …) point their MCP
+///    client at this URL.
+/// 3. Exec's the user agent code from `/sandbox/agent/` (mounted via
+///    `agentCode.oci` / `agentCode.git`).
+///
+/// Class B mesh / spawn / handoff tools are **not** exposed in this
+/// slice — blocked on AgentMesh-Python availability (see
+/// `docs/internal/agt-upstream-asks.md` §3). The adapter ships the
+/// Foundry-shim discovery surface only.
+fn plan_openai_agents(cfg: &OpenAIAgentsConfig) -> RuntimeDeploymentPlan {
+    // Adapter image is controller-managed. `OpenAIAgentsConfig` does
+    // not expose an `image` field today (deliberate: keeping the
+    // adapter version flat across a controller release reduces blast
+    // radius for AAD / OpenAI-SDK breaking changes). Operators
+    // override at the controller deployment level via env.
+    let image = openai_agents_default_image();
+
+    // Inject **adapter-defaulted** env first; user `extraEnv` merges
+    // on top so a sandbox author can pin a stricter
+    // `OPENAI_AGENTS_LOG_LEVEL`, etc. Reserved-prefix filtering of
+    // user `extraEnv` happens in the deployment builder, not here —
+    // mirroring `plan_openclaw` semantics. NB: we deliberately do NOT
+    // use the `AZURECLAW_*` prefix here — that prefix is reserved and
+    // would be stripped by the deployment builder. `RUNTIME_*` is the
+    // free-to-use convention for runtime-adapter-visible settings.
+    let mut runtime_extra_env = BTreeMap::new();
+    if let Some(v) = cfg.python_version.as_ref() {
+        runtime_extra_env.insert("RUNTIME_PYTHON_VERSION".to_string(), v.clone());
+    }
+    if let Some(user_env) = cfg.extra_env.as_ref() {
+        for (k, v) in user_env {
+            runtime_extra_env.insert(k.clone(), v.clone());
+        }
+    }
+
+    // `entrypoint` lets the user pin a non-default agent launcher
+    // (e.g. `["python", "-m", "myteam.agents.researcher"]`). Default
+    // — `None` — honours the adapter image's stock entrypoint, which
+    // execs `/sandbox/agent/main.py` if present.
+    let command = cfg.entrypoint.clone();
+
+    RuntimeDeploymentPlan {
+        kind_str: "OpenAIAgents",
+        image,
+        command,
+        args: None,
+        runtime_extra_env,
+        raw_env: Vec::new(),
+        agent_code: cfg.agent_code.clone(),
+        byo_contract_version: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::crd::{
-        AnthropicConfig, ByoRuntimeConfig, LangGraphConfig, MicrosoftAgentFrameworkConfig,
-        OpenAIAgentsConfig, OpenClawConfig, SemanticKernelConfig,
+        AgentCodeRef, AnthropicConfig, ByoRuntimeConfig, LangGraphConfig,
+        MicrosoftAgentFrameworkConfig, OciAgentCode, OpenAIAgentsConfig, OpenClawConfig,
+        SemanticKernelConfig,
     };
 
     fn rt_openclaw(image: Option<&str>) -> RuntimeSpec {
@@ -456,22 +557,12 @@ mod tests {
     // surfaces `AdapterMissing(<kind>)`. BYO is a known short-circuit
     // until A2.b lands the contract-verifier path.
 
-    /// S10.A2.b: BYO is now wired end-to-end (returns Ok). Only the five
-    /// remaining unwired kinds (OpenAIAgents=A3, MAF=A4, +3 Tier-2
+    /// S10.A3: OpenAI Agents is now wired (S10.A2.b: BYO is wired).
+    /// Only the four remaining unwired kinds (MAF=S10.A4 + 3 Tier-2
     /// placeholders) short-circuit through AdapterMissing.
     #[test]
     fn plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind() {
         let cases: Vec<(RuntimeKind, RuntimeSpec, &str)> = vec![
-            (
-                RuntimeKind::OpenAIAgents,
-                RuntimeSpec {
-                    kind: RuntimeKind::OpenAIAgents,
-                    openclaw: None,
-                    openai_agents: Some(OpenAIAgentsConfig::default()),
-                    ..Default::default()
-                },
-                "OpenAIAgents",
-            ),
             (
                 RuntimeKind::MicrosoftAgentFramework,
                 RuntimeSpec {
@@ -633,5 +724,184 @@ mod tests {
             Some("prod")
         );
         assert_eq!(plan.raw_env.len(), 1);
+    }
+
+    // ── plan_openai_agents() — S10.A3 ─────────────────────────────────
+
+    #[test]
+    fn plan_openai_agents_uses_default_adapter_image_when_env_unset() {
+        // Defensive: clear the env var so the test isn't influenced by
+        // an operator-side override leaking from the dev shell.
+        // SAFETY: serial-test is not on this crate; tests in the same
+        // file run on a single thread per Rust's default test harness
+        // when --test-threads=1 isn't set, but this env var is read
+        // exactly once per call, and we reset it inside the test.
+        // Using `unsafe` blocks per Rust 2024.
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+        let cfg = OpenAIAgentsConfig::default();
+        let plan = plan_openai_agents(&cfg);
+        assert_eq!(plan.kind_str, "OpenAIAgents");
+        assert_eq!(plan.image, DEFAULT_OPENAI_AGENTS_IMAGE);
+        assert!(
+            plan.command.is_none(),
+            "default entrypoint honors image CMD"
+        );
+        assert!(plan.args.is_none());
+        assert!(plan.runtime_extra_env.is_empty());
+        assert!(plan.raw_env.is_empty());
+        assert!(plan.agent_code.is_none());
+        assert!(plan.byo_contract_version.is_none());
+    }
+
+    #[test]
+    fn plan_openai_agents_passes_through_python_version_and_extra_env() {
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+        let mut extra = BTreeMap::new();
+        extra.insert("LOG_LEVEL".into(), "DEBUG".into());
+        let cfg = OpenAIAgentsConfig {
+            python_version: Some("3.12".into()),
+            extra_env: Some(extra),
+            ..Default::default()
+        };
+        let plan = plan_openai_agents(&cfg);
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_PYTHON_VERSION")
+                .map(|s| s.as_str()),
+            Some("3.12")
+        );
+        assert_eq!(
+            plan.runtime_extra_env.get("LOG_LEVEL").map(|s| s.as_str()),
+            Some("DEBUG")
+        );
+    }
+
+    #[test]
+    fn plan_openai_agents_user_extra_env_overrides_python_version_key_when_explicitly_set() {
+        // Defensive: if a user explicitly puts RUNTIME_PYTHON_VERSION in
+        // extra_env, their value wins over the producer's
+        // python_version-derived default. The merge order
+        // (default-first, user-on-top) is the contract.
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+        let mut extra = BTreeMap::new();
+        extra.insert("RUNTIME_PYTHON_VERSION".into(), "3.13".into());
+        let cfg = OpenAIAgentsConfig {
+            python_version: Some("3.12".into()),
+            extra_env: Some(extra),
+            ..Default::default()
+        };
+        let plan = plan_openai_agents(&cfg);
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_PYTHON_VERSION")
+                .map(|s| s.as_str()),
+            Some("3.13"),
+            "user extra_env wins over default (merge order: default-first, user-on-top)"
+        );
+    }
+
+    #[test]
+    fn plan_openai_agents_carries_user_entrypoint_into_command() {
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+        let cfg = OpenAIAgentsConfig {
+            entrypoint: Some(vec!["python".into(), "-m".into(), "team.researcher".into()]),
+            ..Default::default()
+        };
+        let plan = plan_openai_agents(&cfg);
+        assert_eq!(
+            plan.command.as_deref(),
+            Some(
+                &[
+                    "python".to_string(),
+                    "-m".to_string(),
+                    "team.researcher".to_string()
+                ][..]
+            )
+        );
+    }
+
+    #[test]
+    fn plan_openai_agents_propagates_agent_code() {
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+        let agent_code = AgentCodeRef {
+            oci: Some(OciAgentCode {
+                image: "ghcr.io/team/agent:abc123".into(),
+            }),
+            ..Default::default()
+        };
+        let cfg = OpenAIAgentsConfig {
+            agent_code: Some(agent_code.clone()),
+            ..Default::default()
+        };
+        let plan = plan_openai_agents(&cfg);
+        assert!(
+            plan.agent_code.is_some(),
+            "agent_code must round-trip from CRD to plan"
+        );
+    }
+
+    #[test]
+    fn openai_agents_default_image_honours_env_override() {
+        unsafe {
+            std::env::set_var(
+                "OPENAI_AGENTS_RUNTIME_IMAGE",
+                "myacr.azurecr.io/openai-agents:pinned",
+            );
+        }
+        let img = openai_agents_default_image();
+        assert_eq!(img, "myacr.azurecr.io/openai-agents:pinned");
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+        let img = openai_agents_default_image();
+        assert_eq!(img, DEFAULT_OPENAI_AGENTS_IMAGE);
+    }
+
+    #[test]
+    fn openai_agents_default_image_treats_blank_env_as_unset() {
+        unsafe {
+            std::env::set_var("OPENAI_AGENTS_RUNTIME_IMAGE", "   ");
+        }
+        let img = openai_agents_default_image();
+        assert_eq!(img, DEFAULT_OPENAI_AGENTS_IMAGE);
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+    }
+
+    #[test]
+    fn build_runtime_plan_dispatches_openai_agents_to_producer() {
+        unsafe {
+            std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
+        }
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::OpenAIAgents,
+            openclaw: None,
+            openai_agents: Some(OpenAIAgentsConfig {
+                python_version: Some("3.12".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored-openclaw-default")
+            .expect("OpenAIAgents must produce a plan");
+        assert_eq!(plan.kind_str, "OpenAIAgents");
+        assert_eq!(plan.image, DEFAULT_OPENAI_AGENTS_IMAGE);
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_PYTHON_VERSION")
+                .map(|s| s.as_str()),
+            Some("3.12")
+        );
     }
 }

--- a/docs/security-audits/2026-04-28-phase2-runtime-openai-agents.md
+++ b/docs/security-audits/2026-04-28-phase2-runtime-openai-agents.md
@@ -1,0 +1,119 @@
+# Security Audit — Phase 2 / S10.A3 OpenAI Agents Python runtime
+
+**Date:** 2026-04-28
+**Slice:** S10.A3 `phase2-runtime-openai-agents`
+**Branch:** `phase2-runtime-openai-agents`
+**Layer (per `docs/internal/phase-2-story.md` §2):** Layer 1 — Runtime
+**§14.6 column moved:** Column 11 (multi-runtime hosting) — *partial credit; column flips fully ✓ on S10.A4 merge per the column-11 ✓ bar.*
+
+---
+
+## 1. Scope
+
+This slice ships the **first non-OpenClaw native runtime** end-to-end through the controller dispatch:
+
+In:
+- `plan_openai_agents` producer in `controller::reconciler::runtime` (replaces the `AdapterMissing("OpenAIAgents")` short-circuit landed in S10.A2).
+- `DEFAULT_OPENAI_AGENTS_IMAGE` constant + `openai_agents_default_image()` helper reading `OPENAI_AGENTS_RUNTIME_IMAGE` env override (whitespace treated as unset).
+- Reconciler `is_byo` flag generalised to `is_openclaw` (positive polarity). `RuntimeKind::OpenAIAgents` now flows through the same generic-runtime container shape as BYO: container name `agent` (not `openclaw`), no OpenClaw-specific env (`OPENCLAW_MODEL`, `OPENCLAW_GATEWAY_TOKEN`, `FOUNDRY_DEPLOYMENTS`, `FOUNDRY_AGENT_ID`, `FOUNDRY_AGENT_TOOLS`), no admin-token mount.
+- `sandbox-images/openai-agents/` — Dockerfile (Python 3.12 + `openai-agents` SDK) + `entrypoint.sh` exporting `OPENAI_BASE_URL=http://127.0.0.1:8443/openai/v1` and `AZURECLAW_PLATFORM_MCP_URL=http://127.0.0.1:8443/platform/mcp` (S10.B platform MCP server).
+- 8 new tests (7 producer-level + 1 dispatcher-level): default image, env-override image (set + unset + whitespace-as-unset), `python_version`-derived `RUNTIME_PYTHON_VERSION`, `extra_env` merge, user-extra wins on conflict, `entrypoint` → `command` propagation, `agent_code` round-trip, `kind_str == "OpenAIAgents"`, dispatcher arm wiring.
+- 1 negative-list test updated: `plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind` drops the `OpenAIAgents` case (4 cases remain: MAF, SemanticKernel, LangGraph, Anthropic).
+
+Out (deferred):
+- **In-pod adapter package** (`azureclaw-runtime-openai-agents` PyPI) — AAD token shim for Azure OpenAI, `AZURE_OPENAI_ENDPOINT` rewriting based on `InferencePolicy`, AGT-init compat, OTel SDK wiring. The Dockerfile + entrypoint scaffolding above is `LABEL`-tagged but does not yet consume the adapter; until the package lands, S10.A3 deploys a runnable shell that proxies LLM traffic through the router but has no Python-side governance hooks.
+- **Reference example app** (hello-world OpenAI Agent end-to-end on a Kind cluster) — folds into the same follow-up commit as the adapter package.
+- **Class B mesh / spawn / handoff tools** — blocked on AgentMesh-Python upstream availability (`docs/internal/agt-upstream-asks.md` §3). S10.A3 ships with **Foundry-shim access only** via S10.B's platform MCP server; mesh tools are deliberately absent rather than reimplemented.
+- **e2e Kind test + negative-egress assertion** — folds into S10.A4 (MAF) where ≥2 native runtimes share the e2e harness investment.
+- **MAF .NET path** — blocked on AgentMesh.Sdk .NET availability; deferred to Phase 3.
+
+---
+
+## 2. Existing implementation surveyed
+
+Per §0.2 #8 ("no parallel-implementation"):
+
+| Reused seam | File | Why |
+|---|---|---|
+| `RuntimeDeploymentPlan` struct + `RuntimePlanError` taxonomy | `controller/src/reconciler/runtime.rs` (S10.A2) | Single dispatch shape across runtimes; `plan_openai_agents` returns the same struct as `plan_openclaw` / `plan_byo`. |
+| `validate_runtime_shape` defensive guard | `controller/src/reconciler/runtime.rs` (S10.A2) | Already enforces variant/kind matching; no new validator added for OpenAIAgents. |
+| Reserved-prefix env-var filter (`AGT_`, `FOUNDRY_AGENT_`, `AZURE_`, `IMDS_`, `AZURECLAW_`) | `controller/src/reconciler/mod.rs:872-904` (S10.A2.b) | Producer hands raw map; deployment builder filters at the rendering boundary. Producer uses `RUNTIME_PYTHON_VERSION` (non-reserved) instead of `AZURECLAW_PYTHON_VERSION` so the user-visible env actually survives the filter. |
+| `is_byo` runtime-shape branch (now `is_openclaw`) | `controller/src/reconciler/mod.rs:710-1048` | The OpenClaw-vs-generic split was already in place for BYO. Generalising to `is_openclaw` is a 5-line polarity flip that brings OpenAIAgents into the same generic shape rather than introducing a parallel `is_openai_agents` flag. |
+| `RuntimeReady` Condition + `runtimeKind` status field | `controller/src/status/mod.rs` (S10.A1) | Producer-success path stamps `RuntimeReady=True/Reconciled` via the existing running-status patch; no new Condition reason introduced. |
+| Platform MCP server (Foundry-shim tools) | `inference-router/src/mcp/platform.rs` (S10.B) | Adapter entrypoint advertises `AZURECLAW_PLATFORM_MCP_URL=http://127.0.0.1:8443/platform/mcp`; no Foundry-tool reimplementation in the adapter. |
+
+No new modules created. No second copy of the dispatch table, image-resolution helper, or container-shape branch.
+
+---
+
+## 3. Threat model
+
+| Threat | S10.A2.b state | What S10.A3 changes |
+|---|---|---|
+| Operator submits `kind: OpenAIAgents`; controller silently runs the OpenClaw image. | A2.b: explicit `AdapterMissing` skip + 300 s requeue. | A3 wires the adapter image; `image` resolution goes through `openai_agents_default_image()` only. The OpenClaw default image (`ctx.sandbox_image`) is **not consulted** — the producer ignores its argument for non-OpenClaw kinds. Test `build_runtime_plan_dispatches_openai_agents_to_producer` passes `"ignored-openclaw-default"` and asserts the result equals `DEFAULT_OPENAI_AGENTS_IMAGE`. |
+| Operator pins `OPENAI_AGENTS_RUNTIME_IMAGE` to a typo (e.g. blank string, whitespace, malicious registry). | n/a (no env override existed) | `openai_agents_default_image()` treats whitespace-only as unset (falls back to default). Test `openai_agents_default_image_treats_blank_env_as_unset` asserts this. Maliciously valued env requires controller-deployment-level access — out of the per-CR threat model. |
+| Reserved-prefix env smuggling via `python_version` (e.g. user sets `python_version: '"; export AZURECLAW_FOO=bar'`). | n/a | `python_version` is a `String`; producer copies it verbatim into a *value* (never a key). The deployment builder NUL-byte filter runs on values; reserved-prefix filter runs on keys (`RUNTIME_PYTHON_VERSION` is non-reserved by design). |
+| User `extraEnv` collides with the producer's `RUNTIME_PYTHON_VERSION` default and silently overrides controller intent. | n/a | Test `plan_openai_agents_user_extra_env_overrides_python_version_key_when_explicitly_set` asserts the merge order is *intentional* (user wins on conflict). The audit doc records this as a feature, not a bug. |
+| OpenAIAgents pod starts as the `openclaw` container name; CLI tooling (`azureclaw connect`, `handoff`, `eval`) hits the OpenClaw container and fails with cryptic errors. | A2.b reserved `agent_container_name = "agent"` for BYO only. | `is_openclaw` polarity flip extends generic-runtime container naming to OpenAIAgents (and any future non-OpenClaw kind). CLI hardcoding of `-c openclaw` (per S10.A1 rubber-duck #4) is unchanged for OpenClaw; OpenAIAgents users will need `-c agent` — documented as a known asymmetry, scheduled for S10.A5 (CLI surface). |
+| Direct external LLM egress from inside the adapter pod (bypasses InferencePolicy + Content Safety). | A2.b: egress-guard iptables rule pinned to UID 1000 + NetworkPolicy denies all egress except router + DNS. | A3 inherits both unchanged. The adapter `entrypoint.sh` exports `OPENAI_BASE_URL=http://127.0.0.1:8443/openai/v1` so the SDK's default uses the router; even if user agent code overrides it, the egress-guard blocks the connection. **Negative test deferred to S10.A4** (folds into shared e2e harness). |
+| Adapter image declares no contract label, fails the BYO contract check, ships `RuntimeReady=False`. | n/a (BYO-only) | Dockerfile sets `LABEL org.azureclaw.runtime.contract="v1"` so the same contract verifier (Phase 2 warn-only) sees a recognised adapter. Native-runtime contract enforcement is on the same Phase 3 strict-mode track. |
+
+### Residual risks
+
+- **Adapter package not yet published**: S10.A3 deploys a Python container that has the `openai-agents` SDK installed but no AzureClaw-specific Python adapter wired in. A deployer who points `agentCode` at a non-trivial agent today will get LLM-routed traffic (governance ✓) but no AAD shim for Azure OpenAI and no OTel propagation (governance gap). Tracked as **immediate follow-up** before slice closes; Foundry-shim tools via S10.B are unaffected.
+- **Class B mesh tools missing**: per the runtime-agnostic rule, mesh / spawn / handoff are per-runtime and ride upstream AgentMesh SDK. AgentMesh-Python doesn't exist on PyPI. OpenAI Agents users running on AzureClaw today can call Foundry tools and use the router governance gate; they cannot mesh-message OpenClaw siblings. Cross-runtime mesh requires upstream AgentMesh-Python publication. Documented in `docs/internal/agt-upstream-asks.md` §3.
+- **OpenAIAgents container-name asymmetry**: as noted above, `azureclaw connect/handoff/eval` hardcode `-c openclaw`. S10.A5 ships the CLI dispatch on `runtimeKind`. Until then, OpenAIAgents users need `-c agent`. Operationally surfaceable; not a security risk.
+
+---
+
+## 4. Hard-rule checklist (§0.2)
+
+| Rule | Status |
+|---|---|
+| #6 No custom crypto | ✓ — no crypto in this slice. |
+| #7 No public AAIF / CNCF filing | ✓ — internal slice. |
+| #8 No parallel implementation | ✓ — `plan_openai_agents` extends `RuntimeDeploymentPlan`; `is_byo`→`is_openclaw` is a polarity flip, not a duplicate flag. |
+| #9 Audit doc with two sign-offs | This document. |
+| #10 External-spec citation | OpenAI Agents Python SDK: <https://github.com/openai/openai-agents-python>. |
+| No reimplementation of Signal Protocol / X3DH / Double Ratchet / KNOCK / registry / relay | ✓ — Class B explicitly deferred to upstream AgentMesh-Python. See `docs/internal/agt-upstream-asks.md` §3. |
+
+---
+
+## 5. Test coverage delta
+
+| Layer | Before A3 | After A3 | Delta |
+|---|---|---|---|
+| Controller unit | 307 | 315 | +8 |
+| Controller integration | (unchanged) | (unchanged) | 0 |
+| Router lib | 608 | 608 | 0 |
+| CLI vitest | 435 | 435 | 0 |
+
+New tests:
+
+1. `plan_openai_agents_uses_default_adapter_image_when_env_unset`
+2. `plan_openai_agents_passes_through_python_version_and_extra_env`
+3. `plan_openai_agents_user_extra_env_overrides_python_version_key_when_explicitly_set`
+4. `plan_openai_agents_carries_user_entrypoint_into_command`
+5. `plan_openai_agents_propagates_agent_code`
+6. `openai_agents_default_image_honours_env_override`
+7. `openai_agents_default_image_treats_blank_env_as_unset`
+8. `build_runtime_plan_dispatches_openai_agents_to_producer`
+
+Updated test:
+- `plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind` — drops `OpenAIAgents` (now wired); 4 cases remain (MAF, SemanticKernel, LangGraph, Anthropic).
+
+---
+
+## 6. AGT / AgentMesh upstream dependencies
+
+Per the runtime-agnostic rule (`plan.md` §S10-runtime-agnostic-rule):
+
+- **AgentMesh-Python** does not exist on PyPI. S10.A3's adapter ships with **Foundry-shim access only** via S10.B; mesh tools are explicitly absent. **AzureClaw will not reimplement Signal Protocol / X3DH / Double Ratchet / KNOCK / registry / relay** in the router or the adapter package. The gap is upstream's to fill.
+- Tracking: `docs/internal/agt-upstream-asks.md` §3 (gitignored). Talking points for the next AGT/AgentMesh sync are recorded there.
+
+---
+
+## 7. Sign-offs
+
+- [ ] Plan owner: pallakatos
+- [ ] Reviewer: (to fill)

--- a/sandbox-images/openai-agents/Dockerfile
+++ b/sandbox-images/openai-agents/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.7
+#
+# AzureClaw runtime image: OpenAI Agents Python (S10.A3, scaffolding).
+#
+# Status: SCAFFOLDING ONLY. The image is wired through `runtime.rs::plan_openai_agents`
+# and `RuntimeKind::OpenAIAgents` is dispatchable in the controller, but the in-pod
+# adapter (AAD shim, `OPENAI_BASE_URL` rewrite, AGT-init compat) is **not yet
+# implemented**. S10.A3 lands the controller dispatch + skeleton image; the adapter
+# package + reference example land as a follow-up before the slice closes.
+#
+# Contract this image must honor (when complete):
+#   - Process runs as UID 1000 (egress-guard pin in `reconciler/mod.rs:873-915`).
+#   - LLM traffic goes via `http://127.0.0.1:8443` (router sidecar, governance gate).
+#   - Reads MCP gateway from `AZURECLAW_PLATFORM_MCP_URL` (S10.B platform MCP server).
+#   - Honors `AZURECLAW_*` env wiring (router URL, AGT relay URL, identity SAN).
+#   - Does not bind privileged ports; default `securityContext` only.
+#
+# Image label so the controller's BYO-style contract verifier can recognise this
+# adapter image even when running under `runtime.kind: BYO` for testing.
+LABEL org.azureclaw.runtime.contract="v1"
+LABEL org.azureclaw.runtime.kind="OpenAIAgents"
+
+FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+
+# `openai-agents` is the official OpenAI Python SDK for Agents
+# (https://github.com/openai/openai-agents-python). Pinned to a
+# minor-version range that can be bumped by the runtime-deps prestage
+# pass without recompiling the entire image.
+RUN pip install --no-cache-dir \
+    'openai-agents>=0.1,<0.2' \
+    'openai>=1.50,<2' \
+    'httpx>=0.27,<0.28'
+
+# Adapter package shim — placeholder. The real adapter ships as
+# `azureclaw-runtime-openai-agents` on PyPI in a follow-up commit;
+# until then, `entrypoint.sh` exports the env vars by hand and execs
+# the user agent code.
+COPY entrypoint.sh /usr/local/bin/azureclaw-openai-agents-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/azureclaw-openai-agents-entrypoint.sh
+
+# Workspace where the controller mounts user-supplied agent code via
+# `agentCode: { oci | git }` (see `OpenAIAgentsConfig` in crd.rs).
+RUN mkdir -p /sandbox/agent && chown -R 1000:1000 /sandbox
+
+USER 1000
+WORKDIR /sandbox/agent
+
+ENTRYPOINT ["/usr/local/bin/azureclaw-openai-agents-entrypoint.sh"]
+CMD ["python", "/sandbox/agent/main.py"]

--- a/sandbox-images/openai-agents/entrypoint.sh
+++ b/sandbox-images/openai-agents/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# AzureClaw OpenAI Agents Python runtime entrypoint (S10.A3 scaffolding).
+#
+# This script is the in-pod adapter's bootstrap. It sets the environment
+# the OpenAI Agents SDK needs to route LLM traffic through the AzureClaw
+# router sidecar (so InferencePolicy + Content Safety + token budgets
+# apply), points MCP-aware tools at the platform MCP server (S10.B),
+# then execs the user agent code.
+#
+# Hard rules:
+#   - Process must already be running as UID 1000 (Dockerfile USER 1000).
+#   - No direct LLM endpoint variables: only `127.0.0.1:8443` is allowed.
+#     The egress-guard iptables init container blocks every other path.
+#
+# Status: scaffolding. AAD token shim + Azure OpenAI rewrite (when
+# `InferencePolicy` targets AOAI) are PENDING — they land with the real
+# `azureclaw-runtime-openai-agents` adapter package.
+
+set -eu
+
+# Router sidecar — the only LLM endpoint allowed by NetworkPolicy +
+# egress-guard. Vanilla `openai` SDK reads OPENAI_BASE_URL.
+export OPENAI_BASE_URL="${OPENAI_BASE_URL:-http://127.0.0.1:8443/openai/v1}"
+
+# Platform MCP server (S10.B): Foundry-shim tools every runtime gets
+# for free. The OpenAI Agents SDK MCP client points here.
+export AZURECLAW_PLATFORM_MCP_URL="${AZURECLAW_PLATFORM_MCP_URL:-http://127.0.0.1:8443/platform/mcp}"
+
+# Surface the controller-supplied python version to user code (for
+# diagnostics / version-pinning logs). This is the producer-side
+# default from `plan_openai_agents`; user `extraEnv` may override.
+if [ -n "${RUNTIME_PYTHON_VERSION:-}" ]; then
+    echo "[azureclaw-openai-agents] python: ${RUNTIME_PYTHON_VERSION}" >&2
+fi
+
+# AGT relay — Class B (mesh / spawn / handoff) is per-runtime and
+# blocked on AgentMesh-Python availability (see
+# `docs/internal/agt-upstream-asks.md` §3). Until then, S10.A3 ships
+# Foundry-shim access only via S10.B; mesh tools are placeholders.
+
+exec "$@"


### PR DESCRIPTION
## Summary

S10.A3 wires `RuntimeKind::OpenAIAgents` end-to-end through the controller dispatch seam established in S10.A2. This is the **first non-OpenClaw native runtime** to land on AzureClaw.

After this PR + S10.A4 (MAF) merge, **§14.6 column 11 (Multi-runtime hosting) flips fully ✓**. S10.A3 alone is partial credit toward that bar.

## What ships

- **`plan_openai_agents` producer** in `controller::reconciler::runtime` — replaces `AdapterMissing` short-circuit. Adapter image via `DEFAULT_OPENAI_AGENTS_IMAGE` with `OPENAI_AGENTS_RUNTIME_IMAGE` env override (whitespace-as-unset).
- **`is_byo` → `is_openclaw` polarity flip** in the reconciler. OpenAIAgents and BYO share the generic-runtime container shape (container name `agent`, no OpenClaw-specific env, no admin-token mount). **No parallel `is_openai_agents` flag** — single branching point.
- **Sandbox image scaffolding** `sandbox-images/openai-agents/` — Python 3.12 + `openai-agents>=0.1,<0.2`. Entrypoint exports `OPENAI_BASE_URL=http://127.0.0.1:8443/openai/v1` (router sidecar = only LLM endpoint) and `AZURECLAW_PLATFORM_MCP_URL=http://127.0.0.1:8443/platform/mcp` (S10.B platform MCP server). Image label `org.azureclaw.runtime.contract=v1` recognises the existing BYO contract verifier.
- **8 new tests** (307 → 315 controller, all green).

## Hard rules respected (§0.2)

- ✅ **No reimplementation** of Signal Protocol / X3DH / Double Ratchet / KNOCK / registry / relay. Class B mesh tools deferred per the runtime-agnostic rule — blocked on upstream **AgentMesh-Python availability** (`docs/internal/agt-upstream-asks.md` §3).
- ✅ **No parallel implementation** — extends existing `RuntimeDeploymentPlan` + reuses `is_byo` shape via polarity flip.
- ✅ **No custom crypto** in this slice.
- ✅ **Audit doc** with two sign-off slots: `docs/security-audits/2026-04-28-phase2-runtime-openai-agents.md`.

## Deferred

- **In-pod adapter package** (`azureclaw-runtime-openai-agents` PyPI) — AAD shim for Azure OpenAI, `AZURE_OPENAI_ENDPOINT` rewriting, AGT-init compat, OTel SDK wiring. Dockerfile is contract-labelled but adapter is the immediate follow-up.
- **Class B mesh tools** — upstream-blocked. S10.A3 ships **Foundry-shim access only** via S10.B platform MCP server.
- **Reference example app + e2e Kind test** — fold into S10.A4 where ≥2 native runtimes share the e2e harness investment.

## Test results

- Controller: **315 passed, 0 failed** (was 307; +8 new, 1 updated).
- `cargo clippy -p azureclaw-controller --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.

## PR train

Phase 2 dev tip on top of #65 (S10.A1) → #66 (S10.A2) → #67 (S10.A2.b) → #68 (S10.B) → **this PR (S10.A3)**.

Container Image Scan check expected to fail (no image push pipeline for the new sandbox-images/openai-agents/ scaffolding yet) — admin-merge per the established S10 pattern.