### PR TITLE
Phase 2 / S7.E.2: reconcile-duration histograms + outcome counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S7.E.2 `phase2-reconcile-duration-histograms` — reconcile latency + outcome counter
+
+#### Added
+
+- `azureclaw_controller_reconcile_duration_seconds{crd_kind, outcome}`
+  Histogram and `azureclaw_controller_reconcile_total{crd_kind,
+  outcome}` IntCounterVec on the controller's `:9091/metrics`
+  surface. Closes the second half of S7.E (operator-craftsmanship
+  observability per `docs/implementation-plan.md` §9 P0).
+- `controller/src/metrics.rs::observe_reconcile(crd_kind, fut)` —
+  thin generic wrapper threaded through every `Controller::run(...)`
+  call site to record duration + outcome on completion. Generic
+  over the reconciler's `Result<T, E>` so each crate keeps its own
+  `ReconcileError` type unchanged.
+
+#### Wired
+
+- All 8 reconcilers — `reconciler/mod.rs` (ClawSandbox),
+  `a2a_agent_reconciler.rs`, `claw_eval_reconciler.rs`,
+  `claw_memory_reconciler.rs`, `inference_policy_reconciler.rs`,
+  `mcp_server_reconciler.rs`, `pairing_reconciler.rs` (ClawPairing),
+  `tool_policy_reconciler.rs`. Reconcile-fn bodies are untouched.
+
+#### Tests
+
+- 3 new unit tests in `metrics.rs`: success-outcome wiring,
+  error-outcome wiring + non-pollution of the success row,
+  Prometheus text-format render. Controller suite 349 → 352.
+
+#### Audit
+
+- `docs/security-audits/2026-04-29-phase2-reconcile-duration-histograms.md`.
+
 ### S17.A `phase2-sca-permanent-rows` — npm audit as permanent CI gate
 
 #### Added

--- a/controller/src/a2a_agent_reconciler.rs
+++ b/controller/src/a2a_agent_reconciler.rs
@@ -375,7 +375,13 @@ pub async fn run(client: Client) -> Result<()> {
     }
     let ctx = Arc::new(Ctx { client });
     Controller::new(agents, kube::runtime::watcher::Config::default())
-        .run(reconcile, error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("A2AAgent", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::debug!("A2AAgent reconciled {:?}", o),

--- a/controller/src/claw_eval_reconciler.rs
+++ b/controller/src/claw_eval_reconciler.rs
@@ -347,7 +347,13 @@ pub async fn run(client: Client) -> Result<()> {
     }
     let ctx = Arc::new(Ctx { client });
     Controller::new(evals, kube::runtime::watcher::Config::default())
-        .run(reconcile, error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("ClawEval", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::debug!("ClawEval reconciled {:?}", o),

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -339,7 +339,13 @@ pub async fn run(client: Client) -> Result<()> {
     }
     let ctx = Arc::new(Ctx { client });
     Controller::new(memories, kube::runtime::watcher::Config::default())
-        .run(reconcile, error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("ClawMemory", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::debug!("ClawMemory reconciled {:?}", o),

--- a/controller/src/inference_policy_reconciler.rs
+++ b/controller/src/inference_policy_reconciler.rs
@@ -372,7 +372,13 @@ pub async fn run(client: Client) -> Result<()> {
     }
     let ctx = Arc::new(Ctx { client });
     Controller::new(policies, kube::runtime::watcher::Config::default())
-        .run(reconcile, error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("InferencePolicy", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::debug!("InferencePolicy reconciled {:?}", o),

--- a/controller/src/mcp_server_reconciler.rs
+++ b/controller/src/mcp_server_reconciler.rs
@@ -643,7 +643,13 @@ pub async fn run(client: Client) -> Result<()> {
         jwks_fetcher: Arc::new(HttpJwksFetcher::new()),
     });
     Controller::new(mcps, kube::runtime::watcher::Config::default())
-        .run(reconcile, error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("McpServer", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::debug!("McpServer reconciled {:?}", o),

--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -2,16 +2,19 @@
 //!
 //! S7.E (workqueue metrics): exposes counters / histograms that
 //! operators can scrape from the controller pod's `:9091/metrics`
-//! endpoint. Phase 2 ships the error-counter surface; S7.E.2 will
-//! add reconcile-duration histograms + success counters once the
-//! call sites are factored to share a wrapper.
+//! endpoint. S7.E shipped the error-counter surface; **S7.E.2**
+//! adds the reconcile-duration histogram + total-reconcile counter
+//! via [`observe_reconcile`], a thin wrapper threaded through each
+//! `Controller::run(...)` call site.
 //!
 //! Naming follows `azureclaw_controller_*` to disambiguate from the
 //! inference router's `azureclaw_*` series, mirroring the
 //! controller-runtime `controller_runtime_*` convention used by
 //! kubebuilder/operator-sdk-style operators.
 
-use prometheus::{IntCounterVec, opts, register_int_counter_vec};
+use prometheus::{
+    HistogramVec, IntCounterVec, opts, register_histogram_vec, register_int_counter_vec,
+};
 use std::sync::LazyLock;
 
 /// Total reconcile errors by CRD kind and error class.
@@ -56,6 +59,76 @@ pub fn record_reconcile_error(crd_kind: &str, error_class: &str) {
         .with_label_values(&[crd_kind, error_class])
         .inc();
     RECONCILE_RETRIES.with_label_values(&[crd_kind]).inc();
+}
+
+/// Reconcile duration in seconds, by CRD kind and outcome.
+///
+/// Buckets follow the controller-runtime convention (sub-second
+/// happy path; long-tail caught up to 30s before the operator
+/// would notice via Prometheus alerting).
+///
+/// Labels:
+/// - `crd_kind`: same set as [`RECONCILE_ERRORS`].
+/// - `outcome`: `success` | `error`.
+pub static RECONCILE_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        "azureclaw_controller_reconcile_duration_seconds",
+        "Reconcile duration in seconds, by CRD kind and outcome",
+        &["crd_kind", "outcome"],
+        vec![
+            0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0
+        ]
+    )
+    .expect("failed to register azureclaw_controller_reconcile_duration_seconds")
+});
+
+/// Total reconcile invocations by CRD kind and outcome.
+///
+/// Distinct from [`RECONCILE_ERRORS`] (which only counts errors and
+/// is wired through `error_policy`) — `RECONCILE_TOTAL` covers both
+/// `success` and `error` paths via [`observe_reconcile`], so the
+/// operator can compute success rate as
+/// `success / (success + error)` directly from a single metric.
+pub static RECONCILE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        opts!(
+            "azureclaw_controller_reconcile_total",
+            "Total reconcile invocations by CRD kind and outcome"
+        ),
+        &["crd_kind", "outcome"]
+    )
+    .expect("failed to register azureclaw_controller_reconcile_total")
+});
+
+/// Wraps a reconcile future, recording its duration + outcome on
+/// completion. Generic over the `Result` so each reconciler keeps
+/// its own `ReconcileError` type; we only need `is_ok()`.
+///
+/// Usage at the `Controller::run(...)` call site:
+///
+/// ```ignore
+/// .run(
+///     |x, ctx| async move {
+///         crate::metrics::observe_reconcile("ClawSandbox", reconcile(x, ctx)).await
+///     },
+///     error_policy,
+///     ctx,
+/// )
+/// ```
+pub async fn observe_reconcile<F, T, E>(crd_kind: &'static str, fut: F) -> Result<T, E>
+where
+    F: std::future::Future<Output = Result<T, E>>,
+{
+    let start = std::time::Instant::now();
+    let result = fut.await;
+    let outcome = if result.is_ok() { "success" } else { "error" };
+    RECONCILE_DURATION
+        .with_label_values(&[crd_kind, outcome])
+        .observe(start.elapsed().as_secs_f64());
+    RECONCILE_TOTAL
+        .with_label_values(&[crd_kind, outcome])
+        .inc();
+    result
 }
 
 #[cfg(test)]
@@ -115,5 +188,70 @@ mod tests {
         assert!(rendered.contains("azureclaw_controller_reconcile_errors_total"));
         assert!(rendered.contains("azureclaw_controller_reconcile_retries_total"));
         assert!(rendered.contains("RenderKind"));
+    }
+
+    #[tokio::test]
+    async fn observe_reconcile_records_success_outcome() {
+        let before_total = RECONCILE_TOTAL
+            .with_label_values(&["DurKindOk", "success"])
+            .get();
+        let before_count = RECONCILE_DURATION
+            .with_label_values(&["DurKindOk", "success"])
+            .get_sample_count();
+
+        let r: Result<u32, &'static str> =
+            observe_reconcile("DurKindOk", async { Ok::<u32, &'static str>(42) }).await;
+
+        assert_eq!(r.unwrap(), 42);
+        assert_eq!(
+            RECONCILE_TOTAL
+                .with_label_values(&["DurKindOk", "success"])
+                .get(),
+            before_total + 1
+        );
+        assert_eq!(
+            RECONCILE_DURATION
+                .with_label_values(&["DurKindOk", "success"])
+                .get_sample_count(),
+            before_count + 1
+        );
+    }
+
+    #[tokio::test]
+    async fn observe_reconcile_records_error_outcome() {
+        let before_total = RECONCILE_TOTAL
+            .with_label_values(&["DurKindErr", "error"])
+            .get();
+
+        let r: Result<u32, &'static str> =
+            observe_reconcile("DurKindErr", async { Err::<u32, &'static str>("boom") }).await;
+
+        assert!(r.is_err());
+        assert_eq!(
+            RECONCILE_TOTAL
+                .with_label_values(&["DurKindErr", "error"])
+                .get(),
+            before_total + 1
+        );
+        // Success counter for this kind must NOT have been touched.
+        assert_eq!(
+            RECONCILE_TOTAL
+                .with_label_values(&["DurKindErr", "success"])
+                .get(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn observe_reconcile_renders_in_text_format() {
+        let _ = observe_reconcile("RenderDurKind", async { Ok::<(), &'static str>(()) }).await;
+        let mut buf = Vec::new();
+        let encoder = prometheus::TextEncoder::new();
+        let families = prometheus::gather();
+        prometheus::Encoder::encode(&encoder, &families, &mut buf).unwrap();
+        let rendered = String::from_utf8(buf).unwrap();
+        assert!(rendered.contains("azureclaw_controller_reconcile_duration_seconds"));
+        assert!(rendered.contains("azureclaw_controller_reconcile_total"));
+        assert!(rendered.contains("RenderDurKind"));
     }
 }

--- a/controller/src/pairing_reconciler.rs
+++ b/controller/src/pairing_reconciler.rs
@@ -152,7 +152,13 @@ pub async fn run(client: Client) -> Result<()> {
     let ctx = Arc::new(PairingContext { client });
 
     Controller::new(pairings, kube::runtime::watcher::Config::default())
-        .run(reconcile_pairing, pairing_error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("ClawPairing", reconcile_pairing(x, ctx)).await
+            },
+            pairing_error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::debug!("Pairing reconciled {:?}", o),

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1767,7 +1767,13 @@ pub async fn run(client: Client) -> Result<()> {
     });
 
     Controller::new(sandboxes, kube::runtime::watcher::Config::default())
-        .run(reconcile, error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("ClawSandbox", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::info!("Reconciled {:?}", o),

--- a/controller/src/tool_policy_reconciler.rs
+++ b/controller/src/tool_policy_reconciler.rs
@@ -365,7 +365,13 @@ pub async fn run(client: Client) -> Result<()> {
     }
     let ctx = Arc::new(Ctx { client });
     Controller::new(tps, kube::runtime::watcher::Config::default())
-        .run(reconcile, error_policy, ctx)
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("ToolPolicy", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
         .for_each(|res| async move {
             match res {
                 Ok(o) => tracing::debug!("ToolPolicy reconciled {:?}", o),

--- a/docs/security-audits/2026-04-29-phase2-reconcile-duration-histograms.md
+++ b/docs/security-audits/2026-04-29-phase2-reconcile-duration-histograms.md
@@ -1,0 +1,63 @@
+# Security audit — Phase 2 / S7.E.2: reconcile-duration histograms + total counter
+
+**Slice:** `phase2-reconcile-duration-histograms`
+**Branch:** `phase2-reconcile-duration-histograms` → `dev`
+**Date:** 2026-04-29
+**Scope item:** `docs/implementation-plan.md` §9 P0 (operator craftsmanship — observability) — second half of S7.E. Counter-only surface shipped in PR #76; this slice adds the duration histogram + outcome-aware total counter that close out the workqueue-metrics gate.
+
+## Summary
+
+Adds `azureclaw_controller_reconcile_duration_seconds{crd_kind, outcome}` (Histogram) and `azureclaw_controller_reconcile_total{crd_kind, outcome}` (IntCounterVec) to the controller's `:9091/metrics` endpoint, threaded through every `Controller::run(...)` call site via a thin `metrics::observe_reconcile(crd_kind, fut)` wrapper. Operators now see both happy-path latency distribution and a single counter from which to compute success rate, complementing the existing error-only counters from S7.E.
+
+## Existing implementation surveyed (per §0.2 #8 — no parallel-implementation)
+
+- `controller/src/metrics.rs` (S7.E, PR #76) — `RECONCILE_ERRORS` / `RECONCILE_RETRIES` IntCounterVecs + `record_reconcile_error()` helper. Reused. `observe_reconcile` lives in the same module to keep the registry in one place.
+- `controller/src/metrics_server.rs` (S7.E, PR #76) — axum `:9091` server + `/metrics` + `/healthz`. Untouched; new histograms surface automatically through `prometheus::default_registry()` gather.
+- `inference-router/src/metrics.rs` `INFERENCE_LATENCY` — same `register_histogram_vec!` shape, same default-registry dependency, same labels-as-strict-set discipline. Bucket cadence intentionally adapted (controller reconcile is sub-second; router inference can be multi-second).
+- All 8 reconcilers' `Controller::new(...).run(reconcile, error_policy, ctx)` call sites — untouched body; only the first arg wrapped with a closure that times via `observe_reconcile`.
+
+No new dependency added. `prometheus` was already pulled in by S7.E.
+
+## What this slice ships
+
+1. **`metrics::RECONCILE_DURATION`** (`HistogramVec`, labels `crd_kind`, `outcome`):
+   - Buckets: `0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0` seconds — covers fast in-memory reconciles (~1ms typical no-op) through tail latency from K8s API contention or Azure SDK calls (~10s+).
+   - `outcome` ∈ {`success`, `error`} only — closed cardinality.
+2. **`metrics::RECONCILE_TOTAL`** (`IntCounterVec`, same labels): single counter from which `irate(reconcile_total{outcome="success"}[5m]) / irate(reconcile_total[5m])` yields success rate without joining two counter families.
+3. **`metrics::observe_reconcile<F, T, E>(crd_kind, fut)`** — generic wrapper consumed by all 8 reconcilers via a closure at the `Controller::run(...)` callsite. Records duration + total once on completion; passes through the `Result<T, E>` unchanged so `error_policy` keeps its existing semantics.
+4. **8 wired call sites** — `reconciler/mod.rs` (ClawSandbox), `a2a_agent_reconciler.rs`, `claw_eval_reconciler.rs`, `claw_memory_reconciler.rs`, `inference_policy_reconciler.rs`, `mcp_server_reconciler.rs`, `pairing_reconciler.rs` (`ClawPairing`), `tool_policy_reconciler.rs`. Body of each `reconcile`/`reconcile_pairing` fn untouched.
+5. **3 new unit tests** in `metrics.rs`:
+   - `observe_reconcile_records_success_outcome` — Ok future increments success row of both metrics.
+   - `observe_reconcile_records_error_outcome` — Err future increments error row only; success row untouched.
+   - `observe_reconcile_renders_in_text_format` — both new metrics render in Prometheus text-format gather.
+
+## Cardinality discipline
+
+- `crd_kind` is one of 8 fixed values selected at the call site (string literal, never derived from a CR field).
+- `outcome` is one of 2 fixed values.
+- Total cardinality contribution: 8 × 2 = 16 series per metric. No CR `metadata.name` / `metadata.namespace` ever appears in labels.
+- Bucket count: 13 — same order of magnitude as router's `INFERENCE_LATENCY` (8 buckets) and within Prometheus best-practice for per-CRD reconcile latency.
+
+## Threat model deltas
+
+None. Read-only Prometheus surface continues to bind on `0.0.0.0:9091` (S7.E behavior); cluster operators are expected to scope reachability via NetworkPolicy on the controller pod, same as S7.E shipped. No CR data is exposed in label values.
+
+## Verification
+
+```text
+$ cargo build -p azureclaw-controller        # clean
+$ cargo test  -p azureclaw-controller
+   349 → 352 tests, all green
+$ cargo clippy -p azureclaw-controller --all-targets -- -D warnings   # clean
+$ cargo fmt --all -- --check                 # clean
+```
+
+## Deferred
+
+- **OTel reconcile spans** — wrapping the same closure with a `tracing::info_span!("reconcile", crd_kind, ...)` is a single-line addition, but choosing the right propagation parent (incoming reconcile event vs. internal timer trigger) needs a dedicated audit on tracing-vs-metrics double-bookkeeping. Carved out as `phase2-reconcile-otel-spans`.
+- **Workqueue depth gauge** — kube-rs's `Controller::stream_with_config` exposes the predicate-filtered stream but not workqueue depth directly; would need a custom reflector. Carved out alongside S7.C.2 predicated informers.
+
+## Sign-offs
+
+- Core: ✅
+- Security: ✅


### PR DESCRIPTION
## S7.E.2 — closing out the workqueue-metrics gate

Counter-only surface shipped in PR #76. This slice adds the duration histogram + outcome-aware total counter that complete S7.E.

* New: `azureclaw_controller_reconcile_duration_seconds{crd_kind, outcome}` (Histogram, 13 buckets, sub-ms → 30s).
* New: `azureclaw_controller_reconcile_total{crd_kind, outcome}` (IntCounterVec) — single source for success-rate computation.
* New: `metrics::observe_reconcile(crd_kind, fut)` — generic wrapper threaded through every `Controller::run(...)` call site (8 reconcilers).
* Bounded cardinality: 8 × 2 = 16 series per metric. No CR names/namespaces leak into label values.
* Reconcile-fn bodies untouched — only the first arg of `.run(...)` wraps with a closure.

Audit: `docs/security-audits/2026-04-29-phase2-reconcile-duration-histograms.md`.

Controller tests 349 → 352. Clippy + fmt clean.

Carved out separately: OTel reconcile spans, workqueue-depth gauge (paired with S7.C.2 predicated informers).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>