### PR TITLE
S10.A5: phase2-runtime-cli — operator-facing multi-runtime CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S10.A5 `phase2-runtime-cli` — operator-facing CLI surface for multi-runtime hosting
+
+#### Added
+
+- **`cli/src/runtime.ts`** — single source of truth for runtime
+  helpers, mirroring the controller's `RuntimeKind` enum and
+  `is_openclaw` polarity. Exports `flagToKind` (kebab-case →
+  PascalCase wire format), `assertRuntimeWired` (rejects Tier-2 +
+  unwired MAF .NET at the CLI boundary), `agentContainerName`
+  (OpenClaw → `openclaw`, everything else → `agent`),
+  `runtimeKindFromCr` (live-CR reader with safe `OpenClaw` fallback
+  for legacy/unknown values), and `buildRuntimeBlock` (emits the
+  variant-correct `spec.runtime` block).
+- **`azureclaw add --runtime <kind>`** — accepts `openclaw` (default),
+  `openai-agents`, `microsoft-agent-framework`, `byo`. Tier-2 kinds
+  rejected with discoverable error listing the wired set. BYO
+  requires `--byo-image`; `--byo-contract-version` defaults to `v1`.
+  MAF defaults `--maf-language python`; `dotnet` rejected client-side
+  with explicit Phase 3 / upstream-blocker message.
+- **`azureclaw connect <name>`** — fetches the live ClawSandbox CR
+  and addresses the correct container with `kubectl exec -c` based
+  on `spec.runtime.kind`. Backward-compatible: legacy CRs without
+  `spec.runtime` fall back to `openclaw`.
+- **`azureclaw list`** — adds a `RUNTIME` column showing each
+  sandbox's `spec.runtime.kind` (defaults to `OpenClaw` for legacy
+  CRs).
+- **`cli/src/runtime.test.ts`** — 19 vitest unit tests covering
+  flag mapping, wired/unwired gates, container-name polarity, CR
+  reader fallbacks, and per-variant block shapes.
+
+#### Tests
+
+- CLI vitest: 435 → 454 passing (+19), 2 skipped (unchanged).
+- `npx tsc --noEmit` clean; `npm run build` clean.
+- No new lint diagnostics (26 pre-existing `plugin.ts` warnings unchanged).
+
+#### Closes
+
+- §14.6 column 11 (Multi-runtime hosting) **operator-accessible** —
+  the value prop now reachable via `azureclaw add --runtime <kind>`
+  rather than hand-edited CRs.
+
+---
+
 ### S10.A4 `phase2-runtime-microsoft-agent-framework` — second native runtime, flips column 11 fully ✓
 
 #### Added

--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";
 import { loadContext, resolveSecret } from "../config.js";
+import { assertRuntimeWired, buildRuntimeBlock, flagToKind } from "../runtime.js";
 
 export function addCommand(): Command {
   const cmd = new Command("add");
@@ -34,9 +35,25 @@ export function addCommand(): Command {
     .option("--perplexity-api-key <key>", "Perplexity API key")
     .option("--openai-api-key <key>", "OpenAI API key (for dual-provider setups)")
     .option("--learn-egress", "Enable egress learn mode: observe all domains (blocklist still enforced), then review with 'azureclaw policy learn'", false)
+    .option("--runtime <kind>", "Runtime kind: openclaw | openai-agents | microsoft-agent-framework | byo", "openclaw")
+    .option("--byo-image <image>", "Container image for --runtime byo (must declare org.azureclaw.runtime.contract=v1)")
+    .option("--byo-contract-version <version>", "BYO contract version", "v1")
+    .option("--maf-language <lang>", "Microsoft Agent Framework language: python (dotnet is Phase 3)", "python")
     .option("--dry-run", "Print the ClawSandbox YAML without applying", false)
     .action(async (name: string, options) => {
       const { execa } = await import("execa");
+
+      const runtimeKind = flagToKind(options.runtime);
+      assertRuntimeWired(runtimeKind);
+      const runtimeBlock = buildRuntimeBlock({
+        kind: runtimeKind,
+        openclawVersion: "2026.3.13",
+        model: options.model,
+        image: options.image,
+        byoImage: options.byoImage,
+        byoContractVersion: options.byoContractVersion,
+        mafLanguage: options.mafLanguage as "python" | "dotnet",
+      });
 
       const sandbox: Record<string, unknown> = {
         apiVersion: "azureclaw.azure.com/v1alpha1",
@@ -46,18 +63,7 @@ export function addCommand(): Command {
           namespace: "azureclaw-system",
         },
         spec: {
-          runtime: {
-            kind: "OpenClaw",
-            openclaw: {
-              version: "2026.3.13",
-              ...(options.image ? { image: options.image } : {}),
-              config: {
-                agent: {
-                  model: `azure/${options.model}`,
-                },
-              },
-            },
-          },
+          runtime: runtimeBlock,
           sandbox: {
             isolation: options.isolation,
             seccompProfile: options.isolation === "standard" ? "RuntimeDefault" : "azureclaw-strict",

--- a/cli/src/commands/connect.ts
+++ b/cli/src/commands/connect.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { agentContainerName, runtimeKindFromCr, type RuntimeKind } from "../runtime.js";
 
 export function connectCommand(): Command {
   const cmd = new Command("connect");
@@ -41,6 +42,23 @@ export function connectCommand(): Command {
           aksExists = true;
         } catch { /* no AKS deployment */ }
       }
+
+      // S10.A5: resolve container name from the live ClawSandbox CR
+      // so non-OpenClaw runtimes (OpenAIAgents, MAF, BYO) hit the
+      // generic `agent` container rather than the legacy `openclaw`
+      // container name. Falls back to OpenClaw if the CR can't be
+      // read (e.g. local-only flow or AKS not configured) — which is
+      // the safe default since legacy CRs imply OpenClaw.
+      let runtimeKind: RuntimeKind = "OpenClaw";
+      if (aksExists) {
+        try {
+          const { stdout: crJson } = await execa("kubectl", [
+            "get", "clawsandbox", name, "-n", "azureclaw-system", "-o", "json",
+          ], { stdio: "pipe" });
+          runtimeKind = runtimeKindFromCr(JSON.parse(crJson));
+        } catch { /* fall back to OpenClaw default */ }
+      }
+      const podContainer = agentContainerName(runtimeKind);
 
       // Ambiguity: both exist, no explicit flag
       if (localExists && aksExists && !options.local && !options.cloud) {
@@ -146,7 +164,7 @@ export function connectCommand(): Command {
           console.log(chalk.dim("  Falling back to shell mode...\n"));
           await execa("kubectl", [
             "exec", "-it", "-n", namespace,
-            `deploy/${name}`, "-c", "openclaw",
+            `deploy/${name}`, "-c", podContainer,
             "--", "/bin/bash", "--login",
           ], { stdio: "inherit" });
           return;
@@ -209,7 +227,7 @@ export function connectCommand(): Command {
         console.log(chalk.dim(`  Exit:    type "exit"\n`));
         await execa("kubectl", [
           "exec", "-it", "-n", namespace,
-          `deploy/${name}`, "-c", "openclaw",
+          `deploy/${name}`, "-c", podContainer,
           "--", "/bin/bash", "--login",
         ], { stdio: "inherit" });
       }

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -56,13 +56,14 @@ export function listCommand(): Command {
           if (items.length > 0) {
             console.log(chalk.bold("  AKS Cluster"));
             console.log(chalk.dim("  ─────────────────────────────────────────────────────────────────"));
-            console.log(chalk.dim(`  ${"NAME".padEnd(24)} ${"STATUS".padEnd(14)} ${"MODEL".padEnd(18)} ${"ISOLATION".padEnd(14)} NAMESPACE`));
+            console.log(chalk.dim(`  ${"NAME".padEnd(22)} ${"STATUS".padEnd(12)} ${"RUNTIME".padEnd(22)} ${"MODEL".padEnd(14)} ${"ISO".padEnd(10)} NS`));
 
             for (const sb of items) {
               const name = sb.metadata?.name || "unknown";
               const phase = sb.status?.phase || "Unknown";
               const model = sb.spec?.inference?.model || "gpt-4.1";
               const isolation = sb.spec?.sandbox?.isolation || "enhanced";
+              const runtimeKind = sb.spec?.runtime?.kind || "OpenClaw";
               const ns = `azureclaw-${name}`;
 
               let icon: string;
@@ -70,7 +71,7 @@ export function listCommand(): Command {
               else if (phase === "Pending" || phase === "Creating") icon = chalk.yellow("●");
               else icon = chalk.red("●");
 
-              console.log(`  ${icon} ${chalk.bold(name.padEnd(24))} ${phase.padEnd(14)} ${model.padEnd(18)} ${isolation.padEnd(14)} ${chalk.dim(ns)}`);
+              console.log(`  ${icon} ${chalk.bold(name.padEnd(22))} ${phase.padEnd(12)} ${runtimeKind.padEnd(22)} ${model.padEnd(14)} ${isolation.padEnd(10)} ${chalk.dim(ns)}`);
               found = true;
             }
             console.log();

--- a/cli/src/runtime.test.ts
+++ b/cli/src/runtime.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for `runtime.ts` — the CLI's runtime-aware helpers (S10.A5).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  agentContainerName,
+  assertRuntimeWired,
+  buildRuntimeBlock,
+  flagToKind,
+  runtimeKindFromCr,
+} from "./runtime.js";
+
+describe("flagToKind", () => {
+  it("maps each kebab-case flag to its PascalCase RuntimeKind", () => {
+    expect(flagToKind("openclaw")).toBe("OpenClaw");
+    expect(flagToKind("openai-agents")).toBe("OpenAIAgents");
+    expect(flagToKind("microsoft-agent-framework")).toBe("MicrosoftAgentFramework");
+    expect(flagToKind("byo")).toBe("BYO");
+  });
+
+  it("is case-insensitive", () => {
+    expect(flagToKind("OpenClaw")).toBe("OpenClaw");
+    expect(flagToKind("OPENAI-AGENTS")).toBe("OpenAIAgents");
+  });
+
+  it("throws with a helpful error on unknown flags", () => {
+    expect(() => flagToKind("autogen")).toThrow(/Unknown --runtime value: autogen/);
+    expect(() => flagToKind("")).toThrow(/Unknown --runtime value/);
+  });
+});
+
+describe("assertRuntimeWired", () => {
+  it("accepts the four wired runtimes", () => {
+    expect(() => assertRuntimeWired("OpenClaw")).not.toThrow();
+    expect(() => assertRuntimeWired("OpenAIAgents")).not.toThrow();
+    expect(() => assertRuntimeWired("MicrosoftAgentFramework")).not.toThrow();
+    expect(() => assertRuntimeWired("BYO")).not.toThrow();
+  });
+
+  it("rejects the three Tier-2 placeholders", () => {
+    expect(() => assertRuntimeWired("SemanticKernel")).toThrow(/no adapter wired/);
+    expect(() => assertRuntimeWired("LangGraph")).toThrow(/no adapter wired/);
+    expect(() => assertRuntimeWired("Anthropic")).toThrow(/no adapter wired/);
+  });
+
+  it("the rejection message names the wired runtimes for discoverability", () => {
+    try {
+      assertRuntimeWired("LangGraph");
+      throw new Error("must have thrown");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("OpenClaw");
+      expect(msg).toContain("OpenAIAgents");
+      expect(msg).toContain("MicrosoftAgentFramework");
+      expect(msg).toContain("BYO");
+    }
+  });
+});
+
+describe("agentContainerName", () => {
+  it("returns 'openclaw' for the OpenClaw runtime (legacy container name)", () => {
+    expect(agentContainerName("OpenClaw")).toBe("openclaw");
+  });
+
+  it("returns 'agent' for every non-OpenClaw runtime", () => {
+    expect(agentContainerName("OpenAIAgents")).toBe("agent");
+    expect(agentContainerName("MicrosoftAgentFramework")).toBe("agent");
+    expect(agentContainerName("BYO")).toBe("agent");
+    expect(agentContainerName("SemanticKernel")).toBe("agent");
+    expect(agentContainerName("LangGraph")).toBe("agent");
+    expect(agentContainerName("Anthropic")).toBe("agent");
+  });
+});
+
+describe("runtimeKindFromCr", () => {
+  it("reads spec.runtime.kind when present", () => {
+    expect(runtimeKindFromCr({ spec: { runtime: { kind: "OpenAIAgents" } } })).toBe("OpenAIAgents");
+    expect(runtimeKindFromCr({ spec: { runtime: { kind: "MicrosoftAgentFramework" } } }))
+      .toBe("MicrosoftAgentFramework");
+    expect(runtimeKindFromCr({ spec: { runtime: { kind: "BYO" } } })).toBe("BYO");
+  });
+
+  it("falls back to OpenClaw for legacy / missing runtime block", () => {
+    expect(runtimeKindFromCr({})).toBe("OpenClaw");
+    expect(runtimeKindFromCr({ spec: {} })).toBe("OpenClaw");
+    expect(runtimeKindFromCr({ spec: { runtime: {} } })).toBe("OpenClaw");
+    expect(runtimeKindFromCr(null)).toBe("OpenClaw");
+    expect(runtimeKindFromCr(undefined)).toBe("OpenClaw");
+  });
+
+  it("falls back to OpenClaw when the kind value is unknown (defensive)", () => {
+    // A future controller version may add a new kind; the CLI must
+    // not crash — fall back to the safe default.
+    expect(runtimeKindFromCr({ spec: { runtime: { kind: "FutureKind" } } })).toBe("OpenClaw");
+  });
+});
+
+describe("buildRuntimeBlock", () => {
+  it("emits the OpenClaw block with expected defaults", () => {
+    const block = buildRuntimeBlock({ kind: "OpenClaw", model: "gpt-4.1" }) as Record<string, unknown>;
+    expect(block.kind).toBe("OpenClaw");
+    const oc = block.openclaw as Record<string, unknown>;
+    expect(oc.version).toBe("2026.3.13");
+    expect((oc.config as Record<string, Record<string, string>>).agent.model).toBe("azure/gpt-4.1");
+    // No image override.
+    expect("image" in oc).toBe(false);
+  });
+
+  it("respects --image override for OpenClaw", () => {
+    const block = buildRuntimeBlock({
+      kind: "OpenClaw",
+      model: "gpt-4.1",
+      image: "myacr.azurecr.io/openclaw:custom",
+    }) as Record<string, unknown>;
+    expect((block.openclaw as Record<string, unknown>).image).toBe("myacr.azurecr.io/openclaw:custom");
+  });
+
+  it("emits the OpenAIAgents block with no required user input", () => {
+    const block = buildRuntimeBlock({ kind: "OpenAIAgents" }) as Record<string, unknown>;
+    expect(block.kind).toBe("OpenAIAgents");
+    expect(block.openaiAgents).toEqual({});
+  });
+
+  it("emits the MicrosoftAgentFramework block defaulting to python", () => {
+    const block = buildRuntimeBlock({ kind: "MicrosoftAgentFramework" }) as Record<string, unknown>;
+    expect(block.kind).toBe("MicrosoftAgentFramework");
+    expect((block.microsoftAgentFramework as Record<string, string>).language).toBe("python");
+  });
+
+  it("rejects --maf-language dotnet client-side (Phase 3 / upstream-blocked)", () => {
+    expect(() => buildRuntimeBlock({
+      kind: "MicrosoftAgentFramework",
+      mafLanguage: "dotnet",
+    })).toThrow(/dotnet.*not yet wired.*Phase 3/);
+  });
+
+  it("emits the BYO block with the supplied image and contract version", () => {
+    const block = buildRuntimeBlock({
+      kind: "BYO",
+      byoImage: "ghcr.io/team/agent:1.0",
+    }) as Record<string, unknown>;
+    expect(block.kind).toBe("BYO");
+    const byo = block.byo as Record<string, string>;
+    expect(byo.image).toBe("ghcr.io/team/agent:1.0");
+    expect(byo.contractVersion).toBe("v1");
+  });
+
+  it("requires --byo-image when --runtime byo", () => {
+    expect(() => buildRuntimeBlock({ kind: "BYO" })).toThrow(/--byo-image is required/);
+  });
+
+  it("respects custom BYO contract version", () => {
+    const block = buildRuntimeBlock({
+      kind: "BYO",
+      byoImage: "ghcr.io/team/agent:1.0",
+      byoContractVersion: "v2",
+    }) as Record<string, unknown>;
+    expect((block.byo as Record<string, string>).contractVersion).toBe("v2");
+  });
+});

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -1,0 +1,192 @@
+/**
+ * Runtime-aware helpers for CLI commands (S10.A5).
+ *
+ * The controller's `RuntimeKind` enum is the source of truth for which
+ * runtimes the platform supports. The CLI only needs three derived
+ * facts: which container name to address with `kubectl exec -c`, which
+ * `spec.runtime.{variant}` block to emit when scaffolding a CR, and
+ * what user-facing label to print in `list` / `status` output.
+ *
+ * Mirrors `controller::reconciler::runtime::kind_str` and
+ * `controller::reconciler::mod::is_openclaw` so the CLI does not drift
+ * from the controller. Keep the two enums in lockstep.
+ */
+
+/** PascalCase wire-format kinds matching `controller/src/crd.rs::RuntimeKind`. */
+export type RuntimeKind =
+  | "OpenClaw"
+  | "OpenAIAgents"
+  | "MicrosoftAgentFramework"
+  | "SemanticKernel"
+  | "LangGraph"
+  | "Anthropic"
+  | "BYO";
+
+/** kebab-case CLI flag values (e.g. `--runtime openai-agents`). */
+export type RuntimeFlag =
+  | "openclaw"
+  | "openai-agents"
+  | "microsoft-agent-framework"
+  | "semantic-kernel"
+  | "lang-graph"
+  | "anthropic"
+  | "byo";
+
+const FLAG_TO_KIND: Record<RuntimeFlag, RuntimeKind> = {
+  "openclaw": "OpenClaw",
+  "openai-agents": "OpenAIAgents",
+  "microsoft-agent-framework": "MicrosoftAgentFramework",
+  "semantic-kernel": "SemanticKernel",
+  "lang-graph": "LangGraph",
+  "anthropic": "Anthropic",
+  "byo": "BYO",
+};
+
+/** Runtimes whose **adapter is wired end-to-end** in the current controller build. */
+const WIRED_KINDS: RuntimeKind[] = [
+  "OpenClaw",
+  "OpenAIAgents",
+  "MicrosoftAgentFramework",
+  "BYO",
+];
+
+export function flagToKind(flag: string): RuntimeKind {
+  const k = FLAG_TO_KIND[flag.toLowerCase() as RuntimeFlag];
+  if (!k) {
+    throw new Error(
+      `Unknown --runtime value: ${flag}. ` +
+      `Valid values: ${Object.keys(FLAG_TO_KIND).join(", ")}.`,
+    );
+  }
+  return k;
+}
+
+/**
+ * Reject Tier-2 placeholders (SemanticKernel/LangGraph/Anthropic) at
+ * the CLI boundary so the operator gets a clear "not yet wired" error
+ * rather than a `RuntimeReady=False / AdapterMissing` Condition stamp
+ * after the apply round-trips. MAF .NET also unwired (Phase 3).
+ */
+export function assertRuntimeWired(kind: RuntimeKind): void {
+  if (!WIRED_KINDS.includes(kind)) {
+    throw new Error(
+      `Runtime kind '${kind}' has no adapter wired in this controller build. ` +
+      `Wired runtimes: ${WIRED_KINDS.join(", ")}. ` +
+      `Tier-2 runtimes (${(["SemanticKernel", "LangGraph", "Anthropic"] as const).join(", ")}) ` +
+      `are roadmap items pending operator demand.`,
+    );
+  }
+}
+
+/**
+ * Container name for `kubectl exec -c <name>` etc. OpenClaw uses
+ * `openclaw` (legacy); every non-OpenClaw runtime uses the generic
+ * `agent` name (mirrors `is_openclaw` polarity in the reconciler:
+ * `controller::reconciler::mod::is_openclaw` selects "openclaw" /
+ * "agent" identically).
+ */
+export function agentContainerName(kind: RuntimeKind): string {
+  return kind === "OpenClaw" ? "openclaw" : "agent";
+}
+
+/**
+ * Resolve the runtime kind from a `ClawSandbox` CR (live or YAML).
+ * `spec.runtime.kind` is the canonical field after the S10.A1
+ * discriminated-union migration; pre-A1 CRs that have no
+ * `spec.runtime` block fall back to `OpenClaw` (the only legal value
+ * before A1).
+ */
+export function runtimeKindFromCr(cr: unknown): RuntimeKind {
+  const spec = (cr as { spec?: { runtime?: { kind?: string } } } | undefined)?.spec;
+  const kind = spec?.runtime?.kind;
+  if (kind && Object.values(FLAG_TO_KIND).includes(kind as RuntimeKind)) {
+    return kind as RuntimeKind;
+  }
+  return "OpenClaw";
+}
+
+/**
+ * Build the `spec.runtime` block for a new ClawSandbox CR based on
+ * CLI options. Returns the runtime block to splice into the CR
+ * scaffold; callers are responsible for the surrounding spec scaffolding.
+ *
+ * `byoImage` is **required** for `kind: BYO`; passing it for any
+ * other kind is silently ignored (the CLI flag is BYO-specific by
+ * design — no runtime-specific image override for the wired runtimes
+ * because their adapter image is controller-managed).
+ */
+export interface BuildRuntimeBlockOpts {
+  kind: RuntimeKind;
+  /** OpenClaw only — version pin from the legacy CLI default. */
+  openclawVersion?: string;
+  /** OpenClaw only — model name (becomes `azure/<model>`). */
+  model?: string;
+  /** Optional sandbox image override (OpenClaw legacy `--image`). */
+  image?: string;
+  /** BYO only — container image (REQUIRED for `kind: BYO`). */
+  byoImage?: string;
+  /** BYO only — contract version label. */
+  byoContractVersion?: string;
+  /** MAF only — language flavour. Defaults to "python". */
+  mafLanguage?: "python" | "dotnet";
+}
+
+export function buildRuntimeBlock(
+  opts: BuildRuntimeBlockOpts,
+): Record<string, unknown> {
+  switch (opts.kind) {
+    case "OpenClaw":
+      return {
+        kind: "OpenClaw",
+        openclaw: {
+          version: opts.openclawVersion ?? "2026.3.13",
+          ...(opts.image ? { image: opts.image } : {}),
+          config: {
+            agent: {
+              model: `azure/${opts.model ?? "gpt-4.1"}`,
+            },
+          },
+        },
+      };
+    case "OpenAIAgents":
+      return {
+        kind: "OpenAIAgents",
+        openaiAgents: {},
+      };
+    case "MicrosoftAgentFramework": {
+      const language = opts.mafLanguage ?? "python";
+      // Reject dotnet client-side: the controller producer rejects
+      // it via `ShapeInvalid`, but failing here gives the operator
+      // immediate feedback rather than a Conditions-stamp round-trip.
+      if (language !== "python") {
+        throw new Error(
+          `MAF language '${language}' is not yet wired ` +
+          `(blocked on AgentMesh.Sdk .NET upstream — Phase 3). ` +
+          `Use --maf-language python.`,
+        );
+      }
+      return {
+        kind: "MicrosoftAgentFramework",
+        microsoftAgentFramework: { language: "python" },
+      };
+    }
+    case "BYO": {
+      if (!opts.byoImage) {
+        throw new Error(
+          `--byo-image is required when --runtime byo. ` +
+          `The image must declare the org.azureclaw.runtime.contract=v1 label.`,
+        );
+      }
+      return {
+        kind: "BYO",
+        byo: {
+          image: opts.byoImage,
+          contractVersion: opts.byoContractVersion ?? "v1",
+        },
+      };
+    }
+    default:
+      // Defensive — `assertRuntimeWired` should have caught this.
+      throw new Error(`Runtime kind '${opts.kind}' is not wired.`);
+  }
+}

--- a/docs/security-audits/2026-04-28-phase2-runtime-cli.md
+++ b/docs/security-audits/2026-04-28-phase2-runtime-cli.md
@@ -1,0 +1,63 @@
+# Phase 2 — Multi-runtime CLI surface (S10.A5)
+
+**Date:** 2026-04-28
+**Slice:** S10.A5 `phase2-runtime-cli`
+**Branch:** `phase2-runtime-cli`
+**Plan reference:** `docs/implementation-plan.md` §8; session-plan §S10.A5.
+**Predecessors:** S10.A1 (CRD reshape, PR #65), S10.A2 (controller dispatch, PR #66/67), S10.B (platform MCP, PR #68), S10.A3 (OpenAI Agents Python, PR #69), S10.A4 (Microsoft Agent Framework Python, PR #70).
+
+## Scope
+
+Extend the CLI to drive the four wired runtimes end-to-end:
+
+- `azureclaw add --runtime <openclaw|openai-agents|microsoft-agent-framework|byo>` emits the correct `spec.runtime.{kind,variant}` block for each kind.
+- `azureclaw add --runtime byo --byo-image <ref> [--byo-contract-version v1]` requires explicit image, defaults `contractVersion: "v1"`.
+- `azureclaw add --runtime microsoft-agent-framework [--maf-language python]` defaults to `python`; rejects `dotnet` client-side with a clear "Phase 3 / AgentMesh.Sdk .NET upstream-blocked" message (mirrors the controller's `RuntimePlanError::ShapeInvalid` from S10.A4 but fails before the apply round-trip).
+- `azureclaw connect <name>` reads `spec.runtime.kind` from the live CR and addresses the correct container with `kubectl exec -c <name>` — `openclaw` for OpenClaw, `agent` for everything else (mirrors `is_openclaw` polarity at `controller/src/reconciler/mod.rs:710` / `:990`).
+- `azureclaw list` adds a `RUNTIME` column.
+- Tier-2 placeholders (`SemanticKernel`, `LangGraph`, `Anthropic`) are rejected at the CLI boundary with a "no adapter wired" error so operators get immediate feedback rather than a `RuntimeReady=False / AdapterMissing` Conditions stamp after apply.
+
+A new module `cli/src/runtime.ts` is the single source of truth for the kebab-case ↔ PascalCase mapping, the wired-vs-Tier-2 set, the container-name polarity, and the `spec.runtime` block shape. It is consumed by `add.ts`, `connect.ts`, and `list.ts`. Future runtime additions (Phase 3 SK / LG / Anthropic) plug into this one file.
+
+## Out of scope
+
+- `azureclaw push` runtime parity (handled at controller level via per-runtime image overrides in `runtime.rs`; CLI doesn't override).
+- `handoff.ts` / `eval.ts` / `operator.ts` / `up.ts` container-name dispatch — they hardcode `-c openclaw` for legacy reasons; tracked as a follow-up cleanup but not blocking column 11. These commands run only against existing OpenClaw sandboxes today.
+- Sub-agent / plugin scaffolding for non-OpenClaw runtimes (Class B per §S10-runtime-agnostic-rule — upstream AGT SDK responsibility).
+
+## Hard-rule checklist (§0.2)
+
+- [x] **#1 No duplication** — extends existing `add.ts` / `connect.ts` / `list.ts` rather than parallel-implementing; the controller's `RuntimeKind` enum stays the single source of truth, mirrored as a closed type.
+- [x] **#3 No dead schema** — only the four wired kinds (`OpenClaw`, `OpenAIAgents`, `MicrosoftAgentFramework`, `BYO`) accept a CLI flag; Tier-2 kinds throw with a discoverable error listing the wired set.
+- [x] **#8 No custom crypto** — no crypto in this slice.
+- [x] **#9 Audit doc** — this file.
+- [x] **#10 Verify, don't guess** — `agentContainerName` polarity verified against `controller/src/reconciler/mod.rs:990`; `flagToKind` mapping verified against `crd.rs::RuntimeKind` serde renames.
+
+## Test coverage
+
+- `cli/src/runtime.test.ts` (NEW, 19 tests): `flagToKind` happy/unknown/case-insensitive; `assertRuntimeWired` accepts wired, rejects Tier-2 with discoverable message; `agentContainerName` OpenClaw vs everything-else polarity (incl. all three Tier-2 kinds); `runtimeKindFromCr` reads canonical field, falls back to `OpenClaw` for legacy/missing/null/unknown values; `buildRuntimeBlock` happy paths for all four wired kinds + BYO requires image + MAF rejects dotnet + custom contract version respected + `--image` override only on OpenClaw.
+- `cli/src/commands/add.test.ts` — existing 27 tests still pass (manifest-building logic unchanged for OpenClaw default path).
+- Full vitest run: **454 passed | 2 skipped** (was 435 / 2 before this slice; +19 from `runtime.test.ts`).
+- `npx tsc --noEmit`: clean.
+- `npm run lint`: 26 pre-existing warnings in `plugin.ts` (no new lint diagnostics).
+- `npm run build`: clean.
+
+## Threat model
+
+| Concern | Mitigation |
+|---|---|
+| Operator picks a Tier-2 runtime, gets a confusing `RuntimeReady=False` after apply | CLI fails fast with `assertRuntimeWired` listing the four wired kinds + a "Phase 3 roadmap" hint. |
+| Operator sets `--runtime byo` without `--byo-image` and gets a CEL admission error from the API server | CLI throws client-side: "`--byo-image` is required when `--runtime byo`. Image must declare `org.azureclaw.runtime.contract=v1`". |
+| Operator sets `--maf-language dotnet` | Rejected client-side with explicit "Phase 3 / AgentMesh.Sdk .NET upstream-blocked" message; no malformed CR ever reaches the API server. |
+| `connect` against a legacy OpenClaw CR (no `spec.runtime.kind`) | `runtimeKindFromCr` falls back to `OpenClaw` → container name `openclaw` → backward-compatible. |
+| `connect` against a CR with an unknown `kind` (e.g. controller older than CLI) | Falls back to `OpenClaw` (defensive); user gets "container not found" only if the live container differs, with kubectl's standard error. |
+| Reserved-prefix env (`AZURECLAW_*`, `AGT_*`, `FOUNDRY_AGENT_*`, `AZURE_*`, `IMDS_*`) snuck in via flags | Not exposed as a flag; reserved-prefix filter is enforced in the controller's deployment builder regardless. |
+
+## Sign-offs
+
+- [x] Author: GitHub Copilot CLI agent (claude-opus-4.7).
+- [x] Reviewer: Pal Lakatos-Toth (admin merge).
+
+## §14.6 column-11 status after this slice
+
+§14.6 column 11 (Multi-runtime hosting) **flipped to ✓** with S10.A4 (PR #70) — ≥2 native non-OpenClaw runtimes (OpenAI Agents Python + MAF Python) shipped end-to-end, plus BYO with documented contract. S10.A5 makes the value prop **operator-accessible**: a customer can now `azureclaw add --runtime microsoft-agent-framework my-maf-agent` and it works without reading the CRD by hand.


### PR DESCRIPTION
**Slice:** S10.A5 — final piece of the S10 multi-runtime train.

Adds first-class CLI flags for the four wired runtimes (OpenClaw, OpenAIAgents, MicrosoftAgentFramework, BYO) so `azureclaw add --runtime <kind>` works without hand-editing CRDs.

## Surfaces

- `azureclaw add --runtime <openclaw|openai-agents|microsoft-agent-framework|byo>` — Tier-2 kinds + MAF dotnet rejected client-side with Phase-3 / upstream-blocker errors.
- `azureclaw connect <name>` — reads `spec.runtime.kind` from the live CR; routes `kubectl exec -c` to the correct container (`openclaw` legacy, `agent` for everything else). Backward-compatible.
- `azureclaw list` — new RUNTIME column.
- `cli/src/runtime.ts` — single source of truth mirroring controller `RuntimeKind` + `is_openclaw` polarity.

## Tests

- `cli/src/runtime.test.ts` — 19 new vitest tests (flag mapping, wired-vs-Tier-2 gate, container-name polarity, CR reader fallbacks, per-variant block shapes).
- Full vitest: **454 passed | 2 skipped** (was 435/2).
- `tsc --noEmit` clean, `npm run build` clean.

## Audit

`docs/security-audits/2026-04-28-phase2-runtime-cli.md`

## Closes

§14.6 column 11 (Multi-runtime hosting) **operator-accessible** — value prop reachable via single CLI flag, not hand-edited CRs.

Pre-authorized to skip Container Image Scan check; admin-merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>