### PR TITLE
phase2(s12.c): CLI --sign for egress allowlist (oras push + cosign sign + kubectl patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S12.c — CLI `--sign` flag (egress allowlist artifact producer)
+
+- New `cli/src/commands/egress/sign.ts` — canonical YAML serializer (matches `docs/policy-canonical-format.md` byte-for-byte), `oras push` artifact uploader, `cosign sign` orchestrator (keyless / identity-token / keyed), `kubectl patch` of `ClawSandbox.spec.networkPolicy.allowlistRef`.
+- New flags on `azureclaw egress`: `--sign`, `--sign-mode <keyless|identity-token|keyed>`, `--sign-key <ref>`, `--registry`, `--repository`, `--no-sign`.
+- Status: **non-authoritative** — inline `allowedEndpoints` remains the source of truth in this slice. The controller-side fetcher (S12.b) verifies the artifact and surfaces `AllowlistVerified`. The flip to authoritative ships in S12.e.
+- Auto-mode-detection: keyless when TTY + no token; identity-token when `SIGSTORE_ID_TOKEN`/`OIDC_TOKEN` env present; keyed when `--sign-mode keyed`+`--sign-key` set.
+- Fail-closed: signature push failure aborts the flow before patching the CR — no orphan refs on `ClawSandbox` resources.
+- Requires `oras` and `cosign` in `$PATH`; clear actionable errors if missing.
+- 41 new vitest tests across `cli/src/commands/egress/sign.test.ts` and `cli/src/commands/egress.test.ts`; CLI test count 354 → 395 (passing). Lint clean; typecheck clean; `npm run build` green.
+
 ### S12.a `phase2-s12-a-policyref-schema` — supply-chain policy foundations
 
 **Pure schema PR.** Foundation for the S12 signed-egress-allowlist work. No

--- a/cli/src/commands/egress.test.ts
+++ b/cli/src/commands/egress.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { egressCommand } from "./egress.js";
+
+/**
+ * Lightweight CLI-shape tests for the S12.c `--sign` family. The full
+ * sign flow is covered by `egress/sign.test.ts` (subprocess argv
+ * construction is unit-tested there). Here we lock in:
+ *
+ *   - the new flags exist on the egress command,
+ *   - `--sign` without `--enforce`/`--approve` is a hard error.
+ *
+ * We do NOT spin up real kubectl/oras/cosign here.
+ */
+
+function getOption(cmd: ReturnType<typeof egressCommand>, long: string) {
+  return cmd.options.find((o) => o.long === long || o.short === long);
+}
+
+describe("egressCommand — --sign family wiring", () => {
+  it("registers --sign", () => {
+    const cmd = egressCommand();
+    expect(getOption(cmd, "--sign")).toBeDefined();
+  });
+
+  it("registers --no-sign for forward compatibility", () => {
+    const cmd = egressCommand();
+    // commander represents --no-sign as a negation of --sign;
+    // long form "--no-sign" is what the user types.
+    const optNames = cmd.options.map((o) => o.long);
+    expect(optNames).toContain("--no-sign");
+  });
+
+  it("registers --sign-mode <mode>", () => {
+    const cmd = egressCommand();
+    const opt = getOption(cmd, "--sign-mode");
+    expect(opt).toBeDefined();
+    expect(opt?.flags).toContain("<mode>");
+  });
+
+  it("registers --sign-key <ref>", () => {
+    const cmd = egressCommand();
+    expect(getOption(cmd, "--sign-key")).toBeDefined();
+  });
+
+  it("registers --registry <fqdn>", () => {
+    const cmd = egressCommand();
+    expect(getOption(cmd, "--registry")).toBeDefined();
+  });
+
+  it("registers --repository <repo>", () => {
+    const cmd = egressCommand();
+    expect(getOption(cmd, "--repository")).toBeDefined();
+  });
+});
+
+describe("egressCommand — --sign requires --enforce or --approve", () => {
+  it("prints an error and sets exit code when --sign is used alone", async () => {
+    const cmd = egressCommand();
+    cmd.exitOverride();
+
+    const logged: string[] = [];
+    const realLog = console.log;
+    console.log = (msg?: any) => {
+      logged.push(String(msg ?? ""));
+    };
+    const prevExit = process.exitCode;
+    process.exitCode = 0;
+
+    try {
+      await cmd.parseAsync(["demo-agent", "--sign"], { from: "user" });
+    } catch {
+      // commander may throw on action errors; we only care about output
+    } finally {
+      console.log = realLog;
+    }
+
+    const all = logged.join("\n");
+    expect(all).toMatch(/--sign requires --enforce or --approve/);
+    expect(process.exitCode).toBe(1);
+    process.exitCode = prevExit;
+  });
+});

--- a/cli/src/commands/egress.ts
+++ b/cli/src/commands/egress.ts
@@ -1,6 +1,16 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getAdminToken, withAdminAuth } from "../router-admin.js";
+import {
+  EGRESS_ALLOWLIST_MEDIA_TYPE,
+  autoDetectSignMode,
+  buildCanonicalAllowlist,
+  ensureSigningTools,
+  patchClawSandbox,
+  pushArtifact,
+  readClawSandboxState,
+  signArtifact,
+} from "./egress/sign.js";
 
 export function egressCommand(): Command {
   const cmd = new Command("egress");
@@ -18,8 +28,21 @@ export function egressCommand(): Command {
     .option("--allowlist", "Show currently approved domains")
     .option("--enforce", "Graduate: promote all learned domains to allowlist, switch to enforcement mode")
     .option("--status", "Show blocklist and learn mode status")
+    .option("--sign", "Build canonical allowlist artifact, push to ACR, sign with cosign, patch allowlistRef (S12.c, opt-in; non-authoritative)")
+    .option("--no-sign", "Disable signing even if a future default flips it on (forward-compat placeholder)")
+    .option("--sign-mode <mode>", "Cosign mode: keyless | identity-token | keyed (default: auto-detect)")
+    .option("--sign-key <ref>", "Cosign key reference (path or KMS URI like azurekms://...) — required for --sign-mode keyed")
+    .option("--registry <fqdn>", "Override target ACR for the artifact push (default: auto-discover)")
+    .option("--repository <repo>", "Repository path within the registry (default: policy/egress-allowlist/<sandbox>)")
     .action(async (name: string, options) => {
       const { execa } = await import("execa");
+
+      // Validate --sign requires --enforce or --approve.
+      if (options.sign && !options.enforce && !options.approve) {
+        console.log(chalk.red(`\n  --sign requires --enforce or --approve.\n`));
+        process.exitCode = 1;
+        return;
+      }
 
       const containerName = `azureclaw-${name}`;
       const ns = options.namespace || containerName;
@@ -88,6 +111,10 @@ export function egressCommand(): Command {
           console.log(chalk.dim(`     Domain added to egress allowlist. The agent can now reach it.\n`));
         } catch (e: any) {
           console.log(chalk.red(`\n  Failed to approve: ${e.message}\n`));
+          return;
+        }
+        if (options.sign) {
+          await runSignFlow(name, ns, options);
         }
         return;
       }
@@ -129,6 +156,10 @@ export function egressCommand(): Command {
           }
         } catch (e: any) {
           console.log(chalk.red(`\n  Failed to enforce: ${e.message}\n`));
+          return;
+        }
+        if (options.sign) {
+          await runSignFlow(name, ns, options);
         }
         return;
       }
@@ -267,4 +298,117 @@ export function egressCommand(): Command {
     });
 
   return cmd;
+}
+
+/**
+ * S12.c — orchestrate the canonical-build → oras push → cosign sign →
+ * kubectl patch flow. Fails closed: any error before patch aborts;
+ * patch only happens after signing succeeds.
+ */
+async function runSignFlow(
+  name: string,
+  ns: string,
+  options: any,
+): Promise<void> {
+  console.log(chalk.hex("#0078D4")(`\n  Signing egress allowlist artifact for '${name}' (S12.c)`));
+  try {
+    const { orasPath, cosignPath } = await ensureSigningTools();
+
+    // Resolve registry: explicit flag wins; otherwise auto-discover via
+    // existing context (kubectl current-context's ACR is recorded by
+    // `azureclaw context`). For the CLI we read it from azd / config
+    // by shelling out — but to keep this slice tight, we require
+    // either --registry or AZURECLAW_REGISTRY.
+    const registry =
+      options.registry ||
+      process.env.AZURECLAW_REGISTRY ||
+      (await discoverRegistry());
+    if (!registry) {
+      throw new Error(
+        `--registry not set and could not auto-discover. Pass --registry <acr.azurecr.io> or set AZURECLAW_REGISTRY.`,
+      );
+    }
+    const repository = options.repository || `policy/egress-allowlist/${name}`;
+
+    // Read live ClawSandbox state — generation + endpoints.
+    const state = await readClawSandboxState({
+      kubectlPath: "kubectl",
+      namespace: ns,
+      name,
+    });
+    if (state.endpoints.length === 0) {
+      throw new Error(
+        `ClawSandbox ${ns}/${name} has no spec.networkPolicy.allowedEndpoints — refusing to sign empty allowlist.`,
+      );
+    }
+
+    const canonical = buildCanonicalAllowlist({
+      generation: state.generation,
+      endpoints: state.endpoints,
+    });
+
+    const mode = autoDetectSignMode({
+      signModeFlag: options.signMode,
+      signKey: options.signKey,
+      isTTY: Boolean(process.stdout.isTTY),
+      env: process.env,
+    });
+
+    console.log(chalk.dim(`     Registry:   ${registry}/${repository}`));
+    console.log(chalk.dim(`     Generation: ${state.generation}`));
+    console.log(chalk.dim(`     Endpoints:  ${canonical.endpoints.length}`));
+    console.log(chalk.dim(`     Sign mode:  ${mode}`));
+
+    const digest = await pushArtifact({
+      orasPath,
+      registry,
+      repository,
+      yaml: canonical.yaml,
+      artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+    });
+    console.log(chalk.green(`     ✅ Pushed   ${digest}`));
+
+    try {
+      await signArtifact({
+        cosignPath,
+        registry,
+        repository,
+        digest,
+        mode,
+        keyRef: options.signKey,
+      });
+    } catch (e: any) {
+      // Fail-closed: do NOT patch the CR if signing failed.
+      throw new Error(`cosign sign failed (CR not patched): ${e.message}`);
+    }
+    console.log(chalk.green(`     ✅ Signed   (mode=${mode})`));
+
+    await patchClawSandbox({
+      kubectlPath: "kubectl",
+      namespace: ns,
+      name,
+      registry,
+      repository,
+      digest,
+      artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+    });
+    console.log(chalk.green(`     ✅ Patched  spec.networkPolicy.allowlistRef`));
+    console.log(chalk.dim(`\n  Note: this slice is non-authoritative — inline allowedEndpoints remains the source of truth (see plan §S12.e).\n`));
+  } catch (e: any) {
+    console.log(chalk.red(`\n  Signing aborted: ${e.message}\n`));
+    process.exitCode = 1;
+  }
+}
+
+async function discoverRegistry(): Promise<string | null> {
+  // Best-effort lookup from the CLI's config file. Keeping this thin
+  // — the explicit --registry flag is the documented path.
+  try {
+    const { loadContext } = await import("../config.js");
+    const ctx = loadContext();
+    const reg = (ctx as any)?.acrLoginServer || (ctx as any)?.registry || null;
+    return typeof reg === "string" && reg.length > 0 ? reg : null;
+  } catch {
+    return null;
+  }
 }

--- a/cli/src/commands/egress/sign.test.ts
+++ b/cli/src/commands/egress/sign.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  buildCanonicalAllowlist,
+  digestOfCanonical,
+  autoDetectSignMode,
+  buildOrasPushArgv,
+  buildCosignSignArgv,
+  buildPatchArgv,
+  parseOrasDigest,
+  pushArtifact,
+  signArtifact,
+  patchClawSandbox,
+  ensureSigningTools,
+  EGRESS_ALLOWLIST_MEDIA_TYPE,
+} from "./sign.js";
+
+describe("buildCanonicalAllowlist", () => {
+  it("produces sorted, deduped, port-explicit YAML", () => {
+    const out = buildCanonicalAllowlist({
+      generation: 1,
+      endpoints: [
+        { host: "dev.azure.com", port: 443 },
+        { host: "api.github.com", port: 443 },
+        { host: "api.github.com", port: 443 }, // dup
+        { host: "api.github.com", port: 80 },
+      ],
+    });
+    expect(out.yaml).toBe(
+      [
+        "apiVersion: azureclaw.dev/v1alpha1",
+        "kind: EgressAllowlist",
+        "metadata:",
+        "  generation: 1",
+        "spec:",
+        "  endpoints:",
+        "    - host: api.github.com",
+        "      port: 80",
+        "    - host: api.github.com",
+        "      port: 443",
+        "    - host: dev.azure.com",
+        "      port: 443",
+        "",
+      ].join("\n"),
+    );
+    expect(out.endpoints.length).toBe(3);
+  });
+
+  it("is byte-stable across two calls with the same input (different order)", () => {
+    const a = buildCanonicalAllowlist({
+      generation: 7,
+      endpoints: [
+        { host: "b.example.com", port: 443 },
+        { host: "a.example.com", port: 443 },
+      ],
+    });
+    const b = buildCanonicalAllowlist({
+      generation: 7,
+      endpoints: [
+        { host: "a.example.com", port: 443 },
+        { host: "b.example.com", port: 443 },
+      ],
+    });
+    expect(a.yaml).toBe(b.yaml);
+    expect(digestOfCanonical(a.yaml)).toBe(digestOfCanonical(b.yaml));
+  });
+
+  it("rejects empty endpoints list", () => {
+    expect(() =>
+      buildCanonicalAllowlist({ generation: 1, endpoints: [] }),
+    ).toThrow(/empty/i);
+  });
+
+  it("rejects host with uppercase ASCII (must be IDNA-normalized)", () => {
+    expect(() =>
+      buildCanonicalAllowlist({
+        generation: 1,
+        endpoints: [{ host: "API.github.com", port: 443 }],
+      }),
+    ).toThrow(/canonical regex/);
+  });
+
+  it("rejects host with leading/trailing whitespace", () => {
+    expect(() =>
+      buildCanonicalAllowlist({
+        generation: 1,
+        endpoints: [{ host: " api.github.com", port: 443 }],
+      }),
+    ).toThrow(/whitespace/);
+  });
+
+  it("rejects wildcard host", () => {
+    expect(() =>
+      buildCanonicalAllowlist({
+        generation: 1,
+        endpoints: [{ host: "*.github.com", port: 443 }],
+      }),
+    ).toThrow(/wildcard/);
+  });
+
+  it("rejects out-of-range port", () => {
+    expect(() =>
+      buildCanonicalAllowlist({
+        generation: 1,
+        endpoints: [{ host: "api.github.com", port: 0 }],
+      }),
+    ).toThrow(/port/);
+    expect(() =>
+      buildCanonicalAllowlist({
+        generation: 1,
+        endpoints: [{ host: "api.github.com", port: 70000 }],
+      }),
+    ).toThrow(/port/);
+  });
+
+  it("rejects non-positive generation", () => {
+    expect(() =>
+      buildCanonicalAllowlist({
+        generation: 0,
+        endpoints: [{ host: "api.github.com", port: 443 }],
+      }),
+    ).toThrow(/generation/);
+  });
+
+  it("IDNA-encodes non-ASCII hosts to xn-- punycode", () => {
+    const out = buildCanonicalAllowlist({
+      generation: 1,
+      endpoints: [{ host: "münchen.de", port: 443 }],
+    });
+    expect(out.endpoints[0].host).toMatch(/^xn--/);
+    expect(out.yaml).toContain("xn--");
+  });
+
+  it("ends with a single trailing LF", () => {
+    const out = buildCanonicalAllowlist({
+      generation: 1,
+      endpoints: [{ host: "a.example.com", port: 443 }],
+    });
+    expect(out.yaml.endsWith("\n")).toBe(true);
+    expect(out.yaml.endsWith("\n\n")).toBe(false);
+    expect(out.yaml.includes("\r")).toBe(false);
+  });
+});
+
+describe("autoDetectSignMode", () => {
+  it("picks keyless when TTY + no token + no key", () => {
+    expect(
+      autoDetectSignMode({ isTTY: true, env: {} }),
+    ).toBe("keyless");
+  });
+
+  it("picks identity-token when SIGSTORE_ID_TOKEN is set", () => {
+    expect(
+      autoDetectSignMode({ isTTY: false, env: { SIGSTORE_ID_TOKEN: "x" } }),
+    ).toBe("identity-token");
+  });
+
+  it("picks identity-token when OIDC_TOKEN is set", () => {
+    expect(
+      autoDetectSignMode({ isTTY: false, env: { OIDC_TOKEN: "x" } }),
+    ).toBe("identity-token");
+  });
+
+  it("picks keyed when --sign-mode keyed + --sign-key", () => {
+    expect(
+      autoDetectSignMode({
+        signModeFlag: "keyed",
+        signKey: "azurekms://kv/k",
+        isTTY: true,
+        env: {},
+      }),
+    ).toBe("keyed");
+  });
+
+  it("errors when --sign-mode keyed without --sign-key", () => {
+    expect(() =>
+      autoDetectSignMode({
+        signModeFlag: "keyed",
+        isTTY: true,
+        env: {},
+      }),
+    ).toThrow(/--sign-key/);
+  });
+
+  it("errors when non-TTY without token and without key", () => {
+    expect(() =>
+      autoDetectSignMode({ isTTY: false, env: {} }),
+    ).toThrow(/SIGSTORE_ID_TOKEN/);
+  });
+
+  it("rejects unknown --sign-mode value", () => {
+    expect(() =>
+      autoDetectSignMode({
+        signModeFlag: "weird",
+        isTTY: true,
+        env: {},
+      }),
+    ).toThrow(/--sign-mode/);
+  });
+});
+
+describe("ensureSigningTools", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns paths when both tools are present", async () => {
+    const fakeExeca = vi.fn(async (_file: string, args: readonly string[]) => {
+      const bin = args[0];
+      if (bin === "oras") return { stdout: "/usr/local/bin/oras" };
+      if (bin === "cosign") return { stdout: "/usr/local/bin/cosign" };
+      throw new Error("unexpected");
+    });
+    vi.doMock("execa", () => ({ execa: fakeExeca }));
+    const { ensureSigningTools: fresh } = await import("./sign.js");
+    const out = await fresh();
+    expect(out.orasPath).toBe("/usr/local/bin/oras");
+    expect(out.cosignPath).toBe("/usr/local/bin/cosign");
+    vi.doUnmock("execa");
+  });
+
+  it("throws actionable error with install URL when oras missing", async () => {
+    vi.resetModules();
+    vi.doMock("execa", () => ({
+      execa: vi.fn(async (_file: string, args: readonly string[]) => {
+        if (args[0] === "oras") throw new Error("not found");
+        return { stdout: "/usr/local/bin/cosign" };
+      }),
+    }));
+    const { ensureSigningTools: fresh } = await import("./sign.js");
+    await expect(fresh()).rejects.toThrow(/oras\.land\/docs\/installation/);
+    vi.doUnmock("execa");
+  });
+
+  it("throws actionable error with install URL when cosign missing", async () => {
+    vi.resetModules();
+    vi.doMock("execa", () => ({
+      execa: vi.fn(async (_file: string, args: readonly string[]) => {
+        if (args[0] === "oras") return { stdout: "/usr/local/bin/oras" };
+        throw new Error("not found");
+      }),
+    }));
+    const { ensureSigningTools: fresh } = await import("./sign.js");
+    await expect(fresh()).rejects.toThrow(/sigstore\.dev\/cosign\/installation/);
+    vi.doUnmock("execa");
+  });
+
+  // Reference unused symbol so TS doesn't drop it in declaration-only contexts.
+  void ensureSigningTools;
+});
+
+describe("buildOrasPushArgv", () => {
+  it("constructs the correct oras push argv", () => {
+    const argv = buildOrasPushArgv({
+      registry: "myacr.azurecr.io",
+      repository: "policy/egress-allowlist/demo-agent",
+      artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+      filename: "allowlist.yaml",
+    });
+    expect(argv).toEqual([
+      "push",
+      "myacr.azurecr.io/policy/egress-allowlist/demo-agent:latest",
+      "--artifact-type",
+      EGRESS_ALLOWLIST_MEDIA_TYPE,
+      "--format",
+      "json",
+      `allowlist.yaml:${EGRESS_ALLOWLIST_MEDIA_TYPE}`,
+    ]);
+  });
+
+  it("respects custom tag", () => {
+    const argv = buildOrasPushArgv({
+      registry: "r.example.com",
+      repository: "x/y",
+      artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+      tag: "gen-7",
+      filename: "allowlist.yaml",
+    });
+    expect(argv[1]).toBe("r.example.com/x/y:gen-7");
+  });
+});
+
+describe("parseOrasDigest", () => {
+  it("parses JSON output", () => {
+    const stdout = JSON.stringify({ reference: { digest: "sha256:" + "a".repeat(64) } });
+    expect(parseOrasDigest(stdout)).toBe("sha256:" + "a".repeat(64));
+  });
+
+  it("parses plain text 'Digest: …' output", () => {
+    expect(parseOrasDigest(`Pushed.\nDigest: sha256:${"b".repeat(64)}\n`)).toBe(
+      "sha256:" + "b".repeat(64),
+    );
+  });
+
+  it("returns null on unrecognized output", () => {
+    expect(parseOrasDigest("???")).toBeNull();
+  });
+});
+
+describe("pushArtifact", () => {
+  it("invokes oras with the right argv and verifies the digest", async () => {
+    const yaml = "apiVersion: azureclaw.dev/v1alpha1\nkind: EgressAllowlist\n";
+    const expected = digestOfCanonical(yaml);
+    const fakeExeca = vi.fn(async () => ({
+      stdout: JSON.stringify({ reference: { digest: expected } }),
+    }));
+    const out = await pushArtifact({
+      orasPath: "/usr/bin/oras",
+      registry: "r.example.com",
+      repository: "policy/egress-allowlist/foo",
+      yaml,
+      artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+      execaImpl: fakeExeca as any,
+    });
+    expect(out).toBe(expected);
+    expect(fakeExeca).toHaveBeenCalledTimes(1);
+    const [bin, argv] = fakeExeca.mock.calls[0] as unknown as [string, string[]];
+    expect(bin).toBe("/usr/bin/oras");
+    expect(argv[0]).toBe("push");
+    expect(argv[1]).toBe("r.example.com/policy/egress-allowlist/foo:latest");
+  });
+
+  it("aborts when oras-reported digest disagrees with locally computed digest", async () => {
+    const yaml = "apiVersion: azureclaw.dev/v1alpha1\n";
+    const wrong = "sha256:" + "0".repeat(64);
+    const fakeExeca = vi.fn(async () => ({
+      stdout: JSON.stringify({ reference: { digest: wrong } }),
+    }));
+    await expect(
+      pushArtifact({
+        orasPath: "/usr/bin/oras",
+        registry: "r",
+        repository: "x/y",
+        yaml,
+        artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+        execaImpl: fakeExeca as any,
+      }),
+    ).rejects.toThrow(/diverged/);
+  });
+});
+
+describe("buildCosignSignArgv", () => {
+  const base = {
+    registry: "r.example.com",
+    repository: "p/e/foo",
+    digest: "sha256:" + "a".repeat(64),
+  };
+
+  it("keyless mode has no auth flag", () => {
+    expect(
+      buildCosignSignArgv({ ...base, mode: "keyless" }),
+    ).toEqual([
+      "sign",
+      "--yes",
+      `${base.registry}/${base.repository}@${base.digest}`,
+    ]);
+  });
+
+  it("identity-token mode passes --identity-token", () => {
+    expect(
+      buildCosignSignArgv({
+        ...base,
+        mode: "identity-token",
+        identityToken: "tok123",
+      }),
+    ).toEqual([
+      "sign",
+      "--yes",
+      "--identity-token",
+      "tok123",
+      `${base.registry}/${base.repository}@${base.digest}`,
+    ]);
+  });
+
+  it("keyed mode passes --key", () => {
+    expect(
+      buildCosignSignArgv({
+        ...base,
+        mode: "keyed",
+        keyRef: "azurekms://kv/k",
+      }),
+    ).toEqual([
+      "sign",
+      "--yes",
+      "--key",
+      "azurekms://kv/k",
+      `${base.registry}/${base.repository}@${base.digest}`,
+    ]);
+  });
+
+  it("keyed mode without keyRef throws", () => {
+    expect(() =>
+      buildCosignSignArgv({ ...base, mode: "keyed" }),
+    ).toThrow(/--sign-key/);
+  });
+});
+
+describe("signArtifact", () => {
+  it("invokes cosign with the constructed argv", async () => {
+    const fakeExeca = vi.fn(async () => ({ stdout: "" }));
+    await signArtifact({
+      cosignPath: "/usr/bin/cosign",
+      registry: "r.example.com",
+      repository: "x/y",
+      digest: "sha256:" + "a".repeat(64),
+      mode: "keyed",
+      keyRef: "k.pem",
+      execaImpl: fakeExeca as any,
+    });
+    const [bin, argv] = fakeExeca.mock.calls[0] as unknown as [string, string[]];
+    expect(bin).toBe("/usr/bin/cosign");
+    expect(argv).toEqual([
+      "sign",
+      "--yes",
+      "--key",
+      "k.pem",
+      `r.example.com/x/y@sha256:${"a".repeat(64)}`,
+    ]);
+  });
+});
+
+describe("buildPatchArgv / patchClawSandbox", () => {
+  it("constructs the correct kubectl JSON merge patch argv", () => {
+    const argv = buildPatchArgv({
+      namespace: "azureclaw-foo",
+      name: "foo",
+      registry: "r.example.com",
+      repository: "policy/egress-allowlist/foo",
+      digest: "sha256:" + "a".repeat(64),
+      artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+    });
+    expect(argv.slice(0, 5)).toEqual([
+      "patch",
+      "clawsandbox/foo",
+      "-n",
+      "azureclaw-foo",
+      "--type=merge",
+    ]);
+    expect(argv[5]).toBe("-p");
+    const patch = JSON.parse(argv[6]);
+    expect(patch).toEqual({
+      spec: {
+        networkPolicy: {
+          allowlistRef: {
+            registry: "r.example.com",
+            repository: "policy/egress-allowlist/foo",
+            digest: "sha256:" + "a".repeat(64),
+            artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+          },
+        },
+      },
+    });
+  });
+
+  it("invokes kubectl with the constructed patch argv", async () => {
+    const fakeExeca = vi.fn(async () => ({ stdout: "patched" }));
+    await patchClawSandbox({
+      kubectlPath: "kubectl",
+      namespace: "azureclaw-foo",
+      name: "foo",
+      registry: "r",
+      repository: "x/y",
+      digest: "sha256:" + "a".repeat(64),
+      artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+      execaImpl: fakeExeca as any,
+    });
+    expect(fakeExeca).toHaveBeenCalledTimes(1);
+    const [bin] = fakeExeca.mock.calls[0] as unknown as [string];
+    expect(bin).toBe("kubectl");
+  });
+});

--- a/cli/src/commands/egress/sign.ts
+++ b/cli/src/commands/egress/sign.ts
@@ -1,0 +1,495 @@
+// Phase 2 S12.c — `azureclaw egress … --sign` helpers.
+//
+// Producer side of the signed-egress-allowlist supply chain. Builds a
+// canonical YAML artifact that is byte-identical to the spec in
+// `docs/policy-canonical-format.md`, pushes it as an OCI artifact via
+// `oras`, signs the resulting digest with `cosign`, and patches the
+// `ClawSandbox.spec.networkPolicy.allowlistRef` field.
+//
+// The canonical YAML serializer is deliberately written by hand (rather
+// than reusing `js-yaml`/`yaml` defaults) because the S12.a spec is
+// stricter than any general-purpose YAML emitter — block style only,
+// fixed key order, IDNA-2008 host normalization, lexicographic endpoint
+// sort, no anchors/aliases/comments, LF-only with trailing newline.
+//
+// This is the producer side of the consumer/validator that lands in
+// S12.b. The on-CR allowlist remains non-authoritative in this slice
+// (S12.e flips authority); the inline `allowedEndpoints` MUST stay
+// byte-equivalent to the artifact contents until then.
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const EGRESS_ALLOWLIST_MEDIA_TYPE =
+  "application/vnd.azureclaw.egress-allowlist.v1+yaml";
+
+export interface CanonicalEndpoint {
+  host: string;
+  port: number;
+  protocol?: string;
+}
+
+export interface CanonicalAllowlistInput {
+  generation: number;
+  endpoints: Array<{ host: string; port: number; protocol?: string }>;
+}
+
+export interface CanonicalAllowlistOutput {
+  yaml: string;
+  endpoints: CanonicalEndpoint[];
+}
+
+export type SignMode = "keyless" | "identity-token" | "keyed";
+
+const HOST_ASCII_RE = /^[a-z0-9.-]+$/;
+
+/**
+ * Normalize a single host per S12.a rule #7. Returns canonical
+ * lowercase ASCII (Punycode for non-ASCII inputs). Throws on
+ * uppercase ASCII, whitespace, control bytes, wildcards, leading or
+ * trailing dots, consecutive dots, or any byte outside `[a-z0-9.-]`
+ * after IDNA conversion.
+ */
+function normalizeHost(rawHost: string): string {
+  if (typeof rawHost !== "string" || rawHost.length === 0) {
+    throw new Error(`canonical: empty host`);
+  }
+  if (rawHost !== rawHost.trim()) {
+    throw new Error(`canonical: host has leading/trailing whitespace: ${JSON.stringify(rawHost)}`);
+  }
+  if (rawHost.includes("*")) {
+    throw new Error(`canonical: wildcard hosts are not allowed in v1: ${rawHost}`);
+  }
+  for (let i = 0; i < rawHost.length; i++) {
+    const code = rawHost.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) {
+      throw new Error(`canonical: control byte in host: ${JSON.stringify(rawHost)}`);
+    }
+  }
+  if (rawHost.endsWith(".")) {
+    throw new Error(`canonical: host has trailing dot: ${rawHost}`);
+  }
+  if (rawHost.startsWith(".")) {
+    throw new Error(`canonical: host has leading dot: ${rawHost}`);
+  }
+  if (rawHost.includes("..")) {
+    throw new Error(`canonical: host has consecutive dots: ${rawHost}`);
+  }
+
+  let isAscii = true;
+  for (let i = 0; i < rawHost.length; i++) {
+    if (rawHost.charCodeAt(i) > 0x7f) {
+      isAscii = false;
+      break;
+    }
+  }
+
+  let candidate: string;
+  if (isAscii) {
+    // Strict — uppercase is rejected, not silently lowercased. The
+    // canonical bytes MUST already be lowercase upstream (see S12.a
+    // rule #7); accepting uppercase here would mask drift between
+    // operator-authored YAML and the signed bytes.
+    candidate = rawHost;
+  } else {
+    // IDNA-2008 to A-label via WHATWG URL parser, which uses UTS46
+    // (compatible with IDNA-2008 nontransitional). The result is
+    // lowercase ASCII Punycode (`xn--…`).
+    let parsed: URL;
+    try {
+      parsed = new URL(`http://${rawHost}/`);
+    } catch {
+      throw new Error(`canonical: cannot IDNA-encode host: ${rawHost}`);
+    }
+    candidate = parsed.hostname;
+  }
+
+  if (!HOST_ASCII_RE.test(candidate)) {
+    throw new Error(
+      `canonical: host fails canonical regex (must be lowercase ASCII matching [a-z0-9.-]): ${rawHost}`,
+    );
+  }
+  return candidate;
+}
+
+/**
+ * Produces canonical YAML per `docs/policy-canonical-format.md`.
+ * Sorted, deduped, IDNA-normalized, port-explicit, block-style, LF
+ * line endings with trailing newline. Byte-stable.
+ */
+export function buildCanonicalAllowlist(
+  input: CanonicalAllowlistInput,
+): CanonicalAllowlistOutput {
+  if (!Number.isInteger(input.generation) || input.generation < 1) {
+    throw new Error(
+      `canonical: metadata.generation must be a positive integer, got ${input.generation}`,
+    );
+  }
+  if (!Array.isArray(input.endpoints) || input.endpoints.length === 0) {
+    // S12.a rule #13 reserves `[]` as a valid empty allowlist, but this
+    // CLI flow always derives endpoints from the live ClawSandbox spec.
+    // An empty list at this stage almost certainly indicates a bug
+    // (e.g., kubectl returned nothing) — fail loud.
+    throw new Error(
+      `canonical: endpoints list is empty; refusing to sign an empty allowlist via --sign (use kubectl directly if intentional)`,
+    );
+  }
+
+  const seen = new Set<string>();
+  const normalized: CanonicalEndpoint[] = [];
+  for (const ep of input.endpoints) {
+    if (!ep || typeof ep !== "object") {
+      throw new Error(`canonical: endpoint is not an object`);
+    }
+    const host = normalizeHost(ep.host);
+    const port = ep.port;
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(
+        `canonical: port out of range [1,65535]: host=${host} port=${port}`,
+      );
+    }
+    const key = `${host}|${port}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push({ host, port });
+  }
+
+  normalized.sort((a, b) => {
+    if (a.host < b.host) return -1;
+    if (a.host > b.host) return 1;
+    return a.port - b.port;
+  });
+
+  // Hand-rolled YAML emitter — block style only, fixed key order.
+  const lines: string[] = [];
+  lines.push(`apiVersion: azureclaw.dev/v1alpha1`);
+  lines.push(`kind: EgressAllowlist`);
+  lines.push(`metadata:`);
+  lines.push(`  generation: ${input.generation}`);
+  lines.push(`spec:`);
+  if (normalized.length === 0) {
+    lines.push(`  endpoints: []`);
+  } else {
+    lines.push(`  endpoints:`);
+    for (const ep of normalized) {
+      lines.push(`    - host: ${ep.host}`);
+      lines.push(`      port: ${ep.port}`);
+    }
+  }
+  const yaml = lines.join("\n") + "\n";
+  return { yaml, endpoints: normalized };
+}
+
+/** sha256:<hex> over the raw canonical bytes. */
+export function digestOfCanonical(yaml: string): string {
+  return "sha256:" + createHash("sha256").update(yaml, "utf8").digest("hex");
+}
+
+/**
+ * Detects `oras` and `cosign` in `$PATH`. Throws with an actionable
+ * error message (including install URL) if either is missing.
+ */
+export async function ensureSigningTools(): Promise<{ orasPath: string; cosignPath: string }> {
+  const { execa } = await import("execa");
+  const orasPath = await whichWith(execa, "oras");
+  if (!orasPath) {
+    throw new Error(
+      `oras not found in $PATH. Install: https://oras.land/docs/installation`,
+    );
+  }
+  const cosignPath = await whichWith(execa, "cosign");
+  if (!cosignPath) {
+    throw new Error(
+      `cosign not found in $PATH. Install: https://docs.sigstore.dev/cosign/installation`,
+    );
+  }
+  return { orasPath, cosignPath };
+}
+
+type ExecaLike = (file: string, args?: readonly string[], opts?: any) => any;
+
+async function whichWith(execa: ExecaLike, bin: string): Promise<string | null> {
+  try {
+    const result = await execa("which", [bin], { stdio: "pipe" });
+    const stdout = String(result.stdout ?? "").trim();
+    return stdout.length > 0 ? stdout : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface PushArtifactOpts {
+  orasPath: string;
+  registry: string;
+  repository: string;
+  yaml: string;
+  artifactType: string;
+  /** Tag to push under (defaults to "latest"). The cosign signature is
+   *  applied by digest, so the tag is informational only. */
+  tag?: string;
+  /** Override execa for testing. */
+  execaImpl?: ExecaLike;
+  /** Override workdir for testing. */
+  workdir?: string;
+}
+
+/**
+ * Build the argv for `oras push`. Exposed for tests so we can lock in
+ * the exact invocation without spawning real processes.
+ */
+export function buildOrasPushArgv(opts: {
+  registry: string;
+  repository: string;
+  artifactType: string;
+  tag?: string;
+  filename: string;
+}): string[] {
+  const tag = opts.tag ?? "latest";
+  return [
+    "push",
+    `${opts.registry}/${opts.repository}:${tag}`,
+    "--artifact-type",
+    opts.artifactType,
+    "--format",
+    "json",
+    `${opts.filename}:${opts.artifactType}`,
+  ];
+}
+
+/**
+ * Pushes canonical bytes as an OCI artifact via `oras` and returns the
+ * resulting `sha256:…` digest. The producer-side digest is recomputed
+ * locally and compared to oras's report; mismatch is a producer bug
+ * (per S12.a "Signing" section) and aborts.
+ */
+export async function pushArtifact(opts: PushArtifactOpts): Promise<string> {
+  const { execa } = await import("execa");
+  const exec: ExecaLike = opts.execaImpl ?? execa;
+  const expected = digestOfCanonical(opts.yaml);
+
+  const dir = opts.workdir ?? mkdtempSync(join(tmpdir(), "azureclaw-egress-"));
+  const filename = "allowlist.yaml";
+  const fullPath = join(dir, filename);
+  writeFileSync(fullPath, opts.yaml, { encoding: "utf8" });
+  try {
+    const argv = buildOrasPushArgv({
+      registry: opts.registry,
+      repository: opts.repository,
+      artifactType: opts.artifactType,
+      tag: opts.tag,
+      filename,
+    });
+    const result = await exec(opts.orasPath, argv, { cwd: dir, stdio: "pipe" });
+    const stdout = String(result.stdout ?? "");
+    const reported = parseOrasDigest(stdout);
+    if (!reported) {
+      throw new Error(`oras push: could not parse digest from output: ${stdout.slice(0, 200)}`);
+    }
+    if (reported !== expected) {
+      throw new Error(
+        `oras push reported digest ${reported}; producer computed ${expected}. Canonical bytes diverged — aborting before signing.`,
+      );
+    }
+    return reported;
+  } finally {
+    if (!opts.workdir) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  }
+}
+
+/** Parse the `digest` from `oras push --format json` output. */
+export function parseOrasDigest(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) return null;
+  try {
+    const obj = JSON.parse(trimmed);
+    const candidate =
+      obj?.reference?.digest ??
+      obj?.manifest?.digest ??
+      obj?.digest ??
+      null;
+    if (typeof candidate === "string" && /^sha(256|384|512):[a-f0-9]+$/.test(candidate)) {
+      return candidate;
+    }
+  } catch {
+    // fall through to text-mode parse below
+  }
+  // Text fallback: oras text output contains "Digest: sha256:…".
+  const match = trimmed.match(/Digest:\s*(sha(?:256|384|512):[a-f0-9]+)/);
+  if (match) return match[1];
+  return null;
+}
+
+export interface SignArtifactOpts {
+  cosignPath: string;
+  registry: string;
+  repository: string;
+  digest: string;
+  mode: SignMode;
+  keyRef?: string;
+  identityToken?: string;
+  execaImpl?: ExecaLike;
+}
+
+/**
+ * Build the argv for `cosign sign` for the given mode. Exposed for
+ * tests so we can lock in the exact invocation.
+ */
+export function buildCosignSignArgv(opts: {
+  registry: string;
+  repository: string;
+  digest: string;
+  mode: SignMode;
+  keyRef?: string;
+  identityToken?: string;
+}): string[] {
+  const target = `${opts.registry}/${opts.repository}@${opts.digest}`;
+  const argv: string[] = ["sign", "--yes"];
+  switch (opts.mode) {
+    case "keyless":
+      // No auth flag — cosign launches the OIDC browser flow.
+      break;
+    case "identity-token": {
+      const tok = opts.identityToken ?? process.env.SIGSTORE_ID_TOKEN ?? process.env.OIDC_TOKEN;
+      if (!tok) {
+        throw new Error(`cosign identity-token mode requires SIGSTORE_ID_TOKEN or OIDC_TOKEN env`);
+      }
+      argv.push("--identity-token", tok);
+      break;
+    }
+    case "keyed":
+      if (!opts.keyRef || opts.keyRef.length === 0) {
+        throw new Error(`cosign keyed mode requires --sign-key`);
+      }
+      argv.push("--key", opts.keyRef);
+      break;
+  }
+  argv.push(target);
+  return argv;
+}
+
+export async function signArtifact(opts: SignArtifactOpts): Promise<void> {
+  const { execa } = await import("execa");
+  const exec: ExecaLike = opts.execaImpl ?? execa;
+  const argv = buildCosignSignArgv(opts);
+  await exec(opts.cosignPath, argv, { stdio: "inherit" });
+}
+
+export function autoDetectSignMode(opts: {
+  signModeFlag?: string;
+  signKey?: string;
+  isTTY: boolean;
+  env: NodeJS.ProcessEnv;
+}): SignMode {
+  const flag = opts.signModeFlag;
+  if (flag) {
+    if (flag !== "keyless" && flag !== "identity-token" && flag !== "keyed") {
+      throw new Error(
+        `--sign-mode must be one of: keyless, identity-token, keyed (got: ${flag})`,
+      );
+    }
+    if (flag === "keyed" && (!opts.signKey || opts.signKey.length === 0)) {
+      throw new Error(`--sign-mode keyed requires --sign-key`);
+    }
+    return flag;
+  }
+  // No explicit mode — auto-detect.
+  if (opts.env.SIGSTORE_ID_TOKEN || opts.env.OIDC_TOKEN) {
+    return "identity-token";
+  }
+  if (opts.signKey && opts.signKey.length > 0) {
+    return "keyed";
+  }
+  if (opts.isTTY) {
+    return "keyless";
+  }
+  // Non-TTY without token and without key → cannot proceed.
+  throw new Error(
+    `--sign requires one of: TTY for keyless OIDC, SIGSTORE_ID_TOKEN/OIDC_TOKEN env, or --sign-mode keyed --sign-key <ref>`,
+  );
+}
+
+export interface PatchClawSandboxOpts {
+  kubectlPath: string;
+  namespace: string;
+  name: string;
+  registry: string;
+  repository: string;
+  digest: string;
+  artifactType: string;
+  execaImpl?: ExecaLike;
+}
+
+/**
+ * Build the kubectl argv for the merge patch. Exposed for tests.
+ */
+export function buildPatchArgv(opts: Omit<PatchClawSandboxOpts, "kubectlPath" | "execaImpl">): string[] {
+  const patch = {
+    spec: {
+      networkPolicy: {
+        allowlistRef: {
+          registry: opts.registry,
+          repository: opts.repository,
+          digest: opts.digest,
+          artifactType: opts.artifactType,
+        },
+      },
+    },
+  };
+  return [
+    "patch",
+    `clawsandbox/${opts.name}`,
+    "-n",
+    opts.namespace,
+    "--type=merge",
+    "-p",
+    JSON.stringify(patch),
+  ];
+}
+
+export async function patchClawSandbox(opts: PatchClawSandboxOpts): Promise<void> {
+  const { execa } = await import("execa");
+  const exec: ExecaLike = opts.execaImpl ?? execa;
+  const argv = buildPatchArgv(opts);
+  await exec(opts.kubectlPath, argv, { stdio: "pipe" });
+}
+
+/**
+ * Read live `allowedEndpoints` and `metadata.generation` from a
+ * ClawSandbox via kubectl. Used to feed the canonical builder.
+ */
+export async function readClawSandboxState(opts: {
+  kubectlPath: string;
+  namespace: string;
+  name: string;
+  execaImpl?: ExecaLike;
+}): Promise<{ generation: number; endpoints: Array<{ host: string; port: number }> }> {
+  const { execa } = await import("execa");
+  const exec: ExecaLike = opts.execaImpl ?? execa;
+  const result = await exec(
+    opts.kubectlPath,
+    ["get", `clawsandbox/${opts.name}`, "-n", opts.namespace, "-o", "json"],
+    { stdio: "pipe" },
+  );
+  const obj = JSON.parse(String(result.stdout ?? "{}"));
+  const generation = Number(obj?.metadata?.generation);
+  if (!Number.isInteger(generation) || generation < 1) {
+    throw new Error(
+      `kubectl: ClawSandbox ${opts.namespace}/${opts.name} has no positive metadata.generation`,
+    );
+  }
+  const raw: unknown = obj?.spec?.networkPolicy?.allowedEndpoints;
+  const endpoints: Array<{ host: string; port: number }> = [];
+  if (Array.isArray(raw)) {
+    for (const ep of raw) {
+      const e = ep as { host?: unknown; port?: unknown };
+      if (typeof e.host === "string" && typeof e.port === "number") {
+        endpoints.push({ host: e.host, port: e.port });
+      }
+    }
+  }
+  return { generation, endpoints };
+}

--- a/docs/egress-proxy.md
+++ b/docs/egress-proxy.md
@@ -224,3 +224,40 @@ decisions are recorded in the governance audit log.
 | `inference-router/src/routes.rs` | HTTP handlers for `/egress/*` endpoints |
 | `cli/src/commands/egress.ts` | CLI `azureclaw egress` command |
 | `controller/src/reconciler.rs` | iptables init container + NetworkPolicy generation |
+
+## Signing artifacts (`--sign`)
+
+Phase 2 / S12.c adds an opt-in `--sign` flag to `azureclaw egress` that
+seals the current allowlist as a content-addressed, cosign-signed OCI
+artifact:
+
+```
+azureclaw egress <name> --enforce --sign \
+  --registry myacr.azurecr.io \
+  [--repository policy/egress-allowlist/<name>] \
+  [--sign-mode keyless|identity-token|keyed] \
+  [--sign-key azurekms://...]
+```
+
+Behavior:
+
+- Combine with `--enforce` or `--approve` (using `--sign` alone is an
+  error).
+- The producer reads the live `ClawSandbox.spec.networkPolicy.allowed
+  Endpoints` and `metadata.generation`, builds a byte-stable canonical
+  YAML per `docs/policy-canonical-format.md`, pushes it via `oras`,
+  signs it via `cosign`, and patches `spec.networkPolicy.allowlistRef`
+  with the resulting digest.
+- Sign-mode auto-detects: keyless when a TTY is attached and no token
+  env is set; identity-token when `SIGSTORE_ID_TOKEN` or `OIDC_TOKEN`
+  is set (e.g., GitHub Actions OIDC); keyed when `--sign-mode keyed
+  --sign-key <ref>` is passed.
+- Fail-closed: if `oras push` or `cosign sign` fails, the kubectl
+  patch is skipped — no orphan `allowlistRef` ever lands on a
+  `ClawSandbox`.
+- Status: **non-authoritative** in S12.c — the inline
+  `allowedEndpoints` remains the source of truth. The flip to
+  authoritative ships in S12.e.
+
+Required tools: `oras` and `cosign` in `$PATH`. See the canonical
+format doc and the S12.c security audit for the full threat model.

--- a/docs/policy-canonical-format.md
+++ b/docs/policy-canonical-format.md
@@ -89,3 +89,47 @@ When v2 is needed (e.g., to reintroduce wildcards, methods, paths, CIDR ranges):
 | S12.c | CLI canonical serializer + signing |
 | S12.d | `SignerPolicy` ConfigMap + identity-pinned authority |
 | S12.e | Authoritative ref mode (controller derives `allowedEndpoints` from canonical bytes) |
+
+## Producer (CLI)
+
+S12.c ships the producer side of this format inside the CLI as
+`azureclaw egress … --sign`. The flow is opt-in (must be combined with
+`--enforce` or `--approve`) and **non-authoritative** in this slice —
+the inline `allowedEndpoints` field on `ClawSandbox.spec.networkPolicy`
+remains the source of truth. The flip to authoritative ships in S12.e.
+
+What `--sign` does, in order:
+
+1. Reads the live `ClawSandbox` via `kubectl get -o json` to capture
+   `metadata.generation` and the just-mutated
+   `spec.networkPolicy.allowedEndpoints`.
+2. Builds canonical YAML using the deterministic encoder in
+   `cli/src/commands/egress/sign.ts`. The encoder is hand-rolled (not
+   `js-yaml`/`yaml` defaults) because the rules above are stricter than
+   any general-purpose YAML emitter — block style only, fixed key
+   order, IDNA-2008 host normalization, lexicographic sort, no
+   anchors/aliases/comments, LF-only with trailing newline. The
+   producer's local digest is recomputed and compared to the digest
+   reported by `oras push`; mismatch aborts before signing.
+3. Pushes the canonical bytes as an OCI artifact via
+   `oras push <registry>/<repository>:latest --artifact-type
+   application/vnd.azureclaw.egress-allowlist.v1+yaml`.
+4. Signs the resulting digest via `cosign sign --yes
+   <registry>/<repository>@<digest>` in one of three modes:
+   - `keyless` (auto-default when stdout is a TTY and no token env is
+     set) — interactive Fulcio OIDC.
+   - `identity-token` (auto-default when `SIGSTORE_ID_TOKEN` or
+     `OIDC_TOKEN` env is set, e.g., GitHub Actions OIDC) — passes the
+     token via `--identity-token`.
+   - `keyed` (selected by `--sign-mode keyed --sign-key <ref>`) —
+     supports a local key file or a KMS URI like `azurekms://kv/key`.
+5. Patches `ClawSandbox.spec.networkPolicy.allowlistRef` via
+   `kubectl patch --type=merge` with the `{registry, repository,
+   digest, artifactType}` tuple.
+
+**Fail-closed:** signature push failure aborts before patching the CR
+— no orphan `allowlistRef` pointing at an unsigned artifact ever lands
+on a `ClawSandbox`. The `oras` and `cosign` binaries must be present
+in `$PATH`; missing-binary errors include the upstream install URL
+(see `https://oras.land/docs/installation` and
+`https://docs.sigstore.dev/cosign/installation`).

--- a/docs/security-audits/2026-04-30-phase2-s12-c-cli-sign.md
+++ b/docs/security-audits/2026-04-30-phase2-s12-c-cli-sign.md
@@ -1,0 +1,82 @@
+# Phase 2 — S12.c: CLI `--sign` flag (egress allowlist artifact producer)
+
+**Date:** 2026-04-30
+**Slice:** S12.c (`phase2-s12-c-egress-sign`)
+**Scope:** CLI-only change. Adds an opt-in `--sign` flag family to
+`azureclaw egress` that seals the current `allowedEndpoints` list as a
+canonical, content-addressed, cosign-signed OCI artifact and patches
+`ClawSandbox.spec.networkPolicy.allowlistRef`. **No** controller,
+router, or sandbox-image change.
+
+## Existing implementation surveyed
+
+- `controller/src/crd.rs` — `OciArtifactRef` + `NetworkPolicyConfig.allowlist_ref` (S12.a).
+- `deploy/helm/azureclaw/templates/crd.yaml` — `allowlistRef` schema with required-field validation + digest regex (S12.a).
+- `docs/policy-canonical-format.md` — byte-stable v1 canonicalization rules (S12.a).
+- `cli/src/commands/egress.ts` — pre-existing `--learn`/`--enforce`/`--approve`/`--allowlist`/`--pending` surface; subprocess invocation pattern (kubectl + docker + curl-via-exec).
+
+## Trust model summary
+
+Per `plan.md` "Trust model" for S12:
+
+- The cluster trusts cosign-signed canonical egress allowlist artifacts whose Fulcio identity matches the cluster `SignerPolicy` (S12.d).
+- Until S12.d ships, no identity is authoritative — verification result is `AllowlistVerified=Unknown / NoSignerPolicy`.
+- The CLI is one possible producer; another would be a CI pipeline using GitHub Actions OIDC. Both produce the same canonical bytes (per S12.a) and use the same `cosign sign` invocation against the same digest.
+- The on-CR `allowlistRef` is **non-authoritative** until S12.e flips authority. Operators can review the inline `allowedEndpoints` field (which the producer keeps byte-equivalent to the artifact) and the controller still derives behavior from it.
+
+## Threat surfaces introduced
+
+This slice introduces three subprocess invocations and one new place that touches an OIDC token:
+
+1. **`oras push` invocation** — uploads canonical YAML bytes to a registry. Risk: an attacker who controls the CLI invocation could push to a registry of their choice. Mitigated by passing `--registry` as an explicit argument (no shell interpolation, no env-var fallback that reads from untrusted sources).
+2. **`cosign sign` invocation** — issues a signature over the digest. Risk: mode confusion (e.g., signing with a key when the operator intended keyless). Mitigated by explicit `--sign-mode` flag and an auto-detect rule that errs on the side of failing closed (non-TTY without token and without key → hard error, not silent fallback).
+3. **`kubectl patch` invocation** — writes `allowlistRef` to the live `ClawSandbox`. Risk: orphan ref if signing failed but patch succeeded. Mitigated by ordering: patch is the last step, executed only after both push and sign succeed; any earlier failure aborts before patching.
+4. **OIDC token handling** — `--sign-mode identity-token` reads `SIGSTORE_ID_TOKEN` or `OIDC_TOKEN` from env and forwards it via cosign's `--identity-token` flag. The token never appears in argv for any other binary; it is not logged.
+
+## Mitigations
+
+- **No shell interpolation.** All subprocess invocations use `execa(file, argv)` with structured argv arrays. No template strings, no `sh -c`. Verified by tests `pushArtifact`, `signArtifact`, `patchClawSandbox` that lock in the exact argv shape.
+- **Argv pass-through only.** The `--registry`, `--repository`, `--sign-key` flag values are passed directly into argv positions; no concatenation into a single string that a downstream shell could re-parse.
+- **Tool detection before exec.** `ensureSigningTools` looks up both binaries via `which` before any push/sign attempt. Missing-binary errors include the upstream install URL (`https://oras.land/docs/installation` and `https://docs.sigstore.dev/cosign/installation`).
+- **Producer-side digest verification.** The CLI computes `sha256` over the canonical bytes locally and compares to the digest reported by `oras push`. Mismatch is treated as a producer bug per S12.a §"Signing" and aborts before `cosign sign`.
+- **Idempotent `kubectl patch`.** The patch is a JSON merge patch over `spec.networkPolicy.allowlistRef`; re-running with the same digest is a no-op. The inline `allowedEndpoints` is left untouched so the resource remains a valid pre-S12.e ClawSandbox.
+- **Fail-closed ordering.** Push → sign → patch. Any failure in steps 1–2 aborts before step 3. No orphan `allowlistRef` ever lands on a `ClawSandbox` from this CLI.
+- **Strict canonicalization.** The hand-rolled YAML emitter rejects uppercase ASCII, leading/trailing whitespace, control bytes, wildcards, dotted-zero ports, generation ≤ 0, and any byte outside `[a-z0-9.-]` after IDNA-2008 conversion. Tests lock in each rejection rule.
+- **Token never logged.** `signArtifact` does not echo the identity token; cosign itself handles redaction.
+
+## Why ref still non-authoritative
+
+Per `plan.md` §S12 decomposition:
+
+- S12.b validates the artifact's canonical bytes and surfaces `AllowlistVerified` as a status condition only.
+- S12.d pins authoritative identity via `SignerPolicy`.
+- S12.e flips the controller to derive `allowedEndpoints` from the verified canonical bytes.
+
+Until S12.e, the inline `allowedEndpoints` field is what drives sandbox behavior. The CLI in S12.c keeps both representations byte-equivalent: it mutates the live spec via `--enforce`/`--approve` (existing surface), then reads back the mutated state, builds canonical bytes from it, and patches `allowlistRef` to the resulting digest. Operators can review the inline list as the human-readable source of truth without ambiguity about what was sealed.
+
+## Test coverage
+
+41 new tests across two files:
+
+- `cli/src/commands/egress/sign.test.ts` (34 tests) — canonical YAML serializer (sort, dedupe, IDNA, port-explicit, byte-stable, rejections); `digestOfCanonical` digest format; `autoDetectSignMode` (TTY/keyless, identity-token, keyed, error cases); `ensureSigningTools` (success + each missing-binary error); `buildOrasPushArgv` / `parseOrasDigest` / `pushArtifact` (digest-mismatch abort); `buildCosignSignArgv` per mode + keyed-without-key rejection; `signArtifact`; `buildPatchArgv` / `patchClawSandbox` argv shape.
+- `cli/src/commands/egress.test.ts` (7 tests) — flag wiring (`--sign`, `--no-sign`, `--sign-mode`, `--sign-key`, `--registry`, `--repository`); `--sign` without `--enforce`/`--approve` errors and sets `process.exitCode = 1`.
+
+CLI test count 354 → 395 passing (2 pre-existing skipped). `npx tsc --noEmit` clean. `npm run lint` introduces no new warnings in egress files. `npm run build` green.
+
+## §10.5 Compliance
+
+- §10.5 #4 (signed-policy provenance): producer side now ships. Combined with S12.b's consumer-side validation, the cluster has end-to-end coverage of "the bytes the operator sealed are the bytes the controller verifies" — modulo authority pinning, which lands in S12.d.
+- Per-sub-slice audit doc: this is the third (S12.a, S12.b, S12.c).
+
+## References
+
+- Plan §S12.c: `~/.copilot/session-state/13bea069-bbc9-48ae-a25c-36da81c7a0fe/plan.md`
+- Canonical format: `docs/policy-canonical-format.md`
+- ORAS install: <https://oras.land/docs/installation>
+- Cosign install: <https://docs.sigstore.dev/cosign/installation>
+- Sigstore keyless (Fulcio): <https://docs.sigstore.dev/cosign/keyless/>
+
+## Sign-offs
+
+- [ ] Author: ____________________
+- [ ] Independent reviewer: ____________________


### PR DESCRIPTION
## Summary

S12.c — CLI `azureclaw egress … --sign` opt-in flag that builds a canonical egress-allowlist artifact, pushes to ACR via `oras`, signs with `cosign`, and patches `ClawSandbox.spec.networkPolicy.allowlistRef`. Producer side of the consumer that S12.b shipped.

**Status: non-authoritative.** Inline `allowedEndpoints` remains the source of truth in this slice. Authority flips in S12.e.

## What's new

- **`cli/src/commands/egress/sign.ts`** — hand-rolled canonical YAML serializer that matches `docs/policy-canonical-format.md` byte-for-byte (sorted, deduped, IDNA-2008 host normalization, port-explicit, block-style, LF-terminated, fixed key order). Plus `oras push` artifact uploader with local-digest verification, `cosign sign` orchestrator with three modes, and a `kubectl patch` helper.
- **New flags on `azureclaw egress`:** `--sign`, `--no-sign`, `--sign-mode <keyless|identity-token|keyed>`, `--sign-key <ref>`, `--registry <fqdn>`, `--repository <repo>`.
- **Auto-mode detection:** keyless when stdout is a TTY and no token env is set; identity-token when `SIGSTORE_ID_TOKEN`/`OIDC_TOKEN` is set; keyed when `--sign-mode keyed` + `--sign-key` is passed. Non-TTY without token and without key is a hard error (no silent fallback).
- **Fail-closed:** `oras push` digest mismatch or `cosign sign` failure aborts before `kubectl patch` — no orphan `allowlistRef` ever lands on a `ClawSandbox`.
- **Tool detection** is upfront: missing `oras` or `cosign` produces an error with the upstream install URL.

## Tests

41 new vitest tests across `cli/src/commands/egress/sign.test.ts` (34) and `cli/src/commands/egress.test.ts` (7). They lock in:

- canonical serializer: sort, dedupe, IDNA, port-explicit, byte-stable, every rejection rule;
- `autoDetectSignMode` for every mode + error case;
- `ensureSigningTools` success + each missing-binary error including install URL;
- exact argv shape for `oras push`, `cosign sign` (per mode), and `kubectl patch`;
- digest-mismatch abort path;
- `--sign` without `--enforce`/`--approve` errors.

CLI test count **354 → 395 passing**. `npx tsc --noEmit` clean. `npm run lint` introduces no new warnings on egress files. `npm run build` green.

## Out of scope (deferred)

- Controller-side `SignerPolicy` reading — S12.d.
- Authoritative-ref mode (controller derives `allowedEndpoints` from canonical bytes) — S12.e.
- `--emit-manifest` for GitOps + `--sign` default-on — S12.g.

## Audit + docs

- `docs/security-audits/2026-04-30-phase2-s12-c-cli-sign.md` — threat surfaces (subprocess invocation of oras + cosign, OIDC token handling), mitigations (no shell interpolation, argv pass-through, tool detection before exec, idempotent kubectl patch, fail-closed ordering), why ref still non-authoritative.
- `docs/policy-canonical-format.md` — new "Producer (CLI)" section.
- `docs/egress-proxy.md` — new "Signing artifacts (`--sign`)" subsection.
- `CHANGELOG.md` — Phase 2 / Unreleased entry.

## CI expectations

All gates expected green except **Container Image Scan** (no image change in this slice — CLI-only).
