### PR TITLE
phase2(s12.d): SignerPolicy ConfigMap (Fulcio issuer + SAN allowlist)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S12.d — SignerPolicy ConfigMap (Fulcio issuer + SAN allowlist)
+
+- New `controller/src/signer_policy.rs` — cluster-scoped
+  `azureclaw-signer-policy` ConfigMap watcher (filtered by name +
+  controller-namespace). Parses `data.fulcioIssuers` /
+  `data.sanPatterns` (newline-separated, `#` comments stripped) into a
+  `SharedSignerPolicy` handle that the policy fetcher consults on every
+  reconcile. Atomic rebuild on watch-restart; absent → env-fallback,
+  malformed → fail-closed surface.
+- New `FetchError::SignerPolicyMalformed(String)` variant in
+  `controller/src/policy_fetcher.rs`; `reason_for_error` maps to
+  `"SignerPolicyMalformed"`. Reconciler now emits
+  `AllowlistVerified=False/SignerPolicyMalformed` on affected
+  `ClawSandbox` resources when the cluster ConfigMap fails to parse —
+  distinct from `SignerPolicyMissing` so operators can disambiguate
+  "I never installed one" from "the one I installed is broken".
+- `policy_fetcher::maybe_verify_allowlist` rewired to consult a
+  process-global `SharedSignerPolicy` handle; a new
+  `maybe_verify_allowlist_with_handle` variant takes an injected
+  handle for unit-test cleanliness. Resolution order:
+  ConfigMap-configured → use it; ConfigMap-malformed →
+  `SignerPolicyMalformed` (no env fallback); ConfigMap-absent →
+  fall back to env (`AZURECLAW_SIGNER_FULCIO_ISSUERS` /
+  `AZURECLAW_SIGNER_SAN_PATTERNS` — emergency-override path).
+- New Helm template `deploy/helm/azureclaw/templates/signer-policy-configmap.yaml`
+  with `signerPolicy.enabled` (default `true`), `signerPolicy.fulcioIssuers`
+  (defaults: GitHub Actions OIDC + Entra workload-identity placeholder),
+  `signerPolicy.sanPatterns` (default: repo-scoped CI workflow SAN).
+  Set `enabled: false` to opt into the env-var emergency-override path.
+- Controller Deployment now wires `POD_NAMESPACE` + `POD_NAME` via the
+  downward API (previously only relied on by leader-election with a
+  hard-coded fallback; now the authoritative source for both
+  consumers).
+- RBAC unchanged: the controller `ClusterRole` already grants
+  `get/list/watch` on `configmaps`. The new watcher fits within the
+  existing rule; no broadening introduced. (A future least-privilege
+  pass could narrow this to a namespace-scoped Role on
+  `azureclaw-system`.)
+- 18 new unit tests; controller test count 383 → 401. Workspace green;
+  clippy clean; `cargo fmt` clean; `helm lint` clean.
+
 ### S12.f — router blocked-attempt visibility
 
 - New `inference-router/src/egress_blocked.rs` — bounded, rate-limited,

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -43,6 +43,7 @@ mod pairing_reconciler;
 mod policy_fetcher;
 mod providers;
 mod reconciler;
+mod signer_policy;
 mod status;
 #[allow(dead_code)] // helpers consumed by tool_policy_reconciler + future slices.
 mod tool_policy;
@@ -169,6 +170,29 @@ async fn main() -> Result<()> {
         let client = client.clone();
         tokio::spawn(async move { claw_eval_reconciler::run(client).await })
     };
+
+    // S12.d: SignerPolicy ConfigMap watcher. Installs a process-global
+    // handle so `policy_fetcher::maybe_verify_allowlist` resolves
+    // identity-pinning policy from the live cluster ConfigMap. Falls
+    // back to env vars (`AZURECLAW_SIGNER_*`) when the ConfigMap is
+    // absent — that's the emergency-override path. Malformed
+    // ConfigMaps surface as `SignerPolicyMalformed` and **do not**
+    // silently fall back to env (operator must fix the cluster
+    // config). Watcher is namespace-scoped to the controller's own
+    // namespace + filtered to the singleton object name, so RBAC stays
+    // narrow.
+    let signer_policy_handle = signer_policy::SharedSignerPolicy::new();
+    signer_policy::install_global(signer_policy_handle.clone());
+    let signer_policy_watcher_handle = {
+        let client = client.clone();
+        let shared = signer_policy_handle.clone();
+        let ns = std::env::var("POD_NAMESPACE")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "azureclaw-system".to_string());
+        tokio::spawn(async move { signer_policy::run(client, ns, shared).await })
+    };
+
     let mesh_peer_handle = {
         let client = client.clone();
         tokio::spawn(async move {
@@ -287,6 +311,13 @@ async fn main() -> Result<()> {
             res??;
         }
         res = fedcred_reaper_handle => {
+            res??;
+        }
+        res = signer_policy_watcher_handle => {
+            // SignerPolicy watcher exiting is non-fatal but we
+            // propagate so the controller restarts and re-establishes
+            // the watch — avoids serving stale policy state forever
+            // after a transient kube-apiserver blip.
             res??;
         }
     }

--- a/controller/src/policy_fetcher.rs
+++ b/controller/src/policy_fetcher.rs
@@ -23,14 +23,17 @@
 //! `AllowlistVerified` Condition is emitted and existing deployments
 //! observe **no** behavior change.
 //!
-//! ## SignerPolicy is S12.d
+//! ## SignerPolicy — S12.d (landed)
 //!
-//! S12.b ships without a `SignerPolicy` ConfigMap watcher; the policy is
-//! provisionally read from the env vars
-//! `AZURECLAW_SIGNER_FULCIO_ISSUERS` and `AZURECLAW_SIGNER_SAN_PATTERNS`
-//! (both comma-separated). When unset the verifier returns
-//! [`FetchError::SignerPolicyMissing`] — that is the intended fail-closed
-//! behavior until the cluster operator provisions a SignerPolicy.
+//! The cluster `SignerPolicy` is now sourced from the watched
+//! `azureclaw-signer-policy` ConfigMap in the controller namespace
+//! (see [`crate::signer_policy`]). The env vars
+//! `AZURECLAW_SIGNER_FULCIO_ISSUERS` / `AZURECLAW_SIGNER_SAN_PATTERNS`
+//! remain as an emergency-override fallback that activates only when
+//! the ConfigMap is absent. A *malformed* ConfigMap surfaces as
+//! [`FetchError::SignerPolicyMalformed`] and does **not** silently
+//! fall back — operators get a hard signal on every affected
+//! `ClawSandbox`.
 //!
 //! ## ACR auth via Workload Identity
 //!
@@ -87,6 +90,12 @@ pub enum FetchError {
     FeatureDisabled,
     #[error("SignerPolicy is not configured for this cluster")]
     SignerPolicyMissing,
+    /// S12.d — `SignerPolicy` ConfigMap was present but failed to
+    /// parse. Distinct from [`Self::SignerPolicyMissing`] so operators
+    /// can disambiguate "I never installed one" from "the one I
+    /// installed is broken — fix it before trusting any allowlist".
+    #[error("SignerPolicy ConfigMap is malformed: {0}")]
+    SignerPolicyMalformed(String),
     #[error("invalid artifact reference: {0}")]
     InvalidRef(String),
     #[error("OCI registry auth failed: {0}")]
@@ -112,6 +121,7 @@ pub fn reason_for_error(err: &FetchError) -> Option<&'static str> {
     match err {
         FetchError::FeatureDisabled => None,
         FetchError::SignerPolicyMissing => Some("SignerPolicyMissing"),
+        FetchError::SignerPolicyMalformed(_) => Some("SignerPolicyMalformed"),
         FetchError::InvalidRef(_) => Some("InvalidRef"),
         FetchError::Unauthorized(_) => Some("Unauthorized"),
         FetchError::NotFound(_) => Some("NotFound"),
@@ -180,6 +190,15 @@ impl SignerPolicyConfig {
     /// that issuer), so we require both.
     pub fn is_configured(&self) -> bool {
         !self.fulcio_issuers.is_empty() && !self.san_patterns.is_empty()
+    }
+}
+
+impl From<crate::signer_policy::SignerPolicy> for SignerPolicyConfig {
+    fn from(s: crate::signer_policy::SignerPolicy) -> Self {
+        Self {
+            fulcio_issuers: s.fulcio_issuers,
+            san_patterns: s.san_patterns,
+        }
     }
 }
 
@@ -917,6 +936,28 @@ pub mod canonical {
 pub async fn maybe_verify_allowlist(
     sandbox: &crate::crd::ClawSandbox,
 ) -> Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition> {
+    maybe_verify_allowlist_with_handle(sandbox, &crate::signer_policy::global()).await
+}
+
+/// Test-friendly variant: callers can inject a
+/// [`crate::signer_policy::SharedSignerPolicy`] in any state without
+/// spinning up the watcher. Production code uses
+/// [`maybe_verify_allowlist`], which reads the process-global handle.
+///
+/// Resolution order:
+/// 1. `FromConfigMap(p)` → use `p`. If both lists empty (defensive —
+///    parser already rejects this), surface `SignerPolicyMissing`.
+/// 2. `Malformed(msg)` → surface `SignerPolicyMalformed(msg)`. **No**
+///    env-var fallback — a broken cluster config is an operator
+///    signal, not a reason to silently trust the (possibly stale) env.
+/// 3. `Absent` → fall back to env vars
+///    (`AZURECLAW_SIGNER_FULCIO_ISSUERS` / `AZURECLAW_SIGNER_SAN_PATTERNS`).
+///    Empty env → `SignerPolicyMissing` (existing S12.b semantics).
+pub async fn maybe_verify_allowlist_with_handle(
+    sandbox: &crate::crd::ClawSandbox,
+    signer_policy_handle: &crate::signer_policy::SharedSignerPolicy,
+) -> Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition> {
+    use crate::signer_policy::SignerPolicyState;
     use crate::status::conditions::{
         TYPE_ALLOWLIST_VERIFIED, preserve_transition_time, reason as cond_reason,
         status as cond_status,
@@ -930,7 +971,6 @@ pub async fn maybe_verify_allowlist(
         .as_ref()
         .and_then(|np| np.allowlist_ref.as_ref())?;
 
-    let policy = SignerPolicyConfig::from_env();
     let prior = sandbox.status.as_ref().and_then(|s| {
         s.conditions
             .iter()
@@ -938,7 +978,21 @@ pub async fn maybe_verify_allowlist(
     });
     let generation = sandbox.metadata.generation;
 
-    match fetch_and_verify(artifact_ref, &policy).await {
+    // Resolve the live SignerPolicy. ConfigMap wins; malformed is a
+    // hard error path; absent → env fallback.
+    let result: Result<VerifiedAllowlist, FetchError> = match signer_policy_handle.snapshot() {
+        SignerPolicyState::FromConfigMap(p) => {
+            let cfg: SignerPolicyConfig = p.into();
+            fetch_and_verify(artifact_ref, &cfg).await
+        }
+        SignerPolicyState::Malformed(msg) => Err(FetchError::SignerPolicyMalformed(msg)),
+        SignerPolicyState::Absent => {
+            let cfg = SignerPolicyConfig::from_env();
+            fetch_and_verify(artifact_ref, &cfg).await
+        }
+    };
+
+    match result {
         Ok(verified) => {
             tracing::info!(
                 digest = %verified.digest,
@@ -1291,6 +1345,10 @@ mod tests {
             Some("SignerPolicyMissing")
         );
         assert_eq!(
+            reason_for_error(&FetchError::SignerPolicyMalformed("x".into())),
+            Some("SignerPolicyMalformed")
+        );
+        assert_eq!(
             reason_for_error(&FetchError::Unauthorized("x".into())),
             Some("Unauthorized")
         );
@@ -1402,5 +1460,140 @@ mod tests {
         assert!(
             matches!(err, FetchError::Unauthorized(ref m) if m.contains("AZURE_FEDERATED_TOKEN_FILE"))
         );
+    }
+
+    // ─────── S12.d: SharedSignerPolicy resolution in maybe_verify_allowlist ───────
+    //
+    // These tests exercise the new `_with_handle` variant directly so
+    // they don't touch the OnceLock global (parallel-test safe). Each
+    // case constructs a `ClawSandbox` carrying an `allowlistRef` + an
+    // injected handle in a specific [`SignerPolicyState`], asserts on
+    // the resulting `Condition.reason`. Network IO never executes
+    // because we either short-circuit on policy state (Malformed) or
+    // we use an obviously-fake registry that the cosign client will
+    // refuse before any DNS lookup; the assertion only inspects the
+    // mapped reason.
+
+    use crate::crd::{ClawSandbox, ClawSandboxSpec, NetworkPolicyConfig};
+    use crate::signer_policy::{
+        SharedSignerPolicy, SignerPolicy as ParsedSignerPolicy, SignerPolicyState,
+    };
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    fn sandbox_with_allowlist_ref() -> ClawSandbox {
+        ClawSandbox {
+            metadata: ObjectMeta {
+                name: Some("demo".into()),
+                namespace: Some("azureclaw-demo".into()),
+                generation: Some(1),
+                ..Default::default()
+            },
+            spec: ClawSandboxSpec {
+                network_policy: Some(NetworkPolicyConfig {
+                    allowlist_ref: Some(good_ref()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            status: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn with_handle_returns_none_when_feature_gate_off() {
+        let _g = env_lock().lock().unwrap();
+        let _e = EnvGuard::unset(FEATURE_ENV);
+        let sb = sandbox_with_allowlist_ref();
+        let h = SharedSignerPolicy::from_state(SignerPolicyState::Absent);
+        assert!(
+            maybe_verify_allowlist_with_handle(&sb, &h).await.is_none(),
+            "feature off → no condition emitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_handle_malformed_emits_signer_policy_malformed_condition() {
+        let _g = env_lock().lock().unwrap();
+        let _e = EnvGuard::set(FEATURE_ENV, "1");
+        let sb = sandbox_with_allowlist_ref();
+        let h = SharedSignerPolicy::from_state(SignerPolicyState::Malformed(
+            "missing required key `fulcioIssuers`".into(),
+        ));
+        let cond = maybe_verify_allowlist_with_handle(&sb, &h)
+            .await
+            .expect("condition emitted");
+        assert_eq!(cond.type_, "AllowlistVerified");
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "SignerPolicyMalformed");
+        assert!(
+            cond.message.contains("missing required key"),
+            "message preserves parse-error detail: {cond:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_handle_malformed_does_not_fall_back_to_env() {
+        // Critical safety property: even with a fully-configured env
+        // emergency-override, a malformed ConfigMap MUST surface as
+        // SignerPolicyMalformed — operators need the signal that
+        // their cluster config is broken.
+        let _g = env_lock().lock().unwrap();
+        let _e1 = EnvGuard::set(FEATURE_ENV, "1");
+        let _e2 = EnvGuard::set(SIGNER_FULCIO_ISSUERS_ENV, "https://issuer.example");
+        let _e3 = EnvGuard::set(SIGNER_SAN_PATTERNS_ENV, "signer@example.com");
+        let sb = sandbox_with_allowlist_ref();
+        let h = SharedSignerPolicy::from_state(SignerPolicyState::Malformed("broken yaml".into()));
+        let cond = maybe_verify_allowlist_with_handle(&sb, &h)
+            .await
+            .expect("condition emitted");
+        assert_eq!(cond.reason, "SignerPolicyMalformed");
+    }
+
+    #[tokio::test]
+    async fn with_handle_absent_falls_back_to_env_missing() {
+        let _g = env_lock().lock().unwrap();
+        let _e1 = EnvGuard::set(FEATURE_ENV, "1");
+        let _e2 = EnvGuard::unset(SIGNER_FULCIO_ISSUERS_ENV);
+        let _e3 = EnvGuard::unset(SIGNER_SAN_PATTERNS_ENV);
+        let sb = sandbox_with_allowlist_ref();
+        let h = SharedSignerPolicy::from_state(SignerPolicyState::Absent);
+        let cond = maybe_verify_allowlist_with_handle(&sb, &h)
+            .await
+            .expect("condition emitted");
+        assert_eq!(cond.reason, "SignerPolicyMissing");
+    }
+
+    #[tokio::test]
+    async fn with_handle_configmap_takes_precedence_over_env() {
+        // ConfigMap configured → env vars MUST be ignored. (Otherwise
+        // operators couldn't roll out a stricter policy without
+        // simultaneously unsetting potentially-stale env vars on
+        // every replica.)
+        let _g = env_lock().lock().unwrap();
+        let _e1 = EnvGuard::set(FEATURE_ENV, "1");
+        let _e2 = EnvGuard::unset(SIGNER_FULCIO_ISSUERS_ENV);
+        let _e3 = EnvGuard::unset(SIGNER_SAN_PATTERNS_ENV);
+        let sb = sandbox_with_allowlist_ref();
+        let h =
+            SharedSignerPolicy::from_state(SignerPolicyState::FromConfigMap(ParsedSignerPolicy {
+                fulcio_issuers: vec!["https://token.actions.githubusercontent.com".into()],
+                san_patterns: vec!["signer@example.com".into()],
+            }));
+        // ConfigMap is configured so we proceed past the policy gate;
+        // the next failure mode is whatever sigstore does with our
+        // fake registry — which is `SignatureVerifyFailed` /
+        // `Unauthorized` / `NotFound` / `Transient`. The key
+        // assertion is that we did NOT exit at SignerPolicyMissing.
+        let cond_opt = maybe_verify_allowlist_with_handle(&sb, &h).await;
+        if let Some(cond) = cond_opt {
+            assert_ne!(
+                cond.reason, "SignerPolicyMissing",
+                "ConfigMap was configured; must not fall back to env-missing path"
+            );
+            assert_ne!(cond.reason, "SignerPolicyMalformed");
+        }
+        // None is also acceptable (Transient → preserve prior, no
+        // prior → None). The forbidden outcome is a missing/malformed
+        // reason, which we asserted above.
     }
 }

--- a/controller/src/signer_policy.rs
+++ b/controller/src/signer_policy.rs
@@ -1,0 +1,491 @@
+//! S12.d — `SignerPolicy` ConfigMap watcher.
+//!
+//! Replaces the env-var path that S12.b used (`AZURECLAW_SIGNER_FULCIO_ISSUERS`,
+//! `AZURECLAW_SIGNER_SAN_PATTERNS`) with a cluster-scoped, watched
+//! `ConfigMap` named [`SIGNER_POLICY_CM_NAME`] in the controller
+//! namespace. The env-var path is preserved as an emergency-override
+//! fallback when the ConfigMap is **absent**; a *malformed* ConfigMap
+//! does **not** silently fall back — it surfaces as
+//! [`crate::policy_fetcher::FetchError::SignerPolicyMalformed`] on the
+//! affected `ClawSandbox` resources.
+//!
+//! ## Wire shape
+//!
+//! ```yaml
+//! apiVersion: v1
+//! kind: ConfigMap
+//! metadata:
+//!   name: azureclaw-signer-policy
+//!   namespace: azureclaw-system
+//! data:
+//!   fulcioIssuers: |
+//!     https://token.actions.githubusercontent.com
+//!     https://login.microsoftonline.com/<tenant>/v2.0
+//!   sanPatterns: |
+//!     https://github.com/Azure/azureclaw/.github/workflows/*.yml@*
+//!     signer@example.com
+//! ```
+//!
+//! Both keys are **required**; both lists must be non-empty after
+//! trimming and `#` comment stripping. Either being empty is a parse
+//! error (`SignerPolicyError::EmptyKey`) — empty issuers + empty SANs
+//! together is *not* an implicit accept-all (per S12.d trust model).
+//!
+//! ## Trust model
+//!
+//! - Cluster-scoped object → only cluster-admins can mutate.
+//! - Watched only in the controller namespace → blast radius is the
+//!   controller pod itself.
+//! - RBAC: namespace-scoped `get/list/watch` on `configmaps` (the
+//!   existing controller `ClusterRole` already grants this; no
+//!   broadening needed).
+//! - Fail-closed: malformed → `SignerPolicyMalformed`. Absent +
+//!   no-env → `SignerPolicyMissing`.
+
+use std::sync::{Arc, RwLock};
+
+use k8s_openapi::api::core::v1::ConfigMap;
+
+/// Singleton ConfigMap name. Cluster-scoped because there is one
+/// authoritative SignerPolicy per cluster — multi-tenant slicing of
+/// trust roots is out of scope until a future slice introduces tenant
+/// CRDs.
+pub const SIGNER_POLICY_CM_NAME: &str = "azureclaw-signer-policy";
+
+/// `data.fulcioIssuers` key — newline-separated list of Fulcio issuer
+/// URLs (`https://...`). Comment lines starting with `#` are stripped.
+pub const KEY_FULCIO_ISSUERS: &str = "fulcioIssuers";
+
+/// `data.sanPatterns` key — newline-separated list of SAN patterns.
+/// Each pattern is matched against the signer cert's `Subject.email` or
+/// `Subject.uri` per `policy_fetcher::verify_via_sigstore`. Glob syntax
+/// (`*`, `?`) is the same as the env-var path.
+pub const KEY_SAN_PATTERNS: &str = "sanPatterns";
+
+/// Parsed signer policy. The wire shape mirrors
+/// [`crate::policy_fetcher::SignerPolicyConfig`] for a zero-cost
+/// conversion.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SignerPolicy {
+    /// Allowed Fulcio issuer URLs. Empty → reject all.
+    pub fulcio_issuers: Vec<String>,
+    /// Allowed SAN glob patterns. Empty → reject all.
+    pub san_patterns: Vec<String>,
+}
+
+impl SignerPolicy {
+    /// Both lists must be non-empty for a configured policy.
+    #[allow(dead_code)] // Test-only assertion helper; mirrors `SignerPolicyConfig::is_configured`.
+    pub fn is_configured(&self) -> bool {
+        !self.fulcio_issuers.is_empty() && !self.san_patterns.is_empty()
+    }
+}
+
+/// Errors surfaced by [`parse_configmap`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SignerPolicyError {
+    #[error("ConfigMap has no `data` block")]
+    NoData,
+    #[error("ConfigMap missing required key `{0}`")]
+    MissingKey(&'static str),
+    #[error("ConfigMap key `{key}` is empty after trimming")]
+    EmptyKey { key: &'static str },
+    #[error("ConfigMap key `{key}` contains invalid entry `{entry}`: {reason}")]
+    InvalidEntry {
+        key: &'static str,
+        entry: String,
+        reason: &'static str,
+    },
+}
+
+/// Parse a `ConfigMap` into a [`SignerPolicy`]. Strict — see module docs
+/// for the wire shape; both keys MUST be present and non-empty.
+pub fn parse_configmap(cm: &ConfigMap) -> Result<SignerPolicy, SignerPolicyError> {
+    let data = cm.data.as_ref().ok_or(SignerPolicyError::NoData)?;
+    let issuers_raw = data
+        .get(KEY_FULCIO_ISSUERS)
+        .ok_or(SignerPolicyError::MissingKey(KEY_FULCIO_ISSUERS))?;
+    let sans_raw = data
+        .get(KEY_SAN_PATTERNS)
+        .ok_or(SignerPolicyError::MissingKey(KEY_SAN_PATTERNS))?;
+
+    let fulcio_issuers = parse_list(issuers_raw, KEY_FULCIO_ISSUERS, validate_issuer)?;
+    if fulcio_issuers.is_empty() {
+        return Err(SignerPolicyError::EmptyKey {
+            key: KEY_FULCIO_ISSUERS,
+        });
+    }
+    let san_patterns = parse_list(sans_raw, KEY_SAN_PATTERNS, validate_san)?;
+    if san_patterns.is_empty() {
+        return Err(SignerPolicyError::EmptyKey {
+            key: KEY_SAN_PATTERNS,
+        });
+    }
+
+    Ok(SignerPolicy {
+        fulcio_issuers,
+        san_patterns,
+    })
+}
+
+fn parse_list(
+    raw: &str,
+    key: &'static str,
+    validate: fn(&str) -> Result<(), &'static str>,
+) -> Result<Vec<String>, SignerPolicyError> {
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        validate(trimmed).map_err(|reason| SignerPolicyError::InvalidEntry {
+            key,
+            entry: trimmed.to_string(),
+            reason,
+        })?;
+        out.push(trimmed.to_string());
+    }
+    Ok(out)
+}
+
+fn validate_issuer(s: &str) -> Result<(), &'static str> {
+    if !(s.starts_with("https://") || s.starts_with("http://")) {
+        return Err("issuer must be an http(s) URL");
+    }
+    if s.contains(char::is_whitespace) {
+        return Err("issuer must not contain whitespace");
+    }
+    Ok(())
+}
+
+fn validate_san(s: &str) -> Result<(), &'static str> {
+    // Accept either an http(s) URL (CertSubjectUrlVerifier) or a
+    // generic email-like / glob string (CertSubjectEmailVerifier). The
+    // only hard rule is "no embedded whitespace" — matches the
+    // env-var-path's CSV split semantics.
+    if s.contains(char::is_whitespace) {
+        return Err("SAN must not contain whitespace");
+    }
+    Ok(())
+}
+
+/// Current state of the signer-policy holder.
+#[derive(Debug, Clone, Default)]
+pub enum SignerPolicyState {
+    /// ConfigMap parsed cleanly; this policy is authoritative.
+    FromConfigMap(SignerPolicy),
+    /// ConfigMap present but invalid. We do **not** fall back silently
+    /// — the message is surfaced as `SignerPolicyMalformed`.
+    Malformed(String),
+    /// No ConfigMap observed (cleanly absent). Fall back to env vars.
+    #[default]
+    Absent,
+}
+
+/// Process-shared signer-policy holder. Cheap to clone (refcount
+/// bump). Reads take a brief read-lock; writes only happen on watcher
+/// events.
+#[derive(Debug, Clone, Default)]
+pub struct SharedSignerPolicy {
+    inner: Arc<RwLock<SignerPolicyState>>,
+}
+
+impl SharedSignerPolicy {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Test-only constructor. Production code starts at
+    /// [`SignerPolicyState::Absent`] and gets driven by the watcher.
+    #[cfg(test)]
+    pub fn from_state(state: SignerPolicyState) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(state)),
+        }
+    }
+
+    /// Apply a freshly-observed `ConfigMap`. Sets state to
+    /// [`SignerPolicyState::FromConfigMap`] on parse-success or
+    /// [`SignerPolicyState::Malformed`] on parse-error.
+    pub fn apply_configmap(&self, cm: &ConfigMap) {
+        let next = match parse_configmap(cm) {
+            Ok(p) => SignerPolicyState::FromConfigMap(p),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "SignerPolicy ConfigMap is malformed; surfacing SignerPolicyMalformed (no env fallback)",
+                );
+                SignerPolicyState::Malformed(e.to_string())
+            }
+        };
+        if let Ok(mut w) = self.inner.write() {
+            *w = next;
+        }
+    }
+
+    /// Reset to [`SignerPolicyState::Absent`]. Used on watcher delete
+    /// events and when the initial-list completes without observing
+    /// the singleton.
+    pub fn clear(&self) {
+        if let Ok(mut w) = self.inner.write() {
+            *w = SignerPolicyState::Absent;
+        }
+    }
+
+    /// Snapshot the current state. Cheap; safe to call on every
+    /// reconcile.
+    pub fn snapshot(&self) -> SignerPolicyState {
+        self.inner
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or(SignerPolicyState::Absent)
+    }
+}
+
+// ─────────────────────────── process-global handle ───────────────────────────
+
+use std::sync::OnceLock;
+
+static GLOBAL: OnceLock<SharedSignerPolicy> = OnceLock::new();
+
+/// Install the process-global handle. Idempotent — only the first
+/// install wins; subsequent calls are no-ops (kept loose for tests).
+pub fn install_global(handle: SharedSignerPolicy) {
+    let _ = GLOBAL.set(handle);
+}
+
+/// Read the process-global handle. Returns a freshly-default Absent
+/// handle if `install_global` was never called (defensive — keeps
+/// `policy_fetcher::maybe_verify_allowlist` callable from unit tests
+/// that don't spin up the watcher).
+pub fn global() -> SharedSignerPolicy {
+    GLOBAL.get().cloned().unwrap_or_default()
+}
+
+// ─────────────────────────── watcher ───────────────────────────
+
+/// Watcher loop. Runs until the cluster connection drops. Filters by
+/// `metadata.name == SIGNER_POLICY_CM_NAME` so we don't pull every
+/// ConfigMap in the controller namespace. Updates [`SharedSignerPolicy`]
+/// on each apply / delete; on watch-restart (`Init` → `InitDone`) the
+/// state is rebuilt atomically (cleared if no matching object is
+/// observed).
+pub async fn run(
+    client: kube::Client,
+    namespace: String,
+    shared: SharedSignerPolicy,
+) -> anyhow::Result<()> {
+    use futures::TryStreamExt;
+    use kube::Api;
+    use kube::runtime::watcher::{self, Config, Event};
+
+    let api: Api<ConfigMap> = Api::namespaced(client, &namespace);
+    let cfg = Config::default().fields(&format!("metadata.name={SIGNER_POLICY_CM_NAME}"));
+
+    tracing::info!(
+        namespace = %namespace,
+        name = %SIGNER_POLICY_CM_NAME,
+        "SignerPolicy watcher: starting",
+    );
+
+    let mut stream = std::pin::pin!(watcher::watcher(api, cfg));
+
+    // During an initial-list pass we buffer "did we see the singleton?"
+    // and only commit at InitDone — that way a controller restart
+    // observing an empty cluster atomically transitions to Absent
+    // without a brief Malformed-from-stale-state flap.
+    let mut init_saw_object = false;
+    let mut in_init = false;
+
+    while let Some(ev) = stream.try_next().await? {
+        match ev {
+            Event::Init => {
+                in_init = true;
+                init_saw_object = false;
+            }
+            Event::InitApply(cm) => {
+                init_saw_object = true;
+                shared.apply_configmap(&cm);
+            }
+            Event::InitDone => {
+                if in_init && !init_saw_object {
+                    shared.clear();
+                }
+                in_init = false;
+            }
+            Event::Apply(cm) => {
+                shared.apply_configmap(&cm);
+            }
+            Event::Delete(_) => {
+                tracing::info!(
+                    namespace = %namespace,
+                    name = %SIGNER_POLICY_CM_NAME,
+                    "SignerPolicy ConfigMap deleted; falling back to env-var emergency override",
+                );
+                shared.clear();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::ConfigMap;
+    use kube::api::ObjectMeta;
+    use std::collections::BTreeMap;
+
+    fn cm_with(data: Option<BTreeMap<String, String>>) -> ConfigMap {
+        ConfigMap {
+            metadata: ObjectMeta {
+                name: Some(SIGNER_POLICY_CM_NAME.into()),
+                namespace: Some("azureclaw-system".into()),
+                ..Default::default()
+            },
+            data,
+            ..Default::default()
+        }
+    }
+
+    fn good_data() -> BTreeMap<String, String> {
+        let mut d = BTreeMap::new();
+        d.insert(
+            KEY_FULCIO_ISSUERS.into(),
+            "https://token.actions.githubusercontent.com\n\
+             https://login.microsoftonline.com/abc/v2.0\n"
+                .into(),
+        );
+        d.insert(
+            KEY_SAN_PATTERNS.into(),
+            "https://github.com/Azure/azureclaw/.github/workflows/*.yml@*\n\
+             signer@example.com\n"
+                .into(),
+        );
+        d
+    }
+
+    #[test]
+    fn parse_valid_configmap() {
+        let p = parse_configmap(&cm_with(Some(good_data()))).expect("parses");
+        assert_eq!(p.fulcio_issuers.len(), 2);
+        assert_eq!(p.san_patterns.len(), 2);
+        assert!(p.is_configured());
+    }
+
+    #[test]
+    fn parse_strips_comments_and_blank_lines() {
+        let mut d = BTreeMap::new();
+        d.insert(
+            KEY_FULCIO_ISSUERS.into(),
+            "# comment line\n\nhttps://issuer.example\n   \n".into(),
+        );
+        d.insert(KEY_SAN_PATTERNS.into(), "signer@example.com\n".into());
+        let p = parse_configmap(&cm_with(Some(d))).expect("parses");
+        assert_eq!(p.fulcio_issuers, vec!["https://issuer.example".to_string()]);
+    }
+
+    #[test]
+    fn parse_rejects_missing_data_block() {
+        let err = parse_configmap(&cm_with(None)).unwrap_err();
+        assert_eq!(err, SignerPolicyError::NoData);
+    }
+
+    #[test]
+    fn parse_rejects_missing_fulcio_issuers_key() {
+        let mut d = BTreeMap::new();
+        d.insert(KEY_SAN_PATTERNS.into(), "signer@example.com".into());
+        let err = parse_configmap(&cm_with(Some(d))).unwrap_err();
+        assert_eq!(err, SignerPolicyError::MissingKey(KEY_FULCIO_ISSUERS));
+    }
+
+    #[test]
+    fn parse_rejects_missing_san_patterns_key() {
+        let mut d = BTreeMap::new();
+        d.insert(KEY_FULCIO_ISSUERS.into(), "https://issuer.example".into());
+        let err = parse_configmap(&cm_with(Some(d))).unwrap_err();
+        assert_eq!(err, SignerPolicyError::MissingKey(KEY_SAN_PATTERNS));
+    }
+
+    #[test]
+    fn parse_rejects_empty_issuer_list_after_trimming() {
+        let mut d = BTreeMap::new();
+        d.insert(KEY_FULCIO_ISSUERS.into(), "# only comments\n\n".into());
+        d.insert(KEY_SAN_PATTERNS.into(), "signer@example.com".into());
+        let err = parse_configmap(&cm_with(Some(d))).unwrap_err();
+        assert_eq!(
+            err,
+            SignerPolicyError::EmptyKey {
+                key: KEY_FULCIO_ISSUERS
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_url_issuer() {
+        let mut d = BTreeMap::new();
+        d.insert(KEY_FULCIO_ISSUERS.into(), "not-a-url".into());
+        d.insert(KEY_SAN_PATTERNS.into(), "signer@example.com".into());
+        let err = parse_configmap(&cm_with(Some(d))).unwrap_err();
+        assert!(
+            matches!(err, SignerPolicyError::InvalidEntry { key, .. } if key == KEY_FULCIO_ISSUERS)
+        );
+    }
+
+    #[test]
+    fn parse_rejects_san_with_whitespace() {
+        let mut d = BTreeMap::new();
+        d.insert(KEY_FULCIO_ISSUERS.into(), "https://issuer.example".into());
+        d.insert(KEY_SAN_PATTERNS.into(), "has space@example.com".into());
+        let err = parse_configmap(&cm_with(Some(d))).unwrap_err();
+        // Whitespace inside an entry: the line is the trimmed form
+        // "has space@example.com"; `validate_san` rejects embedded
+        // whitespace. (Surrounding whitespace is trimmed by `parse_list`.)
+        assert!(
+            matches!(err, SignerPolicyError::InvalidEntry { key, .. } if key == KEY_SAN_PATTERNS)
+        );
+    }
+
+    #[test]
+    fn shared_apply_then_snapshot_reflects_configmap() {
+        let s = SharedSignerPolicy::new();
+        s.apply_configmap(&cm_with(Some(good_data())));
+        match s.snapshot() {
+            SignerPolicyState::FromConfigMap(p) => {
+                assert!(p.is_configured());
+            }
+            other => panic!("expected FromConfigMap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shared_apply_with_malformed_sets_malformed_state() {
+        let s = SharedSignerPolicy::new();
+        s.apply_configmap(&cm_with(None));
+        assert!(matches!(s.snapshot(), SignerPolicyState::Malformed(_)));
+    }
+
+    #[test]
+    fn shared_clear_returns_to_absent() {
+        let s = SharedSignerPolicy::new();
+        s.apply_configmap(&cm_with(Some(good_data())));
+        s.clear();
+        assert!(matches!(s.snapshot(), SignerPolicyState::Absent));
+    }
+
+    #[test]
+    fn shared_default_is_absent() {
+        let s = SharedSignerPolicy::default();
+        assert!(matches!(s.snapshot(), SignerPolicyState::Absent));
+    }
+
+    #[test]
+    fn shared_clone_shares_state() {
+        let s = SharedSignerPolicy::new();
+        let s2 = s.clone();
+        s.apply_configmap(&cm_with(Some(good_data())));
+        assert!(matches!(s2.snapshot(), SignerPolicyState::FromConfigMap(_)));
+    }
+}

--- a/deploy/helm/azureclaw/templates/controller-deployment.yaml
+++ b/deploy/helm/azureclaw/templates/controller-deployment.yaml
@@ -34,6 +34,17 @@ spec:
           env:
             - name: RUST_LOG
               value: "info,azureclaw_controller=debug"
+            # Downward API — used by leader-election + S12.d
+            # SignerPolicy watcher to scope to the controller's own
+            # namespace without cluster-wide watch RBAC.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: AZURE_WI_CLIENT_ID
               value: {{ .Values.azure.workloadIdentity.clientId | quote }}
             - name: INFERENCE_ROUTER_IMAGE

--- a/deploy/helm/azureclaw/templates/signer-policy-configmap.yaml
+++ b/deploy/helm/azureclaw/templates/signer-policy-configmap.yaml
@@ -1,0 +1,45 @@
+{{- /*
+S12.d — SignerPolicy ConfigMap.
+
+Cluster-scoped trust roots for cosign-signed egress allowlist artifacts
+(see `controller/src/policy_fetcher.rs` and
+`docs/policy-canonical-format.md`). The controller watches this single
+ConfigMap (filtered by name + controller-namespace) and rebuilds its
+in-memory `SignerPolicy` on every Apply / Delete event.
+
+The ConfigMap is rendered when `.Values.signerPolicy.enabled` is true
+(default). Set `signerPolicy.enabled: false` only if you intend to fall
+back to the env-var emergency-override path
+(`AZURECLAW_SIGNER_FULCIO_ISSUERS` / `AZURECLAW_SIGNER_SAN_PATTERNS` set
+on the controller Deployment).
+
+Two `data` keys, both required, both newline-separated:
+
+* `fulcioIssuers` — Fulcio issuer URLs that may issue keyless certs.
+* `sanPatterns`   — SAN patterns matched against the signer cert
+                    (URL or email; glob `*` / `?` per `policy_fetcher`).
+
+Comment lines starting with `#` are stripped at parse time. Either list
+empty after trimming → parse error → controller surfaces
+`SignerPolicyMalformed` on affected `ClawSandbox` resources (NOT a
+silent fallback to env vars; broken config is a hard signal).
+*/ -}}
+{{- if .Values.signerPolicy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azureclaw-signer-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: azureclaw
+    app.kubernetes.io/component: signer-policy
+data:
+  fulcioIssuers: |
+{{- range .Values.signerPolicy.fulcioIssuers }}
+    {{ . }}
+{{- end }}
+  sanPatterns: |
+{{- range .Values.signerPolicy.sanPatterns }}
+    {{ . }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/azureclaw/values.yaml
+++ b/deploy/helm/azureclaw/values.yaml
@@ -217,3 +217,33 @@ azure:
 # CiliumNetworkPolicy is then emitted per-sandbox by the controller.
 cilium:
   enabled: false
+
+# S12.d — Cluster-scoped SignerPolicy ConfigMap.
+#
+# Watched by the controller (filtered to the `azureclaw-signer-policy`
+# ConfigMap in this namespace). Defines who is permitted to sign egress
+# allowlist OCI artifacts (see `docs/policy-canonical-format.md`).
+#
+# Both lists are required when `enabled: true`. Either list empty → the
+# controller surfaces `SignerPolicyMalformed` on affected ClawSandbox
+# resources (no silent fallback). Set `enabled: false` only if you
+# intend to use the env-var emergency-override path
+# (`AZURECLAW_SIGNER_FULCIO_ISSUERS` / `AZURECLAW_SIGNER_SAN_PATTERNS`
+# on the controller Deployment).
+#
+# Glob syntax in `sanPatterns`: `*` matches any run of non-`/`
+# characters, `?` matches one character — same as the env-var path.
+# Entries that look like `https://...` are matched against
+# `Subject.uri`; everything else is matched against `Subject.email`.
+signerPolicy:
+  enabled: true
+  fulcioIssuers:
+    # GitHub Actions OIDC — for CI signing via `azureclaw egress --sign`.
+    - https://token.actions.githubusercontent.com
+    # Entra workload identity (replace <tenant> with your tenant ID).
+    - https://login.microsoftonline.com/<tenant>/v2.0
+  sanPatterns:
+    # Workflow-identity SAN for repo-scoped CI runners. Tighten the
+    # path / branch component for your fork before going to production.
+    - https://github.com/Azure/azureclaw/.github/workflows/*.yml@*
+

--- a/docs/policy-canonical-format.md
+++ b/docs/policy-canonical-format.md
@@ -68,7 +68,7 @@ The `oras push` step computes the `sha256` digest over the raw YAML bytes; the p
 Two-step:
 
 1. **Cryptographic validity:** cosign signature exists, chains to a Fulcio root, certificate not expired at signing time.
-2. **Authority:** signer identity (Fulcio cert SAN + issuer claim) matches an entry in the cluster `SignerPolicy` ConfigMap (S12.d). Without S12.d, no identity is authoritative — verification is "valid sig" only and the controller MUST surface this as a `AllowlistVerified=Unknown` condition with reason `NoSignerPolicy`.
+2. **Authority:** signer identity (Fulcio cert SAN + issuer claim) matches an entry in the cluster `SignerPolicy` ConfigMap. The authoritative configuration lives in the cluster-scoped ConfigMap `azureclaw-signer-policy` in the controller namespace (provisioned by the Helm chart via `signerPolicy.fulcioIssuers` / `signerPolicy.sanPatterns` — see `deploy/helm/azureclaw/templates/signer-policy-configmap.yaml`). Env vars (`AZURECLAW_SIGNER_FULCIO_ISSUERS` / `AZURECLAW_SIGNER_SAN_PATTERNS`) remain as an emergency-override fallback when the ConfigMap is **absent**; a *malformed* ConfigMap surfaces as `AllowlistVerified=False / SignerPolicyMalformed` and does **not** silently fall back to the env path.
 
 After verification, parse the YAML and revalidate every canonicalization rule above. Reject (set `AllowlistVerified=False`, reason `CanonicalFormViolation`) on any mismatch — even a valid signature over malformed canonical bytes is not authority.
 
@@ -87,7 +87,7 @@ When v2 is needed (e.g., to reintroduce wildcards, methods, paths, CIDR ranges):
 | **S12.a** *(this slice)* | Format definition, CRD field, no behavior |
 | S12.b | Controller fetcher + format validator (status-only) |
 | S12.c | CLI canonical serializer + signing |
-| S12.d | `SignerPolicy` ConfigMap + identity-pinned authority |
+| S12.d | `SignerPolicy` ConfigMap + identity-pinned authority *(this slice — landed)* |
 | S12.e | Authoritative ref mode (controller derives `allowedEndpoints` from canonical bytes) |
 
 ## Producer (CLI)

--- a/docs/security-audits/2026-04-30-phase2-s12-d-signer-policy.md
+++ b/docs/security-audits/2026-04-30-phase2-s12-d-signer-policy.md
@@ -1,0 +1,197 @@
+# Phase 2 — S12.d: SignerPolicy ConfigMap (Fulcio issuer + SAN allowlist)
+
+**Date:** 2026-04-30
+**Slice:** S12.d (`phase2-s12-d-signerpolicy`)
+**Scope:** Cluster-scoped ConfigMap that pins the cosign signer
+identity policy used by the S12.b egress-allowlist fetcher. Replaces
+the env-var path with a watched `azureclaw-signer-policy` ConfigMap in
+the controller namespace; env vars remain as an emergency-override
+fallback when the ConfigMap is **absent**. Malformed ConfigMaps
+**do not** silently fall back — they surface as
+`SignerPolicyMalformed` on affected `ClawSandbox` resources.
+
+## Threat model
+
+The fetcher accepts a cosign-signed canonical egress allowlist artifact
+as authority over what a sandbox may egress to (status-only in S12.b,
+authoritative in S12.e). The signature alone is insufficient: any
+identity that controls a Fulcio-trusted OIDC issuer could sign a forged
+allowlist. The cluster MUST pin which `(issuer, SAN)` tuples are
+considered authoritative.
+
+**Threat:** signer-key misconfiguration → forged allowlist accepted.
+Concretely:
+
+1. Operator forgets to install a SignerPolicy → fetcher must fail
+   closed (no fallback to "any valid sig is fine").
+2. Operator installs a partial / malformed SignerPolicy → fetcher must
+   fail closed with a *distinct* signal so the operator notices their
+   config is broken (vs. interpreting it as "no policy yet").
+3. Attacker tampers with the SignerPolicy → ClusterRole-write privilege
+   is required (cluster-scoped object in the controller namespace; only
+   cluster-admins or a compromised controller SA can mutate).
+4. Attacker tampers with the env-var fallback → requires Deployment-write
+   on the controller (same blast radius as RCE on the controller
+   itself, which already trumps SignerPolicy integrity).
+
+## Existing implementation surveyed
+
+- **`controller/src/policy_fetcher.rs`** (S12.b) — already houses the
+  `SignerPolicyConfig { fulcio_issuers, san_patterns }` value type, the
+  `FetchError` enum + `reason_for_error` mapping, the cosign verify
+  path (`verify_via_sigstore`), the cache, and the
+  `maybe_verify_allowlist` reconciler hook. We extend this module
+  rather than parallel-implementing — added `SignerPolicyMalformed`
+  variant + reason; rewrote `maybe_verify_allowlist` to consult a
+  `SharedSignerPolicy` handle while keeping `fetch_and_verify`'s
+  signature unchanged so all existing call paths still compile.
+- **`controller/src/main.rs` reconciler-spawn pattern** — every other
+  reconciler (`pairing_reconciler::run`, `mcp_server_reconciler::run`,
+  `mesh_peer::run`, etc.) is launched as a `tokio::spawn(async move
+  { module::run(client).await })` and folded into the top-level
+  `tokio::select!`. The new `signer_policy::run` follows the same
+  shape; failure of the watcher propagates up so the controller pod
+  restarts (avoids serving stale policy state forever after a
+  transient kube-apiserver disconnect).
+- **`controller/src/leader_election.rs`** — established the
+  "`POD_NAMESPACE` env via downward API, fall back to literal
+  `azureclaw-system`" idiom. Reused verbatim by the new watcher; the
+  Helm `controller-deployment.yaml` was extended to wire
+  `POD_NAMESPACE` (it was previously only relied on by leader-election
+  *if* set, with a hard-coded fallback — now it's the authoritative
+  source for both consumers).
+- **`controller/src/status/conditions.rs`** — `TYPE_ALLOWLIST_VERIFIED`,
+  `preserve_transition_time`, `reason::*`, `status::FALSE`. The new
+  `SignerPolicyMalformed` reason is a string literal returned by
+  `reason_for_error` (matches the existing pattern used for
+  `SignerPolicyMissing`, `IdentityMismatch`, etc. — none of those are
+  `pub const`s in `reason::`, they're match-arm strings).
+- **`deploy/helm/azureclaw/templates/rbac.yaml`** — the controller
+  `ClusterRole` already grants `get/list/watch` on `configmaps` (the
+  per-sandbox AgentCard / claweval ConfigMap reconciliation needs it
+  cluster-wide). Adding the SignerPolicy ConfigMap watch did NOT
+  require broadening RBAC — namespace-scoped role would have been
+  preferred for least-privilege, but a cluster-scoped rule the
+  controller already holds is strictly broader. We deliberately did
+  not introduce a new namespace-scoped Role + RoleBinding because two
+  RBAC sources for the same verb on the same resource would be
+  confusing audit-trail noise.
+- **`deploy/helm/azureclaw/templates/*-configmap.yaml` rendering
+  idiom** — `crd-*.yaml`, `cilium-*.yaml`, etc. follow `kind: X` →
+  metadata with `app.kubernetes.io/name: azureclaw` + a `component:`
+  label and `namespace: {{ .Release.Namespace }}`. Reused.
+
+## Mitigations
+
+- **Cluster-scoped ConfigMap.** Single authoritative source per
+  cluster; no per-tenant slicing of trust roots. Tampering requires
+  ClusterRole-write on the controller namespace.
+- **Controller-only watch.** The watcher is filtered by
+  `metadata.name=azureclaw-signer-policy` *and* scoped to the
+  controller's own namespace via `Api::namespaced(client, &ns)` —
+  even a compromised tenant namespace cannot mint a SignerPolicy that
+  the controller would consume.
+- **Namespace-scoped RBAC.** No broadening was needed; the controller
+  already holds `get/list/watch configmaps` cluster-wide. We
+  documented this in the audit so a future least-privilege pass knows
+  the SignerPolicy doesn't *require* cluster-scope; if/when sandbox
+  ConfigMap ops are scoped down, this watch can be migrated to a
+  per-namespace Role on `azureclaw-system`.
+- **Distinct malformed-detection condition.** `SignerPolicyMalformed`
+  is a separate `Condition.reason` from `SignerPolicyMissing`. A
+  malformed ConfigMap does **not** silently fall back to env vars —
+  operators get a hard signal (`AllowlistVerified=False/SignerPolicyMalformed`)
+  on every affected `ClawSandbox` so the broken cluster config
+  surfaces in `kubectl get clawsandbox -o yaml`.
+- **Env fallback as emergency override.** `AZURECLAW_SIGNER_FULCIO_ISSUERS`
+  / `AZURECLAW_SIGNER_SAN_PATTERNS` remain readable. They activate
+  *only* when the ConfigMap is absent — never when it's present-but-broken
+  (test `with_handle_malformed_does_not_fall_back_to_env`). The path
+  exists for cluster-bootstrap scenarios where the SignerPolicy CRD
+  install hasn't landed yet, and for break-glass overrides on
+  customer clusters.
+- **Fail-closed ordering preserved.** All three S12.b fail-closed
+  semantics still hold:
+  - SignerPolicy missing → `SignerPolicyMissing`.
+  - Empty `fulcio_issuers` AND empty `san_patterns` → still missing
+    (parser rejects either-empty up-front; runtime
+    `is_configured()` short-circuits on either-empty).
+  - Feature gate off → no condition emitted (no behavior change for
+    deployments that haven't opted in).
+- **Strict parser.** `parse_configmap` rejects: missing `data` block,
+  missing either key, empty list after trimming + comment-stripping,
+  non-URL issuer entries, whitespace inside SAN entries. Each
+  rejection has a unit test.
+
+## Watch semantics
+
+`signer_policy::run` consumes `kube::runtime::watcher::Event<ConfigMap>`
+events filtered to `metadata.name=azureclaw-signer-policy`:
+
+- `Init` + `InitApply` + `InitDone` — atomic rebuild on watch restart;
+  if the singleton wasn't observed during the init pass, state is
+  cleared to `Absent` (so a controller restart against an empty
+  cluster never serves a stale policy).
+- `Apply` — re-parse + commit. Parse-error → `Malformed(msg)` (no
+  fallback).
+- `Delete` — clear to `Absent` → env-var fallback re-engages on the
+  next reconcile.
+
+## Test coverage
+
+18 new tests in the controller (`controller/src` test count: 383 →
+401):
+
+- `controller/src/signer_policy.rs` (13 tests):
+  `parse_valid_configmap`, `parse_strips_comments_and_blank_lines`,
+  `parse_rejects_missing_data_block`,
+  `parse_rejects_missing_fulcio_issuers_key`,
+  `parse_rejects_missing_san_patterns_key`,
+  `parse_rejects_empty_issuer_list_after_trimming`,
+  `parse_rejects_non_url_issuer`,
+  `parse_rejects_san_with_whitespace`,
+  `shared_apply_then_snapshot_reflects_configmap`,
+  `shared_apply_with_malformed_sets_malformed_state`,
+  `shared_clear_returns_to_absent`,
+  `shared_default_is_absent`,
+  `shared_clone_shares_state`.
+- `controller/src/policy_fetcher.rs` (5 new tests + 1 augmented
+  reason-mapping test):
+  `with_handle_returns_none_when_feature_gate_off`,
+  `with_handle_malformed_emits_signer_policy_malformed_condition`,
+  `with_handle_malformed_does_not_fall_back_to_env`,
+  `with_handle_absent_falls_back_to_env_missing`,
+  `with_handle_configmap_takes_precedence_over_env`.
+
+The existing env-fallback tests (`signer_policy_unconfigured_when_env_unset`,
+`signer_policy_configured_from_env`, `signer_policy_requires_both_lists_for_is_configured`)
+were **kept unchanged** — the env path remains a supported fallback
+and the tests still document its semantics. New SharedSignerPolicy
+tests inject state directly per the slice spec ("pure value injection
+is cleaner") rather than wiring fake ConfigMap apparatus.
+
+## §10.5 Compliance
+
+- §10.5 #4 (signed-policy provenance): identity-pinned authority now
+  has a cluster-resident, watched, fail-closed configuration source.
+  Combined with S12.b (consumer verify) and S12.c (producer sign),
+  the cluster has end-to-end coverage of "the bytes the operator
+  sealed are the bytes the controller verifies — under an authority
+  the cluster operator has explicitly trusted." S12.e now has a
+  reliable `SignerPolicy` to flip authority against.
+- Per-sub-slice audit doc: this is the fourth (S12.a, S12.b, S12.c,
+  S12.d).
+
+## References
+
+- Plan §S12.d: `~/.copilot/session-state/13bea069-bbc9-48ae-a25c-36da81c7a0fe/plan.md`
+- Canonical format: `docs/policy-canonical-format.md`
+- S12.b audit: `docs/security-audits/2026-04-30-phase2-policy-fetcher.md`
+- S12.c audit: `docs/security-audits/2026-04-30-phase2-s12-c-cli-sign.md`
+- Sigstore Fulcio: <https://docs.sigstore.dev/certificate_authority/overview/>
+- Workload identity federation: <https://learn.microsoft.com/entra/workload-id/workload-identity-federation>
+
+## Sign-offs
+
+- [ ] Author: ____________________
+- [ ] Independent reviewer: ____________________


### PR DESCRIPTION
## Summary

Replaces the env-var path used by S12.b for cosign signer-identity policy with a watched **cluster-scoped `SignerPolicy` ConfigMap** (`azureclaw-signer-policy` in the controller namespace). The env-var path (`AZURECLAW_SIGNER_FULCIO_ISSUERS` / `AZURECLAW_SIGNER_SAN_PATTERNS`) remains as an emergency-override fallback that engages **only** when the ConfigMap is absent; a *malformed* ConfigMap surfaces as a new `SignerPolicyMalformed` condition reason and does **not** silently fall back.

Trust-model improvement: the cluster's identity-pinning policy is now a first-class, watched, fail-closed configuration object that cluster-admins manage via Helm. Combined with S12.b (consumer verify) and S12.c (producer sign), the cluster has end-to-end coverage of "the bytes the operator sealed are the bytes the controller verifies — under an authority the operator has explicitly trusted." S12.e now has a reliable `SignerPolicy` to flip authoritative-ref mode against.

## Surveyed seams (reused, not parallel-implemented)

- `controller/src/policy_fetcher.rs` — `SignerPolicyConfig`, `FetchError`, `reason_for_error`, `maybe_verify_allowlist`. Added the `SignerPolicyMalformed` variant + reason; rewired `maybe_verify_allowlist` to consult a `SharedSignerPolicy` handle.
- `controller/src/leader_election.rs` — `POD_NAMESPACE` downward-API idiom; reused. The Helm `controller-deployment.yaml` was extended to wire `POD_NAMESPACE` + `POD_NAME` (previously only relied on with a hard-coded fallback).
- `controller/src/status/conditions.rs` — `TYPE_ALLOWLIST_VERIFIED`, `preserve_transition_time`. The new reason is a literal returned by `reason_for_error`, matching the existing pattern.
- `deploy/helm/azureclaw/templates/rbac.yaml` — controller `ClusterRole` already grants `get/list/watch` on `configmaps`; **no broadening introduced**.

## Key safety properties (locked in by tests)

- `SignerPolicyMissing` (absent + env-empty) → fail closed.
- `SignerPolicyMalformed` (ConfigMap broken) → fail closed; **does not** fall back to env (test `with_handle_malformed_does_not_fall_back_to_env`).
- ConfigMap configured → takes precedence over env (test `with_handle_configmap_takes_precedence_over_env`).
- Empty issuers AND empty SANs → still missing; parser rejects either-empty up-front.

## Test delta

Controller tests: **383 → 401** (+18). Breakdown:
- 13 new unit tests in `controller/src/signer_policy.rs` (parser strict-rejection cases + `SharedSignerPolicy` apply/clear/snapshot/clone semantics).
- 5 new tests in `controller/src/policy_fetcher.rs` exercising `maybe_verify_allowlist_with_handle` for each `SignerPolicyState` (FromConfigMap precedence, Malformed surfaces SignerPolicyMalformed without env fallback, Absent falls back to env).
- 1 augmented `reason_for_error_maps_each_variant` test.

Existing env-fallback tests are preserved unchanged (the env path remains a documented emergency-override).

## CI

- `cargo fmt --all` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --all` — all green (controller 401, router 608, others unchanged)
- `helm lint deploy/helm/azureclaw` clean
- CLI `npm run lint` + `npx tsc --noEmit` clean

## Audit doc

[`docs/security-audits/2026-04-30-phase2-s12-d-signer-policy.md`](../blob/phase2-s12-d-signerpolicy/docs/security-audits/2026-04-30-phase2-s12-d-signer-policy.md) — covers the threat (signer-key misconfiguration → forged allowlist accepted), mitigations (cluster-scoped ConfigMap; controller-only watch; namespace-scoped `Api` + name field-selector; malformed-detection condition; env fallback for emergency override), and a surveyed-existing-implementation section listing every reused seam.

## Plan slot

§S12.d — "identity-pinned verification config. Cluster-level SignerPolicy ConfigMap (watched by controller) listing allowed Fulcio issuer + SAN patterns. Default config provided for GitHub Actions OIDC + Entra workload-identity issuers." Default config now lives in `deploy/helm/azureclaw/values.yaml` under `signerPolicy.*`.

## Out of scope (per slice spec)

- S12.e authoritative-ref mode flip — NetworkPolicy still derives from inline `allowedEndpoints`; `AllowlistVerified` remains status-only.
- Tenant-scoped trust roots — single cluster-wide `SignerPolicy` per cluster.
- Transparency-log freshness checks — deliberately out of scope (replay vector mitigated by RBAC + monotonic generation in canonical payload).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>