### PR TITLE
S15.d.3: extract up.ts AgentMesh deploy phase (1296 → 1182 LOC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S15.d.3 `phase2-hotspot-up-cli-d3` — up.ts AgentMesh deploy extraction
+
+#### Refactored
+
+- `cli/src/commands/up.ts` 1296 → 1182 LOC (sub-slice d.3 of the
+  S15.d up.ts multi-PR sub-train; d.4 to follow). AgentMesh
+  infrastructure deploy phase (Inspektor Gadget eBPF, relay +
+  registry deployment, external-registry shortcut, optional AGIC
+  ingress) extracted to `cli/src/commands/up/agentmesh_deploy.ts`
+  (174 LOC). The result triple `{ registryMode,
+  globalRegistryUrl, globalRelayUrl }` flows forward unchanged to
+  the ClawSandbox CR creation step and `saveContext()`.
+
+#### Tests
+
+- All 454 CLI tests pass; 2 skipped pre-existing. `tsc --noEmit`,
+  `lint` (27 warnings, baseline-matched), `build` clean. No
+  behavioral change — body moved verbatim.
+
+#### Audit
+
+- `docs/security-audits/2026-04-29-phase2-hotspot-up-cli-d3.md`
+  (sign-offs: Core ✅, Security ✅).
+
 ### S15.d.2 `phase2-hotspot-up-cli-d2` — up.ts preflight extraction
 
 #### Refactored

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -41,7 +41,6 @@ export function upCommand(): Command {
     .option("--skip-preflight", "Skip upfront RBAC & provider checks (advanced; you know what you're doing)", false)
     .action(async (options) => {
       const { execa } = await import("execa");
-      const fs = await import("fs");
 
       // ── FAST UPGRADE PATH (S15.d.1: extracted to ./up/fast_upgrade.ts) ──
       // Skip all prompts and infra — just re-run Helm with cached context.
@@ -719,130 +718,16 @@ export function upCommand(): Command {
 
         stepper.done(`Controller ${helmExists ? "upgraded" : "deployed"}`);
 
-        // ── Step 6b: Deploy Inspektor Gadget (eBPF observability) ────
-        // Non-fatal — kubectl-gadget may not be installed
-        await execa("kubectl", ["gadget", "deploy"], { stdio: "pipe" }).catch(() => {});
-
-        // ── Step 6c: Deploy AgentMesh infrastructure (relay + registry) ──
-        stepper.step("Deploying AgentMesh infrastructure...");
-
-        // Track registry mode for context save at end
-        let registryMode = "local";
-        let globalRegistryUrl: string | undefined;
-        let globalRelayUrl: string | undefined;
-
-        if (options.globalRegistry) {
-          // External registry mode — skip local deployment, set env vars
-          stepper.update(`Using external registry: ${options.globalRegistry}`);
-          kvLine("Registry mode", "global");
-          kvLine("Registry URL", options.globalRegistry);
-
-          registryMode = "global";
-          globalRegistryUrl = options.globalRegistry;
-
-          stepper.done("AgentMesh: using external registry (skipped local deploy)");
-        } else {
-          // Local registry mode — deploy relay + registry in-cluster
-          const agentmeshManifest = path.join(repoRoot, "deploy", "agentmesh.yaml");
-        if (existsSync(agentmeshManifest)) {
-          // Import postgres image into ACR (Azure Policy blocks Docker Hub images)
-          stepper.update("Importing postgres image into ACR...");
-          await execa("az", [
-            "acr", "import",
-            "--name", acr,
-            "--source", "docker.io/library/postgres:16-alpine",
-            "--image", "postgres:16-alpine",
-            "--force",
-          ], { stdio: "pipe" }).catch(() => {
-            // May already exist — non-fatal
-          });
-
-          // Ensure the agentmesh namespace exists before creating the secret
-          await execa("kubectl", ["create", "namespace", "agentmesh"], { stdio: "pipe" }).catch(() => {});
-
-          // Auto-generate postgres credentials if the secret doesn't exist yet
-          const secretExists = await execa("kubectl", [
-            "get", "secret", "agentmesh-db-credentials", "-n", "agentmesh",
-          ], { stdio: "pipe" }).then(() => true).catch(() => false);
-
-          if (!secretExists) {
-            stepper.update("Generating AgentMesh database credentials...");
-            const { randomBytes } = await import("crypto");
-            const dbPassword = randomBytes(24).toString("base64url");
-            await execa("kubectl", [
-              "create", "secret", "generic", "agentmesh-db-credentials",
-              "-n", "agentmesh",
-              `--from-literal=POSTGRES_PASSWORD=${dbPassword}`,
-            ], { stdio: "pipe" });
-          }
-
-          // Substitute ACR login server in the manifest
-          const fs = await import("fs");
-          const manifest = fs.readFileSync(agentmeshManifest, "utf-8");
-          const patchedManifest = manifest.replace(
-            /azureclawacr\.azurecr\.io/g,
-            acrLoginServer
-          );
-          const tmpManifest = path.join(repoRoot, ".tmp-agentmesh.yaml");
-          try {
-            fs.writeFileSync(tmpManifest, patchedManifest);
-            await execa("kubectl", ["apply", "-f", tmpManifest], { stdio: "pipe" });
-
-            // Wait for AgentMesh pods to be ready
-            stepper.update("Waiting for AgentMesh pods to be ready...");
-            await execa("kubectl", [
-              "wait", "--for=condition=Ready", "pod",
-              "-l", "app=agentmesh-relay",
-              "-n", "agentmesh",
-              "--timeout=180s",
-            ], { stdio: "pipe" }).catch(() => {});
-            await execa("kubectl", [
-              "wait", "--for=condition=Ready", "pod",
-              "-l", "app=agentmesh-registry",
-              "-n", "agentmesh",
-              "--timeout=180s",
-            ], { stdio: "pipe" }).catch(() => {});
-
-            stepper.done("AgentMesh infrastructure deployed");
-          } finally {
-            try { fs.unlinkSync(tmpManifest); } catch { /* noop */ }
-          }
-        } else {
-          stepper.warn("AgentMesh manifest not found — skipping");
-        }
-
-          // Deploy AGIC Ingress if --expose-registry is set
-          if (options.exposeRegistry) {
-            stepper.step("Deploying AgentMesh Ingress (public endpoints)...");
-            const ingressManifest = path.join(repoRoot, "deploy", "agentmesh-ingress.yaml");
-            if (existsSync(ingressManifest)) {
-              const ingressYaml = fs.readFileSync(ingressManifest, "utf-8");
-              const domain = `${baseName}.azureclaw.dev`;
-              const { stdout: currentSubId } = await execa("az", [
-                "account", "show", "--query", "id", "--output", "tsv",
-              ], { stdio: "pipe", timeout: 10000 }).catch(() => ({ stdout: "" }));
-              const patchedIngress = ingressYaml
-                .replace(/DOMAIN_PLACEHOLDER/g, domain)
-                .replace(/SUBSCRIPTION_ID/g, currentSubId.trim())
-                .replace(/RESOURCE_GROUP/g, rg)
-                .replace(/azureclawacr\.azurecr\.io/g, acrLoginServer);
-              const tmpIngress = path.join(repoRoot, ".tmp-agentmesh-ingress.yaml");
-              try {
-                fs.writeFileSync(tmpIngress, patchedIngress);
-                await execa("kubectl", ["apply", "-f", tmpIngress], { stdio: "pipe" });
-                stepper.done(`AgentMesh Ingress deployed (registry.${domain}, relay.${domain})`);
-
-                registryMode = "global";
-                globalRegistryUrl = `https://registry.${domain}`;
-                globalRelayUrl = `wss://relay.${domain}`;
-              } finally {
-                try { fs.unlinkSync(tmpIngress); } catch { /* noop */ }
-              }
-            } else {
-              stepper.warn("Ingress manifest not found — skipping");
-            }
-          }
-        }
+        // ── Step 6b/6c: Inspektor Gadget + AgentMesh deploy ──────────
+        // (S15.d.3: extracted to ./up/agentmesh_deploy.ts)
+        const { deployAgentMesh } = await import("./up/agentmesh_deploy.js");
+        const meshResult = await deployAgentMesh(
+          { repoRoot, acr, acrLoginServer, baseName, rg, stepper },
+          { globalRegistry: options.globalRegistry, exposeRegistry: options.exposeRegistry },
+        );
+        const registryMode = meshResult.registryMode;
+        const globalRegistryUrl = meshResult.globalRegistryUrl;
+        const globalRelayUrl = meshResult.globalRelayUrl;
 
         // ── Step 7: Create ClawSandbox CR ────────────────────────────
         stepper.step(`Creating sandbox '${options.name}'...`);

--- a/cli/src/commands/up/agentmesh_deploy.ts
+++ b/cli/src/commands/up/agentmesh_deploy.ts
@@ -1,0 +1,174 @@
+// Sub-slice S15.d.3 of S15.d phase2-hotspot-up-cli.
+//
+// AgentMesh infrastructure deploy phase extracted verbatim from
+// cli/src/commands/up.ts. Covers:
+//   - relay + registry deployment in-cluster (local mode)
+//   - external-registry shortcut (--global-registry)
+//   - optional AGIC Ingress for public endpoints (--expose-registry)
+//
+// Returns the registry-mode triple consumed by the ClawSandbox CR
+// creation step (d.4) and the saveContext() call at end-of-deploy.
+import path from "node:path";
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import type { Stepper } from "../../stepper.js";
+import { kvLine } from "../../stepper.js";
+
+export interface AgentMeshDeployContext {
+  repoRoot: string;
+  /** Bare ACR name (e.g. "azureclawacr"). */
+  acr: string;
+  /** ACR login server (e.g. "azureclawacr.azurecr.io"). */
+  acrLoginServer: string;
+  /** Cluster base name (cluster name with -aks suffix stripped). */
+  baseName: string;
+  /** Resolved resource group name. */
+  rg: string;
+  stepper: Stepper;
+}
+
+export interface AgentMeshDeployOptions {
+  globalRegistry?: string;
+  exposeRegistry?: boolean;
+}
+
+export interface AgentMeshDeployResult {
+  registryMode: "local" | "global";
+  globalRegistryUrl?: string;
+  globalRelayUrl?: string;
+}
+
+/**
+ * Deploy the AgentMesh relay + registry infrastructure (or wire to an
+ * external one), and optionally publish AGIC ingress for cross-cluster
+ * federation.
+ */
+export async function deployAgentMesh(
+  ctx: AgentMeshDeployContext,
+  options: AgentMeshDeployOptions,
+): Promise<AgentMeshDeployResult> {
+  const { execa } = await import("execa");
+  const { repoRoot, acr, acrLoginServer, baseName, rg, stepper } = ctx;
+
+  // Inspektor Gadget (eBPF observability) — non-fatal
+  await execa("kubectl", ["gadget", "deploy"], { stdio: "pipe" }).catch(() => {});
+
+  stepper.step("Deploying AgentMesh infrastructure...");
+
+  let registryMode: "local" | "global" = "local";
+  let globalRegistryUrl: string | undefined;
+  let globalRelayUrl: string | undefined;
+
+  if (options.globalRegistry) {
+    // External registry mode — skip local deployment, set env vars
+    stepper.update(`Using external registry: ${options.globalRegistry}`);
+    kvLine("Registry mode", "global");
+    kvLine("Registry URL", options.globalRegistry);
+
+    registryMode = "global";
+    globalRegistryUrl = options.globalRegistry;
+
+    stepper.done("AgentMesh: using external registry (skipped local deploy)");
+  } else {
+    // Local registry mode — deploy relay + registry in-cluster
+    const agentmeshManifest = path.join(repoRoot, "deploy", "agentmesh.yaml");
+    if (existsSync(agentmeshManifest)) {
+      // Import postgres image into ACR (Azure Policy blocks Docker Hub images)
+      stepper.update("Importing postgres image into ACR...");
+      await execa("az", [
+        "acr", "import",
+        "--name", acr,
+        "--source", "docker.io/library/postgres:16-alpine",
+        "--image", "postgres:16-alpine",
+        "--force",
+      ], { stdio: "pipe" }).catch(() => {
+        // May already exist — non-fatal
+      });
+
+      // Ensure the agentmesh namespace exists before creating the secret
+      await execa("kubectl", ["create", "namespace", "agentmesh"], { stdio: "pipe" }).catch(() => {});
+
+      // Auto-generate postgres credentials if the secret doesn't exist yet
+      const secretExists = await execa("kubectl", [
+        "get", "secret", "agentmesh-db-credentials", "-n", "agentmesh",
+      ], { stdio: "pipe" }).then(() => true).catch(() => false);
+
+      if (!secretExists) {
+        stepper.update("Generating AgentMesh database credentials...");
+        const { randomBytes } = await import("crypto");
+        const dbPassword = randomBytes(24).toString("base64url");
+        await execa("kubectl", [
+          "create", "secret", "generic", "agentmesh-db-credentials",
+          "-n", "agentmesh",
+          `--from-literal=POSTGRES_PASSWORD=${dbPassword}`,
+        ], { stdio: "pipe" });
+      }
+
+      // Substitute ACR login server in the manifest
+      const manifest = readFileSync(agentmeshManifest, "utf-8");
+      const patchedManifest = manifest.replace(
+        /azureclawacr\.azurecr\.io/g,
+        acrLoginServer
+      );
+      const tmpManifest = path.join(repoRoot, ".tmp-agentmesh.yaml");
+      try {
+        writeFileSync(tmpManifest, patchedManifest);
+        await execa("kubectl", ["apply", "-f", tmpManifest], { stdio: "pipe" });
+
+        // Wait for AgentMesh pods to be ready
+        stepper.update("Waiting for AgentMesh pods to be ready...");
+        await execa("kubectl", [
+          "wait", "--for=condition=Ready", "pod",
+          "-l", "app=agentmesh-relay",
+          "-n", "agentmesh",
+          "--timeout=180s",
+        ], { stdio: "pipe" }).catch(() => {});
+        await execa("kubectl", [
+          "wait", "--for=condition=Ready", "pod",
+          "-l", "app=agentmesh-registry",
+          "-n", "agentmesh",
+          "--timeout=180s",
+        ], { stdio: "pipe" }).catch(() => {});
+
+        stepper.done("AgentMesh infrastructure deployed");
+      } finally {
+        try { unlinkSync(tmpManifest); } catch { /* noop */ }
+      }
+    } else {
+      stepper.warn("AgentMesh manifest not found — skipping");
+    }
+
+    // Deploy AGIC Ingress if --expose-registry is set
+    if (options.exposeRegistry) {
+      stepper.step("Deploying AgentMesh Ingress (public endpoints)...");
+      const ingressManifest = path.join(repoRoot, "deploy", "agentmesh-ingress.yaml");
+      if (existsSync(ingressManifest)) {
+        const ingressYaml = readFileSync(ingressManifest, "utf-8");
+        const domain = `${baseName}.azureclaw.dev`;
+        const { stdout: currentSubId } = await execa("az", [
+          "account", "show", "--query", "id", "--output", "tsv",
+        ], { stdio: "pipe", timeout: 10000 }).catch(() => ({ stdout: "" }));
+        const patchedIngress = ingressYaml
+          .replace(/DOMAIN_PLACEHOLDER/g, domain)
+          .replace(/SUBSCRIPTION_ID/g, currentSubId.trim())
+          .replace(/RESOURCE_GROUP/g, rg)
+          .replace(/azureclawacr\.azurecr\.io/g, acrLoginServer);
+        const tmpIngress = path.join(repoRoot, ".tmp-agentmesh-ingress.yaml");
+        try {
+          writeFileSync(tmpIngress, patchedIngress);
+          await execa("kubectl", ["apply", "-f", tmpIngress], { stdio: "pipe" });
+          stepper.done(`AgentMesh Ingress deployed (registry.${domain}, relay.${domain})`);
+
+          registryMode = "global";
+          globalRegistryUrl = `https://registry.${domain}`;
+          globalRelayUrl = `wss://relay.${domain}`;
+        } finally {
+          try { unlinkSync(tmpIngress); } catch { /* noop */ }
+        }
+      } else {
+        stepper.warn("Ingress manifest not found — skipping");
+      }
+    }
+  }
+
+  return { registryMode, globalRegistryUrl, globalRelayUrl };
+}

--- a/docs/security-audits/2026-04-29-phase2-hotspot-up-cli-d3.md
+++ b/docs/security-audits/2026-04-29-phase2-hotspot-up-cli-d3.md
@@ -1,0 +1,124 @@
+# Phase 2 / S15.d.3 — `cli/src/commands/up.ts` AgentMesh deploy extraction
+
+| Metadata    | Value                                                             |
+|-------------|-------------------------------------------------------------------|
+| Slice       | S15.d.3 (sub-slice 3 of 4 in `phase2-hotspot-up-cli` sub-train)   |
+| Branch      | `phase2-hotspot-up-cli-d3`                                        |
+| Date        | 2026-04-29                                                        |
+| Sign-offs   | Core ✅, Security ✅                                              |
+| Linked PRs  | #80 (S15.a), #81 (S15.b), #82 (S15.c), #83 (S15.d.1), #84 (S15.d.2) |
+
+## Summary
+
+Continues the §4.2 800-LOC enforcement on `cli/src/commands/up.ts`.
+
+| File                                       | Pre-d.3 LOC | Post-d.3 LOC | Δ      |
+|--------------------------------------------|-------------|--------------|--------|
+| `cli/src/commands/up.ts`                   | 1296        | **1182**     | −114   |
+| `cli/src/commands/up/agentmesh_deploy.ts`  | (new)       | 174          | +174   |
+
+Extracts the AgentMesh infrastructure deploy phase (Inspektor Gadget eBPF
+deploy, AgentMesh relay + registry deployment in-cluster, external-registry
+shortcut, optional AGIC ingress publication) into
+`cli/src/commands/up/agentmesh_deploy.ts`.
+
+Caller in up.ts becomes a 9-line dispatch:
+
+```ts
+const { deployAgentMesh } = await import("./up/agentmesh_deploy.js");
+const meshResult = await deployAgentMesh(
+  { repoRoot, acr, acrLoginServer, baseName, rg, stepper },
+  { globalRegistry: options.globalRegistry, exposeRegistry: options.exposeRegistry },
+);
+const registryMode = meshResult.registryMode;
+const globalRegistryUrl = meshResult.globalRegistryUrl;
+const globalRelayUrl = meshResult.globalRelayUrl;
+```
+
+The result triple `{ registryMode, globalRegistryUrl, globalRelayUrl }`
+flows forward unchanged to:
+
+- The Step 7 ClawSandbox CR creation (env-var injection).
+- The end-of-deploy `saveContext()` call.
+
+## Decomposition contract
+
+`deployAgentMesh(ctx, options)` is a pure orchestration helper:
+
+- **Inputs:** `{ repoRoot, acr, acrLoginServer, baseName, rg, stepper }`
+  for context; `{ globalRegistry, exposeRegistry }` for option shape.
+- **Outputs:** `{ registryMode: "local" | "global", globalRegistryUrl?,
+  globalRelayUrl? }`.
+- **Side effects:** identical to inline body — `kubectl gadget deploy`,
+  `az acr import`, `kubectl create namespace agentmesh`, postgres
+  credentials secret, `kubectl apply -f` on the patched manifest,
+  `kubectl wait` for relay + registry pods, optional ingress apply.
+- **Tmp-file lifecycle preserved:** `.tmp-agentmesh.yaml` + 
+  `.tmp-agentmesh-ingress.yaml` are written under `try`/`finally` and
+  unlinked on both success and failure paths (verbatim from inline).
+
+The outer-scope `const fs = await import("fs")` in `up.ts` is removed
+(was only used by the AgentMesh manifest-substitution block, which is
+now scoped to the new module). Inner deploy phases each declare their
+own `fs` import inline as before.
+
+## Existing implementation surveyed
+
+- `cli/src/commands/up/fast_upgrade.ts` (S15.d.1) and
+  `cli/src/commands/up/preflight.ts` (S15.d.2) — adjacent helpers, same
+  dynamic-import pattern.
+- `cli/src/stepper.ts` — `kvLine` reused. No re-implementation.
+- `deploy/agentmesh.yaml` and `deploy/agentmesh-ingress.yaml` —
+  consumed unchanged.
+- `crypto.randomBytes` for postgres password — stdlib, same as before.
+
+No duplication, no parallel implementation, no hand-rolled crypto, no
+new network endpoints.
+
+## Behavior delta
+
+**None.** The body moved verbatim. Order of operations, kubectl apply
+arguments, manifest substitution patterns (`azureclawacr.azurecr.io`,
+`DOMAIN_PLACEHOLDER`, `SUBSCRIPTION_ID`, `RESOURCE_GROUP`), tmp-file
+cleanup, `kubectl wait` timeouts, and the registry-mode triple flowing
+forward are all byte-identical.
+
+## Verification
+
+| Check                                           | Result          |
+|-------------------------------------------------|-----------------|
+| `cd cli && npx tsc --noEmit`                    | ✅ clean        |
+| `cd cli && npm run lint`                        | ✅ 27 warnings (baseline-matched), 0 errors |
+| `cd cli && npm run build`                       | ✅ clean        |
+| `cd cli && npm test -- --run`                   | ✅ 454 pass / 2 skipped |
+| `up.ts` LOC ≤ pre-slice                         | ✅ 1296 → 1182  |
+
+## Threat model
+
+Unchanged. The agent-mesh deploy phase has the same Azure surface:
+
+- `az acr import` of the postgres image (same arguments).
+- `kubectl create secret generic agentmesh-db-credentials` (same
+  randomBytes(24) base64url password generation).
+- `kubectl apply` of `deploy/agentmesh.yaml` (same manifest).
+- AGIC ingress apply with the same template substitutions.
+
+No new credentials, no new manifests, no new substitution patterns.
+The single removed line (the redundant `const fs = await import("fs")`
+inside the inline AgentMesh block at original line 780) is replaced by
+named-imports in the new module file, which use the same `node:fs`
+named-import API surface as the rest of the repo.
+
+## Tracker
+
+- §4.2 budget for `cli/src/commands/up.ts`: 800. Post-d.3: 1182. Cap
+  achievement deferred to **d.4** (sandbox bring-up + summary), which
+  will extract the ~315-line ClawSandbox CR creation block.
+- Subsequent sub-slices remaining: **d.4** only.
+
+## Sign-offs
+
+- Core ✅ — body moved verbatim; tests + tsc + lint + build green.
+- Security ✅ — no threat-model surface change; no new dependencies; no
+  new network or auth flows; `randomBytes(24)` and existing manifest
+  patches preserved verbatim.


### PR DESCRIPTION
## Phase 2 / S15.d.3 — `cli/src/commands/up.ts` AgentMesh deploy extraction

Third sub-slice of the **S15.d up.ts multi-PR sub-train**. Extracts the AgentMesh infrastructure deploy phase (Inspektor Gadget eBPF, relay + registry deployment in-cluster, external-registry shortcut, optional AGIC ingress) into `cli/src/commands/up/agentmesh_deploy.ts` (174 LOC).

### Decomposition

`deployAgentMesh(ctx, options)` returns `{ registryMode, globalRegistryUrl, globalRelayUrl }` which flows forward unchanged to the ClawSandbox CR creation step (env-var injection) and `saveContext()` at end-of-deploy. Caller in up.ts is a 9-line dispatch.

### Verification

- ✅ `up.ts` LOC: 1296 → **1182** (−114)
- ✅ `tsc --noEmit` clean
- ✅ `npm run lint` 27 warnings (baseline-matched), 0 errors
- ✅ `npm run build` clean
- ✅ `npm test -- --run` → 454/454 pass (2 skipped pre-existing)

### Behavior delta

**None.** AgentMesh body moved verbatim. `az acr import`, `kubectl create namespace agentmesh`, postgres-credentials secret (same `randomBytes(24)` base64url generation), `kubectl apply` of the patched manifest, `kubectl wait` timeouts, AGIC ingress template substitutions (DOMAIN_PLACEHOLDER, SUBSCRIPTION_ID, RESOURCE_GROUP, ACR), tmp-file lifecycle — all byte-identical.

### Threat model

Unchanged. No new credentials, no new manifests, no new substitution patterns. Single removed line: redundant outer-scope `const fs = await import("fs")` in up.ts (replaced by named imports of `node:fs` in the new module file).

### Audit

`docs/security-audits/2026-04-29-phase2-hotspot-up-cli-d3.md` (Core ✅, Security ✅).

### Tracker

Sub-slice **d.3** of **S15.d** `phase2-hotspot-up-cli` multi-PR sub-train. Final sub-slice:
- **d.4:** sandbox bring-up + summary (~315 LOC remaining over cap)

Follows S15.d.2 (#84), S15.d.1 (#83), S15.c (#82), S15.b (#81), S15.a (#80).