### PR TITLE
S15.f.2: extract plugin.ts delegateToNativeAgent (6974 → 6890 LOC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S15.f.2 `phase2-hotspot-plugin-cli-f2` — plugin.ts native-agent delegate extraction
+
+#### Refactored
+
+- `cli/src/plugin.ts` 6974 → **6890 LOC** (−84, cumulative S15.f
+  −249). `delegateToNativeAgent` (the AGT task-request → native
+  OpenClaw agent dispatcher) extracted to
+  `core/agt-task-delegate.ts`. Pure stdlib helper; zero plugin-internal
+  dependencies.
+- No behavior change.
+
 ### S15.f.1 `phase2-hotspot-plugin-cli-f1` — plugin.ts redact + AMID-cache extraction
 
 #### Refactored

--- a/cli/src/core/agt-task-delegate.ts
+++ b/cli/src/core/agt-task-delegate.ts
@@ -1,0 +1,99 @@
+// Native-agent task delegation — extracted from plugin.ts in S15.f.2
+// to give plugin.ts headroom under the §4.2 800-LOC cap.
+//
+// Pure stdlib (`node:child_process`, `node:fs`) — does not touch any
+// AGT singleton. Owned by the AGT mesh task path which calls it when a
+// peer issues a `task_request` and the local sandbox's openclaw.json
+// permits delegation to the native OpenClaw agent.
+
+interface TaskLogger {
+  info(m: string): void;
+  warn(m: string): void;
+}
+
+/**
+ * Delegate a task to the native OpenClaw agent loop running in the Gateway.
+ * This gives the sub-agent access to ALL OpenClaw tools (exec, process, web_search,
+ * web_fetch, browser, cron, read/write, etc.) plus all AzureClaw plugin skills
+ * (foundry_memory, foundry_web_search, foundry_code, etc.).
+ *
+ * The task is sent via `openclaw agent --message` which goes through the Gateway's
+ * full agent pipeline (AGENTS.md, SOUL.md, TOOLS.md, skills, tool policy, etc.).
+ */
+export async function delegateToNativeAgent(
+  taskContent: string,
+  fromAgent: string,
+  log: TaskLogger,
+): Promise<string> {
+  const { spawn } = await import("node:child_process");
+
+  // Stable session ID per sender → maintains conversation context across tasks
+  const sessionId = `agt-task-${fromAgent}`;
+  const taskText = typeof taskContent === "string" ? taskContent : JSON.stringify(taskContent);
+
+  log.info(`Delegating task to native OpenClaw agent (session: ${sessionId})`);
+
+  const fs = await import("node:fs");
+  try { fs.mkdirSync("/tmp/agt-delegate-home", { recursive: true }); } catch {}
+
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn("openclaw", [
+      "agent",
+      "--message", taskText,
+      "--session-id", sessionId,
+      "--timeout", "300",
+      "--json",
+    ], {
+      env: {
+        ...process.env,
+        // Separate HOME so the agent gets its own device fingerprint and doesn't
+        // conflict with the node host's "node" role pairing.
+        HOME: "/tmp/agt-delegate-home",
+        AGT_SKIP_INIT: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const chunks: Buffer[] = [];
+    // OpenClaw writes all output (plugin logs + JSON result) to stderr
+    child.stderr.on("data", (chunk: Buffer) => chunks.push(chunk));
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+    const timer = setTimeout(() => { child.kill("SIGTERM"); }, 120_000);
+
+    child.on("close", () => {
+      clearTimeout(timer);
+      const output = Buffer.concat(chunks).toString("utf-8");
+
+      // Extract the JSON response by finding the last top-level { ... } block
+      const jsonMatch = output.match(/\n(\{[\s\S]*\})\s*$/);
+      if (jsonMatch) {
+        try {
+          const result = JSON.parse(jsonMatch[1]);
+          const text = result?.reply?.text || result?.text || "";
+          if (text) {
+            log.info(`Native agent responded (${text.length} chars, session: ${sessionId})`);
+            return resolve(text);
+          }
+        } catch { /* fall through */ }
+      }
+
+      // Fallback: strip log lines and return raw text
+      const lines = output.split("\n").filter((l: string) =>
+        !l.startsWith("[plugins]") && !l.startsWith("[") && l.trim());
+      const response = lines.join("\n").trim();
+      if (response) {
+        log.info(`Native agent responded (${response.length} chars, session: ${sessionId})`);
+        return resolve(response);
+      }
+
+      log.warn(`Native agent returned empty response (${output.length} bytes captured)`);
+      reject(new Error("Native agent returned empty response"));
+    });
+
+    child.on("error", (err: Error) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -344,95 +344,11 @@ async function notifyInboxToMemory(log: { info: (m: string) => void; warn: (m: s
   } catch { /* best effort */ }
 }
 import { discoverFoundryProject, type FoundryProjectInfo } from "./core/foundry-discovery.js";
+import { delegateToNativeAgent } from "./core/agt-task-delegate.js";
 let foundryProject: FoundryProjectInfo | null = null;
 let foundryInitialized = false;
 
-/**
- * Delegate a task to the native OpenClaw agent loop running in the Gateway.
- * This gives the sub-agent access to ALL OpenClaw tools (exec, process, web_search,
- * web_fetch, browser, cron, read/write, etc.) plus all AzureClaw plugin skills
- * (foundry_memory, foundry_web_search, foundry_code, etc.).
- *
- * The task is sent via `openclaw agent --message` which goes through the Gateway's
- * full agent pipeline (AGENTS.md, SOUL.md, TOOLS.md, skills, tool policy, etc.).
- */
-async function delegateToNativeAgent(
-  taskContent: string,
-  fromAgent: string,
-  log: { info: (m: string) => void; warn: (m: string) => void },
-): Promise<string> {
-  const { spawn } = await import("node:child_process");
-
-  // Stable session ID per sender → maintains conversation context across tasks
-  const sessionId = `agt-task-${fromAgent}`;
-  const taskText = typeof taskContent === "string" ? taskContent : JSON.stringify(taskContent);
-
-  log.info(`Delegating task to native OpenClaw agent (session: ${sessionId})`);
-
-  const fs = await import("node:fs");
-  try { fs.mkdirSync("/tmp/agt-delegate-home", { recursive: true }); } catch {}
-
-  return new Promise<string>((resolve, reject) => {
-    const child = spawn("openclaw", [
-      "agent",
-      "--message", taskText,
-      "--session-id", sessionId,
-      "--timeout", "300",
-      "--json",
-    ], {
-      env: {
-        ...process.env,
-        // Separate HOME so the agent gets its own device fingerprint and doesn't
-        // conflict with the node host's "node" role pairing.
-        HOME: "/tmp/agt-delegate-home",
-        AGT_SKIP_INIT: "1",
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    const chunks: Buffer[] = [];
-    // OpenClaw writes all output (plugin logs + JSON result) to stderr
-    child.stderr.on("data", (chunk: Buffer) => chunks.push(chunk));
-    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
-
-    const timer = setTimeout(() => { child.kill("SIGTERM"); }, 120_000);
-
-    child.on("close", () => {
-      clearTimeout(timer);
-      const output = Buffer.concat(chunks).toString("utf-8");
-
-      // Extract the JSON response by finding the last top-level { ... } block
-      const jsonMatch = output.match(/\n(\{[\s\S]*\})\s*$/);
-      if (jsonMatch) {
-        try {
-          const result = JSON.parse(jsonMatch[1]);
-          const text = result?.reply?.text || result?.text || "";
-          if (text) {
-            log.info(`Native agent responded (${text.length} chars, session: ${sessionId})`);
-            return resolve(text);
-          }
-        } catch { /* fall through */ }
-      }
-
-      // Fallback: strip log lines and return raw text
-      const lines = output.split("\n").filter((l: string) =>
-        !l.startsWith("[plugins]") && !l.startsWith("[") && l.trim());
-      const response = lines.join("\n").trim();
-      if (response) {
-        log.info(`Native agent responded (${response.length} chars, session: ${sessionId})`);
-        return resolve(response);
-      }
-
-      log.warn(`Native agent returned empty response (${output.length} bytes captured)`);
-      reject(new Error("Native agent returned empty response"));
-    });
-
-    child.on("error", (err: Error) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-  });
-}
+// delegateToNativeAgent — extracted to core/agt-task-delegate.ts in S15.f.2.
 
 /**
  * Fallback: process a task_request with a limited tool-calling loop.

--- a/docs/security-audits/2026-04-29-phase2-hotspot-plugin-cli-f2.md
+++ b/docs/security-audits/2026-04-29-phase2-hotspot-plugin-cli-f2.md
@@ -1,0 +1,57 @@
+# Phase 2 — S15.f.2 — plugin.ts native-agent delegate extraction
+
+**Date:** 2026-04-29
+**Slice:** `phase2-hotspot-plugin-cli-f2`
+**Sign-offs:** Core ✅, Security ✅
+
+## Scope
+
+Second sub-slice of the S15.f plugin.ts decomposition train. Lifts the
+`delegateToNativeAgent` helper — used by the AGT mesh task path to
+dispatch incoming `task_request`s to the local OpenClaw agent loop —
+into a dedicated module.
+
+## What moved
+
+| File | Symbols | LOC |
+|---|---|---|
+| `cli/src/core/agt-task-delegate.ts` (new) | `delegateToNativeAgent(taskContent, fromAgent, log)` + `TaskLogger` interface | 95 |
+
+This function is unusually clean: it depends only on `node:child_process`
+and `node:fs`, and its `log` parameter is already injected by callers.
+**No AGT/router/cache singletons touched** — pure extraction.
+
+## Behavior delta
+
+**None.** Body byte-identical. Only the JSDoc surface gets a small
+local interface (`TaskLogger`) instead of an inline structural type.
+
+## LOC delta
+
+| Slice | plugin.ts | Δ | Cumulative |
+|---|---|---|---|
+| pre-S15.f | 7139 | — | — |
+| S15.f.1 | 6974 | −165 | −165 |
+| **S15.f.2** | **6890** | **−84** | **−249** |
+| §4.2 cap | 800 | | 6090 LOC remaining |
+
+## Verification
+
+- ✅ `npx tsc --noEmit` clean
+- ✅ `npm run lint` 24 warnings (unchanged from f.1), 0 errors
+- ✅ `npm run build` clean
+- ✅ `npm test -- --run` → **454 pass / 2 skipped** (same as baseline)
+
+## Risk + rollback
+
+- **Risk: very low.** Function has zero plugin-internal dependencies;
+  the `log` param is the only injected concern.
+- **Rollback:** simple revert.
+
+## Next slices
+
+- **S15.f.3** — extract `meshSend` (~86 LOC) + `meshHandleTransportMessage`
+  (~121 LOC) to `core/mesh-transport.ts`. These take the AGT client
+  / identity by parameter so the extraction keeps the singletons in
+  plugin.ts but moves the chunked-transfer state machine out.
+- **S15.f.4+** — Class A Foundry shims to `/platform/mcp` (S10.B).


### PR DESCRIPTION
Second sub-slice of S15.f. Lifts `delegateToNativeAgent` (the AGT task-request → native OpenClaw agent dispatcher, ~85 LOC) to `core/agt-task-delegate.ts`. Pure stdlib, zero plugin-internal deps.

| Slice | plugin.ts | Δ | Cumulative |
|---|---|---|---|
| pre-S15.f | 7139 | — | — |
| S15.f.1 | 6974 | −165 | −165 |
| **S15.f.2** | **6890** | **−84** | **−249** |
| §4.2 cap | 800 | | 6090 LOC remaining |

✅ tsc / lint 24 (unchanged) / build / **tests 454 pass, same as baseline**.

Audit: `docs/security-audits/2026-04-29-phase2-hotspot-plugin-cli-f2.md`. Follows S15.f.1 (#96).