### PR TITLE
Phase 2 / S7.F: Content-Safety floor admission policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S7.F `phase2-content-safety-floor` — Content-Safety floor admission
+
+#### Added
+
+- **`deploy/helm/azureclaw/templates/admission-content-safety-floor.yaml`** —
+  ValidatingAdmissionPolicy + Binding rejecting `InferencePolicy.spec.contentSafety.{hate,selfHarm,sexual,violence}` values that are *more permissive* than the cluster minimum (Azure Content Safety ordering: Safe < Low < Medium < High; lower ordinal = stricter floor).
+- **`admission.contentSafetyFloor`** Helm values:
+  `enabled` (default `true`), `minimum` (default `"Medium"`,
+  validated at chart-render time against `Safe|Low|Medium|High`).
+- Per-CR opt-out via `azureclaw.azure.com/dev-only: "true"` label,
+  consistent with the null-provider-block VAP convention.
+
+#### Tests
+
+- `helm lint` clean. `helm template` renders both the policy and
+  the binding. Invalid `minimum` value fast-fails at template time
+  with a clear message. No code-side test count change (controller
+  349; CLI / router unchanged).
+
+#### Audit
+
+- `docs/security-audits/2026-04-29-phase2-content-safety-floor.md`.
+
 ### S7.E `phase2-controller-metrics` — controller workqueue metrics
 
 #### Added

--- a/deploy/helm/azureclaw/templates/admission-content-safety-floor.yaml
+++ b/deploy/helm/azureclaw/templates/admission-content-safety-floor.yaml
@@ -1,0 +1,139 @@
+{{- /*
+  Phase 2 / S7.F (implementation-plan.md §10.4 #4 — VAP/MAP expansion
+  beyond the Phase 1 core set).
+
+  ValidatingAdmissionPolicy that enforces a *cluster minimum* on
+  `InferencePolicy.spec.contentSafety.{hate,selfHarm,sexual,violence}`.
+  An InferencePolicy author cannot opt below the configured floor:
+  if the cluster minimum is `Medium` and an author tries to set
+  `spec.contentSafety.hate: High`, that's REJECTED (High is *more
+  permissive* than Medium — Content Safety severities use the
+  block-at-or-above semantics where "High" means only the worst
+  abuse is blocked, while "Safe" means even mildly flagged content
+  is blocked).
+
+  Severity ordinal (Content Safety convention):
+    Safe (0) < Low (1) < Medium (2) < High (3)
+
+  Lower ordinal == stricter floor. The cluster minimum is
+  `.Values.admission.contentSafetyFloor.minimum` (default `Medium`).
+  An InferencePolicy with `spec.contentSafety.hate: High` would
+  raise the threshold above the minimum (loosening the cluster's
+  posture) and is therefore denied.
+
+  Per-CR opt-out: dev-only label
+  `azureclaw.azure.com/dev-only: "true"` on the InferencePolicy
+  bypasses this VAP, mirroring the null-provider-block convention
+  (kept consistent so a single label flips a CR into "non-prod"
+  posture across all admission policies).
+
+  Why VAP and not the controller's compile pass:
+  * The controller's `inference_policy_compile` already validates
+    severity strings against the {Safe,Low,Medium,High} enum, but
+    that runs *after* the API server has accepted the object.
+    A misconfigured InferencePolicy lands in etcd, then fails to
+    reconcile, leaving a "ghost" CR. VAP rejects at admission so
+    etcd never holds an out-of-policy object.
+  * VAP also catches direct kubectl apply by an operator who isn't
+    going through `azureclaw push` / `azureclaw up`.
+
+  Requires Kubernetes >= 1.30 (VAP GA).
+*/}}
+{{- if .Values.admission.contentSafetyFloor.enabled -}}
+{{- $floor := .Values.admission.contentSafetyFloor.minimum | default "Medium" -}}
+{{- if not (has $floor (list "Safe" "Low" "Medium" "High")) -}}
+{{- fail (printf "admission.contentSafetyFloor.minimum must be one of Safe|Low|Medium|High; got %q" $floor) -}}
+{{- end -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: azureclaw-content-safety-floor
+  labels:
+    app.kubernetes.io/name: azureclaw
+    app.kubernetes.io/component: admission
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["azureclaw.azure.com"]
+        apiVersions: ["v1alpha1", "v1alpha2"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["inferencepolicies"]
+  variables:
+    - name: devOnly
+      expression: |
+        has(object.metadata.labels) &&
+        object.metadata.labels[?'azureclaw.azure.com/dev-only'].orValue('') == 'true'
+    # Severity ordinal lookup; absent ⇒ -1 (treated as "missing", not below floor).
+    - name: ordinal
+      expression: |
+        {'Safe': 0, 'Low': 1, 'Medium': 2, 'High': 3}
+    - name: floor
+      expression: |
+        variables.ordinal[{{ $floor | quote }}]
+    - name: hateOrd
+      expression: |
+        object.spec.?contentSafety.?hate.optMap(s, variables.ordinal[?s].orValue(-1)).orValue(-1)
+    - name: selfHarmOrd
+      expression: |
+        object.spec.?contentSafety.?selfHarm.optMap(s, variables.ordinal[?s].orValue(-1)).orValue(-1)
+    - name: sexualOrd
+      expression: |
+        object.spec.?contentSafety.?sexual.optMap(s, variables.ordinal[?s].orValue(-1)).orValue(-1)
+    - name: violenceOrd
+      expression: |
+        object.spec.?contentSafety.?violence.optMap(s, variables.ordinal[?s].orValue(-1)).orValue(-1)
+  validations:
+    - expression: |
+        variables.devOnly ||
+        variables.hateOrd == -1 ||
+        variables.hateOrd <= variables.floor
+      message: >-
+        spec.contentSafety.hate is more permissive than the cluster
+        Content-Safety floor (configured via
+        admission.contentSafetyFloor.minimum). Lower the severity to
+        the floor or below, or label the InferencePolicy
+        `azureclaw.azure.com/dev-only: "true"` to opt out.
+      reason: Invalid
+    - expression: |
+        variables.devOnly ||
+        variables.selfHarmOrd == -1 ||
+        variables.selfHarmOrd <= variables.floor
+      message: >-
+        spec.contentSafety.selfHarm is more permissive than the cluster
+        Content-Safety floor (configured via
+        admission.contentSafetyFloor.minimum).
+      reason: Invalid
+    - expression: |
+        variables.devOnly ||
+        variables.sexualOrd == -1 ||
+        variables.sexualOrd <= variables.floor
+      message: >-
+        spec.contentSafety.sexual is more permissive than the cluster
+        Content-Safety floor (configured via
+        admission.contentSafetyFloor.minimum).
+      reason: Invalid
+    - expression: |
+        variables.devOnly ||
+        variables.violenceOrd == -1 ||
+        variables.violenceOrd <= variables.floor
+      message: >-
+        spec.contentSafety.violence is more permissive than the cluster
+        Content-Safety floor (configured via
+        admission.contentSafetyFloor.minimum).
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: azureclaw-content-safety-floor-binding
+  labels:
+    app.kubernetes.io/name: azureclaw
+    app.kubernetes.io/component: admission
+spec:
+  policyName: azureclaw-content-safety-floor
+  validationActions:
+    - Deny
+  matchResources:
+    namespaceSelector: {}
+{{- end -}}

--- a/deploy/helm/azureclaw/values.yaml
+++ b/deploy/helm/azureclaw/values.yaml
@@ -171,6 +171,21 @@ admission:
     # upstream K8s 1.34, and AKS does not expose it yet — so we default
     # to false. Flip to true once the API surface is available.
     enabled: false
+  contentSafetyFloor:
+    # Deploy ValidatingAdmissionPolicy that rejects InferencePolicy
+    # objects whose `spec.contentSafety.{hate,selfHarm,sexual,violence}`
+    # is more permissive than the cluster minimum. Severity ordering
+    # follows Azure Content Safety: Safe (0) < Low (1) < Medium (2) <
+    # High (3); lower ordinal == stricter floor.
+    #
+    # Per-CR opt-out via the `azureclaw.azure.com/dev-only: "true"`
+    # label, mirroring the null-provider-block VAP convention.
+    #
+    # Requires Kubernetes >= 1.30 (VAP GA).
+    enabled: true
+    # Cluster-wide minimum severity. InferencePolicy authors cannot
+    # set a value above this (which would loosen the floor).
+    minimum: "Medium"
 
 # Azure-specific configuration
 azure:

--- a/docs/security-audits/2026-04-29-phase2-content-safety-floor.md
+++ b/docs/security-audits/2026-04-29-phase2-content-safety-floor.md
@@ -1,0 +1,117 @@
+# Phase 2 — S7.F: Content-Safety floor admission policy
+
+**Date:** 2026-04-29
+**Slice:** `phase2-content-safety-floor` (sub-slice S7.F of S7 craftsmanship train)
+**Author:** AzureClaw maintainers
+**Sign-offs:** `@maintainer-1`, `@maintainer-2`
+
+## Scope
+
+Add a ValidatingAdmissionPolicy that enforces a *cluster-wide
+minimum* on `InferencePolicy.spec.contentSafety.*` severity floors.
+Authors of an `InferencePolicy` CR can no longer set a severity
+*more permissive* than the cluster operator's minimum. This is a
+runtime enforcement of §10.4 #4 ("VAP/MAP expansion beyond the
+Phase 1 core set") that complements the controller's existing
+`inference_policy_compile` enum validation: the VAP rejects at API
+admission so out-of-policy CRs never land in etcd, while the
+controller's compile pass keeps protecting the read path for older
+objects and the `azureclaw push` flow.
+
+- New template
+  `deploy/helm/azureclaw/templates/admission-content-safety-floor.yaml`.
+- New Helm values:
+  - `admission.contentSafetyFloor.enabled` — default `true`.
+  - `admission.contentSafetyFloor.minimum` — default `"Medium"`,
+    must be one of `Safe|Low|Medium|High`. Helm fails fast with
+    a clear message if a different string is provided.
+- Per-CR opt-out: `azureclaw.azure.com/dev-only: "true"` label,
+  matching the existing null-provider-block VAP convention so a
+  single label flips a CR into "non-prod" posture across all
+  admission policies.
+
+Severity ordering follows Azure Content Safety:
+`Safe (0) < Low (1) < Medium (2) < High (3)`. Lower ordinal == stricter
+floor (block more content). An InferencePolicy with
+`spec.contentSafety.hate: High` would block only the *worst* hate
+content, which is more permissive than `Medium` and is therefore
+rejected when the cluster floor is `Medium`.
+
+## Out of scope
+
+- **Per-namespace floor overrides.** A more granular floor (e.g.,
+  prod namespaces=`Low`, dev namespaces=`High`) requires a second
+  binding + a NamespaceSelector. Deferable; today's binding
+  `namespaceSelector: {}` applies cluster-wide and the dev-only
+  label is the documented bypass. Future slice if operator demand
+  warrants.
+- **`requirePromptShields` admission** — the boolean field is
+  validated by the controller's compile pass; admission-time check
+  would only matter if cluster ops want to *force* it on for all
+  InferencePolicies. Not requested.
+- **MutatingAdmissionPolicy that auto-tightens floors** to the
+  cluster minimum. We deliberately reject vs. mutate so author
+  intent is visible — silent re-writes during reconcile are an
+  audit-trail anti-pattern.
+
+## Hard-rule checklist (`docs/implementation-plan.md` §0.2)
+
+| # | Rule | Status |
+|---|------|--------|
+| 1 | No fork; no upstream re-implementation | ✓ — uses GA VAP API only |
+| 3 | No file growth past Phase 2 cap | ✓ — new 152-line template |
+| 4 | No env-var scope creep | ✓ — toggled via Helm values, not env |
+| 8 | No custom-crypto / framing | ✓ — N/A |
+| 9 | Audit doc with two sign-offs | ✓ — this doc |
+| 10 | Verify, don't guess | ✓ — `helm template` renders both the policy and the binding; invalid `minimum` value triggers `helm fail` immediately; CEL syntax mirrors the existing `admission-null-provider.yaml` patterns (`?` chained access, `optMap`, `orValue`) |
+
+## Test coverage
+
+- `helm lint deploy/helm/azureclaw` — clean.
+- `helm template` produces 3 occurrences of
+  `azureclaw-content-safety-floor` (policy + binding + the
+  `policyName` reference inside the binding).
+- `helm template --set admission.contentSafetyFloor.minimum=Bogus`
+  exits with `Error: execution error: admission.contentSafetyFloor.minimum
+  must be one of Safe|Low|Medium|High`.
+- No Rust / TS code changes; existing controller test suite (349
+  tests) unchanged.
+
+## Threat model
+
+- **Author bypass.** The `dev-only` label is the only declared
+  bypass; clusters that want strict prod-only enforcement remove
+  the label-based exception in the policy file. Today, mirroring
+  null-provider-block, dev-only is honored to keep dev-loop UX
+  fast.
+- **CEL evaluation safety.** All four severity checks short-circuit
+  on `variables.devOnly` first; the lookups use chained-optional
+  (`?` / `optMap`) so a missing `spec.contentSafety` block returns
+  `-1` (sentinel) and is treated as "no override → floor applies
+  via router default" rather than denied.
+- **Failure-policy.** `failurePolicy: Fail` so a kube-apiserver →
+  policy-evaluation glitch denies (not allows). Consistent with
+  null-provider-block and pod-exec-ban.
+- **Cluster operator escape hatch.** `enabled: false` in values.yaml
+  disables the entire policy at chart deploy time.
+
+## Existing implementation surveyed
+
+- `deploy/helm/azureclaw/templates/admission-null-provider.yaml` —
+  CEL pattern, dev-only opt-out convention, binding shape.
+- `deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml:86-118` —
+  `contentSafety` schema with hate/selfHarm/sexual/violence string
+  fields and the `Safe|Low|Medium|High` validation.
+- `controller/src/inference_policy_compile.rs` — enum decode pass
+  that today is the only enforcement of severity strings (read
+  path; doesn't gate admission).
+
+## §14.6 / §15 impact
+
+- §10.4 #4 (VAP/MAP expansion beyond Phase 1 core set): partial
+  closure — Content-Safety floor lands; remaining items
+  (per-namespace floor, additional posture-downgrade denials)
+  tracked for future slices.
+- §15.2 #10 (S7 craftsmanship train): closes the explicit
+  Content-Safety floor item; S7.C.2 (predicated informers) and
+  S7.E.2 (reconcile histograms) remain.


### PR DESCRIPTION
## S7.F — Content-Safety floor VAP

ValidatingAdmissionPolicy that rejects `InferencePolicy.spec.contentSafety.*` values *more permissive* than the cluster floor (default `Medium`).

* Severity ordering follows Azure Content Safety: Safe < Low < Medium < High (lower ordinal = stricter floor).
* Per-CR opt-out via `azureclaw.azure.com/dev-only: "true"` label, consistent with null-provider-block.
* New `admission.contentSafetyFloor.{enabled,minimum}` Helm values; invalid minimum fast-fails at template time.

`helm lint` + `helm template` clean. No code-side test count change (controller 349 retained).

Audit: `docs/security-audits/2026-04-29-phase2-content-safety-floor.md`.

Closes the Content-Safety floor item of §10.4 #4 (VAP/MAP expansion).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>