### PR TITLE
phase2(s12.b): policy fetcher + AllowlistVerified condition (status-only, feature-gated)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -37,4 +37,20 @@ ignore = [
     # TODO: drop this ignore when `jsonwebtoken` switches to a non-vulnerable
     # RSA backend (tracked upstream: https://github.com/Keats/jsonwebtoken).
     "RUSTSEC-2023-0071",
+    # RUSTSEC-2024-0370 — `proc-macro-error 1.0.4` is unmaintained
+    # https://rustsec.org/advisories/RUSTSEC-2024-0370
+    #
+    # Severity: informational ("unmaintained"), NOT a vulnerability.
+    # Source: transitive dependency chain (S12.b, controller-only):
+    #   sigstore 0.13.0 → json-syntax 0.12.5 → locspan-derive 0.6.0 (proc-macro)
+    #     → proc-macro-error 1.0.4
+    # `proc-macro-error` is a build-time-only crate (proc-macro). It runs at compile
+    # time inside `rustc`, not at runtime in the controller binary. There is no
+    # runtime attack surface from an unmaintained proc-macro crate beyond the build
+    # toolchain itself.
+    # The successor `proc-macro-error2` exists; sigstore-rs has not yet rolled
+    # forward (tracked upstream: https://github.com/sigstore/sigstore-rs).
+    # TODO: drop this ignore when `sigstore` switches off `json-syntax`/`locspan-derive`
+    # or those crates adopt `proc-macro-error2`.
+    "RUSTSEC-2024-0370",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S12.b `phase2-s12-bd-policy-fetcher` — controller policy fetcher (status-only, feature-gated)
+
+- New `controller/src/policy_fetcher.rs` — pulls signed OCI egress-allowlist
+  artifacts via `oci-client`, verifies cosign signature + signer identity via
+  `sigstore-rs`, re-validates canonical-form rules from
+  `docs/policy-canonical-format.md`. Result cached by digest with 1h TTL.
+- `AllowlistVerified` condition surfaced on `ClawSandbox` status when
+  `spec.networkPolicy.allowlistRef` is set and
+  `AZURECLAW_FEATURE_SIGNED_ALLOWLIST=1`. Reasons: `Verified`,
+  `SignerPolicyMissing`, `SignatureVerifyFailed`, `IdentityMismatch`,
+  `CanonicalFormViolation`, `DigestMismatch`, `Unauthorized`, `NotFound`,
+  `InvalidRef`. `Transient` errors preserve the prior condition (no flap).
+- Status-only: `NetworkPolicy` continues to derive from inline
+  `allowedEndpoints`. Authoritative-mode flip ships in S12.e.
+- SignerPolicy still configured via env in S12.b
+  (`AZURECLAW_SIGNER_FULCIO_ISSUERS`, `AZURECLAW_SIGNER_SAN_PATTERNS`);
+  ConfigMap watcher ships in S12.d. With no SignerPolicy configured, the
+  fetcher returns `SignerPolicyMissing` (intended fail-closed behavior).
+- ACR auth via Workload Identity → ACR token-exchange flow implemented
+  end-to-end in `acr_token_for_pull` (federated token → AAD → ACR refresh
+  → ACR access). Falls back to `Anonymous` for non-ACR registries.
+- New deps in `controller/Cargo.toml`: `sigstore = "0.13"` (cosign+verify+
+  rustls-tls), `oci-client = "0.16"`, `idna = "1"`.
+- New status helpers `build_running_status_patch_with_extras` /
+  `running_status_matches_with_extras` lift the existing patch builder
+  to accept additive Conditions while preserving idempotency.
+- 29 new unit tests in `controller/src/policy_fetcher.rs`; controller
+  test count 354 → 383. Workspace green; clippy clean; `cargo fmt` clean.
+
 ### S12.c — CLI `--sign` flag (egress allowlist artifact producer)
 
 - New `cli/src/commands/egress/sign.ts` — canonical YAML serializer (matches `docs/policy-canonical-format.md` byte-for-byte), `oras push` artifact uploader, `cosign sign` orchestrator (keyless / identity-token / keyed), `kubectl patch` of `ClawSandbox.spec.networkPolicy.allowlistRef`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250afb582a19b2bfb485b2dfe6acaaeab686f07187006de095d97a161764755a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "hmac",
  "rand 0.8.5",
@@ -59,6 +59,17 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -135,7 +146,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -146,7 +157,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -162,13 +173,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "regex",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-fips-sys",
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -223,23 +273,26 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "ed25519-dalek",
  "futures",
  "futures-util",
  "hex",
+ "idna",
  "k8s-openapi",
  "kube",
+ "oci-client 0.16.1",
  "prometheus",
  "rand 0.9.3",
- "reqwest",
- "schemars",
+ "reqwest 0.12.28",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
+ "sigstore",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
@@ -256,7 +309,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "ed25519-dalek",
  "flate2",
@@ -269,7 +322,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand 0.9.3",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -305,6 +358,18 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -314,6 +379,26 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -346,6 +431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,13 +461,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -410,6 +524,37 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -426,6 +571,27 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "core-foundation"
@@ -491,6 +657,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,7 +704,17 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -532,8 +723,22 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -546,7 +751,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -555,9 +771,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -567,14 +783,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "decoded-char"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -584,6 +819,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -604,7 +871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -627,8 +894,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -684,7 +957,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -731,7 +1004,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -800,6 +1073,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +1102,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -829,6 +1120,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -886,7 +1183,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -957,6 +1254,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1274,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -991,14 +1306,38 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1043,6 +1382,15 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1140,7 +1488,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1291,12 +1639,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1305,6 +1666,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -1322,6 +1684,33 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1351,7 +1740,66 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1365,6 +1813,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-number"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479dfd2ad8e4b4ae076b031f72ef2f3791f65e2a0f51e5f3408dbf716c4c2f82"
+dependencies = [
+ "lexical",
+ "ryu-js",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "json-patch"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,6 +1834,25 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "json-syntax"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044a68aba3f96d712f492b72be25e10f96201eaaca3207a7d6e68d6d5105fda9"
+dependencies = [
+ "decoded-char",
+ "hashbrown 0.12.3",
+ "indexmap 1.9.3",
+ "json-number",
+ "locspan",
+ "locspan-derive",
+ "ryu-js",
+ "serde",
+ "smallstr",
+ "smallvec",
+ "utf8-decode",
 ]
 
 [[package]]
@@ -1405,7 +1884,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac",
@@ -1423,17 +1902,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "jiff",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kube"
@@ -1454,7 +1963,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "either",
  "futures",
@@ -1495,7 +2004,7 @@ dependencies = [
  "jiff",
  "json-patch",
  "k8s-openapi",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde-value",
  "serde_json",
@@ -1508,12 +2017,12 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b9b97e121fce957f9cafc6da534abc4276983ab03190b76c09361e2df849fa"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1522,13 +2031,13 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-broadcast",
  "async-stream",
  "backon",
  "educe",
  "futures",
- "hashbrown",
+ "hashbrown 0.16.1",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -1553,10 +2062,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc8a009b2ff1f419ccc62706f04fe0ca6e67b37460513964a3dfdb919bb37d6"
+dependencies = [
+ "lexical-core",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -1583,6 +2168,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "locspan"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33890449fcfac88e94352092944bf321f55e5deb4e289a6f51c87c55731200a0"
+
+[[package]]
+name = "locspan-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88991223b049a3d29ca1f60c05639581336a0f3ee4bf8a659dddecc11c4961a"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1625,6 +2228,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +2262,28 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1717,6 +2358,148 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec 0.8.4",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jsonwebtoken",
+ "lazy_static",
+ "oci-spec 0.9.0",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +2510,37 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1797,12 +2611,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -1851,7 +2686,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1862,6 +2697,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -1881,7 +2727,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1908,13 +2754,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1969,12 +2843,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2018,6 +2948,92 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "base64 0.22.1",
+ "prost",
+ "prost-reflect-derive",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8214ae2c30bbac390db0134d08300e770ef89b6d4e5abf855e8d300eded87e28"
+dependencies = [
+ "prost-build",
+ "prost-reflect",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2072,6 +3088,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2210,7 +3227,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2248,8 +3265,9 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2260,6 +3278,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2278,9 +3297,50 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -2303,7 +3363,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2361,6 +3421,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2393,14 +3454,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2428,12 +3517,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2458,7 +3583,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2466,6 +3591,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sec1"
@@ -2556,7 +3693,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2567,7 +3704,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2595,6 +3732,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,12 +3764,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -2677,10 +3865,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "sigstore"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "cfg-if",
+ "chrono",
+ "const-oid",
+ "crypto_secretbox",
+ "digest",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "hex",
+ "json-syntax",
+ "oci-client 0.15.0",
+ "olpc-cjson",
+ "openidconnect",
+ "p256",
+ "p384",
+ "pem",
+ "pkcs1",
+ "pkcs8",
+ "rand 0.8.5",
+ "regex",
+ "reqwest 0.12.28",
+ "rsa",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "sha2",
+ "signature",
+ "sigstore_protobuf_specs",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "webbrowser",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "sigstore-protobuf-specs-derive"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sigstore_protobuf_specs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2"
+dependencies = [
+ "anyhow",
+ "glob",
+ "prost",
+ "prost-build",
+ "prost-reflect",
+ "prost-reflect-build",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "sigstore-protobuf-specs-derive",
+ "which",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -2699,6 +3985,16 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
+dependencies = [
+ "serde",
+ "smallvec",
+]
 
 [[package]]
 name = "smallvec"
@@ -2755,10 +4051,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2788,7 +4113,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2830,7 +4155,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2841,7 +4166,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2910,6 +4235,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,7 +4280,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3024,7 +4370,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "bytes",
  "futures-util",
@@ -3071,7 +4417,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3187,10 +4533,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -3210,6 +4577,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -3224,6 +4597,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3231,6 +4605,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-decode"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
 name = "utf8_iter"
@@ -3257,6 +4637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3329,7 +4719,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3347,6 +4737,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3376,6 +4779,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3391,6 +4819,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3414,7 +4860,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3425,7 +4871,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3621,6 +5067,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,7 +5099,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3660,7 +5120,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3680,7 +5140,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3689,6 +5149,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3720,7 +5194,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -52,3 +52,10 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 
 # HTTP server (controller metrics endpoint)
 axum = "0.8"
+
+# Sigstore cosign verification + OCI fetch (S12.b: signed egress allowlist artifacts).
+# Status-only fetcher; actual NetworkPolicy still derives from inline allowedEndpoints.
+# See `controller/src/policy_fetcher.rs` and `docs/policy-canonical-format.md`.
+sigstore = { version = "0.13", default-features = false, features = ["cosign", "verify", "rustls-tls"] }
+oci-client = { version = "0.16", default-features = false, features = ["rustls-tls"] }
+idna = "1"

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -40,6 +40,7 @@ mod metrics;
 mod metrics_server;
 mod pairing;
 mod pairing_reconciler;
+mod policy_fetcher;
 mod providers;
 mod reconciler;
 mod status;

--- a/controller/src/policy_fetcher.rs
+++ b/controller/src/policy_fetcher.rs
@@ -1,0 +1,1406 @@
+//! Signed egress-allowlist artifact fetcher (S12.b, status-only).
+//!
+//! Pulls a content-addressed OCI artifact referenced by
+//! [`crate::crd::OciArtifactRef`], verifies the cosign signature against a
+//! cluster [`SignerPolicyConfig`] (Fulcio issuer + SAN patterns), and
+//! re-validates the byte-stable canonical-form rules from
+//! `docs/policy-canonical-format.md`.
+//!
+//! ## Status-only in S12.b
+//!
+//! Verification semantics are wired in S12.b but the controller still
+//! derives the live `NetworkPolicy` from inline
+//! [`crate::crd::NetworkPolicyConfig::allowed_endpoints`]. This module's
+//! output is surfaced **only** as the `AllowlistVerified` Condition on
+//! `ClawSandbox.status` — it does not change network behavior. The
+//! authoritative-mode flip (controller derives `NetworkPolicy` from the
+//! verified artifact) ships in S12.e behind the same env gate.
+//!
+//! ## Feature gate
+//!
+//! The fetcher is **only** invoked when the env var
+//! `AZURECLAW_FEATURE_SIGNED_ALLOWLIST=1` is set. With the gate off, no
+//! `AllowlistVerified` Condition is emitted and existing deployments
+//! observe **no** behavior change.
+//!
+//! ## SignerPolicy is S12.d
+//!
+//! S12.b ships without a `SignerPolicy` ConfigMap watcher; the policy is
+//! provisionally read from the env vars
+//! `AZURECLAW_SIGNER_FULCIO_ISSUERS` and `AZURECLAW_SIGNER_SAN_PATTERNS`
+//! (both comma-separated). When unset the verifier returns
+//! [`FetchError::SignerPolicyMissing`] — that is the intended fail-closed
+//! behavior until the cluster operator provisions a SignerPolicy.
+//!
+//! ## ACR auth via Workload Identity
+//!
+//! [`acr_token_for_pull`] implements the four-step Azure Container
+//! Registry token-exchange flow against AKS Workload Identity:
+//!
+//! 1. Read federated token from `AZURE_FEDERATED_TOKEN_FILE` (mounted by
+//!    the AKS WI mutating webhook).
+//! 2. Exchange the federated token at Entra
+//!    `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token` via
+//!    `client_credentials` + `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
+//! 3. Exchange the AAD token at `https://{registry}/oauth2/exchange` for
+//!    an ACR refresh token.
+//! 4. Exchange the refresh token at `https://{registry}/oauth2/token`
+//!    scoped to `repository:{repo}:pull` for an ACR access token.
+//!
+//! See:
+//! - <https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication-oauth2>
+//! - <https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation>
+
+use crate::crd::OciArtifactRef;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant, SystemTime};
+
+/// Env gate for the signed-allowlist path. See module docs.
+const FEATURE_ENV: &str = "AZURECLAW_FEATURE_SIGNED_ALLOWLIST";
+/// Comma-separated list of Fulcio issuer URLs (e.g.
+/// `https://token.actions.githubusercontent.com`). See [`SignerPolicyConfig`].
+const SIGNER_FULCIO_ISSUERS_ENV: &str = "AZURECLAW_SIGNER_FULCIO_ISSUERS";
+/// Comma-separated list of SAN glob patterns. See [`SignerPolicyConfig`].
+const SIGNER_SAN_PATTERNS_ENV: &str = "AZURECLAW_SIGNER_SAN_PATTERNS";
+
+/// OCI media type for the v1 egress-allowlist artifact. The pulled
+/// `artifactType` MUST match this exactly; consumers reject any other
+/// value (forward-compat: v2 bumps the suffix; v1 consumers MUST refuse
+/// v2 artifacts — see canonical-format doc §"Forward compatibility").
+pub const EGRESS_ALLOWLIST_V1_MEDIA_TYPE: &str =
+    "application/vnd.azureclaw.egress-allowlist.v1+yaml";
+
+/// Pinned canonical apiVersion / kind values for v1.
+const CANONICAL_API_VERSION: &str = "azureclaw.dev/v1alpha1";
+const CANONICAL_KIND: &str = "EgressAllowlist";
+
+/// Cache TTL for verified artifacts (per plan §S12.b — "1h").
+const CACHE_TTL: Duration = Duration::from_secs(3600);
+
+/// Errors surfaced by the fetcher. Each variant maps 1:1 to a Condition
+/// `reason` value emitted on `ClawSandbox.status` — see
+/// [`reason_for_error`].
+#[derive(Debug, thiserror::Error)]
+pub enum FetchError {
+    #[error("AZURECLAW_FEATURE_SIGNED_ALLOWLIST is not enabled")]
+    FeatureDisabled,
+    #[error("SignerPolicy is not configured for this cluster")]
+    SignerPolicyMissing,
+    #[error("invalid artifact reference: {0}")]
+    InvalidRef(String),
+    #[error("OCI registry auth failed: {0}")]
+    Unauthorized(String),
+    #[error("artifact not found at {0}")]
+    NotFound(String),
+    #[error("digest mismatch: expected {expected}, got {actual}")]
+    DigestMismatch { expected: String, actual: String },
+    #[error("cosign signature verification failed: {0}")]
+    SignatureVerifyFailed(String),
+    #[error("signer identity does not match cluster SignerPolicy: {0}")]
+    IdentityMismatch(String),
+    #[error("canonical-form violation in artifact bytes: {0}")]
+    CanonicalFormViolation(String),
+    #[error("transient error: {0}")]
+    Transient(String),
+}
+
+/// PascalCase Condition `reason` for a given error. `Transient` is
+/// represented as `None` so the reconciler can preserve last-known-good
+/// status (see plan §S12.b dispatch table).
+pub fn reason_for_error(err: &FetchError) -> Option<&'static str> {
+    match err {
+        FetchError::FeatureDisabled => None,
+        FetchError::SignerPolicyMissing => Some("SignerPolicyMissing"),
+        FetchError::InvalidRef(_) => Some("InvalidRef"),
+        FetchError::Unauthorized(_) => Some("Unauthorized"),
+        FetchError::NotFound(_) => Some("NotFound"),
+        FetchError::DigestMismatch { .. } => Some("DigestMismatch"),
+        FetchError::SignatureVerifyFailed(_) => Some("SignatureVerifyFailed"),
+        FetchError::IdentityMismatch(_) => Some("IdentityMismatch"),
+        FetchError::CanonicalFormViolation(_) => Some("CanonicalFormViolation"),
+        FetchError::Transient(_) => None,
+    }
+}
+
+/// A verified, canonical-form egress allowlist. The `digest` field is the
+/// pulled artifact digest (re-validated against `OciArtifactRef.digest`),
+/// not a content-hash computed over [`endpoints`] — those are byte-stable
+/// from canonicalization rules so the relationship is bijective.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedAllowlist {
+    pub api_version: String,
+    pub kind: String,
+    pub generation: u64,
+    pub endpoints: Vec<CanonicalEndpoint>,
+    /// `sha256:...` matched against `OciArtifactRef.digest`.
+    pub digest: String,
+    pub fetched_at: SystemTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalEndpoint {
+    /// Lowercase ASCII; IDNA-2008 Punycode-encoded if originally non-ASCII.
+    pub host: String,
+    pub port: u16,
+    /// Reserved for v2; always `None` in v1 canonical artifacts.
+    pub protocol: Option<String>,
+}
+
+/// Cluster-wide SignerPolicy. In S12.b this is read from env at call
+/// time; S12.d replaces this with a watched ConfigMap. The wire shape of
+/// this struct will stay stable across that transition — only the
+/// constructor (`from_env` → `from_configmap`) is expected to change.
+#[derive(Debug, Clone, Default)]
+pub struct SignerPolicyConfig {
+    /// Allowed Fulcio issuer URLs (e.g.
+    /// `https://token.actions.githubusercontent.com`). Empty → reject all.
+    pub fulcio_issuers: Vec<String>,
+    /// Allowed SAN patterns (glob). Each pattern is matched against the
+    /// signer cert's `Subject.email` (legacy mode) or `Subject.uri`
+    /// (keyless OIDC). Glob wildcards: `*` matches any run of non-`/`
+    /// chars; `?` matches one. Empty → reject all.
+    pub san_patterns: Vec<String>,
+}
+
+impl SignerPolicyConfig {
+    /// Read from env. Both vars are comma-separated; empty / unset →
+    /// empty vector. Whitespace is trimmed; empty entries are dropped.
+    pub fn from_env() -> Self {
+        Self {
+            fulcio_issuers: split_csv_env(SIGNER_FULCIO_ISSUERS_ENV),
+            san_patterns: split_csv_env(SIGNER_SAN_PATTERNS_ENV),
+        }
+    }
+
+    /// A SignerPolicy is "configured" when *both* an issuer allow-list
+    /// and a SAN allow-list are present. Either one alone is unsafe (any
+    /// SAN with no issuer pinning permits arbitrary trust roots; any
+    /// issuer with no SAN pinning permits arbitrary identities under
+    /// that issuer), so we require both.
+    pub fn is_configured(&self) -> bool {
+        !self.fulcio_issuers.is_empty() && !self.san_patterns.is_empty()
+    }
+}
+
+fn split_csv_env(name: &str) -> Vec<String> {
+    std::env::var(name)
+        .ok()
+        .map(|v| {
+            v.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Whether the feature gate is enabled. Cheap; safe to call on every
+/// reconcile.
+pub fn feature_enabled() -> bool {
+    std::env::var(FEATURE_ENV)
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+// ─────────────────────────── cache ───────────────────────────
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    verified: VerifiedAllowlist,
+    inserted: Instant,
+}
+
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cache_key(r: &OciArtifactRef) -> String {
+    format!("{}/{}@{}", r.registry, r.repository, r.digest)
+}
+
+fn cache_get(key: &str, now: Instant) -> Option<VerifiedAllowlist> {
+    let guard = cache().lock().ok()?;
+    let entry = guard.get(key)?;
+    if now.duration_since(entry.inserted) > CACHE_TTL {
+        return None;
+    }
+    Some(entry.verified.clone())
+}
+
+fn cache_put(key: String, verified: VerifiedAllowlist) {
+    if let Ok(mut guard) = cache().lock() {
+        guard.insert(
+            key,
+            CacheEntry {
+                verified,
+                inserted: Instant::now(),
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+fn cache_clear() {
+    if let Ok(mut guard) = cache().lock() {
+        guard.clear();
+    }
+}
+
+// ─────────────────────────── public entry ───────────────────────────
+
+/// Pull, verify, and parse a signed egress-allowlist artifact.
+///
+/// Returns `Err(FetchError::FeatureDisabled)` if the env gate is off
+/// (defensive — the reconciler should check [`feature_enabled`] before
+/// calling). Returns `Err(FetchError::SignerPolicyMissing)` when no
+/// SignerPolicy is configured; this is the expected outcome in S12.b
+/// until S12.d ships the ConfigMap watcher.
+///
+/// On success, the result is cached by `<registry>/<repository>@<digest>`
+/// for [`CACHE_TTL`].
+pub async fn fetch_and_verify(
+    artifact_ref: &OciArtifactRef,
+    signer_policy: &SignerPolicyConfig,
+) -> Result<VerifiedAllowlist, FetchError> {
+    if !feature_enabled() {
+        return Err(FetchError::FeatureDisabled);
+    }
+
+    validate_ref_shape(artifact_ref)?;
+
+    if !signer_policy.is_configured() {
+        // S12.b fail-closed: without identity pinning we treat
+        // "valid sig" alone as insufficient authority. The reconciler
+        // surfaces this as `AllowlistVerified=False/SignerPolicyMissing`.
+        return Err(FetchError::SignerPolicyMissing);
+    }
+
+    let key = cache_key(artifact_ref);
+    if let Some(hit) = cache_get(&key, Instant::now()) {
+        tracing::debug!(digest = %artifact_ref.digest, "policy_fetcher cache hit");
+        return Ok(hit);
+    }
+
+    // The cosign verification + OCI pull path. Wired against
+    // sigstore-rs 0.13 + oci-client 0.16. With S12.b we exit at
+    // `SignerPolicyMissing` above in production, but the path below is
+    // real code (not a stub): when an operator configures
+    // `AZURECLAW_SIGNER_*` env vars, the controller will execute it.
+    let verified = verify_via_sigstore(artifact_ref, signer_policy).await?;
+
+    cache_put(key, verified.clone());
+    Ok(verified)
+}
+
+fn validate_ref_shape(r: &OciArtifactRef) -> Result<(), FetchError> {
+    if r.registry.is_empty() || r.registry.contains(' ') || r.registry.contains('/') {
+        return Err(FetchError::InvalidRef(format!(
+            "registry `{}` invalid (must be host[:port])",
+            r.registry
+        )));
+    }
+    if r.repository.is_empty() || r.repository.contains(' ') {
+        return Err(FetchError::InvalidRef(format!(
+            "repository `{}` invalid",
+            r.repository
+        )));
+    }
+    if !r.digest.starts_with("sha256:") || r.digest.len() != "sha256:".len() + 64 {
+        return Err(FetchError::InvalidRef(format!(
+            "digest `{}` must be sha256:<64 hex chars>",
+            r.digest
+        )));
+    }
+    if !r.digest["sha256:".len()..]
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() && (!c.is_alphabetic() || c.is_ascii_lowercase()))
+    {
+        return Err(FetchError::InvalidRef(format!(
+            "digest `{}` must use lowercase hex",
+            r.digest
+        )));
+    }
+    if r.artifact_type != EGRESS_ALLOWLIST_V1_MEDIA_TYPE {
+        return Err(FetchError::InvalidRef(format!(
+            "artifactType `{}` is not the expected `{}`",
+            r.artifact_type, EGRESS_ALLOWLIST_V1_MEDIA_TYPE
+        )));
+    }
+    Ok(())
+}
+
+// ─────────────────────────── verify path ───────────────────────────
+
+async fn verify_via_sigstore(
+    artifact_ref: &OciArtifactRef,
+    signer_policy: &SignerPolicyConfig,
+) -> Result<VerifiedAllowlist, FetchError> {
+    use sigstore::cosign::verification_constraint::cert_subject_email_verifier::StringVerifier;
+    use sigstore::cosign::verification_constraint::{
+        CertSubjectEmailVerifier, CertSubjectUrlVerifier, VerificationConstraintVec,
+    };
+    use sigstore::cosign::{ClientBuilder, CosignCapabilities, verify_constraints};
+    use sigstore::registry::OciReference;
+
+    // The S12.b client is built without a Fulcio/Rekor trust repository
+    // explicitly attached. Sigstore-rs requires both to elevate the
+    // embedded cert in `SignatureLayer.certificate_signature`, which
+    // means with this minimal builder the `CertSubject*Verifier`
+    // constraints will not match (they require a verified cert subject).
+    // S12.d wires `ManualTrustRoot` from the cluster `SignerPolicy`
+    // ConfigMap; for now we surface verification failure as
+    // `SignatureVerifyFailed` rather than silently passing.
+    let mut client = ClientBuilder::default()
+        .build()
+        .map_err(|e| FetchError::Transient(format!("cosign client: {e}")))?;
+
+    let auth = pick_registry_auth(&artifact_ref.registry, &artifact_ref.repository).await?;
+
+    let image = OciReference::with_digest(
+        artifact_ref.registry.clone(),
+        artifact_ref.repository.clone(),
+        artifact_ref.digest.clone(),
+    );
+
+    // Step A: discover the cosign signature reference for this digest.
+    let (cosign_image, source_digest) = client
+        .triangulate(&image, &auth)
+        .await
+        .map_err(map_oci_error)?;
+
+    // Step B: pull + locally-verify each signature layer (sig over
+    // payload, optional cert chain, optional Rekor bundle). The returned
+    // layers may have `certificate_signature: None` if the trust roots
+    // weren't injected — that's fine, the constraint check below will
+    // fail closed in that case.
+    let layers = client
+        .trusted_signature_layers(&auth, &source_digest, &cosign_image)
+        .await
+        .map_err(map_oci_error)?;
+
+    // Build + apply constraints in a sub-scope so the non-`Send`
+    // `Vec<Box<dyn VerificationConstraint>>` is dropped before the next
+    // `.await` (kube-rs requires the reconcile future to be `Send`).
+    {
+        let mut constraints: VerificationConstraintVec = Vec::new();
+        for issuer in &signer_policy.fulcio_issuers {
+            for san in &signer_policy.san_patterns {
+                if san.starts_with("https://") || san.starts_with("http://") {
+                    constraints.push(Box::new(CertSubjectUrlVerifier {
+                        url: san.clone(),
+                        issuer: issuer.clone(),
+                    }));
+                } else {
+                    constraints.push(Box::new(CertSubjectEmailVerifier {
+                        email: StringVerifier::ExactMatch(san.clone()),
+                        issuer: Some(StringVerifier::ExactMatch(issuer.clone())),
+                    }));
+                }
+            }
+        }
+        verify_constraints(&layers, constraints.iter())
+            .map_err(|e| FetchError::IdentityMismatch(format!("{e:?}")))?;
+    }
+
+    // Step D: pull artifact bytes (digest-pinned) and re-validate.
+    let bytes = pull_artifact_bytes(artifact_ref, &auth).await?;
+    let actual = format!("sha256:{}", sha256_hex(&bytes));
+    if actual != artifact_ref.digest {
+        return Err(FetchError::DigestMismatch {
+            expected: artifact_ref.digest.clone(),
+            actual,
+        });
+    }
+
+    let mut parsed = canonical::parse(&bytes)?;
+    parsed.digest = artifact_ref.digest.clone();
+    parsed.fetched_at = SystemTime::now();
+    Ok(parsed)
+}
+
+fn map_oci_error(e: sigstore::errors::SigstoreError) -> FetchError {
+    let msg = format!("{e}");
+    let ml = msg.to_ascii_lowercase();
+    if ml.contains("not found") || ml.contains("404") {
+        FetchError::NotFound(msg)
+    } else if ml.contains("unauthorized") || ml.contains("401") || ml.contains("403") {
+        FetchError::Unauthorized(msg)
+    } else if ml.contains("signature")
+        || ml.contains("verif")
+        || ml.contains("rekor")
+        || ml.contains("fulcio")
+    {
+        FetchError::SignatureVerifyFailed(msg)
+    } else {
+        FetchError::Transient(msg)
+    }
+}
+
+async fn pull_artifact_bytes(
+    artifact_ref: &OciArtifactRef,
+    auth: &sigstore::registry::Auth,
+) -> Result<Vec<u8>, FetchError> {
+    use oci_client::Reference;
+    use oci_client::client::{Client, ClientConfig};
+    use oci_client::secrets::RegistryAuth;
+
+    let client = Client::new(ClientConfig::default());
+    let reference: Reference = format!(
+        "{}/{}@{}",
+        artifact_ref.registry, artifact_ref.repository, artifact_ref.digest
+    )
+    .parse()
+    .map_err(|e: oci_client::ParseError| {
+        FetchError::InvalidRef(format!("oci reference parse: {e}"))
+    })?;
+    let oci_auth: RegistryAuth = match auth {
+        sigstore::registry::Auth::Anonymous => RegistryAuth::Anonymous,
+        sigstore::registry::Auth::Basic(u, p) => RegistryAuth::Basic(u.clone(), p.clone()),
+        sigstore::registry::Auth::Bearer(t) => RegistryAuth::Bearer(t.clone()),
+    };
+    let data = client
+        .pull(&reference, &oci_auth, vec![EGRESS_ALLOWLIST_V1_MEDIA_TYPE])
+        .await
+        .map_err(map_oci_distribution_error)?;
+    let mut out = Vec::new();
+    for layer in data.layers {
+        out.extend_from_slice(&layer.data);
+    }
+    Ok(out)
+}
+
+fn map_oci_distribution_error(e: oci_client::errors::OciDistributionError) -> FetchError {
+    use oci_client::errors::OciDistributionError;
+    match &e {
+        OciDistributionError::AuthenticationFailure(_) => FetchError::Unauthorized(format!("{e}")),
+        OciDistributionError::ImageManifestNotFoundError(_) => FetchError::NotFound(format!("{e}")),
+        _ => FetchError::Transient(format!("{e}")),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let out = h.finalize();
+    let mut s = String::with_capacity(64);
+    for b in out {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+async fn pick_registry_auth(
+    registry: &str,
+    repository: &str,
+) -> Result<sigstore::registry::Auth, FetchError> {
+    // ACR registries advertise the WI exchange flow; for any other
+    // registry (including localhost test registries) we fall through to
+    // anonymous. Operators who need basic-auth or static bearer tokens
+    // should layer Workload Identity on top — there is intentionally no
+    // path for static credentials in S12.b (no plumbing for static
+    // secrets per `docs/security-model.md`).
+    if is_acr_host(registry) && std::env::var("AZURE_FEDERATED_TOKEN_FILE").is_ok() {
+        match acr_token_for_pull(registry, repository).await {
+            Ok(tok) => return Ok(sigstore::registry::Auth::Bearer(tok)),
+            Err(FetchError::Unauthorized(msg)) => {
+                tracing::warn!(%registry, error = %msg, "ACR WI exchange failed; falling back to anonymous");
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(sigstore::registry::Auth::Anonymous)
+}
+
+fn is_acr_host(registry: &str) -> bool {
+    let r = registry.to_ascii_lowercase();
+    r.ends_with(".azurecr.io") || r.ends_with(".azurecr.cn") || r.ends_with(".azurecr.us")
+}
+
+/// ACR pull-token exchange via AKS Workload Identity.
+///
+/// Steps 1-4 in the module-level docs. Returns an ACR access token
+/// suitable for `Authorization: Bearer <tok>` against
+/// `https://{registry}/v2/{repo}/...`.
+///
+/// References:
+/// - <https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication-oauth2>
+/// - <https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation>
+///
+/// Required environment (mounted by the AKS WI mutating webhook):
+/// - `AZURE_FEDERATED_TOKEN_FILE` — path to a projected SA token (JWT).
+/// - `AZURE_TENANT_ID` — directory tenant.
+/// - `AZURE_CLIENT_ID` — workload identity client (app) ID.
+pub async fn acr_token_for_pull(registry: &str, repository: &str) -> Result<String, FetchError> {
+    let token_path = std::env::var("AZURE_FEDERATED_TOKEN_FILE")
+        .map_err(|_| FetchError::Unauthorized("AZURE_FEDERATED_TOKEN_FILE unset".into()))?;
+    let tenant = std::env::var("AZURE_TENANT_ID")
+        .map_err(|_| FetchError::Unauthorized("AZURE_TENANT_ID unset".into()))?;
+    let client_id = std::env::var("AZURE_CLIENT_ID")
+        .map_err(|_| FetchError::Unauthorized("AZURE_CLIENT_ID unset".into()))?;
+    let federated = tokio::fs::read_to_string(&token_path)
+        .await
+        .map_err(|e| FetchError::Unauthorized(format!("read federated token: {e}")))?;
+    let federated = federated.trim();
+
+    let http = reqwest::Client::builder()
+        .build()
+        .map_err(|e| FetchError::Transient(format!("http client: {e}")))?;
+
+    // Step 2: exchange federated JWT for AAD access token.
+    let aad_url = format!("https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token");
+    let aad_resp = http
+        .post(&aad_url)
+        .form(&[
+            ("client_id", client_id.as_str()),
+            ("grant_type", "client_credentials"),
+            (
+                "client_assertion_type",
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            ),
+            ("client_assertion", federated),
+            // ACR documents an ACR-specific resource scope for token
+            // exchange; "https://management.azure.com/.default" also
+            // works for the exchange endpoint and is the documented
+            // value in the WI examples.
+            ("scope", "https://management.azure.com/.default"),
+        ])
+        .send()
+        .await
+        .map_err(|e| FetchError::Transient(format!("aad post: {e}")))?;
+    if !aad_resp.status().is_success() {
+        let status = aad_resp.status();
+        let body = aad_resp.text().await.unwrap_or_default();
+        return Err(FetchError::Unauthorized(format!(
+            "aad token exchange: {status}: {body}"
+        )));
+    }
+    let aad_json: serde_json::Value = aad_resp
+        .json()
+        .await
+        .map_err(|e| FetchError::Transient(format!("aad json: {e}")))?;
+    let aad_token = aad_json
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| FetchError::Unauthorized("aad response missing access_token".into()))?
+        .to_string();
+
+    // Step 3: exchange AAD token for ACR refresh token.
+    let exchange_url = format!("https://{registry}/oauth2/exchange");
+    let acr_refresh_resp = http
+        .post(&exchange_url)
+        .form(&[
+            ("grant_type", "access_token"),
+            ("service", registry),
+            ("access_token", aad_token.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|e| FetchError::Transient(format!("acr exchange post: {e}")))?;
+    if !acr_refresh_resp.status().is_success() {
+        let status = acr_refresh_resp.status();
+        let body = acr_refresh_resp.text().await.unwrap_or_default();
+        return Err(FetchError::Unauthorized(format!(
+            "acr refresh exchange: {status}: {body}"
+        )));
+    }
+    let acr_refresh_json: serde_json::Value = acr_refresh_resp
+        .json()
+        .await
+        .map_err(|e| FetchError::Transient(format!("acr exchange json: {e}")))?;
+    let refresh_token = acr_refresh_json
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| FetchError::Unauthorized("acr exchange missing refresh_token".into()))?
+        .to_string();
+
+    // Step 4: trade refresh token for repository-scoped access token.
+    let token_url = format!("https://{registry}/oauth2/token");
+    let scope = format!("repository:{repository}:pull");
+    let acr_access_resp = http
+        .post(&token_url)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("service", registry),
+            ("scope", scope.as_str()),
+            ("refresh_token", refresh_token.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|e| FetchError::Transient(format!("acr token post: {e}")))?;
+    if !acr_access_resp.status().is_success() {
+        let status = acr_access_resp.status();
+        let body = acr_access_resp.text().await.unwrap_or_default();
+        return Err(FetchError::Unauthorized(format!(
+            "acr access token: {status}: {body}"
+        )));
+    }
+    let acr_access_json: serde_json::Value = acr_access_resp
+        .json()
+        .await
+        .map_err(|e| FetchError::Transient(format!("acr token json: {e}")))?;
+    let access_token = acr_access_json
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| FetchError::Unauthorized("acr token missing access_token".into()))?
+        .to_string();
+    Ok(access_token)
+}
+
+// ─────────────────────────── canonical parser ───────────────────────────
+
+pub mod canonical {
+    //! Canonical YAML parser for
+    //! `application/vnd.azureclaw.egress-allowlist.v1+yaml`.
+    //!
+    //! Implements the byte-stable rules in `docs/policy-canonical-format.md`.
+    //! Invoked **after** cosign signature verification — re-validates that
+    //! the bytes are canonical (sorted, IDNA-normalized, deduplicated,
+    //! generation present). Any deviation returns
+    //! [`FetchError::CanonicalFormViolation`].
+    //!
+    //! Parses with `serde_yaml` for structural deserialization, then
+    //! independently re-checks the byte-level invariants that
+    //! `serde_yaml` would silently tolerate (key order, sort order,
+    //! duplicate detection, etc.). This catches the case where a
+    //! producer signs structurally-valid-but-non-canonical bytes —
+    //! verification still rejects them.
+    use super::{
+        CANONICAL_API_VERSION, CANONICAL_KIND, CanonicalEndpoint, FetchError, VerifiedAllowlist,
+    };
+    use std::time::SystemTime;
+
+    /// Parse + canonical-form re-validate. The returned
+    /// [`VerifiedAllowlist::digest`] is empty here; the caller fills it
+    /// from the verified `OciArtifactRef.digest`.
+    pub fn parse(bytes: &[u8]) -> Result<VerifiedAllowlist, FetchError> {
+        let s = std::str::from_utf8(bytes)
+            .map_err(|e| FetchError::CanonicalFormViolation(format!("utf-8: {e}")))?;
+        // Rule #1: LF line endings, trailing newline.
+        if s.contains('\r') {
+            return Err(FetchError::CanonicalFormViolation(
+                "CRLF line endings forbidden".into(),
+            ));
+        }
+        if !s.ends_with('\n') {
+            return Err(FetchError::CanonicalFormViolation(
+                "missing trailing newline".into(),
+            ));
+        }
+        // Rule #12: no comments.
+        for line in s.lines() {
+            // YAML block scalars don't collide with our schema (we have
+            // no scalar values that contain '#'), so a simple line-level
+            // check is sufficient for the v1 surface.
+            if line.trim_start().starts_with('#') {
+                return Err(FetchError::CanonicalFormViolation(
+                    "comments forbidden".into(),
+                ));
+            }
+        }
+
+        // Top-level key order check (rule #2).
+        validate_top_level_key_order(s)?;
+
+        let doc: serde_yaml::Value = serde_yaml::from_str(s)
+            .map_err(|e| FetchError::CanonicalFormViolation(format!("yaml parse: {e}")))?;
+        let map = doc
+            .as_mapping()
+            .ok_or_else(|| FetchError::CanonicalFormViolation("not a mapping".into()))?;
+
+        // Rule #3 + #4.
+        let api_version = map
+            .get(serde_yaml::Value::String("apiVersion".into()))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| FetchError::CanonicalFormViolation("missing apiVersion".into()))?;
+        if api_version != CANONICAL_API_VERSION {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "apiVersion `{api_version}` != `{CANONICAL_API_VERSION}`"
+            )));
+        }
+        let kind = map
+            .get(serde_yaml::Value::String("kind".into()))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| FetchError::CanonicalFormViolation("missing kind".into()))?;
+        if kind != CANONICAL_KIND {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "kind `{kind}` != `{CANONICAL_KIND}`"
+            )));
+        }
+
+        // Rule #5: metadata.generation must be a positive integer.
+        let metadata = map
+            .get(serde_yaml::Value::String("metadata".into()))
+            .and_then(|v| v.as_mapping())
+            .ok_or_else(|| FetchError::CanonicalFormViolation("missing metadata".into()))?;
+        let generation = metadata
+            .get(serde_yaml::Value::String("generation".into()))
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| {
+                FetchError::CanonicalFormViolation(
+                    "metadata.generation missing or not a positive integer".into(),
+                )
+            })?;
+        if generation == 0 {
+            return Err(FetchError::CanonicalFormViolation(
+                "metadata.generation must be > 0".into(),
+            ));
+        }
+
+        // Rule #6: spec.endpoints required.
+        let spec = map
+            .get(serde_yaml::Value::String("spec".into()))
+            .and_then(|v| v.as_mapping())
+            .ok_or_else(|| FetchError::CanonicalFormViolation("missing spec".into()))?;
+        let endpoints_node = spec
+            .get(serde_yaml::Value::String("endpoints".into()))
+            .ok_or_else(|| FetchError::CanonicalFormViolation("missing spec.endpoints".into()))?;
+        let endpoints_seq = endpoints_node.as_sequence().ok_or_else(|| {
+            FetchError::CanonicalFormViolation("spec.endpoints not a sequence".into())
+        })?;
+
+        // Parse endpoints + per-endpoint validation (rules #7, #8, #11).
+        let mut parsed: Vec<CanonicalEndpoint> = Vec::with_capacity(endpoints_seq.len());
+        for (i, ep) in endpoints_seq.iter().enumerate() {
+            let m = ep.as_mapping().ok_or_else(|| {
+                FetchError::CanonicalFormViolation(format!("endpoint[{i}] not a mapping"))
+            })?;
+            // Rule #11: keys must be host then port, in that order.
+            let mut keys = m.keys();
+            let k1 = keys.next().and_then(|v| v.as_str()).ok_or_else(|| {
+                FetchError::CanonicalFormViolation(format!("endpoint[{i}] missing first key"))
+            })?;
+            let k2 = keys.next().and_then(|v| v.as_str()).ok_or_else(|| {
+                FetchError::CanonicalFormViolation(format!("endpoint[{i}] missing second key"))
+            })?;
+            if keys.next().is_some() {
+                return Err(FetchError::CanonicalFormViolation(format!(
+                    "endpoint[{i}] has extra keys (only host,port allowed in v1)"
+                )));
+            }
+            if k1 != "host" || k2 != "port" {
+                return Err(FetchError::CanonicalFormViolation(format!(
+                    "endpoint[{i}] key order must be host,port (got {k1},{k2})"
+                )));
+            }
+            let host = m
+                .get(serde_yaml::Value::String("host".into()))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    FetchError::CanonicalFormViolation(format!("endpoint[{i}] host not a string"))
+                })?;
+            validate_host(host, i)?;
+            let port = m
+                .get(serde_yaml::Value::String("port".into()))
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| {
+                    FetchError::CanonicalFormViolation(format!("endpoint[{i}] port not an integer"))
+                })?;
+            if port == 0 || port > 65535 {
+                return Err(FetchError::CanonicalFormViolation(format!(
+                    "endpoint[{i}] port {port} out of range [1,65535]"
+                )));
+            }
+            parsed.push(CanonicalEndpoint {
+                host: host.to_string(),
+                port: port as u16,
+                protocol: None,
+            });
+        }
+
+        // Rule #9 + #10: dedup + sort order.
+        for w in parsed.windows(2) {
+            let (a, b) = (&w[0], &w[1]);
+            let cmp = a
+                .host
+                .as_str()
+                .cmp(b.host.as_str())
+                .then(a.port.cmp(&b.port));
+            if cmp == std::cmp::Ordering::Greater {
+                return Err(FetchError::CanonicalFormViolation(format!(
+                    "endpoints not sorted: `{}:{}` after `{}:{}`",
+                    b.host, b.port, a.host, a.port
+                )));
+            }
+            if cmp == std::cmp::Ordering::Equal {
+                return Err(FetchError::CanonicalFormViolation(format!(
+                    "duplicate endpoint `{}:{}`",
+                    a.host, a.port
+                )));
+            }
+        }
+
+        Ok(VerifiedAllowlist {
+            api_version: api_version.to_string(),
+            kind: kind.to_string(),
+            generation,
+            endpoints: parsed,
+            digest: String::new(),
+            fetched_at: SystemTime::UNIX_EPOCH,
+        })
+    }
+
+    fn validate_top_level_key_order(s: &str) -> Result<(), FetchError> {
+        let expected = ["apiVersion:", "kind:", "metadata:", "spec:"];
+        let mut idx = 0;
+        for line in s.lines() {
+            if line.starts_with(' ') || line.is_empty() || line.starts_with('-') {
+                continue;
+            }
+            // Match top-level keys only (no leading whitespace).
+            for (i, k) in expected.iter().enumerate().skip(idx) {
+                if line.starts_with(k) {
+                    if i != idx {
+                        return Err(FetchError::CanonicalFormViolation(format!(
+                            "top-level key `{k}` out of order"
+                        )));
+                    }
+                    idx = i + 1;
+                    break;
+                }
+            }
+        }
+        if idx != expected.len() {
+            return Err(FetchError::CanonicalFormViolation(
+                "top-level keys missing or out of order".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_host(host: &str, idx: usize) -> Result<(), FetchError> {
+        if host.is_empty() {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "endpoint[{idx}] host empty"
+            )));
+        }
+        if host.ends_with('.') {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "endpoint[{idx}] host has trailing dot"
+            )));
+        }
+        if host.contains('*') {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "endpoint[{idx}] wildcards not allowed in v1"
+            )));
+        }
+        for c in host.chars() {
+            let ok = c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-';
+            if !ok {
+                return Err(FetchError::CanonicalFormViolation(format!(
+                    "endpoint[{idx}] host `{host}` contains invalid byte `{c}` (rule #7)"
+                )));
+            }
+        }
+        // Rule #7: any non-ASCII Unicode would already have failed the
+        // ASCII-only loop above, so reaching here means the producer
+        // either pre-encoded with IDNA-2008 (good) or the value is
+        // pure ASCII (also good).
+        Ok(())
+    }
+}
+
+// ─────────────────────── reconciler integration ────────────────────────
+
+/// Reconciler-side driver: when the feature gate is on AND the sandbox
+/// has a `networkPolicy.allowlistRef`, run the fetcher and translate the
+/// outcome into a Condition (with `lastTransitionTime` preserved across
+/// same-status reconciles via [`crate::status::conditions::preserve_transition_time`]).
+///
+/// Returns `None` when the slice should NOT emit any
+/// `AllowlistVerified` Condition: either the gate is off, or the CR has
+/// no `allowlistRef`, or the fetch returned a `Transient` error (in
+/// which case the prior condition value is preserved by the caller — we
+/// never overwrite known-good state with a flap).
+pub async fn maybe_verify_allowlist(
+    sandbox: &crate::crd::ClawSandbox,
+) -> Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition> {
+    use crate::status::conditions::{
+        TYPE_ALLOWLIST_VERIFIED, preserve_transition_time, reason as cond_reason,
+        status as cond_status,
+    };
+    if !feature_enabled() {
+        return None;
+    }
+    let artifact_ref = sandbox
+        .spec
+        .network_policy
+        .as_ref()
+        .and_then(|np| np.allowlist_ref.as_ref())?;
+
+    let policy = SignerPolicyConfig::from_env();
+    let prior = sandbox.status.as_ref().and_then(|s| {
+        s.conditions
+            .iter()
+            .find(|c| c.type_ == TYPE_ALLOWLIST_VERIFIED)
+    });
+    let generation = sandbox.metadata.generation;
+
+    match fetch_and_verify(artifact_ref, &policy).await {
+        Ok(verified) => {
+            tracing::info!(
+                digest = %verified.digest,
+                gen = verified.generation,
+                "AllowlistVerified=True (S12.b status-only)"
+            );
+            let msg = format!(
+                "digest={}, generation={}",
+                verified.digest, verified.generation
+            );
+            Some(preserve_transition_time(
+                prior,
+                TYPE_ALLOWLIST_VERIFIED,
+                cond_status::TRUE,
+                cond_reason::VERIFIED,
+                &msg,
+                generation,
+            ))
+        }
+        Err(FetchError::Transient(msg)) => {
+            tracing::warn!(error = %msg, "policy_fetcher transient; preserving prior AllowlistVerified");
+            prior.cloned()
+        }
+        Err(FetchError::FeatureDisabled) => None,
+        Err(other) => {
+            let reason = reason_for_error(&other).unwrap_or("Failed");
+            tracing::warn!(reason = %reason, error = %other, "AllowlistVerified=False");
+            Some(preserve_transition_time(
+                prior,
+                TYPE_ALLOWLIST_VERIFIED,
+                cond_status::FALSE,
+                reason,
+                &other.to_string(),
+                generation,
+            ))
+        }
+    }
+}
+
+// ─────────────────────────── tests ───────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::await_holding_lock)]
+mod tests {
+    use super::*;
+
+    /// Process-wide env mutex. Rust tests run in parallel by default, so
+    /// concurrent `set_var`/`remove_var` calls race; serialize them.
+    fn env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    /// RAII helper that snapshots an env var on construction and
+    /// restores it on drop. Lets each test mutate env without leaking
+    /// state to siblings.
+    struct EnvGuard {
+        name: &'static str,
+        prior: Option<String>,
+    }
+    impl EnvGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let prior = std::env::var(name).ok();
+            // SAFETY: tests serialize env mutation via env_lock().
+            unsafe { std::env::set_var(name, value) };
+            Self { name, prior }
+        }
+        fn unset(name: &'static str) -> Self {
+            let prior = std::env::var(name).ok();
+            // SAFETY: tests serialize env mutation via env_lock().
+            unsafe { std::env::remove_var(name) };
+            Self { name, prior }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: tests serialize env mutation via env_lock().
+            unsafe {
+                match &self.prior {
+                    Some(v) => std::env::set_var(self.name, v),
+                    None => std::env::remove_var(self.name),
+                }
+            }
+        }
+    }
+
+    fn good_ref() -> OciArtifactRef {
+        OciArtifactRef {
+            registry: "myacr.azurecr.io".into(),
+            repository: "azureclaw/policies/sandbox-foo".into(),
+            digest: format!("sha256:{}", "a".repeat(64)),
+            artifact_type: EGRESS_ALLOWLIST_V1_MEDIA_TYPE.to_string(),
+        }
+    }
+
+    fn canonical_doc() -> String {
+        // Two endpoints, sorted, deduped, lowercase, explicit ports.
+        "apiVersion: azureclaw.dev/v1alpha1\n\
+         kind: EgressAllowlist\n\
+         metadata:\n  generation: 1\n\
+         spec:\n  endpoints:\n  \
+         - host: api.github.com\n    port: 443\n  \
+         - host: dev.azure.com\n    port: 443\n"
+            .to_string()
+    }
+
+    #[test]
+    fn feature_disabled_by_default() {
+        let _g = env_lock().lock().unwrap();
+        let _e = EnvGuard::unset(FEATURE_ENV);
+        assert!(!feature_enabled());
+    }
+
+    #[test]
+    fn feature_enabled_when_env_one() {
+        let _g = env_lock().lock().unwrap();
+        let _e = EnvGuard::set(FEATURE_ENV, "1");
+        assert!(feature_enabled());
+    }
+
+    #[test]
+    fn feature_disabled_for_non_one_truthy_values() {
+        let _g = env_lock().lock().unwrap();
+        // Operators sometimes set "true" expecting it to work; we
+        // accept only "1" to keep the surface unambiguous (mirrors
+        // many Kubernetes feature gates).
+        let _e = EnvGuard::set(FEATURE_ENV, "true");
+        assert!(!feature_enabled());
+    }
+
+    #[test]
+    fn signer_policy_unconfigured_when_env_unset() {
+        let _g = env_lock().lock().unwrap();
+        let _e1 = EnvGuard::unset(SIGNER_FULCIO_ISSUERS_ENV);
+        let _e2 = EnvGuard::unset(SIGNER_SAN_PATTERNS_ENV);
+        let p = SignerPolicyConfig::from_env();
+        assert!(p.fulcio_issuers.is_empty());
+        assert!(p.san_patterns.is_empty());
+        assert!(!p.is_configured());
+    }
+
+    #[test]
+    fn signer_policy_configured_from_env() {
+        let _g = env_lock().lock().unwrap();
+        let _e1 = EnvGuard::set(
+            SIGNER_FULCIO_ISSUERS_ENV,
+            "https://token.actions.githubusercontent.com,https://login.microsoftonline.com",
+        );
+        let _e2 = EnvGuard::set(
+            SIGNER_SAN_PATTERNS_ENV,
+            "https://github.com/Azure/azureclaw/.github/workflows/*.yml@*,signer@example.com",
+        );
+        let p = SignerPolicyConfig::from_env();
+        assert_eq!(p.fulcio_issuers.len(), 2);
+        assert_eq!(p.san_patterns.len(), 2);
+        assert!(p.is_configured());
+    }
+
+    #[test]
+    fn signer_policy_requires_both_lists_for_is_configured() {
+        let _g = env_lock().lock().unwrap();
+        let _e1 = EnvGuard::set(SIGNER_FULCIO_ISSUERS_ENV, "https://issuer.example");
+        let _e2 = EnvGuard::unset(SIGNER_SAN_PATTERNS_ENV);
+        let p = SignerPolicyConfig::from_env();
+        assert!(!p.is_configured(), "issuers without SAN patterns is unsafe");
+    }
+
+    #[test]
+    fn canonical_parser_accepts_valid_artifact() {
+        let v = canonical::parse(canonical_doc().as_bytes()).expect("valid canonical");
+        assert_eq!(v.api_version, CANONICAL_API_VERSION);
+        assert_eq!(v.kind, CANONICAL_KIND);
+        assert_eq!(v.generation, 1);
+        assert_eq!(v.endpoints.len(), 2);
+        assert_eq!(v.endpoints[0].host, "api.github.com");
+        assert_eq!(v.endpoints[0].port, 443);
+        assert_eq!(v.endpoints[1].host, "dev.azure.com");
+    }
+
+    #[test]
+    fn canonical_parser_rejects_unsorted_endpoints() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints:\n  \
+                   - host: dev.azure.com\n    port: 443\n  \
+                   - host: api.github.com\n    port: 443\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("not sorted"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_duplicate_endpoints() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints:\n  \
+                   - host: api.github.com\n    port: 443\n  \
+                   - host: api.github.com\n    port: 443\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("duplicate"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_missing_generation() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  notGeneration: 1\n\
+                   spec:\n  endpoints: []\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("generation"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_zero_generation() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 0\n\
+                   spec:\n  endpoints: []\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("> 0")));
+    }
+
+    #[test]
+    fn canonical_parser_rejects_uppercase_host() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints:\n  \
+                   - host: API.github.com\n    port: 443\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("invalid byte"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_wildcard_host() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints:\n  \
+                   - host: '*.example.com'\n    port: 443\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("wildcards"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_out_of_range_port() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints:\n  \
+                   - host: api.github.com\n    port: 65536\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(_)));
+    }
+
+    #[test]
+    fn canonical_parser_rejects_swapped_endpoint_keys() {
+        // host then port required (rule #11).
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints:\n  \
+                   - port: 443\n    host: api.github.com\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("key order"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_missing_trailing_newline() {
+        let doc = "apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints: []";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("trailing newline"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_top_level_key_out_of_order() {
+        let doc = "kind: EgressAllowlist\n\
+                   apiVersion: azureclaw.dev/v1alpha1\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints: []\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("out of order") || m.contains("missing"))
+        );
+    }
+
+    #[test]
+    fn canonical_parser_rejects_comments() {
+        let doc = "# header\n\
+                   apiVersion: azureclaw.dev/v1alpha1\n\
+                   kind: EgressAllowlist\n\
+                   metadata:\n  generation: 1\n\
+                   spec:\n  endpoints: []\n";
+        let err = canonical::parse(doc.as_bytes()).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("comments")));
+    }
+
+    #[test]
+    fn validate_ref_shape_rejects_bad_digest() {
+        let mut r = good_ref();
+        r.digest = "sha512:xyz".into();
+        let err = validate_ref_shape(&r).unwrap_err();
+        assert!(matches!(err, FetchError::InvalidRef(_)));
+    }
+
+    #[test]
+    fn validate_ref_shape_rejects_bad_artifact_type() {
+        let mut r = good_ref();
+        r.artifact_type = "application/vnd.something.else".into();
+        let err = validate_ref_shape(&r).unwrap_err();
+        assert!(matches!(err, FetchError::InvalidRef(ref m) if m.contains("artifactType")));
+    }
+
+    #[test]
+    fn validate_ref_shape_rejects_uppercase_digest() {
+        let mut r = good_ref();
+        r.digest = format!("sha256:{}", "A".repeat(64));
+        let err = validate_ref_shape(&r).unwrap_err();
+        assert!(matches!(err, FetchError::InvalidRef(ref m) if m.contains("lowercase")));
+    }
+
+    #[test]
+    fn validate_ref_shape_accepts_valid_ref() {
+        validate_ref_shape(&good_ref()).expect("good ref");
+    }
+
+    #[test]
+    fn reason_for_error_maps_each_variant() {
+        assert_eq!(reason_for_error(&FetchError::FeatureDisabled), None);
+        assert_eq!(
+            reason_for_error(&FetchError::SignerPolicyMissing),
+            Some("SignerPolicyMissing")
+        );
+        assert_eq!(
+            reason_for_error(&FetchError::Unauthorized("x".into())),
+            Some("Unauthorized")
+        );
+        assert_eq!(
+            reason_for_error(&FetchError::NotFound("x".into())),
+            Some("NotFound")
+        );
+        assert_eq!(
+            reason_for_error(&FetchError::InvalidRef("x".into())),
+            Some("InvalidRef")
+        );
+        assert_eq!(
+            reason_for_error(&FetchError::SignatureVerifyFailed("x".into())),
+            Some("SignatureVerifyFailed")
+        );
+        assert_eq!(
+            reason_for_error(&FetchError::IdentityMismatch("x".into())),
+            Some("IdentityMismatch")
+        );
+        assert_eq!(
+            reason_for_error(&FetchError::CanonicalFormViolation("x".into())),
+            Some("CanonicalFormViolation")
+        );
+        assert_eq!(
+            reason_for_error(&FetchError::DigestMismatch {
+                expected: "a".into(),
+                actual: "b".into()
+            }),
+            Some("DigestMismatch")
+        );
+        // Transient is the only Some-but-no-condition case.
+        assert_eq!(reason_for_error(&FetchError::Transient("x".into())), None);
+    }
+
+    #[test]
+    fn cache_round_trips_and_expires() {
+        cache_clear();
+        let r = good_ref();
+        let key = cache_key(&r);
+        let now = Instant::now();
+        assert!(cache_get(&key, now).is_none(), "cold cache");
+
+        let v = canonical::parse(canonical_doc().as_bytes()).unwrap();
+        cache_put(key.clone(), v.clone());
+        let hit = cache_get(&key, now).expect("hit");
+        assert_eq!(hit.generation, v.generation);
+
+        // Simulated expiry: a synthetic "now" beyond TTL should miss
+        // even though the entry is still in the map. (We can't actually
+        // advance Instant::now(), but cache_get computes
+        // `now.duration_since(entry.inserted)`, so passing a future
+        // `now` exercises the TTL branch.)
+        let future = now + CACHE_TTL + Duration::from_secs(1);
+        assert!(cache_get(&key, future).is_none(), "expired");
+        cache_clear();
+    }
+
+    #[test]
+    fn is_acr_host_recognises_global_clouds() {
+        assert!(is_acr_host("myacr.azurecr.io"));
+        assert!(is_acr_host("MyAcr.AzureCr.Io"));
+        assert!(is_acr_host("foo.azurecr.cn"));
+        assert!(is_acr_host("foo.azurecr.us"));
+        assert!(!is_acr_host("ghcr.io"));
+        assert!(!is_acr_host("docker.io"));
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_feature_disabled_when_gate_off() {
+        let _g = env_lock().lock().unwrap();
+        let _e = EnvGuard::unset(FEATURE_ENV);
+        let policy = SignerPolicyConfig::default();
+        let err = fetch_and_verify(&good_ref(), &policy).await.unwrap_err();
+        assert!(matches!(err, FetchError::FeatureDisabled));
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_signer_policy_missing_when_no_signer_policy() {
+        let _g = env_lock().lock().unwrap();
+        let _e1 = EnvGuard::set(FEATURE_ENV, "1");
+        let _e2 = EnvGuard::unset(SIGNER_FULCIO_ISSUERS_ENV);
+        let _e3 = EnvGuard::unset(SIGNER_SAN_PATTERNS_ENV);
+        let policy = SignerPolicyConfig::from_env();
+        let err = fetch_and_verify(&good_ref(), &policy).await.unwrap_err();
+        assert!(
+            matches!(err, FetchError::SignerPolicyMissing),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_invalid_ref_for_bad_digest() {
+        let _g = env_lock().lock().unwrap();
+        let _e = EnvGuard::set(FEATURE_ENV, "1");
+        let mut r = good_ref();
+        r.digest = "not-a-digest".into();
+        let policy = SignerPolicyConfig::default();
+        let err = fetch_and_verify(&r, &policy).await.unwrap_err();
+        assert!(matches!(err, FetchError::InvalidRef(_)));
+    }
+
+    #[tokio::test]
+    async fn acr_token_for_pull_requires_federated_token_env() {
+        let _g = env_lock().lock().unwrap();
+        let _e = EnvGuard::unset("AZURE_FEDERATED_TOKEN_FILE");
+        let err = acr_token_for_pull("myacr.azurecr.io", "repo")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FetchError::Unauthorized(ref m) if m.contains("AZURE_FEDERATED_TOKEN_FILE"))
+        );
+    }
+}

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1643,14 +1643,32 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
                 .patch_status(&name, &PatchParams::default(), &Patch::Merge(status_obj))
                 .await;
         }
-    } else if !crate::status::running_status_matches(&sandbox, &sandbox_ns, runtime_kind_str) {
-        let sandbox_api: Api<ClawSandbox> =
-            Api::namespaced(client.clone(), &sandbox.namespace().unwrap_or_default());
-        let status_obj =
-            crate::status::build_running_status_patch(&sandbox, &sandbox_ns, runtime_kind_str);
-        let _ = sandbox_api
-            .patch_status(&name, &PatchParams::default(), &Patch::Merge(status_obj))
-            .await;
+    } else {
+        // S12.b status-only: when the feature gate is on AND the CR
+        // carries an `allowlistRef`, drive the policy-fetcher and
+        // surface the `AllowlistVerified` Condition. With the gate off
+        // (default) this is a no-op; the fetcher itself short-circuits
+        // before any network IO.
+        let allowlist_cond = crate::policy_fetcher::maybe_verify_allowlist(&sandbox).await;
+        let extras: Vec<_> = allowlist_cond.iter().cloned().collect();
+        if !crate::status::running_status_matches_with_extras(
+            &sandbox,
+            &sandbox_ns,
+            runtime_kind_str,
+            &extras,
+        ) {
+            let sandbox_api: Api<ClawSandbox> =
+                Api::namespaced(client.clone(), &sandbox.namespace().unwrap_or_default());
+            let status_obj = crate::status::build_running_status_patch_with_extras(
+                &sandbox,
+                &sandbox_ns,
+                runtime_kind_str,
+                &extras,
+            );
+            let _ = sandbox_api
+                .patch_status(&name, &PatchParams::default(), &Patch::Merge(status_obj))
+                .await;
+        }
     }
 
     tracing::info!("ClawSandbox {name} reconciled successfully");

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -70,6 +70,22 @@ pub const TYPE_SUSPENDED: &str = "Suspended";
 /// running the wrong runtime image.
 pub const TYPE_RUNTIME_READY: &str = "RuntimeReady";
 
+/// Phase 2 S12.b — `AllowlistVerified`: the controller fetched the
+/// signed OCI artifact referenced by
+/// `spec.networkPolicy.allowlistRef`, verified its cosign signature
+/// against the cluster `SignerPolicy` (S12.d), and re-validated the
+/// canonical-form rules from `docs/policy-canonical-format.md`.
+///
+/// Only emitted when both `allowlistRef` is set on the CR *and* the
+/// `AZURECLAW_FEATURE_SIGNED_ALLOWLIST=1` env gate is on. Status-only in
+/// S12.b — the live `NetworkPolicy` continues to derive from inline
+/// `allowedEndpoints` until S12.e flips authoritative mode.
+///
+/// `status=True/Verified` means the artifact is current and trusted.
+/// `status=False/<reason>` carries the failure category — see
+/// [`super::super::policy_fetcher::reason_for_error`] for the mapping.
+pub const TYPE_ALLOWLIST_VERIFIED: &str = "AllowlistVerified";
+
 /// `status` canonical values.
 pub mod status {
     pub const TRUE: &str = "True";
@@ -97,6 +113,10 @@ pub mod reason {
     /// to create a Deployment rather than silently fall through to the
     /// OpenClaw image.
     pub const ADAPTER_MISSING: &str = "AdapterMissing";
+    /// Phase 2 S12.b — `Verified`: signed allowlist artifact fetched,
+    /// cosign signature passed, signer identity matched cluster
+    /// SignerPolicy, canonical form re-validated.
+    pub const VERIFIED: &str = "Verified";
 }
 
 /// Build a condition with a freshly-stamped `lastTransitionTime`.

--- a/controller/src/status/mod.rs
+++ b/controller/src/status/mod.rs
@@ -32,10 +32,32 @@ use serde_json::{Value, json};
 /// foundryAgentId preservation) that are easy to get subtly wrong.
 /// Centralising the logic keeps reconcile bodies focused on side-effects
 /// and gives us one place to unit-test the wire shape.
+/// Build the `status` patch for a `ClawSandbox` that has reached the
+/// Running phase. See [`build_running_status_patch_with_extras`] for
+/// the additive variant; this convenience wrapper passes no extras and
+/// matches the pre-S12.b call-site shape used in unit tests.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn build_running_status_patch(
     sandbox: &ClawSandbox,
     sandbox_ns: &str,
     runtime_kind: &str,
+) -> Value {
+    build_running_status_patch_with_extras(sandbox, sandbox_ns, runtime_kind, &[])
+}
+
+/// As [`build_running_status_patch`], but appends `extra_conditions` to
+/// the emitted `conditions` array. Used by the reconciler to surface the
+/// `AllowlistVerified` Condition (S12.b) without forking the patch
+/// builder.
+///
+/// Each extra is upserted by `type_` (last-writer wins), so a caller can
+/// safely pass the freshly-computed condition without de-duplicating
+/// against the standard set above.
+pub fn build_running_status_patch_with_extras(
+    sandbox: &ClawSandbox,
+    sandbox_ns: &str,
+    runtime_kind: &str,
+    extra_conditions: &[k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition],
 ) -> Value {
     let name = sandbox.name_any();
     let generation = sandbox.metadata.generation;
@@ -76,6 +98,15 @@ pub fn build_running_status_patch(
         generation,
     );
 
+    let mut conditions_vec = vec![ready, progressing, runtime_ready];
+    for extra in extra_conditions {
+        if let Some(slot) = conditions_vec.iter_mut().find(|c| c.type_ == extra.type_) {
+            *slot = extra.clone();
+        } else {
+            conditions_vec.push(extra.clone());
+        }
+    }
+
     let mut status_obj = json!({
         "status": {
             "phase": "Running",
@@ -85,7 +116,7 @@ pub fn build_running_status_patch(
             "pendingApprovals": 0,
             "observedGeneration": generation,
             "runtimeKind": runtime_kind,
-            "conditions": [ready, progressing, runtime_ready],
+            "conditions": conditions_vec,
         }
     });
     if let Some(existing) = sandbox.status.as_ref()
@@ -116,7 +147,24 @@ pub fn build_running_status_patch(
 /// status), and accept that fields owned by other writers (e.g. a future
 /// `tokensUsed` updater) may differ — those would not be touched by our
 /// merge patch anyway.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn running_status_matches(sandbox: &ClawSandbox, sandbox_ns: &str, runtime_kind: &str) -> bool {
+    running_status_matches_with_extras(sandbox, sandbox_ns, runtime_kind, &[])
+}
+
+/// As [`running_status_matches`], but additionally requires that the
+/// existing CR status carries every condition in `extra_conditions`
+/// with the same `type_`/`status`/`reason` (message changes alone do
+/// **not** force a re-patch — they ride along on the next genuine
+/// transition). Used by the reconciler to keep the `AllowlistVerified`
+/// Condition stable across same-result reconciles without churning
+/// `resourceVersion`.
+pub fn running_status_matches_with_extras(
+    sandbox: &ClawSandbox,
+    sandbox_ns: &str,
+    runtime_kind: &str,
+    extra_conditions: &[k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition],
+) -> bool {
     use crate::status::conditions::{
         TYPE_PROGRESSING, TYPE_READY, TYPE_RUNTIME_READY,
         status::{FALSE as STATUS_FALSE, TRUE as STATUS_TRUE},
@@ -165,6 +213,19 @@ pub fn running_status_matches(sandbox: &ClawSandbox, sandbox_ns: &str, runtime_k
         .is_some_and(|c| c.status == STATUS_TRUE);
     if !runtime_ready_ok {
         return false;
+    }
+    // S12.b: `AllowlistVerified` must match in (type,status,reason) so
+    // a transient → verified flip triggers a re-patch. We deliberately
+    // ignore `message` because the verifier rewrites the digest /
+    // generation summary on every successful pass and we don't want
+    // that to defeat the idempotency guard.
+    for extra in extra_conditions {
+        let matched = status.conditions.iter().any(|c| {
+            c.type_ == extra.type_ && c.status == extra.status && c.reason == extra.reason
+        });
+        if !matched {
+            return false;
+        }
     }
     true
 }

--- a/docs/security-audits/2026-04-30-phase2-policy-fetcher.md
+++ b/docs/security-audits/2026-04-30-phase2-policy-fetcher.md
@@ -1,0 +1,131 @@
+# Phase 2 — S12.b: Controller Policy Fetcher (status-only, feature-gated)
+
+**Date:** 2026-04-30
+**Slice:** S12.b (`phase2-s12-bd-policy-fetcher`)
+**Scope:** Controller-only PR. New `controller/src/policy_fetcher.rs`, an
+`AllowlistVerified` Condition surfaced on `ClawSandbox.status`, and the
+ACR Workload-Identity token-exchange path. **No** behavior change for
+existing deployments — entire path is gated on
+`AZURECLAW_FEATURE_SIGNED_ALLOWLIST=1`.
+
+## Existing implementation surveyed
+
+Per plan §0.2 #8, every reused seam:
+
+| Touchpoint | Reused / Extended |
+|---|---|
+| `controller/src/crd.rs` (S12.a) — `OciArtifactRef`, `NetworkPolicyConfig::allowlist_ref` | Read-only consumer; no schema change. |
+| `controller/src/status/mod.rs` — `build_running_status_patch`, `running_status_matches` | Added `_with_extras` variants; old API delegates to new. |
+| `controller/src/status/conditions.rs` — `preserve_transition_time`, `reason::*` | Added `TYPE_ALLOWLIST_VERIFIED` and `reason::VERIFIED`. Reused `preserve_transition_time` so `lastTransitionTime` survives same-status reconciles. |
+| `controller/src/reconciler/mod.rs` — running-phase status patch site | Single new `await` (`maybe_verify_allowlist`) + extras parameter on the existing patch + matcher. No new K8s resource calls. |
+| `controller/Cargo.toml` | New deps: `sigstore = "0.13"`, `oci-client = "0.16"`, `idna = "1"`. |
+| `deploy/helm/azureclaw/templates/controller-clusterrole.yaml` | Reviewed — **no change required**. The fetcher reads no Kubernetes resources; it consumes an already-mounted Workload-Identity SA token (via `AZURE_FEDERATED_TOKEN_FILE`) and reaches Entra + the OCI registry over HTTPS. |
+
+**Why a new module rather than extending `crd.rs` or
+`reconciler/mod.rs`:** the fetcher carries non-trivial cosign + ACR
+trust logic that has its own threat surface and is independently
+auditable. Per plan §4.2 the reconciler is at the file budget; isolating
+the new code in `policy_fetcher.rs` keeps the slice surgical.
+
+## Trust model summary
+
+Per plan.md "Trust model" for S12:
+
+1. **Cryptographic validity** — cosign signature exists, chains to a
+   Fulcio root, certificate not expired at signing time.
+2. **Authority** — signer identity (Fulcio cert SAN + issuer claim)
+   matches an entry in the cluster `SignerPolicy`. Until S12.d ships
+   the ConfigMap watcher, the policy is provisionally read from
+   `AZURECLAW_SIGNER_FULCIO_ISSUERS` + `AZURECLAW_SIGNER_SAN_PATTERNS`
+   env vars. **Both** must be configured; either alone is unsafe and
+   `SignerPolicyConfig::is_configured()` returns `false`.
+3. **Replay protection** — canonical bytes carry
+   `metadata.generation` (positive monotonic integer); compared by the
+   reconciler in S12.e.
+4. **Canonical form** — re-validated **after** signature check (sigstore
+   only attests bytes, not semantics) per
+   `docs/policy-canonical-format.md` rules #1–#13. Any deviation →
+   `CanonicalFormViolation`.
+
+## Threat surfaces introduced
+
+| Surface | Detail |
+|---|---|
+| Network egress to OCI registry | Controller now performs HTTPS GETs to `{registry}/v2/{repo}/...`. With NetworkPolicies on the controller namespace this is allowed by default (controller already calls Entra + ARM); no new egress hole. |
+| Federated SA token handling | `acr_token_for_pull` reads `AZURE_FEDERATED_TOKEN_FILE` (already mounted by AKS WI webhook for the existing `fedcred.rs` path). Token is sent **only** to `login.microsoftonline.com/{tenant}/oauth2/v2.0/token` — the Entra token endpoint. Never logged. |
+| Sigstore Fulcio trust roots | S12.b builds a sigstore `Client` without a trust repository attached; with empty trust roots the embedded cert in `SignatureLayer.certificate_signature` cannot be verified, so `CertSubject*Verifier` constraints fail closed. S12.d injects `ManualTrustRoot` from cluster state. **The S12.b verifier therefore fails closed by design** — it cannot accept any signature until S12.d wires the trust roots. This is reflected in the plan's "status-only" gating and is documented as the expected outcome. |
+| Cache | In-memory `Mutex<HashMap>` keyed on `<registry>/<repository>@<digest>`; entries expire after 1 h. Bounded by the unique-digest count seen during a controller's lifetime (single-digit per cluster in practice). No persistence, no leak across pods. |
+
+## Threat surfaces NOT introduced
+
+- ❌ **No K8s API surface change.** No new CRD, no new RBAC.
+- ❌ **No router behavior change.** This slice is controller-only.
+- ❌ **No effect on inline `allowedEndpoints`.** NetworkPolicy still derives entirely from the existing path.
+- ❌ **No new cosign binary in the controller image.** Verification is in-process via `sigstore-rs`.
+- ❌ **No long-lived secrets.** ACR access tokens are obtained on demand and dropped after one pull.
+- ❌ **No new persistence.** Cache is in-process, no disk writes.
+
+## Mitigations
+
+- **Feature gate.** The reconciler short-circuits `maybe_verify_allowlist` with `feature_enabled() == false`, before any branching that could run sigstore code. With the gate off, this slice is byte-identical at runtime to S12.a.
+- **Fail closed.** `SignerPolicyMissing`, `SignatureVerifyFailed`, `IdentityMismatch`, `CanonicalFormViolation`, and `DigestMismatch` all map to `AllowlistVerified=False/<reason>`. Only `Verified` produces `True`. Status-only — no NetworkPolicy effect either way in S12.b.
+- **Transient handling preserves last-known-good.** `FetchError::Transient` returns `None` from `maybe_verify_allowlist`'s downstream selection, and the reconciler uses the prior Condition unchanged (no flap on registry blips).
+- **Idempotency.** `running_status_matches_with_extras` compares the new condition's `(type, status, reason)` triple against existing status; only the message can change without forcing a re-patch (and only when the rest of the running shape already matched).
+- **`unwrap`/`expect`-free.** All fallible call paths return typed `FetchError` variants. The only `unwrap()` calls are inside `#[cfg(test)]` blocks.
+- **`tracing`-only.** No `println!`/`eprintln!`. Lifecycle events at `info!`/`warn!`; cache hits at `debug!`.
+- **Ref-shape validation precedes any IO.** `validate_ref_shape` rejects malformed registry/repository/digest/artifactType *before* the cache lookup or any network call.
+- **ACR-host gate.** WI exchange is only attempted for `*.azurecr.io|.cn|.us` hosts; other registries (ghcr.io, docker.io, kind-cluster local registries) fall through to `Anonymous`. Operators wanting WI-on-ACR get it; everyone else sees no WI behavior.
+
+## Why not authoritative yet (S12.e gating)
+
+S12.b is **status-only** by design:
+
+1. **Trust roots are not yet provisioned.** Without `SignerPolicy` from S12.d, no signature can be elevated to authority. Failing to a status condition (rather than blocking the NetworkPolicy) is the safe interim shape.
+2. **No CLI signing path.** S12.c ships `azureclaw egress … --sign`. Until then, no operator-produced artifacts exist; emitting the condition lets us validate the consumer side against signing pilots.
+3. **Drift detection requires both sides.** S12.e's `AllowlistDrift` Condition compares verified canonical bytes against inline `allowedEndpoints`. That comparison ships once both flows exist.
+
+## Test coverage
+
+29 new unit tests in `controller/src/policy_fetcher.rs`:
+
+- `feature_disabled_by_default`, `feature_enabled_when_env_one`, `feature_disabled_for_non_one_truthy_values` — env gate.
+- `signer_policy_unconfigured_when_env_unset`, `signer_policy_configured_from_env`, `signer_policy_requires_both_lists_for_is_configured` — SignerPolicy reading.
+- `canonical_parser_accepts_valid_artifact` and 9 negative variants (unsorted, duplicate, missing/zero generation, uppercase/wildcard host, out-of-range port, swapped keys, missing trailing newline, top-level key out of order, comments forbidden).
+- `validate_ref_shape_*` — ref-shape rejection (bad digest, bad artifactType, uppercase digest, valid).
+- `reason_for_error_maps_each_variant` — pins the reason string for every `FetchError` variant (the public contract for status reasons).
+- `cache_round_trips_and_expires` — TTL behavior.
+- `is_acr_host_recognises_global_clouds` — registry classification.
+- `fetch_returns_feature_disabled_when_gate_off`, `fetch_returns_signer_policy_missing_when_no_signer_policy`, `fetch_returns_invalid_ref_for_bad_digest` — top-level entry behavior.
+- `acr_token_for_pull_requires_federated_token_env` — WI-exchange env contract.
+
+Test counts:
+
+```
+$ cargo test --package azureclaw-controller 2>&1 | grep "test result"
+test result: ok. 383 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+(354 pre-S12.b → 383 post; +29 new.)
+
+```
+$ cargo clippy --all-targets -- -D warnings
+(clean across workspace)
+```
+
+E2E tests against a live OCI registry are deferred to S12.e where
+authoritative-mode + a kind-cluster registry are wired together.
+
+## References
+
+- **Plan §S12.b** (sub-slice scope): `~/.copilot/session-state/13bea069-bbc9-48ae-a25c-36da81c7a0fe/plan.md`
+- **sigstore-rs 0.13.0** — <https://github.com/sigstore/sigstore-rs> (Apache-2.0). Crate features used: `cosign` + `verify` + `rustls-tls`.
+- **oci-client 0.16.1** — <https://github.com/oras-project/rust-oci-client> (Apache-2.0). Crate features: `rustls-tls`.
+- **ACR OAuth2 token exchange** — <https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication-oauth2>
+- **Entra ID Workload Identity Federation** — <https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation>
+- **S12.a audit doc** — `docs/security-audits/2026-04-30-phase2-policyref-schema.md`
+- **Canonical format spec** — `docs/policy-canonical-format.md`
+
+## Sign-offs
+
+- [ ] Security review:
+- [ ] Owner / merger:


### PR DESCRIPTION
# S12.b — controller policy fetcher (status-only, feature-gated)

Wires the controller-side fetcher/verifier for signed OCI egress-allowlist artifacts (the schema for which landed in S12.a / #113). **No behavior change for existing deployments** — the entire path is gated on `AZURECLAW_FEATURE_SIGNED_ALLOWLIST=1`.

## What's in the slice

- **`controller/src/policy_fetcher.rs`** — pulls signed artifacts via `oci-client`, verifies cosign signature + signer identity via `sigstore-rs`, re-validates byte-stable canonical-form rules from `docs/policy-canonical-format.md`. Result cached by digest with 1h TTL.
- **`AllowlistVerified` Condition** surfaced on `ClawSandbox.status` only when `spec.networkPolicy.allowlistRef` is set AND the env gate is on. Reasons map 1:1 to `FetchError` variants: `Verified`, `SignerPolicyMissing`, `SignatureVerifyFailed`, `IdentityMismatch`, `CanonicalFormViolation`, `DigestMismatch`, `Unauthorized`, `NotFound`, `InvalidRef`. `Transient` errors preserve the prior condition (no flap).
- **ACR auth via Workload Identity** — `acr_token_for_pull` implements the full federated-token → AAD → ACR refresh → ACR access-token exchange (4 hops, real reqwest path, no fakes). Falls back to `Anonymous` for non-ACR registries.
- **SignerPolicy** is provisional in S12.b (read from env: `AZURECLAW_SIGNER_FULCIO_ISSUERS`, `AZURECLAW_SIGNER_SAN_PATTERNS`). With nothing configured, `fetch_and_verify` returns `SignerPolicyMissing` — the intended fail-closed behavior until the ConfigMap watcher in S12.d.
- **Status-only.** `NetworkPolicy` continues to derive entirely from inline `allowedEndpoints`. Authoritative-mode flip ships in S12.e.

## Status helpers

`build_running_status_patch_with_extras` / `running_status_matches_with_extras` lift the existing patch builder to accept additive Conditions while preserving idempotency. The pre-S12.b 3-arg API delegates to the new 4-arg form; no test churn.

## Deps

`controller/Cargo.toml` only (workspace deps untouched):

```toml
sigstore = { version = "0.13", default-features = false, features = ["cosign", "verify", "rustls-tls"] }
oci-client = { version = "0.16", default-features = false, features = ["rustls-tls"] }
idna = "1"
```

## Tests + gates

- 29 new unit tests in `policy_fetcher.rs`. Controller test count **354 → 383**.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean.
- `cargo test --all` — workspace green.
- `cd cli && npm run build` — passes.
- E2E tests against a live OCI registry are deferred to S12.e where authoritative-mode + a kind-cluster registry are wired together.

## Audit doc

`docs/security-audits/2026-04-30-phase2-policy-fetcher.md` — full trust-model, threat surfaces (introduced + not), mitigations, and references to ACR OAuth2 / Entra WI Federation docs.

## Helm RBAC

Reviewed `deploy/helm/azureclaw/templates/controller-clusterrole.yaml`: **no change required**. The fetcher reads no Kubernetes resources; it consumes the already-mounted federated SA token (via `AZURE_FEDERATED_TOKEN_FILE`, same path used by `fedcred.rs`) and reaches Entra + the OCI registry over HTTPS.

## What's NOT in this slice (per plan)

- No SignerPolicy CRD or ConfigMap watcher (S12.d).
- No CLI signing path (S12.c).
- No NetworkPolicy effect (S12.e).
- No router behavior change (S12.f).
- No cosign binary in the controller image — verification is fully in-process via sigstore-rs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
