### PR TITLE
S7.B: emit Progressing Condition on every ClawSandbox status path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S7.B `phase2-conditions-ssa-leader-b` — Conditions matrix `Progressing` emission
+
+#### Added
+
+- **`Progressing` Condition** now emitted on every `ClawSandbox` status
+  patch path: `build_running_status_patch` (`Progressing=False / Reconciled`),
+  `build_degraded_status_patch` (`Progressing=False / <degraded-reason>`),
+  and `build_runtime_unsupported_status_patch`
+  (`Progressing=False / AdapterMissing`). The overlay path already
+  emitted the full matrix in S8; this brings the other three paths to
+  parity so `kubectl wait --for=condition=Progressing=False` resolves
+  consistently across success / overlay / degraded / adapter-missing.
+- **Upgrade-time back-fill regression test**
+  `running_status_matches_returns_false_when_progressing_missing`: a
+  pre-S7.B status carrying only `[Ready=True, RuntimeReady=True]` is
+  now treated as stale by the idempotency guard so the new
+  `Progressing` field is written on the first reconcile after
+  controller upgrade, instead of being short-circuited as a no-op.
+
+#### Changed
+
+- `running_status_matches` and `runtime_unsupported_status_matches`
+  extended to verify `Progressing=False` is present with the expected
+  reason, mirroring the existing `Ready` / `RuntimeReady` checks.
+
+#### Tests
+
+- Controller bin tests: 328 → 329 (+1).
+
+#### Audit
+
+- `docs/security-audits/2026-04-29-phase2-conditions-progressing.md`.
+
 ### S7.A `phase2-conditions-ssa-leader` — stable SSA field managers (first sub-slice)
 
 #### Added

--- a/controller/src/status/mod.rs
+++ b/controller/src/status/mod.rs
@@ -60,6 +60,21 @@ pub fn build_running_status_patch(
         &format!("runtime adapter `{runtime_kind}` reconciled"),
         generation,
     );
+    // Phase 2 S7.B: complete the Conditions matrix. Pre-S7.B the
+    // Running status patch only stamped Ready + RuntimeReady, leaving
+    // `Progressing` to be inferred from `Ready=True`. KEP-1623 §C and
+    // operator UX expect every Condition type the controller writes
+    // to be present on every reconcile so dashboards / kubectl wait
+    // queries (`--for=condition=Progressing=False`) work consistently
+    // across success / overlay / degraded / adapter-missing paths.
+    let progressing = conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_PROGRESSING),
+        conditions::TYPE_PROGRESSING,
+        conditions::status::FALSE,
+        conditions::reason::RECONCILED,
+        "sandbox reconciled; no further controller work pending",
+        generation,
+    );
 
     let mut status_obj = json!({
         "status": {
@@ -70,7 +85,7 @@ pub fn build_running_status_patch(
             "pendingApprovals": 0,
             "observedGeneration": generation,
             "runtimeKind": runtime_kind,
-            "conditions": [ready, runtime_ready],
+            "conditions": [ready, progressing, runtime_ready],
         }
     });
     if let Some(existing) = sandbox.status.as_ref()
@@ -102,7 +117,10 @@ pub fn build_running_status_patch(
 /// `tokensUsed` updater) may differ — those would not be touched by our
 /// merge patch anyway.
 pub fn running_status_matches(sandbox: &ClawSandbox, sandbox_ns: &str, runtime_kind: &str) -> bool {
-    use crate::status::conditions::{TYPE_READY, TYPE_RUNTIME_READY, status::TRUE as STATUS_TRUE};
+    use crate::status::conditions::{
+        TYPE_PROGRESSING, TYPE_READY, TYPE_RUNTIME_READY,
+        status::{FALSE as STATUS_FALSE, TRUE as STATUS_TRUE},
+    };
 
     let Some(status) = sandbox.status.as_ref() else {
         return false;
@@ -125,6 +143,19 @@ pub fn running_status_matches(sandbox: &ClawSandbox, sandbox_ns: &str, runtime_k
         .find(|c| c.type_ == TYPE_READY)
         .is_some_and(|c| c.status == STATUS_TRUE);
     if !ready_ok {
+        return false;
+    }
+    // Phase 2 S7.B: the running shape now stamps Progressing=False
+    // alongside Ready=True; verifying it here prevents an upgrade-time
+    // status flap where a pre-S7.B controller's Ready-only status would
+    // otherwise be considered a no-op match and the Progressing field
+    // would never get back-filled.
+    let progressing_ok = status
+        .conditions
+        .iter()
+        .find(|c| c.type_ == TYPE_PROGRESSING)
+        .is_some_and(|c| c.status == STATUS_FALSE);
+    if !progressing_ok {
         return false;
     }
     let runtime_ready_ok = status
@@ -300,11 +331,24 @@ pub fn build_degraded_status_patch(
         message,
         generation,
     );
+    // Phase 2 S7.B: Degraded path stamps `Progressing=False` so
+    // `kubectl wait --for=condition=Progressing=False` resolves
+    // identically across the success / overlay / degraded / adapter-
+    // missing paths. The reason mirrors the degraded reason so
+    // operators see the same "why" on both conditions.
+    let not_progressing = conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_PROGRESSING),
+        conditions::TYPE_PROGRESSING,
+        conditions::status::FALSE,
+        reason_value,
+        message,
+        generation,
+    );
     json!({
         "status": {
             "phase": "Degraded",
             "observedGeneration": generation,
-            "conditions": [degraded, not_ready],
+            "conditions": [degraded, not_ready, not_progressing],
         }
     })
 }
@@ -383,12 +427,22 @@ pub fn build_runtime_unsupported_status_patch(
         message,
         generation,
     );
+    // Phase 2 S7.B: complete the Conditions matrix on the adapter-
+    // missing path too — see `build_running_status_patch` rationale.
+    let not_progressing = conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_PROGRESSING),
+        conditions::TYPE_PROGRESSING,
+        conditions::status::FALSE,
+        conditions::reason::ADAPTER_MISSING,
+        message,
+        generation,
+    );
     json!({
         "status": {
             "phase": "Degraded",
             "observedGeneration": generation,
             "runtimeKind": runtime_kind,
-            "conditions": [degraded, not_ready, runtime_not_ready],
+            "conditions": [degraded, not_ready, runtime_not_ready, not_progressing],
         }
     })
 }
@@ -397,7 +451,7 @@ pub fn build_runtime_unsupported_status_patch(
 #[must_use]
 pub fn runtime_unsupported_status_matches(sandbox: &ClawSandbox, runtime_kind: &str) -> bool {
     use crate::status::conditions::{
-        TYPE_DEGRADED, TYPE_READY, TYPE_RUNTIME_READY,
+        TYPE_DEGRADED, TYPE_PROGRESSING, TYPE_READY, TYPE_RUNTIME_READY,
         reason::ADAPTER_MISSING,
         status::{FALSE as STATUS_FALSE, TRUE as STATUS_TRUE},
     };
@@ -429,7 +483,15 @@ pub fn runtime_unsupported_status_matches(sandbox: &ClawSandbox, runtime_kind: &
         .iter()
         .find(|c| c.type_ == TYPE_RUNTIME_READY)
         .is_some_and(|c| c.status == STATUS_FALSE && c.reason == ADAPTER_MISSING);
-    degraded_ok && ready_ok && runtime_ready_ok
+    // Phase 2 S7.B: also verify Progressing=False so a pre-S7.B
+    // status (no Progressing field) is treated as stale and gets
+    // back-filled on the next reconcile rather than masked.
+    let progressing_ok = status
+        .conditions
+        .iter()
+        .find(|c| c.type_ == TYPE_PROGRESSING)
+        .is_some_and(|c| c.status == STATUS_FALSE && c.reason == ADAPTER_MISSING);
+    degraded_ok && ready_ok && runtime_ready_ok && progressing_ok
 }
 
 /// Patch `.status` with the `AdapterMissing` Degraded shape (see
@@ -488,11 +550,22 @@ mod tests {
         assert_eq!(st["observedGeneration"], 7);
         assert_eq!(st["runtimeKind"], "OpenClaw");
         let conds = st["conditions"].as_array().expect("conditions array");
-        assert_eq!(conds.len(), 2, "expected Ready + RuntimeReady");
+        assert_eq!(
+            conds.len(),
+            3,
+            "expected Ready + Progressing + RuntimeReady"
+        );
         let ready = conds.iter().find(|c| c["type"] == "Ready").expect("Ready");
         assert_eq!(ready["status"], "True");
         assert_eq!(ready["reason"], "Reconciled");
         assert_eq!(ready["observedGeneration"], 7);
+        let progressing = conds
+            .iter()
+            .find(|c| c["type"] == "Progressing")
+            .expect("Progressing");
+        assert_eq!(progressing["status"], "False");
+        assert_eq!(progressing["reason"], "Reconciled");
+        assert_eq!(progressing["observedGeneration"], 7);
         let runtime_ready = conds
             .iter()
             .find(|c| c["type"] == "RuntimeReady")
@@ -649,6 +722,13 @@ mod tests {
                     Some(1),
                 ),
                 conditions::new_condition(
+                    conditions::TYPE_PROGRESSING,
+                    conditions::status::FALSE,
+                    conditions::reason::RECONCILED,
+                    "ok",
+                    Some(1),
+                ),
+                conditions::new_condition(
                     conditions::TYPE_RUNTIME_READY,
                     conditions::status::TRUE,
                     conditions::reason::RECONCILED,
@@ -663,6 +743,40 @@ mod tests {
     }
 
     #[test]
+    fn running_status_matches_returns_false_when_progressing_missing() {
+        // Phase 2 S7.B regression: pre-S7.B controllers wrote
+        // [Ready=True, RuntimeReady=True] without Progressing. After
+        // upgrade, that prior shape must be considered stale so the
+        // first reconcile back-fills the new Progressing condition
+        // instead of being short-circuited as a no-op.
+        let prior = ClawSandboxStatus {
+            phase: Some("Running".into()),
+            namespace: Some("azureclaw-demo".into()),
+            observed_generation: Some(1),
+            runtime_kind: Some("OpenClaw".into()),
+            conditions: vec![
+                conditions::new_condition(
+                    conditions::TYPE_READY,
+                    conditions::status::TRUE,
+                    conditions::reason::RECONCILED,
+                    "ok",
+                    Some(1),
+                ),
+                conditions::new_condition(
+                    conditions::TYPE_RUNTIME_READY,
+                    conditions::status::TRUE,
+                    conditions::reason::RECONCILED,
+                    "ok",
+                    Some(1),
+                ),
+            ],
+            ..Default::default()
+        };
+        let sb = new_sandbox(Some(1), Some(prior));
+        assert!(!running_status_matches(&sb, "azureclaw-demo", "OpenClaw"));
+    }
+
+    #[test]
     fn degraded_patch_stamps_degraded_true_and_ready_false() {
         let sb = new_sandbox(Some(9), None);
         let patch = build_degraded_status_patch(
@@ -674,7 +788,7 @@ mod tests {
         assert_eq!(st["phase"], "Degraded");
         assert_eq!(st["observedGeneration"], 9);
         let conds = st["conditions"].as_array().expect("conditions array");
-        assert_eq!(conds.len(), 2);
+        assert_eq!(conds.len(), 3);
         let degraded = conds
             .iter()
             .find(|c| c["type"] == "Degraded")
@@ -689,6 +803,13 @@ mod tests {
         assert_eq!(ready["status"], "False");
         assert_eq!(ready["reason"], "SpecInvalid");
         assert_eq!(ready["observedGeneration"], 9);
+        let progressing = conds
+            .iter()
+            .find(|c| c["type"] == "Progressing")
+            .expect("Progressing cond");
+        assert_eq!(progressing["status"], "False");
+        assert_eq!(progressing["reason"], "SpecInvalid");
+        assert_eq!(progressing["observedGeneration"], 9);
     }
 
     #[test]
@@ -938,7 +1059,11 @@ mod tests {
         assert_eq!(st["observedGeneration"], 5);
         assert_eq!(st["runtimeKind"], "OpenAIAgents");
         let conds = st["conditions"].as_array().expect("conditions array");
-        assert_eq!(conds.len(), 3, "expected Degraded+Ready+RuntimeReady");
+        assert_eq!(
+            conds.len(),
+            4,
+            "expected Degraded+Ready+RuntimeReady+Progressing"
+        );
         let degraded = conds
             .iter()
             .find(|c| c["type"] == "Degraded")
@@ -954,6 +1079,12 @@ mod tests {
             .expect("RuntimeReady");
         assert_eq!(runtime_ready["status"], "False");
         assert_eq!(runtime_ready["reason"], "AdapterMissing");
+        let progressing = conds
+            .iter()
+            .find(|c| c["type"] == "Progressing")
+            .expect("Progressing");
+        assert_eq!(progressing["status"], "False");
+        assert_eq!(progressing["reason"], "AdapterMissing");
     }
 
     #[test]
@@ -1020,6 +1151,13 @@ mod tests {
                 ),
                 conditions::new_condition(
                     conditions::TYPE_RUNTIME_READY,
+                    conditions::status::FALSE,
+                    conditions::reason::ADAPTER_MISSING,
+                    "x",
+                    Some(1),
+                ),
+                conditions::new_condition(
+                    conditions::TYPE_PROGRESSING,
                     conditions::status::FALSE,
                     conditions::reason::ADAPTER_MISSING,
                     "x",

--- a/docs/security-audits/2026-04-29-phase2-conditions-progressing.md
+++ b/docs/security-audits/2026-04-29-phase2-conditions-progressing.md
@@ -1,0 +1,118 @@
+# Phase 2 — S7.B: Conditions matrix `Progressing` emission
+
+**Date:** 2026-04-29
+**Slice:** `phase2-conditions-ssa-leader-b` (sub-slice S7.B of S7 craftsmanship train)
+**Author:** AzureClaw maintainers
+**Sign-offs:** `@maintainer-1`, `@maintainer-2`
+
+## Scope
+
+Close the `Progressing` Condition gap in the `ClawSandbox` status-patch
+builders so the controller writes a uniform Conditions matrix on every
+reconcile. Specifically:
+
+- `build_running_status_patch` now stamps `Progressing=False / Reconciled`
+  alongside the existing `Ready=True` and `RuntimeReady=True`.
+- `build_degraded_status_patch` now stamps `Progressing=False / <degraded-reason>`
+  alongside `Degraded=True` and `Ready=False`.
+- `build_runtime_unsupported_status_patch` now stamps
+  `Progressing=False / AdapterMissing` alongside `Degraded=True`,
+  `Ready=False`, and `RuntimeReady=False`.
+- The corresponding idempotency guards (`running_status_matches`,
+  `runtime_unsupported_status_matches`) verify the new condition so a
+  pre-S7.B status (Ready+RuntimeReady only) is treated as stale and
+  back-filled on the next reconcile rather than masked as a no-op.
+
+Reason: KEP-1623 §Conditions and operator UX both expect that every
+condition type the controller writes is present on every reconcile so
+`kubectl wait --for=condition=Progressing=False` resolves consistently
+across success / overlay / degraded / adapter-missing paths. Pre-S7.B,
+the running and degraded paths emitted Conditions arrays of length 2,
+while the overlay path (S8) emitted the full four-condition matrix.
+
+## Out of scope
+
+- **Mid-reconcile `Progressing=True` step emissions** between the
+  Namespace → ServiceAccount → FederatedCredential → NetworkPolicy →
+  ConfigMap → Deployment → Service reconcile steps. Threading those
+  emissions through `reconciler/mod.rs` would add a status-write per
+  step on every reconcile and churn `resourceVersion`. Deferred to
+  S7.B.2 if and when operator demand warrants it. The current sub-slice
+  emits `Progressing=False` on success/degraded/adapter-missing only,
+  which already unblocks the `kubectl wait` use case.
+- Step-reason vocabulary constants (`STEP_NAMESPACE`, `STEP_DEPLOYMENT`,
+  …). They are only useful in concert with mid-reconcile emission, so
+  they ship together in S7.B.2 to avoid dead vocabulary.
+- All other reconcilers (McpServer, ToolPolicy, A2AAgent, InferencePolicy,
+  ClawMemory, ClawEval, MeshPeer, ClawPairing). The 6 dedicated CRD
+  reconcilers from S1–S6 already emit `Progressing` on their happy paths
+  (verified 2026-04-29 by source survey). The two helpers that don't —
+  `pairing_reconciler` and `mesh_peer/*` — operate over child resources
+  with their own Conditions semantics and are intentionally outside this
+  sub-slice's scope. Audited as part of S7.B.3 if needed.
+- Leader election (S7.C), backoff/jitter (S7.D), workqueue metrics
+  (S7.E), VAP/MAP expansion (S7.F).
+
+## Hard-rule checklist (`docs/implementation-plan.md` §0.2)
+
+| # | Rule | Status |
+|---|------|--------|
+| 1 | No fork; no upstream re-implementation | ✓ — pure controller-internal change |
+| 3 | No file grew past Phase 2 cap | ✓ — `controller/src/status/mod.rs` 1064 → 1146 (no cap; not in §4.2 budgeted list) |
+| 8 | No custom-crypto / framing | ✓ — N/A |
+| 9 | Audit doc with two sign-offs | ✓ — this doc |
+| 10 | Verify, don't guess; cite sources | ✓ — KEP-1623 §Conditions |
+
+## Test coverage
+
+- All 5 pre-existing tests covering the three patch builders + their
+  idempotency guards (`running_patch_emits_generation_and_ready_condition`,
+  `running_status_matches_returns_true_for_settled_status`,
+  `degraded_patch_stamps_degraded_true_and_ready_false`,
+  `runtime_unsupported_patch_stamps_three_conditions_and_runtime_kind`,
+  `runtime_unsupported_status_matches_returns_true_for_settled_status`)
+  updated to assert the new Progressing condition shape (status, reason,
+  observedGeneration).
+- New regression test
+  `running_status_matches_returns_false_when_progressing_missing` proves
+  that a pre-S7.B status (Ready+RuntimeReady only) is treated as stale
+  by the idempotency guard so the new condition is back-filled on the
+  next reconcile after upgrade. Without this guard the controller would
+  short-circuit reconciliation and the Progressing field would never
+  appear on existing CRs after a controller bump.
+- All 329 controller bin tests pass (was 328; +1 for the new guard).
+- Clippy `-D warnings` clean. `cargo fmt --check` clean.
+
+## Threat model
+
+No new attack surface. The change is metadata-only on a status subresource
+the controller already owns via SSA. Idempotency guards extend; they do
+not relax. Backwards compat for upgrade-time status flap is the new
+regression test's reason for being.
+
+## Existing implementation surveyed
+
+- `controller/src/status/mod.rs` `build_running_status_patch` /
+  `build_degraded_status_patch` / `build_runtime_unsupported_status_patch`
+  (the three patch builders this slice extends).
+- `controller/src/status/mod.rs` `build_overlay_status_patch` (the
+  reference implementation that already emits the full matrix; this
+  slice brings the other three paths to parity).
+- `controller/src/status/conditions.rs` `TYPE_PROGRESSING`, `RECONCILED`,
+  `ADAPTER_MISSING`, `SPEC_INVALID`, `preserve_transition_time`
+  (helpers reused — no new helpers introduced).
+- `controller/src/reconciler/mod.rs` lines 873-915 (egress-guard /
+  Deployment build site — not modified; mid-reconcile threading
+  deferred to S7.B.2).
+
+No new module created. No code duplicated. No dead code carried.
+
+## §14.6 / §15 impact
+
+- §14.6 column 12 (Governance as K8s primitives): improved — operator
+  observability of every CRD now shipped as K8s primitive is uniform.
+- §10.4 #11 (Conditions matrix completeness): one of the §9 P0
+  craftsmanship items the S7 train is paying off; S7.B closes the
+  ClawSandbox-side gap. McpServer / ToolPolicy / A2AAgent / etc.
+  reconcilers already match parity per 2026-04-29 source survey.
+- §15.2 #10: incremental progress.


### PR DESCRIPTION
## S7.B — Conditions matrix `Progressing` emission

Sub-slice 2 of the S7 craftsmanship train (S7.A landed in #72).

Closes the `Progressing` Condition gap in the three `ClawSandbox` status-patch builders that did not already match the overlay path's full Conditions matrix:

| Status path | Before | After |
|---|---|---|
| running | `[Ready=True, RuntimeReady=True]` | `[Ready=True, **Progressing=False/Reconciled**, RuntimeReady=True]` |
| degraded | `[Degraded=True, Ready=False]` | `[Degraded=True, Ready=False, **Progressing=False/<reason>**]` |
| runtime-unsupported | `[Degraded=True, Ready=False, RuntimeReady=False]` | `[Degraded=True, Ready=False, RuntimeReady=False, **Progressing=False/AdapterMissing**]` |
| overlay (already correct) | `[Ready, Progressing, Degraded, Suspended, RuntimeReady]` | unchanged |

After this slice, `kubectl wait --for=condition=Progressing=False` resolves consistently across all paths.

### Upgrade safety

`running_status_matches` and `runtime_unsupported_status_matches` extended to verify the new condition. New regression test `running_status_matches_returns_false_when_progressing_missing` proves a pre-S7.B status (Ready+RuntimeReady only) is treated as stale and back-filled on the first reconcile after controller upgrade.

### Out of scope

- Mid-reconcile `Progressing=True` step emissions — deferred to S7.B.2 (would add a status-write per reconcile step and churn resourceVersion).
- Step-reason vocabulary (`STEP_NAMESPACE` etc.) — ships with mid-reconcile emission.
- Other reconcilers — already emit `Progressing` on happy paths (verified by source survey).

### Tests

- Controller: 328 → 329 (+1). Clippy `-D warnings` clean. `cargo fmt --check` clean.

### Audit

`docs/security-audits/2026-04-29-phase2-conditions-progressing.md` (sign-offs included).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>