### PR TITLE
phase2(s19.c): fix Dockerfile Lint — pipefail SHELL + DL3062 ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
           chmod +x /usr/local/bin/hadolint
       - name: Lint Dockerfiles
         run: |
-          IGNORE="--ignore DL3008 --ignore DL3013 --ignore DL3018 --ignore DL3006 --ignore DL4006 --ignore DL3003 --ignore DL3016 --ignore DL3059 --ignore SC2015 --ignore SC2028"
+          IGNORE="--ignore DL3008 --ignore DL3013 --ignore DL3018 --ignore DL3006 --ignore DL4006 --ignore DL3003 --ignore DL3016 --ignore DL3059 --ignore DL3062 --ignore SC2015 --ignore SC2028"
           hadolint $IGNORE controller/Dockerfile
           hadolint $IGNORE inference-router/Dockerfile
           hadolint $IGNORE sandbox-images/openclaw/Dockerfile.base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S19.c `phase2-dockerfile-lint-fix` — restore Dockerfile Lint job to green
+
+#### Fixed
+
+- `sandbox-images/openclaw/Dockerfile.base`: the `set -o pipefail` shell
+  builtin used to surface `openclaw doctor … | tail -40` failures is not
+  POSIX (only bash/ksh), and Docker's default `RUN` shell is `/bin/sh`.
+  hadolint's SC3040 fired on the previous S19.b commit. Replaced with a
+  scoped `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` directive around
+  the doctor RUN, then restored `SHELL ["/bin/sh", "-c"]` so subsequent
+  RUNs in the builder stage keep the default shell.
+- `.github/workflows/ci.yml` Dockerfile Lint job: added `DL3062` to the
+  hadolint ignore list. The Go builder stage installs blu/eightctl/gifgrep
+  via `go install …@latest` intentionally (per inline comment — small
+  static binaries that we want fresh on every base rebuild). The DL3062
+  warning is new in the latest hadolint release; matches the team's
+  existing convention of ignoring "pin versions" warnings for the
+  intentionally-unpinned tools.
+
 ### S19.b `phase2-ci-image-cache-router-controller` — extend GHCR cache to router + controller
 
 #### Refactored

--- a/sandbox-images/openclaw/Dockerfile.base
+++ b/sandbox-images/openclaw/Dockerfile.base
@@ -92,8 +92,11 @@ RUN npm install -g clawhub mcporter @steipete/oracle 2>/dev/null || true
 # returns "missing.length === 0" with no staging because the deps are either
 # pre-resolved in the global tree or installed lazily at first channel use).
 ENV OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage
-RUN set -o pipefail && \
-    mkdir -p /opt/openclaw-stage && \
+# Use bash with pipefail so the `openclaw doctor … | tail -40` pipe surfaces
+# a non-zero exit code from doctor instead of being masked by tail's success.
+# Scoped to this RUN only — subsequent stages re-default to /bin/sh.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN mkdir -p /opt/openclaw-stage && \
     openclaw doctor --fix --non-interactive --yes 2>&1 | tail -40 && \
     chmod -R a+rX /opt/openclaw-stage && \
     staged_count=$(find /opt/openclaw-stage -mindepth 2 -maxdepth 2 -type d -name node_modules 2>/dev/null | wc -l) && \
@@ -102,6 +105,7 @@ RUN set -o pipefail && \
     else \
       echo "OpenClaw doctor completed cleanly with no staging required"; \
     fi
+SHELL ["/bin/sh", "-c"]
 
 # ─── Go Builder (CLI tools for OpenClaw skills) ──────────────────────────────
 


### PR DESCRIPTION
Fix-up to S19.b. Replaces `set -o pipefail` (non-POSIX → SC3040) with scoped `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` directive in Dockerfile.base; adds DL3062 to the hadolint ignore list for the intentionally-unpinned `go install ...@latest` lines in the Go builder stage. Verified locally: hadolint exit=0 for all four Dockerfiles.