### PR TITLE
phase2(s12.a): policyRef schema + canonical egress allowlist format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S12.a `phase2-s12-a-policyref-schema` — supply-chain policy foundations
+
+**Pure schema PR.** Foundation for the S12 signed-egress-allowlist work. No
+runtime/CLI/controller behavior change yet; existing CRs round-trip unchanged.
+
+#### Added
+
+- New `OciArtifactRef` struct in `controller/src/crd.rs` (`camelCase`,
+  `JsonSchema`-derived, `PartialEq + Eq`) — generic shape for referencing a
+  signed, content-addressed OCI artifact: `{ registry, repository, digest,
+  artifactType }`. Sized to be reusable by future supply-chain-grade
+  references (not just egress allowlists).
+- New optional `ClawSandbox.spec.networkPolicy.allowlistRef: OciArtifactRef`
+  field. Audit-only in S12.a — no consumer reads it yet. Becomes
+  status-surfaced in S12.b behind `AZURECLAW_FEATURE_SIGNED_ALLOWLIST`,
+  authoritative in S12.e.
+- `docs/policy-canonical-format.md` — byte-stable canonicalization rules
+  for the v1 egress allowlist artifact (artifactType
+  `application/vnd.azureclaw.egress-allowlist.v1+yaml`). Locks down: IDNA
+  2008 host normalization, explicit ports, `(host, port)` deduplication,
+  lexicographic sort, `metadata.generation` for replay protection,
+  forward-compat path for v2.
+- Helm CRD schema for `allowlistRef` with required-field validation +
+  digest regex (`^sha(256|384|512):[a-f0-9]+$`).
+
+#### Tests
+
+- `allowlist_ref_round_trips_through_camel_case_json` — locks in
+  `artifactType` camelCase wire format.
+- `allowlist_ref_omitted_when_none` — confirms backwards-compat: default
+  `NetworkPolicyConfig` does not emit `allowlistRef`.
+
+#### Decomposition note
+
+S12 was re-scoped 2026-04-30 after rubber-duck critique. The original
+single-slice plan is now S12.a–S12.g; this is slice (a). See plan.md §S12.
+
 ### S19.c `phase2-dockerfile-lint-fix` — restore Dockerfile Lint job to green
 
 #### Fixed

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -959,14 +959,18 @@ mod tests {
         let r = OciArtifactRef {
             registry: "myacr.azurecr.io".into(),
             repository: "azureclaw/policies/sandbox-foo".into(),
-            digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000".into(),
+            digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .into(),
             artifact_type: "application/vnd.azureclaw.egress-allowlist.v1+yaml".into(),
         };
         let v = serde_json::to_value(&r).unwrap();
         assert!(v.get("registry").is_some());
         assert!(v.get("repository").is_some());
         assert!(v.get("digest").is_some());
-        assert!(v.get("artifactType").is_some(), "must use camelCase artifactType");
+        assert!(
+            v.get("artifactType").is_some(),
+            "must use camelCase artifactType"
+        );
         let back: OciArtifactRef = serde_json::from_value(v).unwrap();
         assert_eq!(back, r);
     }
@@ -977,8 +981,10 @@ mod tests {
         // unchanged. `skip_serializing_if = "Option::is_none"` enforces this.
         let cfg = NetworkPolicyConfig::default();
         let v = serde_json::to_value(&cfg).unwrap();
-        assert!(v.get("allowlistRef").is_none(),
-            "default NetworkPolicyConfig must not emit allowlistRef field");
+        assert!(
+            v.get("allowlistRef").is_none(),
+            "default NetworkPolicyConfig must not emit allowlistRef field"
+        );
     }
 
     #[test]

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -711,6 +711,15 @@ pub struct NetworkPolicyConfig {
     /// Use `azureclaw policy learn <name>` to export the learned allowlist.
     #[serde(default)]
     pub learn_egress: bool,
+    /// Reference to a signed OCI artifact containing the canonical egress
+    /// allowlist. Populated by `azureclaw egress … --sign` (S12.c). Audit-only
+    /// in S12.a — controller still derives `NetworkPolicy` from
+    /// `allowed_endpoints`. Becomes authoritative in S12.e behind the
+    /// `AZURECLAW_FEATURE_SIGNED_ALLOWLIST` env gate (S12.b).
+    ///
+    /// Canonical format documented at `docs/policy-canonical-format.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowlist_ref: Option<OciArtifactRef>,
 }
 
 impl Default for NetworkPolicyConfig {
@@ -720,6 +729,7 @@ impl Default for NetworkPolicyConfig {
             approval_required: true,
             allowed_endpoints: None,
             learn_egress: false,
+            allowlist_ref: None,
         }
     }
 }
@@ -730,6 +740,36 @@ pub struct EndpointConfig {
     pub port: Option<u16>,
     pub methods: Option<Vec<String>>,
     pub paths: Option<Vec<String>>,
+}
+
+/// Reference to a signed OCI artifact (e.g., a sealed policy document).
+///
+/// Generic shape: any consumer that needs to point at a content-addressed,
+/// cosign-signed OCI blob uses this struct. Keep registry-agnostic — works
+/// against ACR, GHCR, or any OCI-1.1 distribution endpoint.
+///
+/// Verification (consumer-side) requires:
+/// 1. Cryptographic validity (cosign sig present, chain valid).
+/// 2. Signer identity match against a cluster `SignerPolicy` (S12.d):
+///    Fulcio issuer + SAN/subject pattern.
+///
+/// Both checks must pass; "valid sig" alone is not authority.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OciArtifactRef {
+    /// Registry hostname (e.g. `myacr.azurecr.io`, `ghcr.io`).
+    pub registry: String,
+    /// Repository path (e.g. `azureclaw/policies/sandbox-foo`).
+    pub repository: String,
+    /// Content-addressed digest, including the algorithm prefix
+    /// (`sha256:abc…`). The digest covers the canonical artifact bytes —
+    /// see `docs/policy-canonical-format.md` for the egress-allowlist
+    /// canonicalization rules.
+    pub digest: String,
+    /// OCI artifactType media-type, e.g.
+    /// `application/vnd.azureclaw.egress-allowlist.v1+yaml`. Consumers MUST
+    /// reject artifacts whose pulled `artifactType` doesn't match.
+    pub artifact_type: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
@@ -909,6 +949,36 @@ mod tests {
         assert!(cfg.approval_required);
         assert!(cfg.allowed_endpoints.is_none());
         assert!(!cfg.learn_egress);
+        assert!(cfg.allowlist_ref.is_none());
+    }
+
+    #[test]
+    fn allowlist_ref_round_trips_through_camel_case_json() {
+        // Wire-format hygiene: K8s uses camelCase, so `allowlistRef` /
+        // `artifactType` must serialize as such (S12.a contract).
+        let r = OciArtifactRef {
+            registry: "myacr.azurecr.io".into(),
+            repository: "azureclaw/policies/sandbox-foo".into(),
+            digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000".into(),
+            artifact_type: "application/vnd.azureclaw.egress-allowlist.v1+yaml".into(),
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert!(v.get("registry").is_some());
+        assert!(v.get("repository").is_some());
+        assert!(v.get("digest").is_some());
+        assert!(v.get("artifactType").is_some(), "must use camelCase artifactType");
+        let back: OciArtifactRef = serde_json::from_value(v).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn allowlist_ref_omitted_when_none() {
+        // S12.a: existing CRs without `allowlistRef` must round-trip
+        // unchanged. `skip_serializing_if = "Option::is_none"` enforces this.
+        let cfg = NetworkPolicyConfig::default();
+        let v = serde_json::to_value(&cfg).unwrap();
+        assert!(v.get("allowlistRef").is_none(),
+            "default NetworkPolicyConfig must not emit allowlistRef field");
     }
 
     #[test]

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -436,6 +436,41 @@ spec:
                             type: array
                             items:
                               type: string
+                    allowlistRef:
+                      type: object
+                      description: |
+                        Reference to a signed OCI artifact containing the
+                        canonical egress allowlist. Populated by
+                        `azureclaw egress … --sign` (S12.c). Audit-only
+                        in S12.a — controller still derives NetworkPolicy
+                        from `allowedEndpoints`. Becomes authoritative in
+                        S12.e behind the AZURECLAW_FEATURE_SIGNED_ALLOWLIST
+                        env gate. See docs/policy-canonical-format.md.
+                      required:
+                        - registry
+                        - repository
+                        - digest
+                        - artifactType
+                      properties:
+                        registry:
+                          type: string
+                          description: "Registry hostname (e.g. myacr.azurecr.io, ghcr.io)."
+                        repository:
+                          type: string
+                          description: "Repository path (e.g. azureclaw/policies/sandbox-foo)."
+                        digest:
+                          type: string
+                          pattern: "^sha(256|384|512):[a-f0-9]+$"
+                          description: |
+                            Content-addressed digest including algorithm
+                            prefix. Covers the canonical artifact bytes
+                            per docs/policy-canonical-format.md.
+                        artifactType:
+                          type: string
+                          description: |
+                            OCI artifactType media-type, e.g.
+                            application/vnd.azureclaw.egress-allowlist.v1+yaml.
+                            Consumers MUST reject mismatched artifactTypes.
                 resources:
                   type: object
                   properties:

--- a/docs/policy-canonical-format.md
+++ b/docs/policy-canonical-format.md
@@ -1,0 +1,91 @@
+# Canonical Policy Format (S12.a)
+
+This document defines the **byte-stable** serialization rules for AzureClaw policy artifacts that are sealed as signed OCI blobs.
+
+The artifact digest in `OciArtifactRef.digest` covers the canonical bytes specified here. Two functionally equivalent allowlists MUST produce identical digests; any deviation from these rules is a bug.
+
+## Why canonicalization matters
+
+Cosign signs bytes, not semantics. If an artifact's payload differs from its semantic intent (e.g., re-ordered keys, alternative case, default ports omitted vs. explicit), then:
+
+- The signature still verifies (bytes match)
+- But operators reviewing the source manifest may believe a different policy is in force
+- And drift detection (`AllowlistDrift` condition in S12.e) becomes unreliable
+
+A canonical form eliminates ambiguity so two operators producing the same logical allowlist always produce the same digest.
+
+## Egress Allowlist v1 (`application/vnd.azureclaw.egress-allowlist.v1+yaml`)
+
+### Wire format
+
+```yaml
+apiVersion: azureclaw.dev/v1alpha1
+kind: EgressAllowlist
+metadata:
+  generation: <monotonic positive integer, see "Replay protection" below>
+spec:
+  endpoints:
+    - host: api.github.com
+      port: 443
+    - host: dev.azure.com
+      port: 443
+```
+
+### Canonicalization rules
+
+1. **YAML serializer:** block style only; no flow style; no anchors/aliases. UTF-8 encoded; LF (`\n`) line endings; trailing newline.
+2. **Top-level keys** appear in this exact order: `apiVersion`, `kind`, `metadata`, `spec`.
+3. **`apiVersion`** MUST be the literal `azureclaw.dev/v1alpha1`. Reject any other value at consumer side.
+4. **`kind`** MUST be the literal `EgressAllowlist`.
+5. **`metadata.generation`** MUST be a positive integer, monotonically increasing per logical policy lineage. New seals derived from a prior digest MUST set `generation = previous + 1`. Replay protection: a controller comparing two refs for the same lineage MUST reject a digest whose `generation` is less than the current observed `generation`.
+6. **`spec.endpoints`** is a list of `{host, port}` objects. Other fields (`methods`, `paths`) are deliberately excluded from v1 to keep the canonicalization surface small; future versions bump the `+yaml` suffix.
+7. **Endpoint hostnames** (`host`):
+   - Lowercased ASCII.
+   - **IDNA 2008** Punycode-encoded for any non-ASCII characters (use `idna.encode` / `tonic` / `punycode-rs`; never raw Unicode).
+   - No trailing dot.
+   - No `*` wildcards in v1 (deferred to v2).
+   - Reject leading/trailing whitespace, embedded control bytes, and any byte not in `[a-z0-9.-]`.
+8. **Endpoint ports** (`port`): integer in `[1, 65535]`. **Always explicit** — no implicit-443 defaults. Reject `0` and out-of-range.
+9. **Endpoint deduplication:** the producer MUST collapse `(host, port)` tuples that compare bytewise-equal after rule #7 normalization. The canonical document contains zero duplicates.
+10. **Endpoint sort order:** the canonical document sorts endpoints lexicographically, primarily by `host` (byte-by-byte after lowercasing), secondarily by `port` ascending.
+11. **YAML key order within each endpoint:** `host` then `port`. Producers MUST emit fields in this order.
+12. **No comments** in the canonical document. Comments are stripped before signing.
+13. **No empty maps or empty lists** (`metadata: {}` is invalid; omit instead). The one exception is `spec.endpoints: []` for an explicit empty allowlist (which means "deny all egress except the always-allowed defaults") — this MUST be emitted as the four bytes `[]\n` after the `endpoints:` key, not as an indented empty block.
+
+### Signing
+
+```
+oras push <registry>/<repository>@sha256:<digest> \
+    --artifact-type application/vnd.azureclaw.egress-allowlist.v1+yaml \
+    canonical.yaml
+cosign sign <registry>/<repository>@sha256:<digest>
+```
+
+The `oras push` step computes the `sha256` digest over the raw YAML bytes; the producer MUST verify the digest matches the canonical bytes it just computed before invoking `cosign sign`. Mismatch is a producer bug — abort.
+
+### Verification (consumer)
+
+Two-step:
+
+1. **Cryptographic validity:** cosign signature exists, chains to a Fulcio root, certificate not expired at signing time.
+2. **Authority:** signer identity (Fulcio cert SAN + issuer claim) matches an entry in the cluster `SignerPolicy` ConfigMap (S12.d). Without S12.d, no identity is authoritative — verification is "valid sig" only and the controller MUST surface this as a `AllowlistVerified=Unknown` condition with reason `NoSignerPolicy`.
+
+After verification, parse the YAML and revalidate every canonicalization rule above. Reject (set `AllowlistVerified=False`, reason `CanonicalFormViolation`) on any mismatch — even a valid signature over malformed canonical bytes is not authority.
+
+## Forward compatibility
+
+When v2 is needed (e.g., to reintroduce wildcards, methods, paths, CIDR ranges):
+
+- Bump artifactType to `application/vnd.azureclaw.egress-allowlist.v2+yaml`.
+- Define new canonicalization rules. v2 consumers SHOULD also accept v1 artifacts; v1 consumers MUST reject v2 artifacts (forward incompatibility is the safe direction).
+- The on-CR `OciArtifactRef.artifactType` is the authority — controllers select the canonical-format codec by media-type, not by `apiVersion` field inside the document.
+
+## Status
+
+| Slice | Owns |
+|---|---|
+| **S12.a** *(this slice)* | Format definition, CRD field, no behavior |
+| S12.b | Controller fetcher + format validator (status-only) |
+| S12.c | CLI canonical serializer + signing |
+| S12.d | `SignerPolicy` ConfigMap + identity-pinned authority |
+| S12.e | Authoritative ref mode (controller derives `allowedEndpoints` from canonical bytes) |

--- a/docs/security-audits/2026-04-30-phase2-policyref-schema.md
+++ b/docs/security-audits/2026-04-30-phase2-policyref-schema.md
@@ -1,0 +1,78 @@
+# Phase 2 — S12.a: Policy Reference Schema + Canonical Egress Allowlist Format
+
+**Date:** 2026-04-30
+**Slice:** S12.a (`phase2-s12-a-policyref-schema`)
+**Scope:** Pure schema PR. CRD addition + canonical format spec. **No** controller, CLI, or runtime behavior change.
+
+## Summary
+
+Adds the `OciArtifactRef` shape to `controller/src/crd.rs` and surfaces a new optional field `ClawSandbox.spec.networkPolicy.allowlistRef` of that shape. Defines the byte-stable canonical format for the v1 egress allowlist artifact in `docs/policy-canonical-format.md`.
+
+This is the foundation for the S12 supply-chain-grade policy work; it ships before any code that produces or consumes signed artifacts so that:
+
+1. The schema lands first and stabilizes (no churn in subsequent slices).
+2. The canonical format is reviewable in isolation, before signing tooling is built on top of it.
+3. Existing CRs without `allowlistRef` round-trip unchanged (`skip_serializing_if = "Option::is_none"`).
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `controller/src/crd.rs` | New `OciArtifactRef` struct (camelCase, `JsonSchema`, `PartialEq + Eq`); new optional `allowlist_ref` field on `NetworkPolicyConfig`. |
+| `controller/src/crd.rs` (tests) | New `allowlist_ref_round_trips_through_camel_case_json` and `allowlist_ref_omitted_when_none` tests; existing `default_network_policy_denies_all` extended. |
+| `deploy/helm/azureclaw/templates/crd.yaml` | New `allowlistRef` sub-schema under `networkPolicy`. Required-field validation, digest regex pattern. |
+| `docs/policy-canonical-format.md` | New. Defines canonicalization rules, signing/verification flow, and forward-compatibility strategy for the egress allowlist v1 artifact. |
+
+## Threat-Model Implications
+
+S12.a alone is informational — the field is read by no consumer yet. The threat surface is therefore limited to:
+
+- **Schema spoofing:** an operator could populate `allowlistRef` with a bogus reference. Today this is harmless because no code reads it; once S12.b ships behind `AZURECLAW_FEATURE_SIGNED_ALLOWLIST` the controller will surface verification failures as `AllowlistVerified=False`. Authority is enforced in S12.d (identity pinning), not here.
+- **Replay protection:** the canonical document carries `metadata.generation` (positive monotonic integer). Replay protection at the controller side (S12.e) compares incoming `generation` to last-observed; never relies on Rekor freshness. The schema does not yet enforce this — S12.b validators will.
+- **Drift / wire format:** rules #1–#13 of the canonical-format doc eliminate equivalence ambiguity. Two operators producing the same logical allowlist always produce the same digest. Rule #7 (IDNA 2008 + lowercase) prevents homograph-style policy spoofing.
+
+## What This Slice Does NOT Do
+
+By design, none of these are in S12.a:
+
+- ❌ No CLI flag, no signing.
+- ❌ No controller fetch or verification.
+- ❌ No `SignerPolicy` ConfigMap.
+- ❌ No router behavior change (blocked-domain capture is S12.f).
+- ❌ No effect on existing `allowedEndpoints` precedence.
+
+These land in S12.b–S12.g, each with its own audit doc.
+
+## Test Evidence
+
+```
+$ cargo test --package azureclaw-controller -- crd::
+running 36 tests
+....................................
+test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 318 filtered out
+
+$ cargo clippy --package azureclaw-controller --all-targets -- -D warnings
+(clean)
+```
+
+The new tests (`allowlist_ref_round_trips_through_camel_case_json`, `allowlist_ref_omitted_when_none`) lock in:
+
+- camelCase JSON wire format (`artifactType`, not `artifact_type`)
+- Backwards-compat: `NetworkPolicyConfig::default()` does not emit `allowlistRef`
+
+## Migration / Rollback
+
+- **In-place v1alpha1 schema edit** (we are pre-release per S13's plan). No conversion webhook needed.
+- **Rollback** is trivial: revert this PR; no live data references the field yet.
+- **Forward compat** for v2: future artifactTypes bump the `+yaml` suffix; consumers select codec by media-type (see canonical-format doc §"Forward compatibility").
+
+## §10.5 Compliance
+
+- §10.5 #4 (signed-policy provenance): foundation laid; full coverage delivered across S12.a–S12.g.
+- Per-sub-slice audit docs are mandatory; this is the first.
+
+## References
+
+- Plan §S12 (post-critique decomposition): `~/.copilot/session-state/.../plan.md`
+- ADR-0001 step #4 (gateway component) — independent; this slice doesn't touch the public-edge path.
+- Rubber-duck critique 2026-04-30: trust model + decomposition adopted; in-sandbox cosign rejected as out-of-scope (controller-side verification only).


### PR DESCRIPTION
First slice of the S12 supply-chain-grade policy work, decomposed safely after rubber-duck critique.

**Pure schema PR.** No runtime/CLI/controller behavior change. Existing CRs round-trip unchanged.

## Adds

- `OciArtifactRef` struct + `ClawSandbox.spec.networkPolicy.allowlistRef` field (audit-only — no consumer reads it yet)
- Helm CRD schema with required-field validation + digest regex
- `docs/policy-canonical-format.md` — byte-stable canonicalization rules for v1 egress allowlist (IDNA 2008, explicit ports, dedup, sort, generation for replay protection)
- 2 new tests + audit doc + CHANGELOG entry

## Follow-up slices

S12.b (controller verify, status-only, feature-gated) → S12.c (CLI sign) → S12.d (SignerPolicy) → S12.e (authoritative ref) → S12.f (router blocked-attempt visibility) → S12.g (default-on close-out).

## Verification

- `cargo test --package azureclaw-controller` → 354 passed (+2 new)
- `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` → clean

See `docs/security-audits/2026-04-30-phase2-policyref-schema.md` for full audit.