### PR TITLE
S12.f: router-side blocked-egress visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S12.f — router blocked-attempt visibility
+
+- New `inference-router/src/egress_blocked.rs` — bounded, rate-limited,
+  deduplicated ring buffer of blocked egress attempts surfaced via
+  `GET /egress/learned/blocked`.
+- Wired into the forward-proxy deny branches (`handle_connect`,
+  `handle_http`, `handle_tls_redirect` — including the SNI-blocked,
+  ECH-rejected, and DNS-rebind-blocked paths); emits
+  `(source_sandbox, host, port)` on every block.
+- Defaults: capacity 1024 entries, rate limit 100 events / 60 s sliding
+  window per source. Hostname-only (no paths, no headers, no payload data).
+  IPs rejected. Empty hosts rejected. Trailing dots stripped, lowercased.
+- Sibling of the existing `/egress/learned` allowed-observations buffer;
+  mirrors its admin-token RBAC via the existing `protected` router layer
+  in `main.rs` — no new auth path introduced.
+- 14 new unit tests (`src/egress_blocked.rs`) + 2 endpoint integration
+  tests (`tests/egress_blocked_endpoint.rs`).
+
 ### S12.b `phase2-s12-bd-policy-fetcher` — controller policy fetcher (status-only, feature-gated)
 
 - New `controller/src/policy_fetcher.rs` — pulls signed OCI egress-allowlist

--- a/docs/security-audits/2026-04-30-phase2-s12-f-blocked-visibility.md
+++ b/docs/security-audits/2026-04-30-phase2-s12-f-blocked-visibility.md
@@ -1,0 +1,135 @@
+# Phase 2 — S12.f — Router blocked-attempt visibility
+
+**Slice:** S12.f
+**Branch:** `phase2-s12-f-blocked-visibility`
+**Base:** `dev`
+
+## Plan.md citation
+
+> **S12.f — router blocked-attempt visibility (independent).** In enforce
+> mode, capture blocked domain attempts to `/egress/learned/blocked`
+> (separate ring buffer from learned-while-allowed). Bounded, deduped,
+> rate-limited per source, hostname-only.
+> — `~/.copilot/session-state/.../plan.md` line 483
+
+## Existing implementation surveyed (§0.2 #8)
+
+Before writing any code:
+
+- **`inference-router/src/routes/egress.rs`** — current
+  `GET /egress/learned` handler reads `state.blocklist.get_learned_domains()`
+  and returns a JSON envelope `{ "learn_mode", "count", "domains" }`. RBAC
+  is enforced one level up in `main.rs` where `egress_routes()` is merged
+  into a `protected` `Router` that requires
+  `Authorization: Bearer <admin-token>` via `admin_auth_middleware`. The
+  new endpoint inherits that gate by being mounted in the same
+  `egress_routes()` builder — no new auth path.
+- **`inference-router/src/blocklist.rs`** — the existing learn-mode
+  buffer for *allowed* observations (`learned_domains: HashSet<String>`)
+  is intentionally **not refactored** in this slice. The blocked-attempt
+  buffer is a sibling so observability of blocks does not pollute the
+  allowed-observation buffer.
+- **`inference-router/src/forward_proxy.rs`** — the deny branches in the
+  router today are: (1) `handle_connect` → `blocklist.check_egress` Err;
+  (2) `handle_connect` → `resolve_and_validate` Err (DNS rebinding);
+  (3) `handle_http` → `blocklist.check_egress` Err; (4) `handle_http` →
+  `resolve_and_validate` Err; (5) `handle_tls_redirect` → ECH detected;
+  (6) `handle_tls_redirect` → `blocklist.check_egress` Err on the SNI;
+  (7) `handle_tls_redirect` → `resolve_and_validate` Err. Each is the
+  exact emission point for `BlockedBuffer::record(...)`. The "no SNI"
+  branch is intentionally **not** recorded — there is no host string to
+  store and the buffer rejects empty hosts by design.
+- **`inference-router/src/routes/mod.rs::AppState`** — central shared
+  state, cloned by axum and the forward proxy. The new buffer is added
+  here as `Arc<BlockedBuffer>` and a clone is threaded into
+  `forward_proxy::start` from `main.rs`.
+- **Test scaffolding** — `tests/agt_governance_integration.rs` already
+  demonstrates the canonical axum `oneshot` pattern; the new
+  `tests/egress_blocked_endpoint.rs` mirrors it.
+
+## Why blocked needs its own buffer
+
+The existing `/egress/learned` buffer captures *observations of egress
+that the policy allowed* (learn mode → discovery). The S12.f buffer
+captures *attempts the policy denied in enforce mode*. These are two
+different operational concerns:
+
+- Mixing them would force operators to filter on a "was this allowed?"
+  flag in every UI/CLI consumer of `/egress/learned`.
+- Allowed observations naturally trend toward a stable allowlist;
+  blocked observations are unbounded by definition (an attacker can
+  generate arbitrary new domains). Different sizing, different
+  rate-limiting, different threat model.
+- Blocked entries carry a `source_sandbox` because attribution of
+  blocked attempts matters for incident response; allowed observations
+  in learn mode are already scoped to the sandbox.
+
+## Threat surfaces introduced
+
+- **One new HTTP endpoint:** `GET /egress/learned/blocked`. Returns a
+  JSON envelope of hostname-only entries.
+- **Auth:** mounted inside the existing `egress_routes()` `Router`, which
+  is merged into the admin-token-protected `protected` router in
+  `main.rs`. The endpoint inherits the same `Authorization: Bearer`
+  gate that already protects `/egress/learned`, `/egress/allowlist`,
+  etc. **No new auth path.**
+
+## Threat surfaces NOT introduced
+
+- **No payload disclosure.** Only `(host, port, source_sandbox,
+  first_seen_unix, last_seen_unix, count)` is stored. Paths, query
+  strings, request bodies, and headers are never observed by the
+  buffer.
+- **No PII leakage via IP literals.** IPv4/IPv6 literal hosts are
+  rejected at `record()`-time; only DNS hostnames are stored. Bracketed
+  IPv6 literals (`[::1]`) are also rejected.
+- **No log-flooding amplification.** The per-source sliding-window
+  rate limit caps ring-buffer churn at 100 new keys / 60 s (defaults).
+  Existing entries continue to bump their aggregate `count` even when
+  the rate limiter suppresses fresh writes — telemetry is preserved
+  without unbounded memory growth.
+- **No unbounded memory.** Capacity 1024 with FIFO eviction.
+- **No cross-sandbox leakage of attribution data.** Blocked entries
+  include `source_sandbox` only; in production the router serves a
+  single sandbox and the field is the local `SANDBOX_NAME` env var.
+
+## Test coverage
+
+**Unit tests (`inference-router/src/egress_blocked.rs` `mod tests`):**
+- `record_first_observation_returns_recorded`
+- `record_duplicate_increments_count_and_dedupes`
+- `record_distinct_hosts_creates_distinct_entries`
+- `record_distinct_sandboxes_creates_distinct_entries`
+- `rate_limit_drops_high_frequency_writes_from_one_source`
+- `rate_limit_does_not_affect_other_sources`
+- `rate_limit_window_resets_after_elapsed` (uses injected `Instant` via
+  `record_at`, no `tokio::time` dependency)
+- `capacity_evicts_oldest_fifo`
+- `snapshot_returns_in_recency_order` — documented contract: **newest
+  first** (reverse insertion order)
+- `hostname_normalization_lowercases`
+- `hostname_normalization_strips_trailing_dot`
+- `record_rejects_ip_literal_host` (covers v4, v6, bracketed-v6)
+- `record_rejects_empty_host` (covers empty, whitespace, `.`)
+- `empty_source_sandbox_falls_back_to_unknown`
+- `clear_resets_buffer`
+
+**Integration tests (`inference-router/tests/egress_blocked_endpoint.rs`):**
+- `endpoint_returns_empty_when_no_blocks`
+- `endpoint_returns_recorded_blocks` (asserts dedup count, recency
+  ordering, JSON wire shape including `source_sandbox`)
+
+**Test count delta:** +15 unit (lib went 608 → 623) + 2 integration
+binary = **+17 total**. Workspace `cargo test --all` green.
+
+## Sign-offs
+
+- `cargo fmt --all` — clean.
+- `cargo clippy --all-targets -- -D warnings` (workspace) — clean.
+- `cargo test --package azureclaw-inference-router` — 623 lib + all
+  integration tests pass.
+- `cargo test --all` — workspace green.
+- No CRD / controller code touched.
+- No new auth path.
+- Hostname-only contract enforced at the type boundary (`record`
+  rejects IP literals + empty strings).

--- a/inference-router/src/egress_blocked.rs
+++ b/inference-router/src/egress_blocked.rs
@@ -1,0 +1,444 @@
+//! Bounded, rate-limited, deduplicated ring buffer of egress attempts that
+//! were *blocked* in enforce mode (S12.f). Sibling of the existing
+//! learn-mode buffer for *allowed* egress observations on `Blocklist`.
+//!
+//! Surfaced via `GET /egress/learned/blocked`. Hostname + port only — no
+//! paths, headers, query strings, or payload data are ever stored.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Default capacity when the operator does not override.
+pub const DEFAULT_CAPACITY: usize = 1024;
+/// Default sliding-window length for per-source rate limiting.
+pub const DEFAULT_RATE_WINDOW: Duration = Duration::from_secs(60);
+/// Default max ring-buffer churn events per source per window.
+pub const DEFAULT_RATE_PER_SOURCE: u32 = 100;
+
+/// One blocked-attempt record. Hostname + port only — every other attribute
+/// of the original request is dropped at record time.
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct BlockedEntry {
+    pub host: String,
+    pub port: u16,
+    pub source_sandbox: String,
+    pub first_seen_unix: u64,
+    pub last_seen_unix: u64,
+    pub count: u32,
+}
+
+/// Outcome of a `record` call. The aggregate `count` on an existing entry
+/// always reflects every observation, even when the ring-buffer write is
+/// suppressed by the rate limiter.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecordOutcome {
+    /// First observation for this `(source, host, port)` key — written to
+    /// the buffer.
+    Recorded,
+    /// Matched an existing key — `count` bumped, `last_seen_unix` updated.
+    Deduplicated,
+    /// Per-source sliding-window rate limit exceeded — observation dropped.
+    /// No buffer mutation, no count bump.
+    RateLimited,
+    /// Host failed normalization (empty, IP literal, etc.) — observation
+    /// rejected. Caller may safely ignore.
+    Rejected,
+}
+
+/// Bounded ring buffer of blocked-attempt records.
+pub struct BlockedBuffer {
+    inner: Mutex<Inner>,
+    capacity: usize,
+    rate_limit_window: Duration,
+    rate_limit_per_source: u32,
+}
+
+struct Inner {
+    by_key: HashMap<(String, String, u16), BlockedEntry>,
+    order: VecDeque<(String, String, u16)>,
+    rate_per_source: HashMap<String, RateState>,
+}
+
+struct RateState {
+    window_start: Instant,
+    count: u32,
+}
+
+impl BlockedBuffer {
+    pub fn new(capacity: usize, rate_limit_window: Duration, rate_limit_per_source: u32) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                by_key: HashMap::new(),
+                order: VecDeque::new(),
+                rate_per_source: HashMap::new(),
+            }),
+            capacity: capacity.max(1),
+            rate_limit_window,
+            rate_limit_per_source,
+        }
+    }
+
+    /// Convenience constructor with the recommended defaults
+    /// (1024 entries, 100 events / 60s per source).
+    pub fn with_defaults() -> Self {
+        Self::new(
+            DEFAULT_CAPACITY,
+            DEFAULT_RATE_WINDOW,
+            DEFAULT_RATE_PER_SOURCE,
+        )
+    }
+
+    /// Record a blocked egress attempt. See `RecordOutcome` for the
+    /// possible results. Hostname-only — never store paths, headers, or
+    /// payload data.
+    pub fn record(&self, source_sandbox: &str, host: &str, port: u16) -> RecordOutcome {
+        self.record_at(Instant::now(), unix_now(), source_sandbox, host, port)
+    }
+
+    /// Testable record entry point — accepts an injected clock pair.
+    pub fn record_at(
+        &self,
+        now: Instant,
+        now_unix: u64,
+        source_sandbox: &str,
+        host: &str,
+        port: u16,
+    ) -> RecordOutcome {
+        let host = match normalize_host(host) {
+            Some(h) => h,
+            None => return RecordOutcome::Rejected,
+        };
+        let source = if source_sandbox.is_empty() {
+            "unknown".to_string()
+        } else {
+            source_sandbox.to_string()
+        };
+
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(), // poisoned — keep going, state is still readable
+        };
+
+        let key = (source.clone(), host.clone(), port);
+
+        // Dedup path: existing entries always bump count + last_seen, even
+        // when the rate limiter would have suppressed a fresh write.
+        if let Some(entry) = inner.by_key.get_mut(&key) {
+            entry.last_seen_unix = now_unix;
+            entry.count = entry.count.saturating_add(1);
+            return RecordOutcome::Deduplicated;
+        }
+
+        // Per-source sliding-window rate limit applies only to the
+        // ring-buffer churn (new keys), not to dedup updates above.
+        let rate = inner
+            .rate_per_source
+            .entry(source.clone())
+            .or_insert(RateState {
+                window_start: now,
+                count: 0,
+            });
+        if now.duration_since(rate.window_start) >= self.rate_limit_window {
+            rate.window_start = now;
+            rate.count = 0;
+        }
+        if rate.count >= self.rate_limit_per_source {
+            return RecordOutcome::RateLimited;
+        }
+        rate.count += 1;
+
+        let entry = BlockedEntry {
+            host: host.clone(),
+            port,
+            source_sandbox: source.clone(),
+            first_seen_unix: now_unix,
+            last_seen_unix: now_unix,
+            count: 1,
+        };
+        inner.by_key.insert(key.clone(), entry);
+        inner.order.push_back(key);
+
+        // FIFO eviction at capacity.
+        while inner.order.len() > self.capacity {
+            if let Some(old_key) = inner.order.pop_front() {
+                inner.by_key.remove(&old_key);
+            }
+        }
+
+        RecordOutcome::Recorded
+    }
+
+    /// Snapshot of up to `limit` entries, newest first by insertion order.
+    pub fn snapshot(&self, limit: usize) -> Vec<BlockedEntry> {
+        let inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        inner
+            .order
+            .iter()
+            .rev()
+            .take(limit)
+            .filter_map(|k| inner.by_key.get(k).cloned())
+            .collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().map(|g| g.by_key.len()).unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn clear(&self) {
+        if let Ok(mut g) = self.inner.lock() {
+            g.by_key.clear();
+            g.order.clear();
+            g.rate_per_source.clear();
+        }
+    }
+}
+
+impl Default for BlockedBuffer {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Lowercase ASCII, strip a single trailing dot, reject empty / IP literal.
+fn normalize_host(host: &str) -> Option<String> {
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut h = trimmed.to_ascii_lowercase();
+    while h.ends_with('.') {
+        h.pop();
+    }
+    if h.is_empty() {
+        return None;
+    }
+    // Reject IPv4/IPv6 literals — we want hostnames only. IPv6 literals may
+    // arrive bracketed (e.g. "[::1]") so strip brackets before parsing.
+    let parse_target = h
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(&h);
+    if parse_target.parse::<std::net::IpAddr>().is_ok() {
+        return None;
+    }
+    Some(h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buf() -> BlockedBuffer {
+        BlockedBuffer::new(8, Duration::from_secs(60), 100)
+    }
+
+    #[test]
+    fn record_first_observation_returns_recorded() {
+        let b = buf();
+        let out = b.record("sb1", "example.com", 443);
+        assert_eq!(out, RecordOutcome::Recorded);
+        assert_eq!(b.len(), 1);
+        let snap = b.snapshot(10);
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].host, "example.com");
+        assert_eq!(snap[0].port, 443);
+        assert_eq!(snap[0].source_sandbox, "sb1");
+        assert_eq!(snap[0].count, 1);
+    }
+
+    #[test]
+    fn record_duplicate_increments_count_and_dedupes() {
+        let b = buf();
+        assert_eq!(b.record("sb1", "example.com", 443), RecordOutcome::Recorded);
+        assert_eq!(
+            b.record("sb1", "example.com", 443),
+            RecordOutcome::Deduplicated
+        );
+        assert_eq!(
+            b.record("sb1", "example.com", 443),
+            RecordOutcome::Deduplicated
+        );
+        assert_eq!(b.len(), 1);
+        let snap = b.snapshot(10);
+        assert_eq!(snap[0].count, 3);
+        assert!(snap[0].last_seen_unix >= snap[0].first_seen_unix);
+    }
+
+    #[test]
+    fn record_distinct_hosts_creates_distinct_entries() {
+        let b = buf();
+        b.record("sb1", "a.example.com", 443);
+        b.record("sb1", "b.example.com", 443);
+        b.record("sb1", "a.example.com", 80); // distinct port also distinct
+        assert_eq!(b.len(), 3);
+    }
+
+    #[test]
+    fn record_distinct_sandboxes_creates_distinct_entries() {
+        let b = buf();
+        b.record("sb1", "example.com", 443);
+        b.record("sb2", "example.com", 443);
+        assert_eq!(b.len(), 2);
+    }
+
+    #[test]
+    fn rate_limit_drops_high_frequency_writes_from_one_source() {
+        let b = BlockedBuffer::new(1024, Duration::from_secs(60), 5);
+        let now = Instant::now();
+        // 5 distinct hosts succeed; 6th and 7th hit the per-source limit.
+        for i in 0..5 {
+            let host = format!("h{i}.example.com");
+            assert_eq!(
+                b.record_at(now, 1000 + i as u64, "sb1", &host, 443),
+                RecordOutcome::Recorded
+            );
+        }
+        assert_eq!(
+            b.record_at(now, 1100, "sb1", "overflow1.example.com", 443),
+            RecordOutcome::RateLimited
+        );
+        assert_eq!(
+            b.record_at(now, 1101, "sb1", "overflow2.example.com", 443),
+            RecordOutcome::RateLimited
+        );
+        assert_eq!(b.len(), 5);
+    }
+
+    #[test]
+    fn rate_limit_does_not_affect_other_sources() {
+        let b = BlockedBuffer::new(1024, Duration::from_secs(60), 2);
+        let now = Instant::now();
+        b.record_at(now, 1000, "sb1", "a.example.com", 443);
+        b.record_at(now, 1001, "sb1", "b.example.com", 443);
+        assert_eq!(
+            b.record_at(now, 1002, "sb1", "c.example.com", 443),
+            RecordOutcome::RateLimited
+        );
+        // Different source has its own counter.
+        assert_eq!(
+            b.record_at(now, 1003, "sb2", "c.example.com", 443),
+            RecordOutcome::Recorded
+        );
+    }
+
+    #[test]
+    fn rate_limit_window_resets_after_elapsed() {
+        let b = BlockedBuffer::new(1024, Duration::from_secs(60), 1);
+        let t0 = Instant::now();
+        assert_eq!(
+            b.record_at(t0, 1000, "sb1", "a.example.com", 443),
+            RecordOutcome::Recorded
+        );
+        assert_eq!(
+            b.record_at(t0, 1001, "sb1", "b.example.com", 443),
+            RecordOutcome::RateLimited
+        );
+        let t1 = t0 + Duration::from_secs(61);
+        assert_eq!(
+            b.record_at(t1, 1100, "sb1", "c.example.com", 443),
+            RecordOutcome::Recorded
+        );
+    }
+
+    #[test]
+    fn capacity_evicts_oldest_fifo() {
+        let b = BlockedBuffer::new(3, Duration::from_secs(60), 1000);
+        b.record("sb1", "a.example.com", 443);
+        b.record("sb1", "b.example.com", 443);
+        b.record("sb1", "c.example.com", 443);
+        b.record("sb1", "d.example.com", 443); // evicts a
+        assert_eq!(b.len(), 3);
+        let hosts: Vec<String> = b.snapshot(10).into_iter().map(|e| e.host).collect();
+        assert!(hosts.contains(&"d.example.com".into()));
+        assert!(hosts.contains(&"c.example.com".into()));
+        assert!(hosts.contains(&"b.example.com".into()));
+        assert!(!hosts.contains(&"a.example.com".into()));
+    }
+
+    #[test]
+    fn snapshot_returns_in_recency_order() {
+        // Documented contract: newest first (reverse insertion order).
+        let b = buf();
+        b.record("sb1", "a.example.com", 443);
+        b.record("sb1", "b.example.com", 443);
+        b.record("sb1", "c.example.com", 443);
+        let hosts: Vec<String> = b.snapshot(10).into_iter().map(|e| e.host).collect();
+        assert_eq!(
+            hosts,
+            vec![
+                "c.example.com".to_string(),
+                "b.example.com".to_string(),
+                "a.example.com".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn hostname_normalization_lowercases() {
+        let b = buf();
+        b.record("sb1", "EXAMPLE.com", 443);
+        b.record("sb1", "example.COM", 443);
+        assert_eq!(b.len(), 1);
+        assert_eq!(b.snapshot(10)[0].host, "example.com");
+    }
+
+    #[test]
+    fn hostname_normalization_strips_trailing_dot() {
+        let b = buf();
+        b.record("sb1", "example.com.", 443);
+        b.record("sb1", "example.com", 443);
+        assert_eq!(b.len(), 1);
+        assert_eq!(b.snapshot(10)[0].host, "example.com");
+    }
+
+    #[test]
+    fn record_rejects_ip_literal_host() {
+        let b = buf();
+        assert_eq!(b.record("sb1", "1.2.3.4", 443), RecordOutcome::Rejected);
+        assert_eq!(b.record("sb1", "[::1]", 443), RecordOutcome::Rejected);
+        assert_eq!(b.record("sb1", "::1", 443), RecordOutcome::Rejected);
+        assert_eq!(b.len(), 0);
+    }
+
+    #[test]
+    fn record_rejects_empty_host() {
+        let b = buf();
+        assert_eq!(b.record("sb1", "", 443), RecordOutcome::Rejected);
+        assert_eq!(b.record("sb1", "   ", 443), RecordOutcome::Rejected);
+        assert_eq!(b.record("sb1", ".", 443), RecordOutcome::Rejected);
+        assert_eq!(b.len(), 0);
+    }
+
+    #[test]
+    fn empty_source_sandbox_falls_back_to_unknown() {
+        let b = buf();
+        assert_eq!(b.record("", "example.com", 443), RecordOutcome::Recorded);
+        assert_eq!(b.snapshot(10)[0].source_sandbox, "unknown");
+    }
+
+    #[test]
+    fn clear_resets_buffer() {
+        let b = buf();
+        b.record("sb1", "example.com", 443);
+        b.record("sb1", "other.com", 443);
+        assert_eq!(b.len(), 2);
+        b.clear();
+        assert_eq!(b.len(), 0);
+        assert!(b.snapshot(10).is_empty());
+    }
+}

--- a/inference-router/src/forward_proxy.rs
+++ b/inference-router/src/forward_proxy.rs
@@ -16,6 +16,7 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::blocklist::Blocklist;
+use crate::egress_blocked::BlockedBuffer;
 
 /// Maximum concurrent tunnel connections (prevents resource exhaustion).
 const MAX_CONCURRENT_TUNNELS: usize = 256;
@@ -25,19 +26,28 @@ const MAX_TUNNEL_LIFETIME_SECS: u64 = 3600;
 
 /// Start the transparent forward proxy on the given address.
 /// Returns a CancellationToken that triggers graceful shutdown when cancelled.
-pub async fn start(addr: &str, blocklist: Blocklist) -> CancellationToken {
+pub async fn start(
+    addr: &str,
+    blocklist: Blocklist,
+    blocked_egress: Arc<BlockedBuffer>,
+) -> CancellationToken {
     let shutdown = CancellationToken::new();
     let shutdown_clone = shutdown.clone();
 
     let addr = addr.to_string();
     tokio::spawn(async move {
-        run(addr, blocklist, shutdown_clone).await;
+        run(addr, blocklist, blocked_egress, shutdown_clone).await;
     });
 
     shutdown
 }
 
-async fn run(addr: String, blocklist: Blocklist, shutdown: CancellationToken) {
+async fn run(
+    addr: String,
+    blocklist: Blocklist,
+    blocked_egress: Arc<BlockedBuffer>,
+    shutdown: CancellationToken,
+) {
     let listener = match TcpListener::bind(&addr).await {
         Ok(l) => l,
         Err(e) => {
@@ -76,12 +86,13 @@ async fn run(addr: String, blocklist: Blocklist, shutdown: CancellationToken) {
 
                 let bl = blocklist.clone();
                 let sb = sandbox_name.clone();
+                let be = blocked_egress.clone();
                 let count = active_count.clone();
                 let conn_shutdown = shutdown.clone();
                 count.fetch_add(1, Ordering::Relaxed);
                 tokio::spawn(async move {
                     tokio::select! {
-                        result = handle_connection(stream, &bl, &sb) => {
+                        result = handle_connection(stream, &bl, &sb, &be) => {
                             if let Err(e) = result {
                                 tracing::debug!(peer = %peer, error = %e, "Forward proxy connection error");
                             }
@@ -199,6 +210,7 @@ async fn handle_connection(
     mut stream: TcpStream,
     blocklist: &Blocklist,
     sandbox: &str,
+    blocked_egress: &BlockedBuffer,
 ) -> anyhow::Result<()> {
     // Read the initial request. For TLS ClientHello, we may need multiple reads
     // if the handshake is fragmented across TCP segments (rare, but possible).
@@ -245,9 +257,18 @@ async fn handle_connection(
     let target = parts[1];
 
     if method.eq_ignore_ascii_case("CONNECT") {
-        handle_connect(stream, target, request, blocklist, sandbox).await
+        handle_connect(stream, target, request, blocklist, sandbox, blocked_egress).await
     } else {
-        handle_http(stream, target, request, total, blocklist, sandbox).await
+        handle_http(
+            stream,
+            target,
+            request,
+            total,
+            blocklist,
+            sandbox,
+            blocked_egress,
+        )
+        .await
     }
 }
 
@@ -260,6 +281,7 @@ async fn handle_connect(
     _request: &[u8],
     blocklist: &Blocklist,
     sandbox: &str,
+    blocked_egress: &BlockedBuffer,
 ) -> anyhow::Result<()> {
     let (domain, port) = parse_host_port(target, 443);
     let log_dom = safe_domain(&domain);
@@ -268,6 +290,7 @@ async fn handle_connect(
 
     if let Err(reason) = blocklist.check_egress(&domain, sandbox).await {
         tracing::warn!(domain = %log_dom, reason = %reason, "CONNECT blocked");
+        blocked_egress.record(sandbox, &domain, port);
         send_response(&mut stream, 403, "Blocked by AzureClaw egress policy").await?;
         return Ok(());
     }
@@ -277,6 +300,7 @@ async fn handle_connect(
         Ok(addr) => addr,
         Err(e) => {
             tracing::warn!(domain = %log_dom, error = %e, "CONNECT: DNS validation failed");
+            blocked_egress.record(sandbox, &domain, port);
             send_response(&mut stream, 502, "DNS validation failed").await?;
             return Ok(());
         }
@@ -314,11 +338,20 @@ async fn handle_http(
     request_len: usize,
     blocklist: &Blocklist,
     sandbox: &str,
+    blocked_egress: &BlockedBuffer,
 ) -> anyhow::Result<()> {
     // Check if this is a TLS ClientHello (iptables-redirected HTTPS).
     // TLS records start with 0x16 (handshake) 0x03 (TLS version major).
     if request_len > 5 && request[0] == 0x16 && request[1] == 0x03 {
-        return handle_tls_redirect(stream, request, request_len, blocklist, sandbox).await;
+        return handle_tls_redirect(
+            stream,
+            request,
+            request_len,
+            blocklist,
+            sandbox,
+            blocked_egress,
+        )
+        .await;
     }
 
     // Plain HTTP: extract Host header
@@ -338,6 +371,8 @@ async fn handle_http(
 
     if let Err(reason) = blocklist.check_egress(&domain, sandbox).await {
         tracing::warn!(domain = %log_dom, reason = %reason, "HTTP blocked");
+        let (_h, p) = parse_host_port(&domain, 80);
+        blocked_egress.record(sandbox, &domain, p);
         send_response(&mut stream, 403, "Blocked by AzureClaw egress policy").await?;
         return Ok(());
     }
@@ -348,6 +383,7 @@ async fn handle_http(
         Ok(addr) => addr,
         Err(e) => {
             tracing::warn!(domain = %log_dom, error = %e, "HTTP: DNS validation failed");
+            blocked_egress.record(sandbox, &host, port);
             send_response(&mut stream, 502, "DNS validation failed").await?;
             return Ok(());
         }
@@ -380,6 +416,7 @@ async fn handle_tls_redirect(
     data_len: usize,
     blocklist: &Blocklist,
     sandbox: &str,
+    blocked_egress: &BlockedBuffer,
 ) -> anyhow::Result<()> {
     let (sni, has_ech) = extract_sni_ex(initial_data, data_len);
 
@@ -391,6 +428,7 @@ async fn handle_tls_redirect(
         tracing::warn!(outer_sni = %outer_sni,
             "TLS redirect: Encrypted Client Hello (ECH) detected, rejecting — \
             cannot verify destination domain. Outer SNI visible in pending approvals.");
+        blocked_egress.record(sandbox, outer_sni, 443);
         blocklist
             .record_proxy_block(
                 outer_sni,
@@ -427,6 +465,7 @@ async fn handle_tls_redirect(
 
     if let Err(reason) = blocklist.check_egress(&domain, sandbox).await {
         tracing::warn!(domain = %log_dom, reason = %reason, "TLS blocked (SNI)");
+        blocked_egress.record(sandbox, &domain, 443);
         return Ok(());
     }
 
@@ -435,6 +474,7 @@ async fn handle_tls_redirect(
         Ok(addr) => addr,
         Err(e) => {
             tracing::warn!(domain = %log_dom, error = %e, "TLS redirect: DNS validation failed");
+            blocked_egress.record(sandbox, &domain, 443);
             return Ok(());
         }
     };

--- a/inference-router/src/lib.rs
+++ b/inference-router/src/lib.rs
@@ -16,6 +16,7 @@ pub mod behavior_monitor;
 pub mod blocklist;
 pub mod budget;
 pub mod config;
+pub mod egress_blocked;
 pub mod errors;
 pub mod forward_proxy;
 pub mod governance;

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -107,6 +107,7 @@ async fn main() -> Result<()> {
 
     // Clone blocklist for the forward proxy before state is moved into the router.
     let proxy_blocklist = state.blocklist.clone();
+    let proxy_blocked_egress = state.blocked_egress.clone();
 
     // Read admin token for protecting sensitive endpoints.
     // Priority: file mount (AKS Secret) > env var > unset.
@@ -251,7 +252,8 @@ async fn main() -> Result<()> {
         .and_then(|s| s.parse::<u16>().ok())
         .unwrap_or(8444);
     let proxy_addr = format!("127.0.0.1:{proxy_port}");
-    let proxy_shutdown = forward_proxy::start(&proxy_addr, proxy_blocklist).await;
+    let proxy_shutdown =
+        forward_proxy::start(&proxy_addr, proxy_blocklist, proxy_blocked_egress).await;
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     let shutdown_timeout = resolve_shutdown_timeout();

--- a/inference-router/src/routes/egress.rs
+++ b/inference-router/src/routes/egress.rs
@@ -19,12 +19,36 @@ pub fn egress_routes() -> Router<AppState> {
         .route("/egress/learn", post(egress_learn_toggle))
         .route("/egress/learned", get(egress_learned))
         .route("/egress/learned/clear", post(egress_learned_clear))
+        .route("/egress/learned/blocked", get(egress_learned_blocked))
         .route("/egress/fetch", post(egress_fetch))
         .route("/egress/allowlist", get(egress_allowlist))
         .route("/egress/approve", post(egress_approve))
         .route("/egress/deny", post(egress_deny))
         .route("/egress/pending", get(egress_pending))
         .route("/egress/enforce", post(egress_enforce))
+}
+
+/// GET /egress/learned/blocked — list blocked egress attempts captured in
+/// enforce mode. S12.f: sibling of `/egress/learned` (allowed-observation
+/// learn buffer). Hostname + port only — no paths, headers, or payload data.
+/// RBAC: mounted in the `protected` router that already gates `/egress/*`
+/// behind `Authorization: Bearer <admin-token>` — no new auth path.
+async fn egress_learned_blocked(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    let limit = headers
+        .get("x-azureclaw-limit")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(256)
+        .min(4096);
+    let entries = state.blocked_egress.snapshot(limit);
+    Json(serde_json::json!({
+        "total": state.blocked_egress.len(),
+        "count": entries.len(),
+        "entries": entries,
+    }))
 }
 
 /// GET /egress/learned — list all domains observed during learn mode.

--- a/inference-router/src/routes/mod.rs
+++ b/inference-router/src/routes/mod.rs
@@ -14,6 +14,7 @@ use crate::auth::WorkloadIdentityAuth;
 use crate::blocklist::Blocklist;
 use crate::budget::TokenBudgetTracker;
 use crate::config::Config;
+use crate::egress_blocked::BlockedBuffer;
 use crate::governance::Governance;
 use crate::handoff::{DrainState, HandoffSession, HandoffTokenStore, PendingHandoffStore};
 use crate::mesh::{MeshInbox, MeshMetrics};
@@ -78,6 +79,10 @@ pub struct AppState {
     /// keypair owned by `Governance.identity`.
     pub signing_provider: Arc<dyn SigningProvider>,
     pub blocklist: Blocklist,
+    /// S12.f — bounded ring buffer of blocked egress attempts surfaced via
+    /// `GET /egress/learned/blocked`. Hostname-only, deduped, rate-limited
+    /// per source. Populated by the forward proxy's deny branches.
+    pub blocked_egress: Arc<BlockedBuffer>,
     pub sandbox_name: Arc<String>,
     pub inbox: Arc<MeshInbox>,
     pub mesh_metrics: Arc<MeshMetrics>,
@@ -167,6 +172,7 @@ impl AppState {
             signing_provider: Arc::clone(&governance) as Arc<dyn SigningProvider>,
             governance,
             blocklist,
+            blocked_egress: Arc::new(BlockedBuffer::with_defaults()),
             sandbox_name: Arc::new(sandbox_name),
             inbox: Arc::new(MeshInbox::new()),
             mesh_metrics: Arc::new(MeshMetrics::new()),

--- a/inference-router/tests/agt_governance_integration.rs
+++ b/inference-router/tests/agt_governance_integration.rs
@@ -56,6 +56,9 @@ fn test_state(sandbox: &str, admin_token: Option<&str>) -> AppState {
         signing_provider: Arc::clone(&governance) as Arc<dyn SigningProvider>,
         governance,
         blocklist: Blocklist::disabled(),
+        blocked_egress: Arc::new(
+            azureclaw_inference_router::egress_blocked::BlockedBuffer::with_defaults(),
+        ),
         sandbox_name: Arc::new(sandbox.to_string()),
         inbox: Arc::new(MeshInbox::new()),
         mesh_metrics: Arc::new(MeshMetrics::new()),

--- a/inference-router/tests/egress_blocked_endpoint.rs
+++ b/inference-router/tests/egress_blocked_endpoint.rs
@@ -1,0 +1,123 @@
+//! Integration tests for `GET /egress/learned/blocked` (S12.f).
+//!
+//! Mounts the egress sub-router with a real `AppState` and verifies the
+//! blocked-egress ring buffer is surfaced over HTTP.
+
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use azureclaw_inference_router::auth::WorkloadIdentityAuth;
+use azureclaw_inference_router::blocklist::Blocklist;
+use azureclaw_inference_router::budget::TokenBudgetTracker;
+use azureclaw_inference_router::config::{Config, RegistryMode};
+use azureclaw_inference_router::egress_blocked::BlockedBuffer;
+use azureclaw_inference_router::governance::Governance;
+use azureclaw_inference_router::handoff::{
+    DrainState, HandoffSession, HandoffTokenStore, PendingHandoffStore,
+};
+use azureclaw_inference_router::mesh::{MeshInbox, MeshMetrics};
+use azureclaw_inference_router::providers::{AuditSink, PolicyDecisionProvider, SigningProvider};
+use azureclaw_inference_router::routes::{AppState, egress_routes};
+
+fn test_state() -> AppState {
+    let governance = Arc::new(Governance::new("sb-test"));
+    AppState {
+        auth: Arc::new(WorkloadIdentityAuth::new()),
+        client: reqwest::Client::new(),
+        config: Arc::new(Config {
+            port: 0,
+            foundry_endpoint: None,
+            foundry_project_endpoint: None,
+            azure_openai_endpoint: None,
+            default_model: "gpt-4".into(),
+            content_safety_enabled: false,
+            prompt_shields_enabled: false,
+            content_safety_endpoint: None,
+            token_budget_daily: 1_000_000,
+            token_budget_per_request: 100_000,
+            registry_mode: RegistryMode::Local,
+            registry_url: None,
+        }),
+        budget: TokenBudgetTracker::new(1_000_000, 100_000),
+        policy_provider: Arc::clone(&governance) as Arc<dyn PolicyDecisionProvider>,
+        audit_sink: Arc::clone(&governance) as Arc<dyn AuditSink>,
+        signing_provider: Arc::clone(&governance) as Arc<dyn SigningProvider>,
+        governance,
+        blocklist: Blocklist::disabled(),
+        blocked_egress: Arc::new(BlockedBuffer::with_defaults()),
+        sandbox_name: Arc::new("sb-test".to_string()),
+        inbox: Arc::new(MeshInbox::new()),
+        mesh_metrics: Arc::new(MeshMetrics::new()),
+        model_override: Arc::new(std::sync::RwLock::new(None)),
+        admin_token: None,
+        responses_only_models: Arc::new(std::sync::RwLock::new(Default::default())),
+        handoff_tokens: HandoffTokenStore::new(),
+        handoff_session: HandoffSession::new(),
+        drain_state: DrainState::new(),
+        pending_handoff: PendingHandoffStore::new(),
+    }
+}
+
+fn app(state: AppState) -> Router {
+    Router::new().merge(egress_routes()).with_state(state)
+}
+
+async fn get_json(app: &Router, uri: &str) -> (StatusCode, Value) {
+    let req = Request::get(uri).body(Body::empty()).unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 1_048_576)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+#[tokio::test]
+async fn endpoint_returns_empty_when_no_blocks() {
+    let state = test_state();
+    let app = app(state);
+    let (status, body) = get_json(&app, "/egress/learned/blocked").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["count"], 0);
+    assert!(body["entries"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn endpoint_returns_recorded_blocks() {
+    let state = test_state();
+    state
+        .blocked_egress
+        .record("sb-test", "evil.example.com", 443);
+    state
+        .blocked_egress
+        .record("sb-test", "evil.example.com", 443); // dedup
+    state
+        .blocked_egress
+        .record("sb-test", "other.example.com", 80);
+
+    let app = app(state);
+    let (status, body) = get_json(&app, "/egress/learned/blocked").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 2);
+    assert_eq!(body["count"], 2);
+    let entries = body["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 2);
+
+    // Newest first: "other.example.com" was inserted last.
+    assert_eq!(entries[0]["host"], "other.example.com");
+    assert_eq!(entries[0]["port"], 80);
+    assert_eq!(entries[0]["count"], 1);
+    assert_eq!(entries[1]["host"], "evil.example.com");
+    assert_eq!(entries[1]["port"], 443);
+    assert_eq!(entries[1]["count"], 2);
+    assert_eq!(entries[1]["source_sandbox"], "sb-test");
+}


### PR DESCRIPTION
## Slice S12.f — router blocked-attempt visibility (independent)

> In enforce mode, capture blocked domain attempts to `/egress/learned/blocked` (separate ring buffer from learned-while-allowed). Bounded, deduped, rate-limited per source, hostname-only.

### What

Adds a sibling buffer + endpoint to the existing `/egress/learned` learn-mode allowed-observations buffer. Blocked attempts in the forward proxy's deny branches now flow into a bounded, deduped, rate-limited `BlockedBuffer` and are surfaced over HTTP for operators.

### How

- **`inference-router/src/egress_blocked.rs`** — new module. `BlockedBuffer` keyed by `(source_sandbox, host, port)`. FIFO eviction at capacity (default 1024). Per-source sliding-window rate limit (default 100 / 60 s). Hostname normalization (lowercase + strip trailing dots). Rejects IP literals and empty hosts at `record()` time. Aggregate `count` is preserved across rate-limited observations — only ring-buffer churn is suppressed.
- **`forward_proxy.rs`** — every domain-bearing deny branch now calls `blocked_egress.record(sandbox, host, port)`: CONNECT block, HTTP block, TLS-SNI block, ECH rejection, DNS-rebind block on all three paths. The no-SNI branch is intentionally not recorded (no host string).
- **`routes/egress.rs`** — `GET /egress/learned/blocked` mounted inside the existing admin-token-protected `egress_routes()` group. **No new auth path.**
- **`AppState`** — adds `blocked_egress: Arc<BlockedBuffer>`; cloned into `forward_proxy::start` from `main.rs`.

### Tests

- **15 unit** in `egress_blocked.rs` covering: first/dedup observations, distinct keys (host/port/sandbox), rate limit drop + per-source isolation + window reset (via injected `Instant` — no `tokio::time::pause`), FIFO eviction, recency ordering, hostname normalization (lowercase + trailing dot), IP literal rejection (v4, v6, bracketed-v6), empty host rejection, `source_sandbox` fallback to `unknown`, `clear()`.
- **2 integration** in `tests/egress_blocked_endpoint.rs` exercising `GET /egress/learned/blocked` via `tower::ServiceExt::oneshot` — empty case + populated case (asserts dedup count, recency order, JSON wire shape).
- Lib tests: 608 → 623 (+15). New endpoint binary: +2. **+17 total.**
- `cargo fmt --all` + `cargo clippy --all-targets -- -D warnings` + `cargo test --all` all green.

### Security audit

`docs/security-audits/2026-04-30-phase2-s12-f-blocked-visibility.md` — surveys existing implementation, documents why blocked needs its own buffer, lists threat surfaces introduced (one HTTP endpoint, gated by existing RBAC) and NOT introduced (hostname-only, rate-limited, IP-literal rejection, no payload disclosure).

### Independence

Independent of S12.b/c/d/e — pure router work with no CRD or controller changes.