### PR TITLE
S15.e.1: extract operator.ts types + pure helpers (2894 → 2739 LOC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S15.e.1 `phase2-hotspot-operator-cli-e1` — operator.ts type + helper extraction
+
+#### Refactored
+
+- `cli/src/commands/operator.ts` 2894 → **2739 LOC** — first
+  sub-slice of the S15.e operator.ts decomposition train.
+  Module-level types (`HealthState`, `SandboxInfo`, `EgressDomain`,
+  `SecurityState`, `NodeInfo`, `ClusterHealth`, `MeshHealth`)
+  extracted to `cli/src/commands/operator/types.ts` (128 LOC);
+  module-level pure helpers (`timeSince`, `sumPrometheusCounter`)
+  extracted to `cli/src/commands/operator/helpers.ts` (65 LOC).
+- No behavior change; all declarations are byte-identical to the
+  originals. §4.2 cap (800) not yet met — multi-PR sub-train.
+
+#### Tests
+
+- All 454 CLI tests pass; tsc / lint (27 baseline) / build clean.
+
+#### Audit
+
+- `docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e1.md`
+
 ### S15.d.4 `phase2-hotspot-up-cli-d4` — up.ts sandbox bring-up extraction (caps S15.d at 766 ✅)
 
 #### Refactored

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -17,126 +17,16 @@ import {
   statusBarForTopology,
   statusBarForCluster,
 } from "./operator/keymap.js";
-
-// ── Types ───────────────────────────────────────────────────────────
-
-type HealthState = "healthy" | "degraded" | "down" | "pending" | "unknown" | "dormant";
-
-interface SandboxInfo {
-  name: string;
-  namespace: string;
-  status: string;
-  health: HealthState;
-  model: string;
-  isolation: string;
-  channels: string;
-  age: string;
-  podName: string;
-  restarts: number;
-  role: "controller" | "sub-agent";
-  parent: string;  // parent agent name (empty if controller)
-  handoffState?: "dormant" | "active-successor" | "returning";
-  runtime: "docker" | "aks";
-}
-
-interface EgressDomain {
-  domain: string;
-  sandbox: string;
-  namespace: string;
-  state: "learned" | "approved";
-}
-
-/** Security state polled from a single sandbox's router + k8s objects. */
-interface SecurityState {
-  sandbox: string;
-  isolation: string;
-  runtime: string;         // "runc" | "kata-vm-isolation"
-  seccomp: string;         // "azureclaw-strict" | "RuntimeDefault"
-  networkPolicy: boolean;
-  adminAuth: boolean;
-  readyz: boolean;
-  readyzDetail: string;    // "ok" | "not ready — ..." | "content safety unreachable"
-  egressMode: string;      // "learning" | "enforcing" | "unknown"
-  learnedDomains: number;
-  allowlistDomains: number;
-  blocklistDomains: number;
-  blocklistLearnMode: boolean;
-  agtEnabled: boolean;
-  agtAuditEntries: number;
-  agtAuditIntegrity: boolean;
-  agtKnownAgents: number;
-  agtTrustThreshold: number;
-  // AGT detail — populated from /agt/audit, /agt/trust, relay/registry logs
-  agtRecentAudit: string[];     // last few audit entries
-  agtTrustScores: { agent: string; score: number; tier: string; interactions: number; lastSeen: string }[];
-  agtRelayConnected: boolean;
-  agtRegistryAgents: number;
-  agtAmid: string;  // cryptographic identity from registry
-  // Mesh counters (from router MeshMetrics)
-  agtMeshSessions: number;
-  agtMeshSent: number;
-  agtMeshReceived: number;
-  agtTrustUpdates: number;
-  agtTotalInteractions: number;
-  // Native governance stats (from /agt/status when governance_mode === "native")
-  agtGovernanceMode: string;     // "native" | ""
-  agtPolicyEvaluations: number;
-  agtPolicyDenials: number;
-  agtPolicyRateLimits: number;
-  agtEvalLatencyUs: number;      // average eval latency in microseconds
-  agtBehaviorAlerts: number;
-  agtBehaviorDetail: Array<{ agent: string; reasons: string[] }>;
-  agtContentFlags: number;
-  agtPolicyRules: number;
-  // Registry reputation (from agentmesh-registry)
-  agtReputation: {
-    score: number;       // 0.0–1.0 composite
-    tier: string;
-    completionRate: number;
-    totalSessions: number;
-    feedbackCount: number;
-    avgFeedback: number;
-    tags: { tag: string; count: number }[];
-  } | null;
-  // AGT relay/registry URLs
-  agtRelayUrl: string;
-  agtRegistryUrl: string;
-  // Prometheus metrics
-  totalRequests: number;
-  errorRequests: number;
-  inputTokens: number;
-  outputTokens: number;
-  avgLatencyMs: number;
-}
-
-interface NodeInfo {
-  name: string;
-  pool: string;
-  status: string;
-  version: string;
-  cpuCores: string;
-  cpuPct: string;
-  memBytes: string;
-  memPct: string;
-  os: string;
-  runtime: string;
-}
-
-interface ClusterHealth {
-  apiLatencyMs: number;
-  apiReachable: boolean;
-  nodes: NodeInfo[];
-  quotas: { namespace: string; cpuUsed: string; cpuHard: string; memUsed: string; memHard: string }[];
-  pvcs: { namespace: string; name: string; phase: string; size: string }[];
-  warnings: { time: string; reason: string; object: string; message: string }[];
-}
-
-interface MeshHealth {
-  relayReady: boolean;
-  registryReady: boolean;
-  registryPods: number;
-  registryReadyPods: number;
-}
+import type {
+  HealthState,
+  SandboxInfo,
+  EgressDomain,
+  SecurityState,
+  NodeInfo,
+  ClusterHealth,
+  MeshHealth,
+} from "./operator/types.js";
+import { timeSince, sumPrometheusCounter } from "./operator/helpers.js";
 
 // ── Command ─────────────────────────────────────────────────────────
 
@@ -2846,49 +2736,4 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
 
   refreshTimer = setInterval(async () => { await refresh(); }, refreshInterval);
   screen.on("destroy", () => { if (refreshTimer) clearInterval(refreshTimer); stopSpinner(); });
-}
-
-function timeSince(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 0) return "0s";
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `${days}d`;
-}
-
-/**
- * Parse Prometheus text format and sum values for a given metric name.
- * Optionally filter by label key=value pairs.
- *
- * Example line: `azureclaw_tokens_total{direction="input",model="gpt-4",sandbox="s1"} 8500`
- */
-function sumPrometheusCounter(
-  text: string,
-  metricName: string,
-  labelFilter?: Record<string, string>,
-): number {
-  let total = 0;
-  for (const line of text.split("\n")) {
-    if (line.startsWith("#") || !line.startsWith(metricName)) continue;
-
-    // Check label filter
-    if (labelFilter) {
-      let match = true;
-      for (const [k, v] of Object.entries(labelFilter)) {
-        if (!line.includes(`${k}="${v}"`)) { match = false; break; }
-      }
-      if (!match) continue;
-    }
-
-    // Extract numeric value after the closing brace (or after metric name if no labels)
-    const valMatch = line.match(/\}\s+([0-9eE.+-]+)$/) || line.match(/^[^\s{]+\s+([0-9eE.+-]+)$/);
-    if (valMatch) {
-      total += parseFloat(valMatch[1]) || 0;
-    }
-  }
-  return total;
 }

--- a/cli/src/commands/operator/helpers.ts
+++ b/cli/src/commands/operator/helpers.ts
@@ -1,0 +1,65 @@
+/**
+ * Operator-TUI pure helper functions.
+ *
+ * Extracted from `cli/src/commands/operator.ts` (S15.e.1) so the
+ * top-level dashboard module can stay under §4.2's 800-line cap.
+ *
+ * Both helpers are pure: no I/O, no closure capture, no state.
+ * They were already module-level in operator.ts (not nested inside
+ * `startDashboard`) and are byte-identical to the originals.
+ */
+
+/**
+ * Return a compact human-readable duration string for "time since `date`".
+ *
+ *   < 60s  → "Ns"
+ *   < 60m  → "Nm"
+ *   < 24h  → "Nh"
+ *   else   → "Nd"
+ *
+ * Future dates clamp to "0s" (no negative output).
+ */
+export function timeSince(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 0) return "0s";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+/**
+ * Parse Prometheus text format and sum values for a given metric name.
+ * Optionally filter by label key=value pairs.
+ *
+ * Example line: `azureclaw_tokens_total{direction="input",model="gpt-4",sandbox="s1"} 8500`
+ */
+export function sumPrometheusCounter(
+  text: string,
+  metricName: string,
+  labelFilter?: Record<string, string>,
+): number {
+  let total = 0;
+  for (const line of text.split("\n")) {
+    if (line.startsWith("#") || !line.startsWith(metricName)) continue;
+
+    // Check label filter
+    if (labelFilter) {
+      let match = true;
+      for (const [k, v] of Object.entries(labelFilter)) {
+        if (!line.includes(`${k}="${v}"`)) { match = false; break; }
+      }
+      if (!match) continue;
+    }
+
+    // Extract numeric value after the closing brace (or after metric name if no labels)
+    const valMatch = line.match(/\}\s+([0-9eE.+-]+)$/) || line.match(/^[^\s{]+\s+([0-9eE.+-]+)$/);
+    if (valMatch) {
+      total += parseFloat(valMatch[1]) || 0;
+    }
+  }
+  return total;
+}

--- a/cli/src/commands/operator/types.ts
+++ b/cli/src/commands/operator/types.ts
@@ -1,0 +1,128 @@
+/**
+ * Operator-TUI shared type declarations.
+ *
+ * Extracted from `cli/src/commands/operator.ts` (S15.e.1) so the
+ * top-level dashboard module can stay under §4.2's 800-line cap.
+ *
+ * No behavioral or shape change — all interfaces are byte-identical
+ * to the originals. They are used only inside the operator command
+ * (no cross-file consumers as of S15.e.1).
+ */
+
+export type HealthState = "healthy" | "degraded" | "down" | "pending" | "unknown" | "dormant";
+
+export interface SandboxInfo {
+  name: string;
+  namespace: string;
+  status: string;
+  health: HealthState;
+  model: string;
+  isolation: string;
+  channels: string;
+  age: string;
+  podName: string;
+  restarts: number;
+  role: "controller" | "sub-agent";
+  parent: string;  // parent agent name (empty if controller)
+  handoffState?: "dormant" | "active-successor" | "returning";
+  runtime: "docker" | "aks";
+}
+
+export interface EgressDomain {
+  domain: string;
+  sandbox: string;
+  namespace: string;
+  state: "learned" | "approved";
+}
+
+/** Security state polled from a single sandbox's router + k8s objects. */
+export interface SecurityState {
+  sandbox: string;
+  isolation: string;
+  runtime: string;         // "runc" | "kata-vm-isolation"
+  seccomp: string;         // "azureclaw-strict" | "RuntimeDefault"
+  networkPolicy: boolean;
+  adminAuth: boolean;
+  readyz: boolean;
+  readyzDetail: string;    // "ok" | "not ready — ..." | "content safety unreachable"
+  egressMode: string;      // "learning" | "enforcing" | "unknown"
+  learnedDomains: number;
+  allowlistDomains: number;
+  blocklistDomains: number;
+  blocklistLearnMode: boolean;
+  agtEnabled: boolean;
+  agtAuditEntries: number;
+  agtAuditIntegrity: boolean;
+  agtKnownAgents: number;
+  agtTrustThreshold: number;
+  // AGT detail — populated from /agt/audit, /agt/trust, relay/registry logs
+  agtRecentAudit: string[];     // last few audit entries
+  agtTrustScores: { agent: string; score: number; tier: string; interactions: number; lastSeen: string }[];
+  agtRelayConnected: boolean;
+  agtRegistryAgents: number;
+  agtAmid: string;  // cryptographic identity from registry
+  // Mesh counters (from router MeshMetrics)
+  agtMeshSessions: number;
+  agtMeshSent: number;
+  agtMeshReceived: number;
+  agtTrustUpdates: number;
+  agtTotalInteractions: number;
+  // Native governance stats (from /agt/status when governance_mode === "native")
+  agtGovernanceMode: string;     // "native" | ""
+  agtPolicyEvaluations: number;
+  agtPolicyDenials: number;
+  agtPolicyRateLimits: number;
+  agtEvalLatencyUs: number;      // average eval latency in microseconds
+  agtBehaviorAlerts: number;
+  agtBehaviorDetail: Array<{ agent: string; reasons: string[] }>;
+  agtContentFlags: number;
+  agtPolicyRules: number;
+  // Registry reputation (from agentmesh-registry)
+  agtReputation: {
+    score: number;       // 0.0–1.0 composite
+    tier: string;
+    completionRate: number;
+    totalSessions: number;
+    feedbackCount: number;
+    avgFeedback: number;
+    tags: { tag: string; count: number }[];
+  } | null;
+  // AGT relay/registry URLs
+  agtRelayUrl: string;
+  agtRegistryUrl: string;
+  // Prometheus metrics
+  totalRequests: number;
+  errorRequests: number;
+  inputTokens: number;
+  outputTokens: number;
+  avgLatencyMs: number;
+}
+
+export interface NodeInfo {
+  name: string;
+  pool: string;
+  status: string;
+  version: string;
+  cpuCores: string;
+  cpuPct: string;
+  memBytes: string;
+  memPct: string;
+  os: string;
+  runtime: string;
+}
+
+export interface ClusterHealth {
+  apiLatencyMs: number;
+  apiReachable: boolean;
+  nodes: NodeInfo[];
+  quotas: { namespace: string; cpuUsed: string; cpuHard: string; memUsed: string; memHard: string }[];
+  pvcs: { namespace: string; name: string; phase: string; size: string }[];
+  warnings: { time: string; reason: string; object: string; message: string }[];
+}
+
+export interface MeshHealth {
+  relayReady: boolean;
+  registryReady: boolean;
+  registryPods: number;
+  registryReadyPods: number;
+}

--- a/docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e1.md
+++ b/docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e1.md
@@ -1,0 +1,109 @@
+# 2026-04-29 — Phase 2 / S15.e.1 — operator.ts type + helper extraction
+
+**Slice:** `phase2-hotspot-operator-cli-e1`
+**Branch:** `phase2-hotspot-operator-cli-e1` → `dev`
+**Hotspot tracker:** `cli/src/commands/operator.ts` — Phase 2 cap **800** (§4.2)
+
+## Scope
+
+First sub-slice of S15.e (`operator.ts` decomposition). Lifts the
+purely declarative + purely-functional pieces — module-level types
+and the two module-level pure helpers — into dedicated files under
+`cli/src/commands/operator/`.
+
+S15.e is necessarily a multi-PR sub-train: `operator.ts` is
+**2,894 LOC, 99% inside one giant `startDashboard` closure**. There
+is no honest way to flip it under cap in a single review-able PR.
+S15.e.1 is the lowest-risk first cut that establishes the
+`operator/` directory pattern (already used for `keymap.ts`) for
+follow-up sub-slices to extend.
+
+## What moved
+
+| File | Type | LOC moved |
+|---|---|---|
+| `cli/src/commands/operator/types.ts` (new) | pure interfaces / types | 118 |
+| `cli/src/commands/operator/helpers.ts` (new) | pure functions | 51 |
+
+Source declarations (verbatim):
+
+- **Types** (originally `operator.ts:21-139`):
+  `HealthState`, `SandboxInfo`, `EgressDomain`, `SecurityState`,
+  `NodeInfo`, `ClusterHealth`, `MeshHealth`. All re-exported
+  unchanged; each `interface` was promoted from internal to
+  `export interface` (no shape edits).
+- **Helpers** (originally `operator.ts:2851-2894`):
+  `timeSince(date)`, `sumPrometheusCounter(text, metricName, labelFilter?)`.
+  Both module-level (not nested in `startDashboard`); zero closure
+  capture; byte-identical bodies.
+
+`operator.ts` now imports these via `type { ... } from "./operator/types.js"`
+and `{ timeSince, sumPrometheusCounter } from "./operator/helpers.js"`.
+
+## LOC delta
+
+| Slice | `operator.ts` | Δ | Cumulative |
+|---|---|---|---|
+| pre-S15.e | 2894 | — | — |
+| **S15.e.1** | **2739** | **−155** | **−155** |
+| §4.2 cap | 800 | | (cap not yet met; S15.e.2+ pending) |
+
+## Behavior delta
+
+**None.** Types are byte-identical. Both helpers' bodies are
+byte-identical. No call sites touched. No public surface change
+(types were never exported; their visibility is now wider but
+no consumer outside `operator.ts` exists today — verified via
+`rg 'SandboxInfo|EgressDomain|SecurityState|NodeInfo|ClusterHealth|MeshHealth|HealthState' cli/src/`).
+
+## Verification
+
+- `npx tsc --noEmit` → clean.
+- `npm run lint` → 27 warnings, 0 errors (baseline).
+- `npm run build` → clean.
+- `npm test -- --run` → **454 / 454 passing** (2 skipped pre-existing).
+
+## §0.2 hard-rule check
+
+- ✓ no new TODOs / `unimplemented!` / `panic!` / stubs
+- ✓ no new file exceeds Phase 2 cap (`types.ts` 128, `helpers.ts` 65)
+- ✓ touched hotspot file shrank (`operator.ts` 2894 → 2739)
+- ✓ no custom-crypto added (none touched)
+- ✓ no duplication — types + helpers had a single home (operator.ts);
+  moved to a single new home (`operator/`); no parallel implementation
+- ✓ no dead code carried — superseded declarations removed in this slice
+- ✓ existing implementation surveyed — `operator/keymap.ts` was the
+  only prior decomposition; this slice extends the same pattern; no
+  new abstraction layer introduced
+
+## Sign-off
+
+| Lens | Verdict |
+|---|---|
+| Core — correctness, completeness, regression risk | ✅ pure type/helper move, no behavior change |
+| Security — threat model, secrets, crypto, attack surface | ✅ no new attack surface; no secrets / crypto / RBAC touched |
+
+## Tracker — §15 hotspot status (post-merge state)
+
+| File | Pre-Phase 2 | Cap | Status |
+|---|---|---|---|
+| `cli/src/commands/handoff.ts` | 1119 | 800 | ✅ S15.a (798) |
+| `cli/src/commands/mesh.ts` | 1583 | 800 | ✅ S15.b (667) |
+| `inference-router/src/routes/inference.rs` | 1359 | 800 | ✅ S15.c (776) |
+| `cli/src/commands/up.ts` | 1849 | 800 | ✅ S15.d (766) |
+| `cli/src/commands/operator.ts` | 2894 | 800 | 🔄 **S15.e.1 (2739)** — multi-PR sub-train |
+| `cli/src/commands/plugin.ts` | 7139 | 800 | pending S15.f |
+
+## Follow-ups
+
+S15.e.2+ candidate seams (each is its own PR):
+
+- `fetchSandboxes*` (Docker + AKS, ~240 LOC) → `operator/fetchers/sandboxes.ts`
+- `fetchSecurityState` (~254 LOC) → `operator/fetchers/security.ts`
+- `fetchEgressDomains` + `fetchAgtQuick` + `fetchClusterHealth` + `fetchMeshHealth` (~280 LOC combined) → `operator/fetchers/`
+- `renderSecurity` + `renderAGT*` + `renderTopology` + `renderCluster` rendering helpers (~600 LOC) → `operator/render/`
+- `approveDomain` / `denyDomain` / `enforceEgress` / `learnEgress` action helpers (~90 LOC) → `operator/actions.ts`
+- Modal / dialog interaction helpers (`startEdit`, `launch`, `connectToAgent`) — ~700 LOC, needs context object pattern (similar to `up.ts` S15.d.4 `SandboxBringUpContext`)
+
+Each sub-slice should land independently behind its own audit doc;
+target is `operator.ts` ≤ 800 LOC by S15.e close-out.


### PR DESCRIPTION
## Phase 2 / S15.e.1 — operator.ts type + helper extraction

**First sub-slice of S15.e** (operator.ts decomposition multi-PR sub-train).

Lifts the only purely-declarative + closure-free pieces of operator.ts:

- Module-level types (`HealthState`, `SandboxInfo`, `EgressDomain`, `SecurityState`, `NodeInfo`, `ClusterHealth`, `MeshHealth`) → `cli/src/commands/operator/types.ts` (128 LOC).
- Module-level pure helpers (`timeSince`, `sumPrometheusCounter`) → `cli/src/commands/operator/helpers.ts` (65 LOC).

`operator.ts` imports both via `./operator/types.js` + `./operator/helpers.js`. Bodies and declarations are byte-identical — no shape edits, no logic edits. Continues the `operator/` subdirectory pattern already started by `operator/keymap.ts`.

### LOC delta

| Slice | operator.ts | Δ |
|---|---|---|
| pre-S15.e | 2894 | — |
| **S15.e.1** | **2739** | **−155** |
| §4.2 cap | 800 | (cap not yet met; multi-PR sub-train) |

### Verification

- ✅ operator.ts: 2894 → 2739
- ✅ `tsc --noEmit` clean
- ✅ `npm run lint` 27 warnings (baseline), 0 errors
- ✅ `npm run build` clean
- ✅ `npm test -- --run` → 454/454 pass (2 skipped pre-existing)

### Behavior delta

**None.** Types byte-identical; helper bodies byte-identical; no call sites touched. Cross-file usage check (`rg` over cli/src) confirmed types had zero external consumers; making them `export` is a no-op outside operator.ts.

### Audit

`docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e1.md` (Core ✅, Security ✅).

### Tracker — §15 hotspot status

| File | Pre-Phase 2 | Cap | Status |
|---|---|---|---|
| `cli/src/commands/handoff.ts` | 1119 | 800 | ✅ S15.a (798) |
| `cli/src/commands/mesh.ts` | 1583 | 800 | ✅ S15.b (667) |
| `inference-router/src/routes/inference.rs` | 1359 | 800 | ✅ S15.c (776) |
| `cli/src/commands/up.ts` | 1849 | 800 | ✅ S15.d (766) |
| `cli/src/commands/operator.ts` | 2894 | 800 | 🔄 **S15.e.1 (2739)** |
| `cli/src/commands/plugin.ts` | 7139 | 800 | pending S15.f |

### Follow-up sub-slices (each its own PR)

- `fetchSandboxes*` → `operator/fetchers/sandboxes.ts`
- `fetchSecurityState` → `operator/fetchers/security.ts`
- `fetchEgressDomains` + `fetchAgtQuick` + `fetchClusterHealth` + `fetchMeshHealth` → `operator/fetchers/`
- Render helpers (`renderSecurity`, `renderAGT*`, `renderTopology`, `renderCluster`) → `operator/render/`
- Action helpers (`approveDomain`/`denyDomain`/`enforceEgress`/`learnEgress`) → `operator/actions.ts`
- Modal/dialog interaction (`startEdit`, `launch`, `connectToAgent`) — context-object pattern (similar to S15.d.4 `SandboxBringUpContext`)