### PR TITLE
S15.e.2: extract operator.ts sandbox-list fetchers (2739 → 2483 LOC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S15.e.2 `phase2-hotspot-operator-cli-e2` — operator.ts sandbox-list fetcher extraction
+
+#### Refactored
+
+- `cli/src/commands/operator.ts` 2739 → **2483 LOC** (cumulative
+  S15.e: 2894 → 2483, −411). Sandbox-list fetchers
+  (`fetchSandboxes`, `fetchSandboxesAKS`, `fetchSandboxesDocker`)
+  extracted to `cli/src/commands/operator/fetchers/sandboxes.ts`
+  (287 LOC). Also moved `kctl(args, context?)` helper to
+  `operator/helpers.ts` so the new fetcher module can reuse it.
+- Closure-captured `kubeContext` now passed as explicit parameter
+  to AKS variant; semantics identical.
+- No behavior change; bodies byte-identical.
+
+#### Tests
+
+- All 454 CLI tests pass; tsc / lint (27 baseline) / build clean.
+
+#### Audit
+
+- `docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e2.md`
+
 ### S15.e.1 `phase2-hotspot-operator-cli-e1` — operator.ts type + helper extraction
 
 #### Refactored

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -18,7 +18,6 @@ import {
   statusBarForCluster,
 } from "./operator/keymap.js";
 import type {
-  HealthState,
   SandboxInfo,
   EgressDomain,
   SecurityState,
@@ -26,7 +25,8 @@ import type {
   ClusterHealth,
   MeshHealth,
 } from "./operator/types.js";
-import { timeSince, sumPrometheusCounter } from "./operator/helpers.js";
+import { timeSince, sumPrometheusCounter, kctl } from "./operator/helpers.js";
+import { fetchSandboxes } from "./operator/fetchers/sandboxes.js";
 
 // ── Command ─────────────────────────────────────────────────────────
 
@@ -50,9 +50,7 @@ export function operatorCommand(): Command {
 }
 
 // Helper to build kubectl args with optional context
-function kctl(args: string[], context?: string): string[] {
-  return context ? ["--context", context, ...args] : args;
-}
+
 
 async function startDashboard(refreshInterval: number, kubeContext?: string, devMode = false) {
   // ── Resolve cluster ───────────────────────────────────────────────
@@ -276,260 +274,6 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
 
   // ── Data fetching ─────────────────────────────────────────────────
 
-  async function fetchSandboxes(): Promise<SandboxInfo[]> {
-    // Always fetch both Docker and AKS — unified view
-    const [dockerResult, aksResult] = await Promise.allSettled([
-      fetchSandboxesDocker(),
-      fetchSandboxesAKS(),
-    ]);
-    const docker = dockerResult.status === "fulfilled" ? dockerResult.value : [];
-    const aks = aksResult.status === "fulfilled" ? aksResult.value : [];
-
-    // Deduplicate: if same name exists in both, mark relationships
-    // (e.g., dormant local + active-successor cloud after handoff)
-    return [...docker, ...aks];
-  }
-
-  async function fetchSandboxesAKS(): Promise<SandboxInfo[]> {
-    try {
-      const { stdout } = await execa("kubectl", kctl([
-        "get", "clawsandbox", "-A", "-o", "json",
-      ], kubeContext), { stdio: "pipe" });
-
-      const data = JSON.parse(stdout);
-      const items: any[] = data.items || [];
-
-      // Fetch pods + secrets for ALL sandboxes in parallel (not sequentially)
-      const enriched = await Promise.allSettled(items.map(async (item) => {
-        const name: string = item.metadata?.name || "";
-        if (!name) return null;
-        const phase: string = item.status?.phase || "Unknown";
-        const model: string = item.spec?.inference?.model || "gpt-4.1";
-        const isolation: string = item.spec?.sandbox?.isolation || "enhanced";
-        const created: string = item.metadata?.creationTimestamp || "";
-        const labels: Record<string, string> = item.metadata?.labels || {};
-        const parentLabel = labels["azureclaw.azure.com/parent"] || "";
-        const role: "controller" | "sub-agent" = parentLabel ? "sub-agent" : "controller";
-
-        // Detect handoff successor (CRD has spec.handoff.mode = "restore")
-        let handoffState: SandboxInfo["handoffState"] = undefined;
-        if (item.spec?.handoff?.mode === "restore") {
-          handoffState = "active-successor";
-        }
-
-        const sandboxNs = `azureclaw-${name}`;
-        let podStatus = phase;
-        let podName = "";
-        let podCreated = "";
-        let channels = "";
-        let health: HealthState = "pending";
-        let restarts = 0;
-
-        // Fetch pods and secret in parallel
-        const [podResult, secretResult] = await Promise.allSettled([
-          execa("kubectl", kctl([
-            "get", "pods", "-n", sandboxNs, "-o", "json",
-          ], kubeContext), { stdio: "pipe", timeout: 15000 }),
-          execa("kubectl", kctl([
-            "get", "secret", `${name}-credentials`, "-n", sandboxNs,
-            "-o", "jsonpath={.data}",
-          ], kubeContext), { stdio: "pipe", timeout: 10000 }),
-        ]);
-
-        if (podResult.status === "fulfilled") {
-          try {
-            const pods = JSON.parse(podResult.value.stdout);
-            if (pods.items?.length > 0) {
-              const sorted = [...pods.items].sort((a: any, b: any) => {
-                const order = (p: any) => {
-                  if (p.metadata?.deletionTimestamp) return 3;
-                  const phase = p.status?.phase || "";
-                  if (phase === "Running") return 0;
-                  if (phase === "Pending") return 1;
-                  return 2;
-                };
-                return order(a) - order(b);
-              });
-              const pod = sorted[0];
-              const isTerminating = !!pod.metadata?.deletionTimestamp;
-              podName = pod.metadata?.name || "";
-              podCreated = pod.metadata?.creationTimestamp || "";
-              const pPhase = isTerminating ? "Terminating" : (pod.status?.phase || "Unknown");
-              const statuses: any[] = pod.status?.containerStatuses || [];
-              const readyCount = statuses.filter((c: any) => c.ready).length;
-              const totalCount = statuses.length;
-              restarts = statuses.reduce((sum: number, c: any) => sum + (c.restartCount || 0), 0);
-              podStatus = totalCount > 0 ? `${pPhase} (${readyCount}/${totalCount})` : pPhase;
-
-              const hasCrash = statuses.some((c: any) =>
-                c.state?.waiting?.reason === "CrashLoopBackOff" ||
-                c.state?.waiting?.reason === "Error",
-              );
-              if (isTerminating) health = "degraded";
-              else if (hasCrash || pPhase === "Failed") health = "down";
-              else if (readyCount === totalCount && totalCount > 0) health = "healthy";
-              else if (readyCount > 0) health = "degraded";
-              else if (pPhase === "Pending") health = "pending";
-              else health = "unknown";
-
-              if (isTerminating || pPhase === "Pending" || readyCount === 0) podName = "";
-            }
-          } catch { /* bad JSON */ }
-        }
-
-        if (secretResult.status === "fulfilled") {
-          const secretOut = secretResult.value.stdout;
-          const chs: string[] = [];
-          if (secretOut.includes("TELEGRAM")) chs.push("TG");
-          if (secretOut.includes("SLACK")) chs.push("SL");
-          if (secretOut.includes("DISCORD")) chs.push("DC");
-          channels = chs.join(",") || "-";
-        } else {
-          channels = "-";
-        }
-
-        let age = "-";
-        const ageSource = podCreated || created;
-        if (ageSource) {
-          const d = new Date(ageSource);
-          if (!isNaN(d.getTime())) age = timeSince(d);
-        }
-
-        return {
-          name, namespace: sandboxNs, status: podStatus,
-          health, model, isolation,
-          channels, age, podName, restarts,
-          role, parent: parentLabel, handoffState,
-          runtime: "aks",
-        } as SandboxInfo;
-      }));
-
-      const results: SandboxInfo[] = enriched
-        .filter((r): r is PromiseFulfilledResult<SandboxInfo | null> => r.status === "fulfilled" && r.value !== null)
-        .map((r) => r.value!);
-
-      // Build tree: controllers sorted alphabetically, sub-agents right after their parent
-      const controllers = results.filter((s) => s.role === "controller").sort((a, b) => a.name.localeCompare(b.name));
-      const subAgents = results.filter((s) => s.role === "sub-agent");
-      const tree: SandboxInfo[] = [];
-      for (const ctrl of controllers) {
-        tree.push(ctrl);
-        // Attach sub-agents that belong to this controller
-        const children = subAgents.filter((s) => s.parent === ctrl.name).sort((a, b) => a.name.localeCompare(b.name));
-        tree.push(...children);
-      }
-      // Orphaned sub-agents (parent not in list) go at the end
-      const placed = new Set(tree.map((s) => s.name));
-      for (const s of subAgents) {
-        if (!placed.has(s.name)) tree.push(s);
-      }
-
-      return tree;
-    } catch {
-      return [];
-    }
-  }
-
-  async function fetchSandboxesDocker(): Promise<SandboxInfo[]> {
-    try {
-      const { stdout } = await execa("docker", [
-        "ps", "-a", "--format",
-        "{{.Names}}|{{.Status}}|{{.Label \"azureclaw.parent\"}}|{{.Label \"azureclaw.spawned-by\"}}|{{.CreatedAt}}",
-        "--filter", "name=azureclaw-",
-      ], { stdio: "pipe" });
-
-      const results: SandboxInfo[] = [];
-      for (const line of stdout.split("\n").filter(Boolean)) {
-        const [containerName, status, parent, , createdAt] = line.split("|");
-        if (!containerName?.startsWith("azureclaw-")) continue;
-        // Skip AGT infrastructure containers
-        if (containerName.includes("agt-postgres") || containerName.includes("agt-relay") || containerName.includes("agt-registry")) continue;
-
-        const name = containerName.replace(/^azureclaw-/, "");
-        const isUp = status?.startsWith("Up") ?? false;
-        const health: HealthState = isUp ? "healthy" : "down";
-        const podStatus = isUp ? "Running" : "Exited";
-        const role: "controller" | "sub-agent" = parent ? "sub-agent" : "controller";
-
-        let age = "-";
-        if (createdAt) {
-          const d = new Date(createdAt);
-          if (!isNaN(d.getTime())) age = timeSince(d);
-        }
-
-        // Probe model + handoff state + channels from container env vars
-        let model = "gpt-4.1";
-        let channels = "-";
-        let handoffState: SandboxInfo["handoffState"] = undefined;
-        if (isUp) {
-          // Read model + channels from env vars (single exec call)
-          try {
-            const { stdout: envOut } = await execa("docker", [
-              "exec", containerName, "printenv",
-            ], { stdio: "pipe", timeout: 5000 });
-            const chs: string[] = [];
-            for (const line of envOut.split("\n")) {
-              if (line.startsWith("TELEGRAM_BOT_TOKEN=")) chs.push("TG");
-              else if (line.startsWith("SLACK_BOT_TOKEN=")) chs.push("SL");
-              else if (line.startsWith("DISCORD_BOT_TOKEN=")) chs.push("DC");
-              else if (line.startsWith("DEFAULT_MODEL=")) {
-                const val = line.split("=")[1]?.trim();
-                if (val) model = val;
-              }
-            }
-            channels = chs.join(",") || "-";
-          } catch { /* env probe fail */ }
-
-          // Check if this agent has been handed off (dormant)
-          try {
-            const { stdout: hsOut } = await execa("docker", [
-              "exec", containerName, "curl", "-s", "--max-time", "2", "http://localhost:8443/agt/handoff/status",
-            ], { stdio: "pipe" });
-            const hs = JSON.parse(hsOut);
-            if (hs.phase === "complete" && hs.direction === "local_to_aks") {
-              handoffState = "dormant";
-            } else if (hs.phase === "running" && hs.direction === "aks_to_local") {
-              handoffState = "returning";
-            }
-          } catch { /* no handoff state */ }
-        }
-
-        results.push({
-          name,
-          namespace: containerName,
-          status: podStatus,
-          health: handoffState === "dormant" ? "dormant" : health,
-          model,
-          isolation: "standard",
-          channels,
-          age,
-          podName: containerName,
-          restarts: 0,
-          role,
-          parent: parent || "",
-          handoffState,
-          runtime: "docker",
-        });
-      }
-
-      // Tree ordering: controllers first, sub-agents after their parent
-      const controllers = results.filter((s) => s.role === "controller").sort((a, b) => a.name.localeCompare(b.name));
-      const subAgents = results.filter((s) => s.role === "sub-agent");
-      const tree: SandboxInfo[] = [];
-      for (const ctrl of controllers) {
-        tree.push(ctrl);
-        tree.push(...subAgents.filter((s) => s.parent === ctrl.name));
-      }
-      const placed = new Set(tree.map((s) => s.name));
-      for (const s of subAgents) {
-        if (!placed.has(s.name)) tree.push(s);
-      }
-
-      return tree;
-    } catch {
-      return [];
-    }
-  }
 
   async function fetchEgressDomains(sb: SandboxInfo): Promise<EgressDomain[]> {
     if (!sb.podName) return [];
@@ -1924,7 +1668,7 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
 
     try {
       // Always fetch sandbox list (lightweight: 1 CRD query + parallel pod/secret)
-      sandboxes = await fetchSandboxes();
+      sandboxes = await fetchSandboxes(kubeContext);
       const running = sandboxes.filter((s) => s.podName);
 
       // Tiered: only fetch detail data every Nth cycle to reduce API load

--- a/cli/src/commands/operator/fetchers/sandboxes.ts
+++ b/cli/src/commands/operator/fetchers/sandboxes.ts
@@ -1,0 +1,275 @@
+/**
+ * Sandbox-list fetchers (Docker + AKS).
+ *
+ * Extracted from `cli/src/commands/operator.ts` (S15.e.2) so the
+ * top-level dashboard module can stay under §4.2's 800-line cap.
+ *
+ * Each fetcher returns a tree-ordered `SandboxInfo[]`:
+ * controllers sorted alphabetically; sub-agents grouped under
+ * their parent; orphans appended last.
+ *
+ * No behavioral change vs. the originals — bodies are byte-identical
+ * apart from one mechanical edit: the closure-captured outer-scope
+ * `kubeContext` is now passed in as an explicit parameter to the AKS
+ * fetcher.
+ */
+
+import { execa } from "execa";
+import type { HealthState, SandboxInfo } from "../types.js";
+import { kctl, timeSince } from "../helpers.js";
+
+/**
+ * Unified Docker + AKS sandbox view (concatenated; deduplication is
+ * intentionally avoided — same-named sandboxes in both runtimes are a
+ * legitimate handoff state, e.g. dormant local + active-successor cloud).
+ */
+export async function fetchSandboxes(kubeContext?: string): Promise<SandboxInfo[]> {
+  const [dockerResult, aksResult] = await Promise.allSettled([
+    fetchSandboxesDocker(),
+    fetchSandboxesAKS(kubeContext),
+  ]);
+  const docker = dockerResult.status === "fulfilled" ? dockerResult.value : [];
+  const aks = aksResult.status === "fulfilled" ? aksResult.value : [];
+  return [...docker, ...aks];
+}
+
+export async function fetchSandboxesAKS(kubeContext?: string): Promise<SandboxInfo[]> {
+  try {
+    const { stdout } = await execa("kubectl", kctl([
+      "get", "clawsandbox", "-A", "-o", "json",
+    ], kubeContext), { stdio: "pipe" });
+
+    const data = JSON.parse(stdout);
+    const items: any[] = data.items || [];
+
+    // Fetch pods + secrets for ALL sandboxes in parallel (not sequentially)
+    const enriched = await Promise.allSettled(items.map(async (item) => {
+      const name: string = item.metadata?.name || "";
+      if (!name) return null;
+      const phase: string = item.status?.phase || "Unknown";
+      const model: string = item.spec?.inference?.model || "gpt-4.1";
+      const isolation: string = item.spec?.sandbox?.isolation || "enhanced";
+      const created: string = item.metadata?.creationTimestamp || "";
+      const labels: Record<string, string> = item.metadata?.labels || {};
+      const parentLabel = labels["azureclaw.azure.com/parent"] || "";
+      const role: "controller" | "sub-agent" = parentLabel ? "sub-agent" : "controller";
+
+      // Detect handoff successor (CRD has spec.handoff.mode = "restore")
+      let handoffState: SandboxInfo["handoffState"] = undefined;
+      if (item.spec?.handoff?.mode === "restore") {
+        handoffState = "active-successor";
+      }
+
+      const sandboxNs = `azureclaw-${name}`;
+      let podStatus = phase;
+      let podName = "";
+      let podCreated = "";
+      let channels = "";
+      let health: HealthState = "pending";
+      let restarts = 0;
+
+      // Fetch pods and secret in parallel
+      const [podResult, secretResult] = await Promise.allSettled([
+        execa("kubectl", kctl([
+          "get", "pods", "-n", sandboxNs, "-o", "json",
+        ], kubeContext), { stdio: "pipe", timeout: 15000 }),
+        execa("kubectl", kctl([
+          "get", "secret", `${name}-credentials`, "-n", sandboxNs,
+          "-o", "jsonpath={.data}",
+        ], kubeContext), { stdio: "pipe", timeout: 10000 }),
+      ]);
+
+      if (podResult.status === "fulfilled") {
+        try {
+          const pods = JSON.parse(podResult.value.stdout);
+          if (pods.items?.length > 0) {
+            const sorted = [...pods.items].sort((a: any, b: any) => {
+              const order = (p: any) => {
+                if (p.metadata?.deletionTimestamp) return 3;
+                const phase = p.status?.phase || "";
+                if (phase === "Running") return 0;
+                if (phase === "Pending") return 1;
+                return 2;
+              };
+              return order(a) - order(b);
+            });
+            const pod = sorted[0];
+            const isTerminating = !!pod.metadata?.deletionTimestamp;
+            podName = pod.metadata?.name || "";
+            podCreated = pod.metadata?.creationTimestamp || "";
+            const pPhase = isTerminating ? "Terminating" : (pod.status?.phase || "Unknown");
+            const statuses: any[] = pod.status?.containerStatuses || [];
+            const readyCount = statuses.filter((c: any) => c.ready).length;
+            const totalCount = statuses.length;
+            restarts = statuses.reduce((sum: number, c: any) => sum + (c.restartCount || 0), 0);
+            podStatus = totalCount > 0 ? `${pPhase} (${readyCount}/${totalCount})` : pPhase;
+
+            const hasCrash = statuses.some((c: any) =>
+              c.state?.waiting?.reason === "CrashLoopBackOff" ||
+              c.state?.waiting?.reason === "Error",
+            );
+            if (isTerminating) health = "degraded";
+            else if (hasCrash || pPhase === "Failed") health = "down";
+            else if (readyCount === totalCount && totalCount > 0) health = "healthy";
+            else if (readyCount > 0) health = "degraded";
+            else if (pPhase === "Pending") health = "pending";
+            else health = "unknown";
+
+            if (isTerminating || pPhase === "Pending" || readyCount === 0) podName = "";
+          }
+        } catch { /* bad JSON */ }
+      }
+
+      if (secretResult.status === "fulfilled") {
+        const secretOut = secretResult.value.stdout;
+        const chs: string[] = [];
+        if (secretOut.includes("TELEGRAM")) chs.push("TG");
+        if (secretOut.includes("SLACK")) chs.push("SL");
+        if (secretOut.includes("DISCORD")) chs.push("DC");
+        channels = chs.join(",") || "-";
+      } else {
+        channels = "-";
+      }
+
+      let age = "-";
+      const ageSource = podCreated || created;
+      if (ageSource) {
+        const d = new Date(ageSource);
+        if (!isNaN(d.getTime())) age = timeSince(d);
+      }
+
+      return {
+        name, namespace: sandboxNs, status: podStatus,
+        health, model, isolation,
+        channels, age, podName, restarts,
+        role, parent: parentLabel, handoffState,
+        runtime: "aks",
+      } as SandboxInfo;
+    }));
+
+    const results: SandboxInfo[] = enriched
+      .filter((r): r is PromiseFulfilledResult<SandboxInfo | null> => r.status === "fulfilled" && r.value !== null)
+      .map((r) => r.value!);
+
+    // Build tree: controllers sorted alphabetically, sub-agents right after their parent
+    const controllers = results.filter((s) => s.role === "controller").sort((a, b) => a.name.localeCompare(b.name));
+    const subAgents = results.filter((s) => s.role === "sub-agent");
+    const tree: SandboxInfo[] = [];
+    for (const ctrl of controllers) {
+      tree.push(ctrl);
+      // Attach sub-agents that belong to this controller
+      const children = subAgents.filter((s) => s.parent === ctrl.name).sort((a, b) => a.name.localeCompare(b.name));
+      tree.push(...children);
+    }
+    // Orphaned sub-agents (parent not in list) go at the end
+    const placed = new Set(tree.map((s) => s.name));
+    for (const s of subAgents) {
+      if (!placed.has(s.name)) tree.push(s);
+    }
+
+    return tree;
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchSandboxesDocker(): Promise<SandboxInfo[]> {
+  try {
+    const { stdout } = await execa("docker", [
+      "ps", "-a", "--format",
+      "{{.Names}}|{{.Status}}|{{.Label \"azureclaw.parent\"}}|{{.Label \"azureclaw.spawned-by\"}}|{{.CreatedAt}}",
+      "--filter", "name=azureclaw-",
+    ], { stdio: "pipe" });
+
+    const results: SandboxInfo[] = [];
+    for (const line of stdout.split("\n").filter(Boolean)) {
+      const [containerName, status, parent, , createdAt] = line.split("|");
+      if (!containerName?.startsWith("azureclaw-")) continue;
+      // Skip AGT infrastructure containers
+      if (containerName.includes("agt-postgres") || containerName.includes("agt-relay") || containerName.includes("agt-registry")) continue;
+
+      const name = containerName.replace(/^azureclaw-/, "");
+      const isUp = status?.startsWith("Up") ?? false;
+      const health: HealthState = isUp ? "healthy" : "down";
+      const podStatus = isUp ? "Running" : "Exited";
+      const role: "controller" | "sub-agent" = parent ? "sub-agent" : "controller";
+
+      let age = "-";
+      if (createdAt) {
+        const d = new Date(createdAt);
+        if (!isNaN(d.getTime())) age = timeSince(d);
+      }
+
+      // Probe model + handoff state + channels from container env vars
+      let model = "gpt-4.1";
+      let channels = "-";
+      let handoffState: SandboxInfo["handoffState"] = undefined;
+      if (isUp) {
+        // Read model + channels from env vars (single exec call)
+        try {
+          const { stdout: envOut } = await execa("docker", [
+            "exec", containerName, "printenv",
+          ], { stdio: "pipe", timeout: 5000 });
+          const chs: string[] = [];
+          for (const line of envOut.split("\n")) {
+            if (line.startsWith("TELEGRAM_BOT_TOKEN=")) chs.push("TG");
+            else if (line.startsWith("SLACK_BOT_TOKEN=")) chs.push("SL");
+            else if (line.startsWith("DISCORD_BOT_TOKEN=")) chs.push("DC");
+            else if (line.startsWith("DEFAULT_MODEL=")) {
+              const val = line.split("=")[1]?.trim();
+              if (val) model = val;
+            }
+          }
+          channels = chs.join(",") || "-";
+        } catch { /* env probe fail */ }
+
+        // Check if this agent has been handed off (dormant)
+        try {
+          const { stdout: hsOut } = await execa("docker", [
+            "exec", containerName, "curl", "-s", "--max-time", "2", "http://localhost:8443/agt/handoff/status",
+          ], { stdio: "pipe" });
+          const hs = JSON.parse(hsOut);
+          if (hs.phase === "complete" && hs.direction === "local_to_aks") {
+            handoffState = "dormant";
+          } else if (hs.phase === "running" && hs.direction === "aks_to_local") {
+            handoffState = "returning";
+          }
+        } catch { /* no handoff state */ }
+      }
+
+      results.push({
+        name,
+        namespace: containerName,
+        status: podStatus,
+        health: handoffState === "dormant" ? "dormant" : health,
+        model,
+        isolation: "standard",
+        channels,
+        age,
+        podName: containerName,
+        restarts: 0,
+        role,
+        parent: parent || "",
+        handoffState,
+        runtime: "docker",
+      });
+    }
+
+    // Tree ordering: controllers first, sub-agents after their parent
+    const controllers = results.filter((s) => s.role === "controller").sort((a, b) => a.name.localeCompare(b.name));
+    const subAgents = results.filter((s) => s.role === "sub-agent");
+    const tree: SandboxInfo[] = [];
+    for (const ctrl of controllers) {
+      tree.push(ctrl);
+      tree.push(...subAgents.filter((s) => s.parent === ctrl.name));
+    }
+    const placed = new Set(tree.map((s) => s.name));
+    for (const s of subAgents) {
+      if (!placed.has(s.name)) tree.push(s);
+    }
+
+    return tree;
+  } catch {
+    return [];
+  }
+}

--- a/cli/src/commands/operator/helpers.ts
+++ b/cli/src/commands/operator/helpers.ts
@@ -4,10 +4,20 @@
  * Extracted from `cli/src/commands/operator.ts` (S15.e.1) so the
  * top-level dashboard module can stay under §4.2's 800-line cap.
  *
- * Both helpers are pure: no I/O, no closure capture, no state.
+ * All helpers are pure: no I/O, no closure capture, no state.
  * They were already module-level in operator.ts (not nested inside
  * `startDashboard`) and are byte-identical to the originals.
  */
+
+/**
+ * Build a `kubectl` argv with an optional `--context` prefix.
+ *
+ * `kctl(["get","pods"], "my-cluster")` → `["--context","my-cluster","get","pods"]`
+ * `kctl(["get","pods"], undefined)`     → `["get","pods"]`
+ */
+export function kctl(args: string[], context?: string): string[] {
+  return context ? ["--context", context, ...args] : args;
+}
 
 /**
  * Return a compact human-readable duration string for "time since `date`".

--- a/docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e2.md
+++ b/docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e2.md
@@ -1,0 +1,96 @@
+# 2026-04-29 — Phase 2 / S15.e.2 — operator.ts sandbox-list fetcher extraction
+
+**Slice:** `phase2-hotspot-operator-cli-e2`
+**Branch:** `phase2-hotspot-operator-cli-e2` → `dev`
+**Hotspot tracker:** `cli/src/commands/operator.ts` — Phase 2 cap **800** (§4.2)
+
+## Scope
+
+Second sub-slice of S15.e. Lifts the three sandbox-list fetcher
+functions (`fetchSandboxes`, `fetchSandboxesAKS`, `fetchSandboxesDocker`)
+out of the giant `startDashboard` closure into a sibling module.
+Also moves the 2-line module-level `kctl(args, context?)` helper to
+`operator/helpers.ts` so the new fetcher module can reuse it.
+
+## What moved
+
+| File | Type | LOC moved |
+|---|---|---|
+| `cli/src/commands/operator/fetchers/sandboxes.ts` (new) | data-fetching | 286 |
+| `cli/src/commands/operator/helpers.ts` (existing) | `kctl()` (4 LOC added) | 4 |
+
+`operator.ts` imports `fetchSandboxes` from the new module; the AKS
++ Docker variants are exported but used only internally by
+`fetchSandboxes`, so the top-level module pulls in just the unified
+entry point.
+
+## Behavioral delta
+
+**None.** Bodies are byte-identical to the originals apart from one
+mechanical edit: the closure-captured outer-scope `kubeContext` is now
+passed as an explicit parameter (`fetchSandboxes(kubeContext)`,
+`fetchSandboxesAKS(kubeContext)`). The single call site in
+`startDashboard.refresh()` was updated to pass `kubeContext`
+(previously closure-captured); semantics are identical.
+
+The 2-line `kctl(args, context?)` helper is byte-identical (still:
+`return context ? ["--context", context, ...args] : args;`).
+
+## LOC delta
+
+| Slice | `operator.ts` | Δ | Cumulative |
+|---|---|---|---|
+| pre-S15.e | 2894 | — | — |
+| S15.e.1 | 2739 | −155 | −155 |
+| **S15.e.2** | **2483** | **−256** | **−411** |
+| §4.2 cap | 800 | | (cap not yet met; multi-PR sub-train continues) |
+
+## Verification
+
+- `npx tsc --noEmit` → clean.
+- `npm run lint` → 27 warnings, 0 errors (baseline).
+- `npm run build` → clean.
+- `npm test -- --run` → **454 / 454 passing** (2 skipped pre-existing).
+
+Removed unused `HealthState` import from operator.ts (now only used
+inside the extracted module). All other types remain consumed by the
+remaining in-file rendering / action / dialog code.
+
+## §0.2 hard-rule check
+
+- ✓ no new TODOs / `unimplemented!` / `panic!` / stubs
+- ✓ no new file exceeds Phase 2 cap (`fetchers/sandboxes.ts` 287 LOC)
+- ✓ touched hotspot file shrank (`operator.ts` 2739 → 2483)
+- ✓ no custom-crypto added (none touched)
+- ✓ no duplication — local `kctl` removed; the new helpers.ts
+  `kctl` is the sole owner; no second copy
+- ✓ no dead code carried — original three fetcher functions deleted
+  in this slice
+- ✓ existing implementation surveyed — `operator/types.ts` +
+  `operator/helpers.ts` (S15.e.1) consumed; no parallel abstraction
+
+## Sign-off
+
+| Lens | Verdict |
+|---|---|
+| Core — correctness, completeness, regression risk | ✅ pure move + one mechanical param-pass; no behavior change |
+| Security — threat model, secrets, crypto, attack surface | ✅ no new attack surface; no secrets / crypto / RBAC touched; Docker-only `printenv` exec scope unchanged |
+
+## Tracker — §15 hotspot status (post-merge state)
+
+| File | Pre-Phase 2 | Cap | Status |
+|---|---|---|---|
+| `cli/src/commands/handoff.ts` | 1119 | 800 | ✅ S15.a (798) |
+| `cli/src/commands/mesh.ts` | 1583 | 800 | ✅ S15.b (667) |
+| `inference-router/src/routes/inference.rs` | 1359 | 800 | ✅ S15.c (776) |
+| `cli/src/commands/up.ts` | 1849 | 800 | ✅ S15.d (766) |
+| `cli/src/commands/operator.ts` | 2894 | 800 | 🔄 **S15.e.2 (2483)** — multi-PR sub-train |
+| `cli/src/commands/plugin.ts` | 7139 | 800 | pending S15.f |
+
+## Follow-up sub-slices (each its own PR)
+
+- `fetchSecurityState` (~254 LOC) → `operator/fetchers/security.ts`
+- `fetchEgressDomains` + `fetchAgtQuick` + `fetchClusterHealth` + `fetchMeshHealth` → `operator/fetchers/`
+- Render helpers (`renderSecurity`, `renderAGT*`, `renderTopology`, `renderCluster`) → `operator/render/`
+- Action helpers (`approveDomain`/`denyDomain`/`enforceEgress`/`learnEgress`) → `operator/actions.ts`
+- Modal/dialog (`startEdit`, `launch`, `connectToAgent`) — context-object pattern (similar to S15.d.4)


### PR DESCRIPTION
## Phase 2 / S15.e.2 — operator.ts sandbox-list fetcher extraction

**Second sub-slice of S15.e**. Lifts the three sandbox-list fetchers out of the giant `startDashboard` closure:

- `fetchSandboxes(kubeContext?)` — unified Docker + AKS view
- `fetchSandboxesAKS(kubeContext?)` — kubectl-driven CRD + pod + secret inspection with parallel per-sandbox enrichment
- `fetchSandboxesDocker()` — `docker ps` + per-container env/handoff probe

→ `cli/src/commands/operator/fetchers/sandboxes.ts` (287 LOC).

Also moves the 2-line module-level `kctl(args, context?)` helper to `operator/helpers.ts` so the new fetcher module can reuse it.

### Behavior delta

**None.** Bodies byte-identical. `kctl` byte-identical. Mechanical edit: closure-captured `kubeContext` now passed as explicit parameter; the single call site in `startDashboard.refresh()` updated to forward it. Tree ordering, handoff-state detection, channel parsing, health-state derivation, secret-data scraping — all unchanged.

### LOC delta

| Slice | operator.ts | Δ | Cumulative |
|---|---|---|---|
| pre-S15.e | 2894 | — | — |
| S15.e.1 (#87) | 2739 | −155 | −155 |
| **S15.e.2** | **2483** | **−256** | **−411** |
| §4.2 cap | 800 | | (not yet met) |

### Verification

- ✅ `tsc --noEmit` clean
- ✅ `npm run lint` 27 warnings (baseline), 0 errors
- ✅ `npm run build` clean
- ✅ `npm test -- --run` → 454/454 pass (2 skipped pre-existing)

Removed unused `HealthState` import (now only used inside the extracted fetcher module).

### Audit

`docs/security-audits/2026-04-29-phase2-hotspot-operator-cli-e2.md` (Core ✅, Security ✅).

Follows S15.e.1 (#87).