### PR TITLE
phase2(s19): fix container image scan + publish base to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      packages: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -196,6 +197,14 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Log in to GHCR (for cached base image pull)
+        if: steps.base-check.outputs.changed != 'true'
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build sandbox base image (only when Dockerfile.base changed)
         if: steps.base-check.outputs.changed == 'true'
         run: docker build -t azureclaw-sandbox-base:test -f sandbox-images/openclaw/Dockerfile.base .
@@ -203,11 +212,20 @@ jobs:
       - name: Pull cached base image (when Dockerfile.base unchanged)
         if: steps.base-check.outputs.changed != 'true'
         run: |
-          # Use the ACR base image if available, otherwise build locally
-          if docker pull azureclawacr.azurecr.io/azureclaw-sandbox-base:latest 2>/dev/null; then
-            docker tag azureclawacr.azurecr.io/azureclaw-sandbox-base:latest azureclaw-sandbox-base:test
+          # Pull from GHCR (published by sandbox-base-publish.yml on dev/main).
+          # Falls back to local build only if the image isn't available yet
+          # (e.g. before the first publish run, or for forks without access).
+          REPO_LOWER="${GITHUB_REPOSITORY,,}"
+          GHCR_IMG="ghcr.io/${REPO_LOWER}-sandbox-base:latest"
+          ACR_IMG="azureclawacr.azurecr.io/azureclaw-sandbox-base:latest"
+          if docker pull "$GHCR_IMG" 2>/dev/null; then
+            echo "Pulled cached base image from GHCR: $GHCR_IMG"
+            docker tag "$GHCR_IMG" azureclaw-sandbox-base:test
+          elif docker pull "$ACR_IMG" 2>/dev/null; then
+            echo "Pulled cached base image from ACR: $ACR_IMG"
+            docker tag "$ACR_IMG" azureclaw-sandbox-base:test
           else
-            echo "::warning::ACR base image unavailable — building locally (slow)"
+            echo "::warning::No cached base image available (GHCR or ACR) — building locally (slow)"
             docker build -t azureclaw-sandbox-base:test -f sandbox-images/openclaw/Dockerfile.base .
           fi
 

--- a/.github/workflows/sandbox-base-publish.yml
+++ b/.github/workflows/sandbox-base-publish.yml
@@ -1,0 +1,63 @@
+name: Sandbox Base Image Publish
+
+# Publishes the OpenClaw sandbox base image to GHCR so the Container Image Scan
+# job in ci.yml can pull a known-good prebuilt image instead of rebuilding the
+# entire base from scratch on every PR (which is slow and brittle — it transitively
+# depends on upstream npm/network availability for openclaw + bundled-plugin
+# runtime deps).
+#
+# Visibility: package should be marked PRIVATE in the GitHub UI under
+# Packages → azureclaw-sandbox-base → Package settings → Change visibility →
+# Private. CI in this repo can still pull private GHCR images using the
+# auto-provided GITHUB_TOKEN (no extra secrets needed).
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'sandbox-images/openclaw/Dockerfile.base'
+      - 'vendor/sandbox-wheels/**'
+      - '.github/workflows/sandbox-base-publish.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish sandbox base image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          REPO_LOWER="${GITHUB_REPOSITORY,,}"
+          IMG="ghcr.io/${REPO_LOWER}-sandbox-base"
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=$IMG:sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "branch_tag=$IMG:${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          if [ "$GITHUB_REF_NAME" = "main" ] || [ "$GITHUB_REF_NAME" = "dev" ]; then
+            echo "latest_tag=$IMG:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push base image
+        run: |
+          TAGS=( -t "${{ steps.tags.outputs.sha_tag }}" -t "${{ steps.tags.outputs.branch_tag }}" )
+          if [ -n "${{ steps.tags.outputs.latest_tag }}" ]; then
+            TAGS+=( -t "${{ steps.tags.outputs.latest_tag }}" )
+          fi
+          docker build "${TAGS[@]}" -f sandbox-images/openclaw/Dockerfile.base .
+          for tag in "${{ steps.tags.outputs.sha_tag }}" "${{ steps.tags.outputs.branch_tag }}" "${{ steps.tags.outputs.latest_tag }}"; do
+            [ -n "$tag" ] && docker push "$tag"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S19 `phase2-container-image-scan-fix` — sandbox base image build/pull resilience
+
+#### Fixed
+
+- **Container Image Scan** CI job (and any local rebuild of `sandbox-images/openclaw/Dockerfile.base`)
+  no longer fails on `ERROR: openclaw doctor did not stage any node_modules under /opt/openclaw-stage`.
+
+  Root cause: `openclaw` 2026.4.26+ now resolves all bundled-plugin runtime deps
+  (telegram → grammy, discord → @discordjs/opus, slack → @slack/bolt, feishu →
+  @larksuiteoapi/node-sdk, etc.) directly under `/usr/local/lib/node_modules/openclaw/node_modules/`
+  via the global `npm install -g openclaw` step. As a consequence,
+  `openclaw doctor --fix` reports `missing.length === 0` and exits successfully
+  without creating a `<OPENCLAW_PLUGIN_STAGE_DIR>/openclaw-<version>-<hash>/`
+  version directory. The previous strict count check (≥1 staged version dir)
+  treated this success path as a failure.
+
+  Fix in `sandbox-images/openclaw/Dockerfile.base`:
+  - drop the `|| true` mask on `openclaw doctor` so real failures surface;
+  - replace the "≥1 staged version dir" check with a positive sanity check
+    that the four channel deps we ship resolve in the global openclaw tree;
+  - treat 0 staged dirs as a non-failure (logged informationally).
+
+#### CI
+
+- New workflow `.github/workflows/sandbox-base-publish.yml` publishes the
+  sandbox base image to GHCR (`ghcr.io/<owner>/<repo>-sandbox-base:latest`,
+  `:<branch>`, `:sha-<short>`) on every push to `dev`/`main` that touches
+  `sandbox-images/openclaw/Dockerfile.base` or `vendor/sandbox-wheels/`.
+  Uses the auto-provided `GITHUB_TOKEN`; package should be marked **private**
+  in GHCR settings to preserve current exposure surface.
+- `container-scan` in `.github/workflows/ci.yml` now logs into GHCR with
+  `GITHUB_TOKEN` and pulls the cached base image from there first, falling
+  back to ACR, then to a local rebuild only as last resort. PRs no longer
+  rebuild the entire base image from scratch (which transitively depended on
+  upstream npm/network availability).
+
 ### S15.g.1 `phase2-runtime-package-split` — runtime adapter moved out of `cli/`
 
 #### Refactored

--- a/docs/security-audits/2026-04-29-phase2-container-image-scan-fix-s19.md
+++ b/docs/security-audits/2026-04-29-phase2-container-image-scan-fix-s19.md
@@ -1,0 +1,104 @@
+# Phase 2 — S19 Container Image Scan Fix
+
+**Date:** 2026-04-29
+**Branch:** `phase2-container-image-scan-fix`
+**Slice:** S19 (sandbox base image build/pull resilience)
+
+## Scope
+
+Two changes:
+
+1. `sandbox-images/openclaw/Dockerfile.base` — replace the brittle "≥1 staged
+   node_modules dir under `/opt/openclaw-stage`" assertion with a positive
+   sanity check on the four channel deps we ship, and stop masking real
+   `openclaw doctor` errors with `|| true`.
+
+2. New `.github/workflows/sandbox-base-publish.yml` + updated `container-scan`
+   step in `.github/workflows/ci.yml` — publish the sandbox base image to
+   GHCR on `dev`/`main` pushes, and have CI pull from GHCR (using
+   `GITHUB_TOKEN`) before falling back to local rebuild.
+
+## Root cause analysis
+
+In OpenClaw 2026.4.26 the bundled-plugin runtime dependencies (telegram, discord,
+slack, feishu, etc.) are resolved as direct dependencies of the `openclaw` npm
+package itself, so `npm install -g openclaw` already populates
+`/usr/local/lib/node_modules/openclaw/node_modules/`. When
+`openclaw doctor --fix --non-interactive --yes` runs after that, its
+`maybeRepairBundledPluginRuntimeDeps` flow finds `missing.length === 0` and
+returns early without creating a `<stage>/openclaw-<version>-<hash>/` version
+directory. The previous build-time assertion treated 0 staged dirs as a hard
+failure, masking the actual cause behind a misleading error message and
+`|| true`.
+
+Confirmed from the upstream sources I extracted from `openclaw@2026.4.26` on
+npm (`bundled-runtime-root-DEMD7-O_.js`,
+`doctor-bundled-plugin-runtime-deps-CiQxW0ig.js`,
+`effective-plugin-ids-KWubC1um.js`).
+
+## Security considerations
+
+### Dockerfile.base
+
+- Dropped `|| true` on `openclaw doctor` — real failures will now fail the
+  build instead of being silently swallowed. This is a strict improvement in
+  the build-time integrity posture.
+- Sanity check uses `[ -e ]` against four well-known channel package paths
+  inside `/usr/local/lib/node_modules/openclaw/node_modules/`. No new
+  network or registry surface; purely a filesystem assertion against the
+  already-installed openclaw tree.
+- `chmod -R a+rX /opt/openclaw-stage` retained so the runtime user (UID 1000)
+  can read whatever doctor *did* stage.
+
+### GHCR publish workflow
+
+- Image is built from the same `Dockerfile.base` we ship. Contains only
+  publicly-available OSS (Mariner base, openclaw npm, Node.js, ripgrep, gh,
+  himalaya, op CLI, Python wheels from `vendor/sandbox-wheels/`). No secrets,
+  no AzureClaw runtime/router/controller code (those are added in later
+  multi-stage builds layered on top of this base).
+- Authentication uses the workflow-provided `GITHUB_TOKEN` (`packages: write`).
+  No long-lived credentials added to the repository.
+- Package visibility should be **private** in GHCR settings to preserve the
+  current exposure surface. CI in this repo can still pull a private GHCR
+  image using `GITHUB_TOKEN` (`packages: read`), so making it private does
+  not break the CI pull path.
+
+### container-scan workflow update
+
+- Adds `packages: read` permission to the existing job (least-privilege add).
+- Logs into GHCR with `GITHUB_TOKEN` only when the base image is unchanged
+  (i.e. only on the pull path, not the rebuild path).
+- Falls back to ACR pull, then to local rebuild — preserves the ability to
+  scan local rebuilds if neither registry has the image (e.g. forks).
+
+## Verification
+
+- `git diff sandbox-images/openclaw/Dockerfile.base` reviewed manually.
+- CI must pass `Container Image Scan` for this PR — that **is** the
+  verification, since this is the first PR where Container Image Scan needs
+  to actually go green.
+
+## CI scope
+
+No changes to the gating contract. Container Image Scan was already a job in
+`ci.yml` — this PR only fixes its build behavior and adds a faster path via
+GHCR caching.
+
+## Risks
+
+- Sanity check could become a false negative if upstream openclaw drops one
+  of the four channel deps (`grammy`, `@discordjs/opus`, `@slack/bolt`,
+  `@larksuiteoapi/node-sdk`). That would be a real channel regression we'd
+  want to catch at build time, not silently ship.
+- GHCR publish workflow needs `packages: write` on `dev`/`main` pushes. This
+  is a new permission grant on those branches' workflow runs, but is scoped
+  to the `azureclaw-sandbox-base` package only.
+
+## Files touched
+
+- `sandbox-images/openclaw/Dockerfile.base`
+- `.github/workflows/ci.yml` (container-scan job)
+- `.github/workflows/sandbox-base-publish.yml` (new)
+- `CHANGELOG.md`
+- `docs/security-audits/2026-04-29-phase2-container-image-scan-fix-s19.md` (this file)

--- a/sandbox-images/openclaw/Dockerfile.base
+++ b/sandbox-images/openclaw/Dockerfile.base
@@ -84,26 +84,38 @@ RUN npm install -g clawhub mcporter @steipete/oracle 2>/dev/null || true
 # whole tree at build time (full network) into a stable path that we mount read-only
 # at runtime via `OPENCLAW_PLUGIN_STAGE_DIR`.
 #
-# `openclaw doctor --fix --non-interactive --yes` invokes `installBundledRuntimeDeps`
-# from `dist/bundled-runtime-deps-*.js`, which honours `OPENCLAW_PLUGIN_STAGE_DIR`
-# (or `STATE_DIRECTORY`) by writing to `<dir>/openclaw-<version>-<hash>/`.
-# `<hash>` = `createPathHash(packageRoot)` and is deterministic for the fixed
-# `/usr/local/lib/node_modules/openclaw` install path → cache hits at runtime.
+# `openclaw doctor --fix --non-interactive --yes` invokes
+# `maybeRepairBundledPluginRuntimeDeps`. When *missing* deps are detected it
+# stages them under `<OPENCLAW_PLUGIN_STAGE_DIR>/openclaw-<version>-<hash>/`.
+# In OpenClaw 2026.4.26+ the global `npm install -g openclaw` already resolves
+# every bundled-plugin runtime dep (channels included), so doctor's
+# `missing.length === 0` early-returns and no version dir is created. That is
+# expected and not a failure — at runtime the same deps resolve directly from
+# `/usr/local/lib/node_modules/openclaw/node_modules/`.
 #
-# `@tencent-connect/qqbot-connector` is geo-restricted upstream and may 403 even
-# from open networks. We tolerate that single failure (|| true) — qqbot is the
-# only currently-shipped channel we don't expose; staging still succeeds for
-# every other channel.
+# We sanity-check by asserting that the channel deps we care about actually
+# resolve in the global openclaw tree (telegram → grammy, discord →
+# @discordjs/opus, slack → @slack/bolt, feishu → @larksuiteoapi/node-sdk).
+# qqbot is geo-restricted upstream and not in our shipping set.
 ENV OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage
 RUN mkdir -p /opt/openclaw-stage && \
-    openclaw doctor --fix --non-interactive --yes 2>&1 | tail -20 || true && \
-    staged_count=$(find /opt/openclaw-stage -mindepth 2 -maxdepth 2 -type d -name node_modules | wc -l) && \
-    if [ "$staged_count" -lt 1 ]; then \
-      echo "ERROR: openclaw doctor did not stage any node_modules under /opt/openclaw-stage" >&2; \
-      ls -la /opt/openclaw-stage >&2; exit 1; \
-    fi && \
+    openclaw doctor --fix --non-interactive --yes 2>&1 | tail -20 && \
+    OC_NM="/usr/local/lib/node_modules/openclaw/node_modules" && \
+    missing=0 && \
+    for dep in grammy @discordjs/opus @slack/bolt @larksuiteoapi/node-sdk; do \
+      if [ ! -e "$OC_NM/$dep" ]; then \
+        echo "ERROR: openclaw doctor finished but channel dep '$dep' is not resolvable under $OC_NM" >&2; \
+        missing=1; \
+      fi; \
+    done && \
+    [ "$missing" -eq 0 ] && \
+    staged_count=$(find /opt/openclaw-stage -mindepth 2 -maxdepth 2 -type d -name node_modules 2>/dev/null | wc -l) && \
     chmod -R a+rX /opt/openclaw-stage && \
-    echo "OpenClaw bundled-runtime-deps pre-staged: $(du -sh /opt/openclaw-stage | cut -f1) (${staged_count} version dirs)"
+    if [ "$staged_count" -gt 0 ]; then \
+      echo "OpenClaw bundled-runtime-deps pre-staged: $(du -sh /opt/openclaw-stage | cut -f1) (${staged_count} version dirs)"; \
+    else \
+      echo "OpenClaw bundled-runtime-deps already resolved in global tree — no staging needed"; \
+    fi
 
 # ─── Go Builder (CLI tools for OpenClaw skills) ──────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes Phase 2 slice **S19** (container-image-scan-fix).

### Two fixes

**1. `sandbox-images/openclaw/Dockerfile.base`** — stop failing on the false-negative "openclaw doctor did not stage any node_modules" error. In OpenClaw 2026.4.26 the global \`npm install -g openclaw\` already resolves all bundled-plugin runtime deps, so \`openclaw doctor --fix\` legitimately returns early with \`missing.length === 0\` and creates no staged version dir. Replace the strict count check with a positive sanity check on the four channel deps we ship (grammy, @discordjs/opus, @slack/bolt, @larksuiteoapi/node-sdk). Drop the \`|| true\` mask so real doctor failures surface.

**2. New `.github/workflows/sandbox-base-publish.yml`** — publish the sandbox base image to GHCR on dev/main pushes. Update \`container-scan\` in ci.yml to pull from GHCR first (using the auto-provided \`GITHUB_TOKEN\`), with ACR + local rebuild as fallbacks. PRs no longer rebuild the base from scratch on every run.

### Manual follow-up after merge

After the first publish run completes on dev, set the GHCR package \`azureclaw-sandbox-base\` to **private** in GitHub Packages settings to preserve the current exposure surface. CI in this repo can still pull a private GHCR image with \`GITHUB_TOKEN\`.

### Files

- \`sandbox-images/openclaw/Dockerfile.base\`
- \`.github/workflows/ci.yml\` (container-scan job)
- \`.github/workflows/sandbox-base-publish.yml\` (new)
- \`CHANGELOG.md\`
- \`docs/security-audits/2026-04-29-phase2-container-image-scan-fix-s19.md\`

### Verification

This **is** the first PR where the Container Image Scan job is expected to actually go green — that's the verification.