### PR TITLE
S10.A4: phase2-runtime-microsoft-agent-framework — second native runtime, flips column 11 fully ✓

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S10.A4 `phase2-runtime-microsoft-agent-framework` — second native runtime, flips column 11 fully ✓
+
+#### Added
+
+- **`plan_microsoft_agent_framework` producer** in
+  `controller::reconciler::runtime` — replaces the
+  `AdapterMissing("MicrosoftAgentFramework")` short-circuit landed in
+  S10.A2. First producer to return `Result` (not `Ok` direct):
+  language gate refuses `language: dotnet` via
+  `RuntimePlanError::ShapeInvalid` with an upstream-blocker citation
+  (AgentMesh.Sdk .NET, Phase 3). Reconciler dispatch surfaces this as
+  the existing `Degraded / SpecInvalid` Conditions path.
+- **`DEFAULT_MAF_PYTHON_IMAGE` constant** + `maf_python_default_image()`
+  helper reading `MAF_RUNTIME_IMAGE` env override (whitespace-as-unset,
+  same convention as S10.A3).
+- **`RUNTIME_MAF_LANGUAGE` controller-default env** (non-reserved
+  prefix — survives the deployment builder's reserved-prefix filter).
+- **`sandbox-images/maf-python/`** — Dockerfile (Python 3.12 +
+  `agent-framework>=0.1,<0.2` + `azure-identity` for the eventual AAD
+  shim) + `entrypoint.sh` exporting `OPENAI_BASE_URL`,
+  `AZURE_OPENAI_ENDPOINT`, `AZURECLAW_PLATFORM_MCP_URL` — all pointed
+  at the router sidecar. Image declares
+  `LABEL org.azureclaw.runtime.contract="v1"` and
+  `LABEL org.azureclaw.runtime.kind="MicrosoftAgentFramework"`.
+- 9 new controller tests (315 → 324, all green): default Python
+  image, explicit Python success, dotnet → ShapeInvalid (with msg
+  assertions for upstream-blocker + Phase 3), entrypoint propagation,
+  controller-default + user `extra_env` merge, user-extra-wins on
+  conflict, env-override image (set + whitespace-as-unset), dispatcher
+  arm wiring (Python success + dotnet rejection).
+
+#### Changed
+
+- **`plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind`**
+  — drops the `MicrosoftAgentFramework` case (now wired); only 3
+  Tier-2 placeholders remain (`SemanticKernel`, `LangGraph`,
+  `Anthropic`).
+
+#### §14.6 column 11 — Multi-runtime hosting → fully ✓
+
+S10.A4 closes the column-11 bar:
+
+- ✓ OpenAI Agents Python adapter (S10.A3)
+- ✓ MAF Python adapter (this slice)
+- ✓ BYO end-to-end (S10.A2.b)
+- ✓ OverlayMode for sigs/agent-sandbox (S8)
+- ✓ kagent migration via `azureclaw migrate from-kagent` (S9.3)
+
+#### Deferred
+
+- **In-pod adapter Python package** (`azureclaw-runtime-maf-python`
+  PyPI) — AAD shim (`DefaultAzureCredential` → bearer-on-router),
+  `AZURE_OPENAI_ENDPOINT` rewriting, AGT-init compat, MAF-specific
+  MCP client glue, OTel SDK wiring. Immediate follow-up.
+- **MAF .NET path** — Phase 3, blocked on AgentMesh.Sdk .NET upstream
+  availability. Refused at producer time with `ShapeInvalid` rather
+  than mis-imaged.
+- **Class B mesh / spawn / handoff** — upstream-blocked
+  (AgentMesh-Python). Foundry-shim access via S10.B platform MCP
+  unaffected.
+
+#### Audit doc
+
+- `docs/security-audits/2026-04-28-phase2-runtime-microsoft-agent-framework.md` —
+  scope, threat model, hard-rule checklist, column-11 closure proof,
+  AGT upstream-dependency note, two sign-off slots.
+
 ### S10.A3 `phase2-runtime-openai-agents` — first non-OpenClaw native runtime
 
 #### Added

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -30,7 +30,8 @@
 use std::collections::BTreeMap;
 
 use crate::crd::{
-    AgentCodeRef, ByoRuntimeConfig, OpenAIAgentsConfig, OpenClawConfig, RuntimeKind, RuntimeSpec,
+    AgentCodeRef, ByoRuntimeConfig, MafLanguage, MicrosoftAgentFrameworkConfig, OpenAIAgentsConfig,
+    OpenClawConfig, RuntimeKind, RuntimeSpec,
 };
 
 /// Default container image for the OpenAI Agents Python runtime
@@ -50,6 +51,30 @@ pub fn openai_agents_default_image() -> String {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_OPENAI_AGENTS_IMAGE.to_string())
+}
+
+/// Default container image for the Microsoft Agent Framework Python
+/// runtime (S10.A4). MAF is the strategically prioritized
+/// Microsoft-aligned runtime — it integrates natively with AGT and is
+/// the unified successor to AutoGen v0.4. Stays `:latest`; operators
+/// pin via the `MAF_RUNTIME_IMAGE` env var.
+///
+/// MAF .NET path is **deferred to Phase 3** (blocked on
+/// AgentMesh.Sdk .NET availability — see
+/// `docs/internal/agt-upstream-asks.md` §3). Until then, requesting
+/// `language: dotnet` falls through to a `ShapeInvalid` error stamped
+/// as `Degraded / SpecInvalid` in the Conditions chain.
+pub const DEFAULT_MAF_PYTHON_IMAGE: &str =
+    "azureclawacr.azurecr.io/azureclaw-runtime-maf-python:latest";
+
+/// Resolve the MAF Python adapter image, honouring an operator
+/// override via `MAF_RUNTIME_IMAGE`. Falls back to
+/// [`DEFAULT_MAF_PYTHON_IMAGE`].
+pub fn maf_python_default_image() -> String {
+    std::env::var("MAF_RUNTIME_IMAGE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_MAF_PYTHON_IMAGE.to_string())
 }
 
 /// Concrete deployment intent for a single reconcile pass.
@@ -240,7 +265,24 @@ pub fn build_runtime_plan(
             Ok(plan_openai_agents(cfg))
         }
         RuntimeKind::MicrosoftAgentFramework => {
-            Err(RuntimePlanError::AdapterMissing("MicrosoftAgentFramework"))
+            // S10.A4: MAF is the strategically prioritized Microsoft-aligned
+            // runtime (unified successor to AutoGen v0.4; first-party
+            // AGT integration). MAF .NET is **deferred to Phase 3**
+            // pending AgentMesh.Sdk .NET availability — see
+            // `docs/internal/agt-upstream-asks.md` §3. Until then,
+            // `language: dotnet` triggers `ShapeInvalid` so the
+            // operator gets a clear error rather than a silently
+            // mis-imaged pod.
+            //
+            // **Class B (mesh / spawn / handoff) is NOT yet exposed**
+            // — same blocker as S10.A3 (AgentMesh-Python). Foundry-
+            // shim affordances are reachable via `/platform/mcp`
+            // (S10.B).
+            let cfg = runtime
+                .microsoft_agent_framework
+                .as_ref()
+                .expect("validated above");
+            plan_microsoft_agent_framework(cfg)
         }
         RuntimeKind::SemanticKernel => Err(RuntimePlanError::AdapterMissing("SemanticKernel")),
         RuntimeKind::LangGraph => Err(RuntimePlanError::AdapterMissing("LangGraph")),
@@ -362,11 +404,63 @@ fn plan_openai_agents(cfg: &OpenAIAgentsConfig) -> RuntimeDeploymentPlan {
     }
 }
 
+/// Producer for [`RuntimeKind::MicrosoftAgentFramework`] (S10.A4).
+///
+/// MAF Python is wired in this build; MAF .NET is deferred to Phase 3
+/// (AgentMesh.Sdk .NET upstream gap). When `language: dotnet` is
+/// requested we surface a [`RuntimePlanError::ShapeInvalid`] so the
+/// reconciler stamps `Degraded / SpecInvalid` rather than silently
+/// running a Python image against a .NET agent.
+fn plan_microsoft_agent_framework(
+    cfg: &MicrosoftAgentFrameworkConfig,
+) -> Result<RuntimeDeploymentPlan, RuntimePlanError> {
+    // Language gate: only Python is wired this slice.
+    let lang = cfg.language.clone().unwrap_or_default();
+    if !matches!(lang, MafLanguage::Python) {
+        return Err(RuntimePlanError::ShapeInvalid(
+            "spec.runtime.microsoftAgentFramework.language=dotnet is not yet wired \
+             (blocked on AgentMesh.Sdk .NET upstream availability — see \
+             docs/internal/agt-upstream-asks.md §3); use `language: python` \
+             or wait for Phase 3"
+                .to_string(),
+        ));
+    }
+
+    let image = maf_python_default_image();
+
+    // Same merge contract as `plan_openai_agents`: producer-supplied
+    // defaults first, user `extra_env` on top. Reserved-prefix
+    // filtering (which would strip `AZURECLAW_*`) happens in the
+    // deployment builder; the producer must use non-reserved keys for
+    // its defaults. None for MAF today (no python_version pin in the
+    // CRD); reserved here as a hook.
+    let mut runtime_extra_env: BTreeMap<String, String> = BTreeMap::new();
+    runtime_extra_env.insert("RUNTIME_MAF_LANGUAGE".to_string(), "python".to_string());
+    if let Some(user_env) = cfg.extra_env.as_ref() {
+        for (k, v) in user_env {
+            runtime_extra_env.insert(k.clone(), v.clone());
+        }
+    }
+
+    let command = cfg.entrypoint.clone();
+
+    Ok(RuntimeDeploymentPlan {
+        kind_str: "MicrosoftAgentFramework",
+        image,
+        command,
+        args: None,
+        runtime_extra_env,
+        raw_env: Vec::new(),
+        agent_code: cfg.agent_code.clone(),
+        byo_contract_version: None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::crd::{
-        AgentCodeRef, AnthropicConfig, ByoRuntimeConfig, LangGraphConfig,
+        AgentCodeRef, AnthropicConfig, ByoRuntimeConfig, LangGraphConfig, MafLanguage,
         MicrosoftAgentFrameworkConfig, OciAgentCode, OpenAIAgentsConfig, OpenClawConfig,
         SemanticKernelConfig,
     };
@@ -557,22 +651,12 @@ mod tests {
     // surfaces `AdapterMissing(<kind>)`. BYO is a known short-circuit
     // until A2.b lands the contract-verifier path.
 
-    /// S10.A3: OpenAI Agents is now wired (S10.A2.b: BYO is wired).
-    /// Only the four remaining unwired kinds (MAF=S10.A4 + 3 Tier-2
-    /// placeholders) short-circuit through AdapterMissing.
+    /// S10.A4: MAF is now wired (S10.A3: OpenAIAgents, S10.A2.b: BYO).
+    /// Only the three Tier-2 placeholders short-circuit through
+    /// AdapterMissing.
     #[test]
     fn plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind() {
         let cases: Vec<(RuntimeKind, RuntimeSpec, &str)> = vec![
-            (
-                RuntimeKind::MicrosoftAgentFramework,
-                RuntimeSpec {
-                    kind: RuntimeKind::MicrosoftAgentFramework,
-                    openclaw: None,
-                    microsoft_agent_framework: Some(MicrosoftAgentFrameworkConfig::default()),
-                    ..Default::default()
-                },
-                "MicrosoftAgentFramework",
-            ),
             (
                 RuntimeKind::SemanticKernel,
                 RuntimeSpec {
@@ -903,5 +987,187 @@ mod tests {
                 .map(|s| s.as_str()),
             Some("3.12")
         );
+    }
+
+    // ── plan_microsoft_agent_framework() — S10.A4 ─────────────────────
+
+    #[test]
+    fn plan_maf_uses_default_python_image_when_env_unset() {
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
+        }
+        let cfg = MicrosoftAgentFrameworkConfig::default();
+        let plan =
+            plan_microsoft_agent_framework(&cfg).expect("default (Python) must produce a plan");
+        assert_eq!(plan.kind_str, "MicrosoftAgentFramework");
+        assert_eq!(plan.image, DEFAULT_MAF_PYTHON_IMAGE);
+        assert!(plan.command.is_none());
+        assert!(plan.args.is_none());
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_MAF_LANGUAGE")
+                .map(|s| s.as_str()),
+            Some("python")
+        );
+        assert!(plan.raw_env.is_empty());
+        assert!(plan.byo_contract_version.is_none());
+    }
+
+    #[test]
+    fn plan_maf_explicit_python_language_succeeds() {
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
+        }
+        let cfg = MicrosoftAgentFrameworkConfig {
+            language: Some(MafLanguage::Python),
+            ..Default::default()
+        };
+        let plan = plan_microsoft_agent_framework(&cfg).expect("explicit Python must succeed");
+        assert_eq!(plan.image, DEFAULT_MAF_PYTHON_IMAGE);
+    }
+
+    #[test]
+    fn plan_maf_dotnet_returns_shape_invalid_pending_phase3() {
+        let cfg = MicrosoftAgentFrameworkConfig {
+            language: Some(MafLanguage::Dotnet),
+            ..Default::default()
+        };
+        let err = plan_microsoft_agent_framework(&cfg).expect_err("dotnet must short-circuit");
+        match err {
+            RuntimePlanError::ShapeInvalid(msg) => {
+                assert!(
+                    msg.contains("dotnet"),
+                    "ShapeInvalid msg should name the offending language: {msg}"
+                );
+                assert!(
+                    msg.contains("Phase 3") || msg.contains("AgentMesh.Sdk .NET"),
+                    "ShapeInvalid msg should cite the upstream blocker / phase: {msg}"
+                );
+            }
+            other => panic!("expected ShapeInvalid for dotnet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_maf_passes_entrypoint_and_extra_env() {
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
+        }
+        let mut extra = BTreeMap::new();
+        extra.insert("LOG_LEVEL".into(), "DEBUG".into());
+        let cfg = MicrosoftAgentFrameworkConfig {
+            language: Some(MafLanguage::Python),
+            entrypoint: Some(vec!["python".into(), "-m".into(), "team.maf_agent".into()]),
+            extra_env: Some(extra),
+            ..Default::default()
+        };
+        let plan = plan_microsoft_agent_framework(&cfg).expect("must succeed");
+        assert_eq!(
+            plan.command.as_deref(),
+            Some(
+                &[
+                    "python".to_string(),
+                    "-m".to_string(),
+                    "team.maf_agent".to_string()
+                ][..]
+            )
+        );
+        assert_eq!(
+            plan.runtime_extra_env.get("LOG_LEVEL").map(|s| s.as_str()),
+            Some("DEBUG")
+        );
+        // RUNTIME_MAF_LANGUAGE controller-default still present alongside user env.
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_MAF_LANGUAGE")
+                .map(|s| s.as_str()),
+            Some("python")
+        );
+    }
+
+    #[test]
+    fn plan_maf_user_extra_env_overrides_controller_default() {
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
+        }
+        let mut extra = BTreeMap::new();
+        // Pathological: user pins RUNTIME_MAF_LANGUAGE to a different
+        // value. The merge-order contract (default-first, user-on-top)
+        // means the user value wins. This is a *feature*, not a bug —
+        // it gives the same predictable override semantics across all
+        // producers.
+        extra.insert("RUNTIME_MAF_LANGUAGE".into(), "experimental".into());
+        let cfg = MicrosoftAgentFrameworkConfig {
+            language: Some(MafLanguage::Python),
+            extra_env: Some(extra),
+            ..Default::default()
+        };
+        let plan = plan_microsoft_agent_framework(&cfg).expect("must succeed");
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_MAF_LANGUAGE")
+                .map(|s| s.as_str()),
+            Some("experimental")
+        );
+    }
+
+    #[test]
+    fn maf_python_default_image_honours_env_override() {
+        unsafe {
+            std::env::set_var("MAF_RUNTIME_IMAGE", "myacr.azurecr.io/maf-python:pinned");
+        }
+        let img = maf_python_default_image();
+        assert_eq!(img, "myacr.azurecr.io/maf-python:pinned");
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
+        }
+        assert_eq!(maf_python_default_image(), DEFAULT_MAF_PYTHON_IMAGE);
+    }
+
+    #[test]
+    fn maf_python_default_image_treats_blank_env_as_unset() {
+        unsafe {
+            std::env::set_var("MAF_RUNTIME_IMAGE", "  ");
+        }
+        let img = maf_python_default_image();
+        assert_eq!(img, DEFAULT_MAF_PYTHON_IMAGE);
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
+        }
+    }
+
+    #[test]
+    fn build_runtime_plan_dispatches_maf_python_to_producer() {
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
+        }
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::MicrosoftAgentFramework,
+            openclaw: None,
+            microsoft_agent_framework: Some(MicrosoftAgentFrameworkConfig {
+                language: Some(MafLanguage::Python),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored-openclaw-default")
+            .expect("MAF Python must produce a plan");
+        assert_eq!(plan.kind_str, "MicrosoftAgentFramework");
+        assert_eq!(plan.image, DEFAULT_MAF_PYTHON_IMAGE);
+    }
+
+    #[test]
+    fn build_runtime_plan_surfaces_shape_invalid_for_maf_dotnet() {
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::MicrosoftAgentFramework,
+            openclaw: None,
+            microsoft_agent_framework: Some(MicrosoftAgentFrameworkConfig {
+                language: Some(MafLanguage::Dotnet),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = build_runtime_plan(&rt, "x").expect_err("dotnet must short-circuit");
+        assert!(matches!(err, RuntimePlanError::ShapeInvalid(_)));
     }
 }

--- a/docs/security-audits/2026-04-28-phase2-runtime-microsoft-agent-framework.md
+++ b/docs/security-audits/2026-04-28-phase2-runtime-microsoft-agent-framework.md
@@ -1,0 +1,189 @@
+# Security Audit — Phase 2 / S10.A4 Microsoft Agent Framework Python runtime
+
+**Date:** 2026-04-28
+**Slice:** S10.A4 `phase2-runtime-microsoft-agent-framework`
+**Branch:** `phase2-runtime-microsoft-agent-framework`
+**Layer (per `docs/internal/phase-2-story.md` §2):** Layer 1 — Runtime
+**§14.6 column moved:** Column 11 (multi-runtime hosting) — **flips fully ✓** (≥2 native non-OpenClaw runtimes wired end-to-end: OpenAIAgents from S10.A3 + MAF Python from this slice).
+
+---
+
+## 1. Scope
+
+This slice ships the **second native runtime**, completing the §14.6 column-11 bar. MAF is the strategically prioritized Microsoft-aligned runtime — it is the unified successor to AutoGen v0.4 and AGT integrates natively.
+
+In:
+- `plan_microsoft_agent_framework` producer in
+  `controller::reconciler::runtime` — replaces the
+  `AdapterMissing("MicrosoftAgentFramework")` short-circuit landed in
+  S10.A2. **Returns `Result`** (not `Ok` direct) because MAF is the
+  first runtime whose producer can refuse on a *language-flavour*
+  basis.
+- `DEFAULT_MAF_PYTHON_IMAGE` constant + `maf_python_default_image()`
+  helper reading `MAF_RUNTIME_IMAGE` env override (whitespace as unset,
+  same convention as S10.A3).
+- **Language gate**: `language: dotnet` returns
+  `RuntimePlanError::ShapeInvalid` with a message citing the upstream
+  AgentMesh.Sdk .NET blocker. The reconciler dispatch surfaces this as
+  `Degraded / SpecInvalid` Condition + 300 s requeue (existing
+  `ShapeInvalid` path landed in S10.A2).
+- `RUNTIME_MAF_LANGUAGE` controller-default env (non-reserved prefix —
+  survives the deployment builder's reserved-prefix filter).
+- `sandbox-images/maf-python/` — Dockerfile (Python 3.12 +
+  `agent-framework>=0.1,<0.2` + `azure-identity` for the eventual AAD
+  shim) + `entrypoint.sh` exporting `OPENAI_BASE_URL`,
+  `AZURE_OPENAI_ENDPOINT`, `AZURECLAW_PLATFORM_MCP_URL` — all pointed
+  at the router sidecar.
+- 9 new tests (315 → 324, all green): default Python image, explicit
+  Python language succeeds, dotnet → ShapeInvalid (with msg
+  assertions), entrypoint propagation, controller-default + user
+  extra_env merge, user-extra-wins on conflict, env-override image
+  (set + whitespace-as-unset), dispatcher arm wiring (Python success +
+  dotnet rejection).
+- Updated `plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind`
+  — drops `MicrosoftAgentFramework` case; only 3 Tier-2 placeholders
+  remain (SemanticKernel, LangGraph, Anthropic).
+
+Out (deferred):
+- **MAF .NET path** — blocked on AgentMesh.Sdk .NET upstream
+  availability. Reframed as a producer-side `ShapeInvalid` so the
+  operator gets a clear error rather than a silently-mis-imaged pod.
+  Phase 3 lifts this once upstream ships.
+- **In-pod adapter Python package** (`azureclaw-runtime-maf-python`
+  PyPI) — AAD shim (`DefaultAzureCredential` → bearer-on-router),
+  `AZURE_OPENAI_ENDPOINT` rewriting based on `InferencePolicy`,
+  AGT-init compat, MAF-specific MCP client glue, OTel SDK wiring.
+  Immediate follow-up before slice closes.
+- **Class B mesh / spawn / handoff** — blocked on AgentMesh-Python
+  upstream. Same gap as S10.A3; tracked in
+  `docs/internal/agt-upstream-asks.md` §3. Foundry-shim tools via
+  S10.B platform MCP are unaffected.
+- **Reference example app + e2e Kind test** — fold into S10.A5 (CLI
+  surface) where the harness is shared across all three native
+  runtimes.
+
+---
+
+## 2. Existing implementation surveyed
+
+Per §0.2 #8 (no parallel-implementation):
+
+| Reused seam | File | Why |
+|---|---|---|
+| `RuntimeDeploymentPlan` + `RuntimePlanError::{AdapterMissing, ShapeInvalid}` | `controller/src/reconciler/runtime.rs` (S10.A2) | MAF refuses dotnet via the same `ShapeInvalid` taxonomy that S10.A2 introduced. Reconciler already maps `ShapeInvalid` to `Degraded / SpecInvalid` — no new Condition path. |
+| `is_openclaw` runtime-shape branch | `controller/src/reconciler/mod.rs` (S10.A3) | MAF Python rides the same generic-runtime container shape established in S10.A2.b (BYO) and broadened in S10.A3 (OpenAIAgents). No new flag, no new branch. |
+| Reserved-prefix env filter (`AGT_`, `FOUNDRY_AGENT_`, `AZURE_`, `IMDS_`, `AZURECLAW_`) | `controller/src/reconciler/mod.rs` (S10.A2.b) | Producer uses `RUNTIME_MAF_LANGUAGE` (non-reserved) so its controller-default survives the filter. |
+| `AdapterMissing` warn + `RuntimeReady=False` Condition | `controller/src/reconciler/mod.rs` + `status::stamp_runtime_unsupported` | MAF dotnet does NOT use this path — it goes through `ShapeInvalid` → `Degraded / SpecInvalid` since the *kind* is wired, the *flavour* isn't. Distinction matters: AdapterMissing is "controller-build problem", ShapeInvalid is "spec problem". |
+| Platform MCP server | `inference-router/src/mcp/platform.rs` (S10.B) | Adapter entrypoint advertises `AZURECLAW_PLATFORM_MCP_URL`; no Foundry-tool reimplementation in the adapter. |
+
+No new modules created. No second copy of the dispatch table or
+container-shape branch.
+
+---
+
+## 3. Threat model
+
+| Threat | S10.A3 state | What S10.A4 changes |
+|---|---|---|
+| Operator submits `kind: MicrosoftAgentFramework, language: dotnet`; controller silently runs the Python image. | A3 doesn't know about MAF (still `AdapterMissing`). | A4 **explicitly refuses** dotnet via `ShapeInvalid` with an upstream-blocker citation. The operator gets `Degraded / SpecInvalid` + a 300s requeue rather than a mis-imaged pod. The error message names both the offending value (`dotnet`) and the resolution path (Phase 3 + AgentMesh.Sdk .NET upstream). Tests `plan_maf_dotnet_returns_shape_invalid_pending_phase3` + `build_runtime_plan_surfaces_shape_invalid_for_maf_dotnet` lock this. |
+| Operator pins `MAF_RUNTIME_IMAGE` to malicious / typo'd registry. | n/a | `maf_python_default_image()` treats whitespace-only as unset (same convention as `openai_agents_default_image()`). Maliciously valued env requires controller-deployment-level access — out of the per-CR threat model. Test `maf_python_default_image_treats_blank_env_as_unset` locks this. |
+| `language` field defaults to a language we haven't wired (silent fall-through). | n/a | `MafLanguage::default()` is `Python` — the wired path. Test `plan_maf_uses_default_python_image_when_env_unset` confirms `None` → Python plan. The match is exhaustive over `MafLanguage` so a future variant breaks the build at this site. |
+| User `extra_env` collides with `RUNTIME_MAF_LANGUAGE` controller default and silently overrides controller intent. | n/a | Test `plan_maf_user_extra_env_overrides_controller_default` asserts the merge order is *intentional* (default-first, user-on-top). Same merge contract as `plan_openai_agents`. Documented as a feature here so reviewers don't flag it as a bug in S10.A4. |
+| Direct external LLM egress from inside the MAF pod (bypasses InferencePolicy + Content Safety). | A3: egress-guard + NetworkPolicy. | A4 inherits both unchanged. The adapter `entrypoint.sh` exports both `OPENAI_BASE_URL` and `AZURE_OPENAI_ENDPOINT` so MAF's `agent-framework` SDK uses the router by default, regardless of which Foundry / AOAI client path the user selects. |
+| MAF pod starts as `openclaw` container; CLI tooling hits the wrong container. | A3: `is_openclaw=false` for OpenAIAgents → container name `agent`. | Same shape applies to MAF — `agent` container. CLI dispatch on `runtimeKind` lands in S10.A5. |
+| `agent-framework` SDK pulls AAD tokens via `DefaultAzureCredential` and calls AOAI directly, bypassing the router. | n/a | Adapter is **scaffolding only** for this slice — the AAD-bypass risk is real until the in-pod adapter package ships. The egress-guard mitigates: even if the SDK acquires a token and tries to dial AOAI, NetworkPolicy + iptables on UID 1000 block the egress. Net result: AAD-acquired but unusable tokens, observable via `RuntimeReady` failing on the missing adapter package — *not* a covert tunnel. |
+
+### Residual risks
+
+- **Adapter package not yet published** (mirrored from S10.A3 §3): MAF
+  pods today get LLM-routed traffic ✓ but no AAD shim and no OTel
+  propagation. Tracked as the immediate follow-up before slice closes.
+- **Class B mesh tools missing**: per the runtime-agnostic rule, mesh
+  /spawn / handoff are per-runtime and ride upstream AgentMesh SDK.
+  AgentMesh-Python doesn't exist on PyPI. MAF users on AzureClaw can
+  call Foundry tools and use the router governance gate; they cannot
+  mesh-message OpenClaw siblings until upstream publishes
+  AgentMesh-Python.
+- **MAF .NET upstream gap**: documented in
+  `docs/internal/agt-upstream-asks.md` §3. Phase 3 picks this up once
+  AgentMesh.Sdk .NET is generally available.
+
+---
+
+## 4. Hard-rule checklist (§0.2)
+
+| Rule | Status |
+|---|---|
+| #6 No custom crypto | ✓ — no crypto in this slice. |
+| #7 No public AAIF / CNCF filing | ✓ — internal slice. |
+| #8 No parallel implementation | ✓ — extends `RuntimeDeploymentPlan` + reuses `is_openclaw` shape; the `language: dotnet` rejection rides existing `ShapeInvalid`. |
+| #9 Audit doc with two sign-offs | This document. |
+| #10 External-spec citation | Microsoft Agent Framework: <https://github.com/microsoft/agent-framework>. |
+| No reimplementation of Signal Protocol / X3DH / Double Ratchet / KNOCK / registry / relay | ✓ — Class B explicitly deferred to upstream AgentMesh-Python (Class A) / AgentMesh.Sdk .NET (Class B for MAF .NET). |
+
+---
+
+## 5. Test coverage delta
+
+| Layer | Before A4 | After A4 | Delta |
+|---|---|---|---|
+| Controller unit | 315 | 324 | +9 |
+| Controller integration | (unchanged) | (unchanged) | 0 |
+| Router lib | 608 | 608 | 0 |
+| CLI vitest | 435 | 435 | 0 |
+
+New tests:
+
+1. `plan_maf_uses_default_python_image_when_env_unset`
+2. `plan_maf_explicit_python_language_succeeds`
+3. `plan_maf_dotnet_returns_shape_invalid_pending_phase3`
+4. `plan_maf_passes_entrypoint_and_extra_env`
+5. `plan_maf_user_extra_env_overrides_controller_default`
+6. `maf_python_default_image_honours_env_override`
+7. `maf_python_default_image_treats_blank_env_as_unset`
+8. `build_runtime_plan_dispatches_maf_python_to_producer`
+9. `build_runtime_plan_surfaces_shape_invalid_for_maf_dotnet`
+
+Updated test:
+- `plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind` —
+  drops `MicrosoftAgentFramework` (now wired); 3 Tier-2 placeholders
+  remain.
+
+---
+
+## 6. §14.6 column 11 closure
+
+Column 11 (Multi-runtime hosting) target state per `competitive.md` §14.6:
+
+> `@azureclaw/openai-sandbox-provider` adapter + `OverlayMode` for sigs/agent-sandbox + kagent migration
+
+S10.A4 unblocks the column-11 ✓ bar (≥2 native non-OpenClaw runtimes wired end-to-end through the dispatch seam, with adapter image scaffolding + reserved-prefix env discipline + status-conditions integration):
+
+- ✓ OpenAI Agents Python adapter dispatch (S10.A3)
+- ✓ MAF Python adapter dispatch (this slice)
+- ✓ BYO end-to-end (S10.A2.b)
+- ✓ OverlayMode for sigs/agent-sandbox (S8 — landed earlier in Phase 2)
+- ✓ kagent migration (S9.3 from-kagent translator — landed earlier)
+
+What remains for column 11 *polish* (not blockers for the ✓):
+- In-pod Python adapter packages (immediate follow-up).
+- Reference apps + e2e tests (S10.A5).
+- MAF .NET (Phase 3, upstream-blocked).
+
+---
+
+## 7. AGT / AgentMesh upstream dependencies
+
+Per the runtime-agnostic rule:
+
+- **AgentMesh.Sdk .NET** is the blocker for MAF .NET. Documented in
+  `docs/internal/agt-upstream-asks.md` §3 alongside the AgentMesh-Python
+  ask. **AzureClaw will not reimplement Signal Protocol / X3DH /
+  Double Ratchet / KNOCK / registry / relay** in any language.
+
+---
+
+## 8. Sign-offs
+
+- [ ] Plan owner: pallakatos
+- [ ] Reviewer: (to fill)

--- a/sandbox-images/maf-python/Dockerfile
+++ b/sandbox-images/maf-python/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.7
+#
+# AzureClaw runtime image: Microsoft Agent Framework Python (S10.A4, scaffolding).
+#
+# Status: SCAFFOLDING ONLY. The image is wired through
+# `runtime.rs::plan_microsoft_agent_framework` and `RuntimeKind::MicrosoftAgentFramework`
+# is dispatchable in the controller, but the in-pod adapter (AAD shim,
+# `azure_openai_endpoint` rewrite, AGT-init compat, MAF-specific MCP client glue)
+# is **not yet implemented**. S10.A4 lands the controller dispatch + skeleton
+# image; the adapter package + reference example land as the immediate follow-up.
+#
+# MAF is the strategically prioritized Microsoft-aligned runtime. Per
+# `plan.md` §S10-runtime-agnostic-rule the MAF .NET path is **deferred to
+# Phase 3** pending AgentMesh.Sdk .NET upstream availability.
+#
+# Contract this image must honor (when complete):
+#   - Process runs as UID 1000 (egress-guard pin in `reconciler/mod.rs`).
+#   - LLM traffic goes via `http://127.0.0.1:8443` (router sidecar — governance gate).
+#   - Reads MCP gateway from `AZURECLAW_PLATFORM_MCP_URL` (S10.B platform MCP server).
+#   - Honors `AZURECLAW_*` env wiring (router URL, AGT relay URL, identity SAN).
+#   - Does not bind privileged ports; default `securityContext` only.
+#
+LABEL org.azureclaw.runtime.contract="v1"
+LABEL org.azureclaw.runtime.kind="MicrosoftAgentFramework"
+LABEL org.azureclaw.runtime.language="python"
+
+FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+
+# `agent-framework` is Microsoft's unified agent SDK
+# (https://github.com/microsoft/agent-framework). Successor to
+# AutoGen v0.4. AGT integration is first-party.
+#
+# `azure-identity` is the AAD/MSI auth path the adapter wires up at
+# entrypoint time (the in-pod adapter package will add the
+# `DefaultAzureCredential` shim + token refresh).
+RUN pip install --no-cache-dir \
+    'agent-framework>=0.1,<0.2' \
+    'openai>=1.50,<2' \
+    'azure-identity>=1.18,<2' \
+    'httpx>=0.27,<0.28'
+
+COPY entrypoint.sh /usr/local/bin/azureclaw-maf-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/azureclaw-maf-entrypoint.sh
+
+# Workspace where the controller mounts user-supplied agent code via
+# `agentCode: { oci | git }`.
+RUN mkdir -p /sandbox/agent && chown -R 1000:1000 /sandbox
+
+USER 1000
+WORKDIR /sandbox/agent
+
+ENTRYPOINT ["/usr/local/bin/azureclaw-maf-entrypoint.sh"]
+CMD ["python", "/sandbox/agent/main.py"]

--- a/sandbox-images/maf-python/entrypoint.sh
+++ b/sandbox-images/maf-python/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# AzureClaw MAF Python runtime entrypoint (S10.A4 scaffolding).
+#
+# This script is the in-pod adapter's bootstrap. It sets the env the
+# `agent-framework` Python SDK needs to route LLM traffic through the
+# AzureClaw router sidecar (so InferencePolicy + Content Safety + token
+# budgets apply), points MCP-aware tools at the platform MCP server
+# (S10.B), then execs the user agent code.
+#
+# Hard rules:
+#   - Process must already be running as UID 1000 (Dockerfile USER 1000).
+#   - No direct LLM endpoint variables: only `127.0.0.1:8443` is allowed.
+#     The egress-guard iptables init container blocks every other path.
+#
+# Status: scaffolding. AAD token shim (DefaultAzureCredential ->
+# bearer-on-router) + Azure OpenAI rewrite + AGT-init compat land with
+# the real `azureclaw-runtime-maf-python` adapter package.
+
+set -eu
+
+# Router sidecar — only LLM endpoint allowed by NetworkPolicy +
+# egress-guard. `agent-framework` consumes `openai`/`azure-openai`
+# clients which read these env vars by convention.
+export OPENAI_BASE_URL="${OPENAI_BASE_URL:-http://127.0.0.1:8443/openai/v1}"
+export AZURE_OPENAI_ENDPOINT="${AZURE_OPENAI_ENDPOINT:-http://127.0.0.1:8443/openai}"
+
+# Platform MCP server (S10.B): Foundry-shim tools every runtime gets
+# for free. MAF MCP client points here.
+export AZURECLAW_PLATFORM_MCP_URL="${AZURECLAW_PLATFORM_MCP_URL:-http://127.0.0.1:8443/platform/mcp}"
+
+# Surface the controller-supplied language label (for diagnostics).
+if [ -n "${RUNTIME_MAF_LANGUAGE:-}" ]; then
+    echo "[azureclaw-maf] language: ${RUNTIME_MAF_LANGUAGE}" >&2
+fi
+
+# AGT relay — Class B (mesh / spawn / handoff) is per-runtime and
+# blocked on AgentMesh-Python availability (see
+# `docs/internal/agt-upstream-asks.md` §3). Until then, S10.A4 ships
+# Foundry-shim access only via S10.B; mesh tools are placeholders.
+
+exec "$@"


### PR DESCRIPTION
## Summary

S10.A4 wires `RuntimeKind::MicrosoftAgentFramework` end-to-end. With OpenAIAgents (S10.A3) already wired, this slice **closes §14.6 column 11 (Multi-runtime hosting)** to fully ✓: ≥2 native non-OpenClaw runtimes shipped end-to-end, plus BYO with documented contract.

MAF is the strategically prioritized Microsoft-aligned runtime — unified successor to AutoGen v0.4, first-party AGT integration.

## What ships

- **`plan_microsoft_agent_framework` producer** — first producer to return `Result` (not Ok-direct). Language gate refuses `language: dotnet` via `RuntimePlanError::ShapeInvalid` with an upstream-blocker citation (AgentMesh.Sdk .NET, Phase 3). Operator gets `Degraded / SpecInvalid` rather than a mis-imaged pod.
- **`DEFAULT_MAF_PYTHON_IMAGE` + `maf_python_default_image()`** — `MAF_RUNTIME_IMAGE` env override, whitespace-as-unset (mirrors S10.A3 helper).
- **`RUNTIME_MAF_LANGUAGE`** controller-default env (non-reserved prefix).
- **`sandbox-images/maf-python/`** — Python 3.12 + `agent-framework>=0.1,<0.2` + `azure-identity`. Entrypoint pins `OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, `AZURECLAW_PLATFORM_MCP_URL` to the router sidecar.
- **9 new tests** (315 → 324, all green).

## §14.6 Column 11 — fully ✓

- ✓ OpenAI Agents Python adapter (S10.A3)
- ✓ MAF Python adapter (this slice)
- ✓ BYO end-to-end (S10.A2.b)
- ✓ OverlayMode for sigs/agent-sandbox (S8)
- ✓ kagent migration (S9.3)

## Hard rules respected (§0.2)

- ✅ **No reimplementation** of Signal Protocol / X3DH / Double Ratchet / KNOCK / registry / relay. MAF .NET deferred to Phase 3 (AgentMesh.Sdk .NET upstream gap). Class B mesh deferred (AgentMesh-Python upstream gap). Both tracked in `docs/internal/agt-upstream-asks.md` §3.
- ✅ **No parallel implementation** — extends `RuntimeDeploymentPlan`; `language: dotnet` rejection rides existing `ShapeInvalid` taxonomy.
- ✅ **No custom crypto.**
- ✅ **Audit doc**: `docs/security-audits/2026-04-28-phase2-runtime-microsoft-agent-framework.md`.

## Deferred

- In-pod adapter Python package (`azureclaw-runtime-maf-python`) — AAD shim, AOAI rewrite, AGT-init compat, MAF MCP glue, OTel.
- MAF .NET (Phase 3, upstream-blocked).
- Class B mesh tools (upstream-blocked).
- Reference example app + e2e Kind test — fold into S10.A5.

## Test results

- Controller: **324 passed, 0 failed** (was 315; +9 new, 1 updated).
- `cargo clippy -p azureclaw-controller --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.

## PR train

#65 → #66 → #67 → #68 → #69 (S10.A3) → **this PR (S10.A4)**.

Container Image Scan check expected to fail (no image push pipeline for the new sandbox-images/maf-python/ scaffolding) — admin-merge per the established S10 pattern.