### PR TITLE
phase2(s13): config authority via refs — InferencePolicy + ToolPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Phase 2
 
+### S13 `phase2-config-authority-refs` — sandbox config moves to refs
+
+**BREAKING (in-place v1alpha1 schema edit; pre-release, no conversion webhook).**
+
+The `ClawSandbox` spec no longer carries inline inference or tool-policy
+configuration. Instead, the sandbox holds same-namespace references to
+sibling `InferencePolicy` and `ToolPolicy` CRDs which become the single
+source of truth.
+
+Schema changes (`controller/src/crd.rs`,
+`deploy/helm/azureclaw/templates/crd.yaml`):
+
+- `spec.inference: InferenceConfig` → **removed**.
+- `spec.inferenceRef: { name: string }` → **new, required**. References
+  a sibling `InferencePolicy` CR. Cross-namespace refs are not supported
+  (same-namespace only — security invariant).
+- `spec.governance.toolPolicy: string` (profile name) → **removed**.
+- `spec.governance.toolPolicyRef: { name: string }` → **new**. Required
+  when `governance.enabled=true` (CEL-enforced). References a sibling
+  `ToolPolicy` CR; the resolved CR's `metadata.name` doubles as the AGT
+  policy profile carried into the sandbox via `AGT_POLICY_PROFILE`.
+- New status reasons `InferencePolicyNotFound`, `ToolPolicyNotFound` —
+  emitted on `Degraded` when a referenced CR is missing.
+
+CLI updates (`cli/src/commands/{up/sandbox_bringup,add,attest}.ts`,
+`cli/src/migrate/from_kagent.ts`, new `cli/src/refs.ts`): the `azureclaw
+up` and `azureclaw add` commands now emit a multi-doc bundle
+(`InferencePolicy` + optional `ToolPolicy` + `ClawSandbox`) and apply
+all three in one shot. Naming convention: `<sandbox>-inference` and
+`<sandbox>-toolpolicy`, DNS-1123 truncated to 63 chars. The
+`from-kagent` migrator now always emits an `<sandbox>-inference`
+InferencePolicy (preserving any kagent `modelConfig` provenance) and
+adds an aggregator `<sandbox>-toolpolicy` whenever governance is on.
+
+Examples (`examples/basic-agent/`, `examples/confidential-agent/`,
+`examples/telegram-agent/`, `examples/demo-clawshield/*-agent.yaml`)
+and e2e fixtures (`tests/e2e/run.sh`,
+`tests/compat/fixtures/null-provider-*.yaml`) updated to the
+two-doc-per-sandbox shape.
+
 ### S12.d — SignerPolicy ConfigMap (Fulcio issuer + SAN allowlist)
 
 - New `controller/src/signer_policy.rs` — cluster-scoped

--- a/cli/src/commands/add.test.ts
+++ b/cli/src/commands/add.test.ts
@@ -72,15 +72,8 @@ function buildSandboxManifest(name: string, options: AddOptions) {
         allowPrivilegeEscalation: false,
         writablePaths: ["/sandbox", "/tmp"],
       },
-      inference: {
-        provider: "azure-ai-foundry",
-        model: options.model,
-        contentSafety: true,
-        promptShields: true,
-        tokenBudget: {
-          daily: parseInt(options.tokenBudgetDaily) || 0,
-          perRequest: parseInt(options.tokenBudgetPerRequest) || 0,
-        },
+      inferenceRef: {
+        name: `${name}-inference`,
       },
       networkPolicy: {
         defaultDeny: true,
@@ -108,7 +101,7 @@ function buildSandboxManifest(name: string, options: AddOptions) {
   if (options.governance) {
     (sandbox.spec as Record<string, unknown>).governance = {
       enabled: true,
-      toolPolicy: options.policyProfile || "default",
+      toolPolicyRef: { name: `${name}-toolpolicy` },
       trustThreshold: parseInt(options.trustThreshold) || 500,
     };
   }
@@ -190,14 +183,16 @@ describe("ClawSandbox manifest generation", () => {
     const spec = manifest.spec as any;
     expect(spec.runtime.kind).toBe("OpenClaw");
     expect(spec.runtime.openclaw.config.agent.model).toBe("azure/gpt-4.1");
-    expect(spec.inference.model).toBe("gpt-4.1");
+    expect(spec.inferenceRef.name).toBe("a-inference");
   });
 
   it("uses custom model when specified", () => {
     const manifest = buildSandboxManifest("a", defaultOptions({ model: "o4-mini" }));
     const spec = manifest.spec as any;
     expect(spec.runtime.openclaw.config.agent.model).toBe("azure/o4-mini");
-    expect(spec.inference.model).toBe("o4-mini");
+    // S13: model is carried on the sibling InferencePolicy CR, not the
+    // sandbox spec. The runtime block still seeds OpenClaw config.
+    expect(spec.inferenceRef.name).toBe("a-inference");
   });
 
   it("sets standard isolation with RuntimeDefault seccomp", () => {
@@ -221,21 +216,23 @@ describe("ClawSandbox manifest generation", () => {
     expect(spec.sandbox.seccompProfile).toBe("azureclaw-strict");
   });
 
-  it("applies token budget values", () => {
+  it("references the InferencePolicy CR by name (token budget lives on the policy)", () => {
     const manifest = buildSandboxManifest(
       "a",
       defaultOptions({ tokenBudgetDaily: "100000", tokenBudgetPerRequest: "4096" }),
     );
     const spec = manifest.spec as any;
-    expect(spec.inference.tokenBudget.daily).toBe(100000);
-    expect(spec.inference.tokenBudget.perRequest).toBe(4096);
+    // S13 phase2-config-authority-refs: budgets are carried on the
+    // sibling InferencePolicy CR, not inline on the sandbox spec.
+    expect(spec.inferenceRef.name).toBe("a-inference");
+    expect(spec.inference).toBeUndefined();
   });
 
-  it("defaults token budgets to 0 (unlimited)", () => {
+  it("does not emit an inline inference block (S13 refs-only)", () => {
     const manifest = buildSandboxManifest("a", defaultOptions());
     const spec = manifest.spec as any;
-    expect(spec.inference.tokenBudget.daily).toBe(0);
-    expect(spec.inference.tokenBudget.perRequest).toBe(0);
+    expect(spec.inference).toBeUndefined();
+    expect(spec.inferenceRef).toEqual({ name: "a-inference" });
   });
 
   it("includes custom image when specified", () => {
@@ -269,7 +266,7 @@ describe("ClawSandbox manifest generation", () => {
     expect(spec.networkPolicy.learnEgress).toBe(true);
   });
 
-  it("adds governance config when enabled", () => {
+  it("adds governance config when enabled (S13: toolPolicyRef)", () => {
     const manifest = buildSandboxManifest(
       "a",
       defaultOptions({ governance: true, trustThreshold: "750", policyProfile: "strict" }),
@@ -277,7 +274,7 @@ describe("ClawSandbox manifest generation", () => {
     const spec = manifest.spec as any;
     expect(spec.governance).toEqual({
       enabled: true,
-      toolPolicy: "strict",
+      toolPolicyRef: { name: "a-toolpolicy" },
       trustThreshold: 750,
     });
   });

--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -3,6 +3,12 @@ import chalk from "chalk";
 import ora from "ora";
 import { loadContext, resolveSecret } from "../config.js";
 import { assertRuntimeWired, buildRuntimeBlock, flagToKind } from "../runtime.js";
+import {
+  buildInferencePolicy,
+  buildToolPolicy,
+  inferenceRefName,
+  toolPolicyRefName,
+} from "../refs.js";
 
 export function addCommand(): Command {
   const cmd = new Command("add");
@@ -72,15 +78,8 @@ export function addCommand(): Command {
             allowPrivilegeEscalation: false,
             writablePaths: ["/sandbox", "/tmp"],
           },
-          inference: {
-            provider: "azure-ai-foundry",
-            model: options.model,
-            contentSafety: true,
-            promptShields: true,
-            tokenBudget: {
-              daily: parseInt(options.tokenBudgetDaily) || 0,
-              perRequest: parseInt(options.tokenBudgetPerRequest) || 0,
-            },
+          inferenceRef: {
+            name: inferenceRefName(name),
           },
           networkPolicy: {
             defaultDeny: true,
@@ -113,7 +112,7 @@ export function addCommand(): Command {
       if (options.governance) {
         (sandbox.spec as Record<string, unknown>).governance = {
           enabled: true,
-          toolPolicy: options.policyProfile || "default",
+          toolPolicyRef: { name: toolPolicyRefName(name) },
           trustThreshold: parseInt(options.trustThreshold) || 500,
         };
       }
@@ -209,7 +208,29 @@ export function addCommand(): Command {
         console.log(chalk.dim(`  Skills: ${options.skills}`));
       }
 
-      const yaml = JSON.stringify(sandbox, null, 2);
+      // S13: build companion same-namespace policy CRs (sibling to ClawSandbox).
+      const inferencePolicy = buildInferencePolicy({
+        sandboxName: name,
+        namespace: "azureclaw-system",
+        model: options.model,
+        provider: "azure-ai-foundry",
+        contentSafety: true,
+        promptShields: true,
+        tokenBudgetDaily: parseInt(options.tokenBudgetDaily) || 0,
+        tokenBudgetPerRequest: parseInt(options.tokenBudgetPerRequest) || 0,
+      });
+      const toolPolicy = options.governance
+        ? buildToolPolicy({
+            sandboxName: name,
+            namespace: "azureclaw-system",
+            profile: options.policyProfile || "default",
+          })
+        : undefined;
+
+      const bundle: Record<string, unknown>[] = [inferencePolicy];
+      if (toolPolicy) bundle.push(toolPolicy);
+      bundle.push(sandbox);
+      const yaml = JSON.stringify(bundle, null, 2);
 
       if (options.dryRun) {
         console.log(chalk.bold("\nClawSandbox manifest (dry-run):\n"));
@@ -363,8 +384,16 @@ export function addCommand(): Command {
           }
         }
         spinner.text = `Creating sandbox '${name}'...`;
+        // Apply InferencePolicy + (optional) ToolPolicy + ClawSandbox as a
+        // single multi-doc bundle. The controller resolves refs at reconcile
+        // time; if the policy CRs are missing the sandbox goes Degraded.
+        const bundleManifest = {
+          apiVersion: "v1",
+          kind: "List",
+          items: bundle,
+        };
         await execa("kubectl", ["apply", "-f", "-"], {
-          input: JSON.stringify(sandbox),
+          input: JSON.stringify(bundleManifest),
           stdio: ["pipe", "pipe", "pipe"],
         });
 

--- a/cli/src/commands/attest.ts
+++ b/cli/src/commands/attest.ts
@@ -49,7 +49,13 @@ const POLICY_CR_KINDS: ReadonlyArray<{
   plural: string;
   refField: string;
 }> = [
+  // S13: spec-level refs.
   { kind: "ToolPolicy", plural: "toolpolicies", refField: "toolPolicyRef" },
+  {
+    kind: "InferencePolicy",
+    plural: "inferencepolicies",
+    refField: "inferenceRef",
+  },
   {
     kind: "InferencePolicy",
     plural: "inferencepolicies",
@@ -213,12 +219,26 @@ export function extractPolicyRefs(spec: unknown): Array<{
   }
   const gov = s.governance as Record<string, unknown> | undefined;
   if (gov && typeof gov === "object") {
+    // S13: same-namespace `toolPolicyRef.name` shape.
+    const tpr = gov.toolPolicyRef as Record<string, unknown> | undefined;
+    if (tpr && typeof tpr === "object" && typeof tpr.name === "string") {
+      out.push({ kind: "ToolPolicy", name: tpr.name });
+    }
+    // Legacy `governance.toolPolicy.ref: string` shape — pre-S13.
     const tp = gov.toolPolicy as Record<string, unknown> | undefined;
-    if (tp && typeof tp.ref === "string") {
+    if (tp && typeof tp === "object" && typeof tp.ref === "string") {
       out.push({ kind: "ToolPolicy", name: tp.ref });
     }
   }
-  return out;
+  // De-duplicate (S13 may reference the same ToolPolicy via two paths
+  // during the rollout window).
+  const seen = new Set<string>();
+  return out.filter((r) => {
+    const k = `${r.kind}/${r.name}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
 }
 
 async function buildReport(name: string, opts: { namespace: string }): Promise<AttestationReport> {

--- a/cli/src/commands/up/sandbox_bringup.ts
+++ b/cli/src/commands/up/sandbox_bringup.ts
@@ -13,6 +13,12 @@ import chalk from "chalk";
 import type { Stepper } from "../../stepper.js";
 import { section, kvLine, checkLine } from "../../stepper.js";
 import { saveContext } from "../../config.js";
+import {
+  buildInferencePolicy,
+  buildToolPolicy,
+  inferenceRefName,
+  toolPolicyRefName,
+} from "../../refs.js";
 
 export interface SandboxBringUpContext {
   options: {
@@ -325,12 +331,27 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
   }
 
   stepper.update(`Creating sandbox '${options.name}'...`);
+  const sandboxNamespace = "azureclaw-system";
+  const inferencePolicy = buildInferencePolicy({
+    sandboxName: options.name,
+    namespace: sandboxNamespace,
+    model: options.model,
+    provider: "azure-openai",
+    endpoint: openAiEndpoint,
+    contentSafety: true,
+    promptShields: true,
+  });
+  const toolPolicy = buildToolPolicy({
+    sandboxName: options.name,
+    namespace: sandboxNamespace,
+    profile: "default",
+  });
   const sandboxManifest = {
     apiVersion: "azureclaw.azure.com/v1alpha1",
     kind: "ClawSandbox",
     metadata: {
       name: options.name,
-      namespace: "azureclaw-system",
+      namespace: sandboxNamespace,
     },
     spec: {
       runtime: {
@@ -342,12 +363,8 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
       sandbox: {
         isolation: options.isolation,
       },
-      inference: {
-        provider: "azure-openai",
-        model: options.model,
-        endpoint: openAiEndpoint,
-        contentSafety: true,
-        promptShields: true,
+      inferenceRef: {
+        name: inferenceRefName(options.name),
       },
       networkPolicy: {
         defaultDeny: true,
@@ -356,13 +373,18 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
       },
       governance: {
         enabled: true,
-        toolPolicy: "default",
+        toolPolicyRef: { name: toolPolicyRefName(options.name) },
         trustThreshold: 500,
       },
     },
   };
+  const bundleManifest = {
+    apiVersion: "v1",
+    kind: "List",
+    items: [inferencePolicy, toolPolicy, sandboxManifest],
+  };
   await execa("kubectl", ["apply", "-f", "-"], {
-    input: JSON.stringify(sandboxManifest),
+    input: JSON.stringify(bundleManifest),
     stdio: ["pipe", "pipe", "pipe"],
   });
 

--- a/cli/src/migrate/from_kagent.test.ts
+++ b/cli/src/migrate/from_kagent.test.ts
@@ -344,14 +344,16 @@ describe("translate: Declarative agent runnability", () => {
     ).toBe(true);
   });
 
-  it("does NOT emit InferencePolicy when modelConfig is absent", () => {
+  it("emits InferencePolicy without modelConfig annotation when modelConfig is absent (S13: ref is required)", () => {
     const noModel = {
       ...decl,
       spec: { type: "Declarative", declarative: { runtime: "python" } },
     };
     const r = translate(noModel, { image: "x" });
-    expect(r.resources.find((x) => x.kind === "InferencePolicy")).toBeUndefined();
-    expect(r.summary.inferencePolicyCount).toBe(0);
+    const ip = r.resources.find((x) => x.kind === "InferencePolicy");
+    expect(ip).toBeDefined();
+    expect(ip!.metadata.annotations?.[`${AZURECLAW_GROUP}/kagent-model-config`]).toBeUndefined();
+    expect(r.summary.inferencePolicyCount).toBe(1);
   });
 });
 
@@ -373,13 +375,16 @@ describe("translate: Tools", () => {
       ]),
       { image: "x" },
     );
-    const tps = r.resources.filter((x) => x.kind === "ToolPolicy");
+    const tps = r.resources
+      .filter((x) => x.kind === "ToolPolicy")
+      .filter((t) => (t.spec.appliesTo as { tool?: string }).tool !== undefined);
     expect(tps).toHaveLength(2);
     expect(tps.map((t) => (t.spec.appliesTo as { tool: string }).tool).sort()).toEqual(
       ["read", "write"],
     );
     // governance auto-enabled when at least one ToolPolicy is emitted.
-    expect((r.resources[0]!.spec.governance as { enabled: boolean }).enabled).toBe(
+    const sandbox = r.resources.find((x) => x.kind === "ClawSandbox")!;
+    expect((sandbox.spec.governance as { enabled: boolean }).enabled).toBe(
       true,
     );
   });
@@ -412,7 +417,9 @@ describe("translate: Tools", () => {
       withTools([{ type: "McpServer", mcpServer: { name: "fs" } }]),
       { image: "x" },
     );
-    const tps = r.resources.filter((x) => x.kind === "ToolPolicy");
+    const tps = r.resources
+      .filter((x) => x.kind === "ToolPolicy")
+      .filter((t) => (t.spec.appliesTo as { tool?: string }).tool !== undefined);
     expect(tps).toHaveLength(1);
     expect((tps[0]!.spec.appliesTo as { tool: string }).tool).toBe("*");
     expect(r.warnings.some((w) => w.message.includes("wildcard"))).toBe(true);
@@ -464,7 +471,11 @@ describe("translate: Tools", () => {
       ]),
       { image: "x" },
     );
-    expect(r.resources.filter((x) => x.kind === "ToolPolicy")).toHaveLength(1);
+    expect(
+      r.resources
+        .filter((x) => x.kind === "ToolPolicy")
+        .filter((t) => (t.spec.appliesTo as { tool?: string }).tool !== undefined),
+    ).toHaveLength(1);
   });
 
   it("warns on Tool.headersFrom and mcpServer.allowedHeaders", () => {
@@ -648,6 +659,7 @@ describe("translate: bundle ordering and JSON shape", () => {
     expect(r.resources.map((x) => x.kind)).toEqual([
       "ClawSandbox",
       "InferencePolicy",
+      "ToolPolicy",
       "ToolPolicy",
     ]);
   });

--- a/cli/src/migrate/from_kagent.ts
+++ b/cli/src/migrate/from_kagent.ts
@@ -647,7 +647,19 @@ export function translate(
   }
   if (resources) sbSpec.resources = resources;
   if (networkPolicy) sbSpec.networkPolicy = networkPolicy;
-  if (governanceEnabled) sbSpec.governance = { enabled: true };
+  // S13: ClawSandbox.spec.inferenceRef is required. Emit a sibling
+  // InferencePolicy CR named `<sandbox>-inference` and reference it.
+  sbSpec.inferenceRef = { name: `${sandboxName}-inference` };
+  if (governanceEnabled) {
+    sbSpec.governance = {
+      enabled: true,
+      // S13: same-namespace reference to a top-level ToolPolicy CR
+      // (per-tool ToolPolicy CRs are still emitted below for fine-grained
+      // approval/rate-limit scoping; the sandbox's ref points at the
+      // synthetic `<sandbox>-toolpolicy` aggregator).
+      toolPolicyRef: { name: `${sandboxName}-toolpolicy` },
+    };
+  }
 
   const clawsandbox: KubeResource = {
     apiVersion: `${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`,
@@ -661,35 +673,64 @@ export function translate(
     spec: sbSpec,
   };
 
-  // ---- InferencePolicy (provenance-only) ----------------------------------
+  // ---- InferencePolicy ----------------------------------------------------
+  // S13: ClawSandbox.spec.inferenceRef is required, so always emit a
+  // sibling `<sandbox>-inference` InferencePolicy CR. When the upstream
+  // kagent Agent declared a `modelConfig`, preserve it as provenance.
   const inferencePolicies: KubeResource[] = [];
-  if (agentType === "Declarative" && isObj(spec.declarative)) {
-    const modelConfig = asString((spec.declarative as Record<string, unknown>).modelConfig);
-    if (modelConfig && modelConfig.length > 0) {
-      warnings.push(
-        warn(
-          "spec.declarative.modelConfig",
-          `kagent ModelConfig '${modelConfig}' is preserved only as an InferencePolicy annotation; AzureClaw inference provider/model are not configured from it`,
-        ),
-      );
-      inferencePolicies.push({
-        apiVersion: `${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`,
-        kind: "InferencePolicy",
-        metadata: {
-          name: `${sandboxName}-inference`,
-          namespace,
-          labels: { [SANDBOX_LABEL_KEY]: sandboxName },
-          annotations: {
-            [PROVENANCE_FROM_KEY]: `${KAGENT_API_VERSION} ${KAGENT_KIND}`,
-            [PROVENANCE_AGENT_KEY]: `${inputNs}/${sandboxName}`,
-            [KAGENT_MODEL_CONFIG_KEY]: modelConfig,
-          },
-        },
-        spec: {
-          appliesTo: { sandboxName },
-        },
-      });
+  {
+    const ipAnnotations: Record<string, string> = {
+      [PROVENANCE_FROM_KEY]: `${KAGENT_API_VERSION} ${KAGENT_KIND}`,
+      [PROVENANCE_AGENT_KEY]: `${inputNs}/${sandboxName}`,
+    };
+    if (agentType === "Declarative" && isObj(spec.declarative)) {
+      const modelConfig = asString((spec.declarative as Record<string, unknown>).modelConfig);
+      if (modelConfig && modelConfig.length > 0) {
+        warnings.push(
+          warn(
+            "spec.declarative.modelConfig",
+            `kagent ModelConfig '${modelConfig}' is preserved only as an InferencePolicy annotation; AzureClaw inference provider/model are not configured from it`,
+          ),
+        );
+        ipAnnotations[KAGENT_MODEL_CONFIG_KEY] = modelConfig;
+      }
     }
+    inferencePolicies.push({
+      apiVersion: `${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`,
+      kind: "InferencePolicy",
+      metadata: {
+        name: `${sandboxName}-inference`,
+        namespace,
+        labels: { [SANDBOX_LABEL_KEY]: sandboxName },
+        annotations: ipAnnotations,
+      },
+      spec: {
+        appliesTo: { sandboxName },
+      },
+    });
+  }
+
+  // S13: when governance is on, emit a synthetic top-level
+  // `<sandbox>-toolpolicy` aggregator (the per-tool CRs above stay; this
+  // one is what `ClawSandbox.spec.governance.toolPolicyRef` points at).
+  if (governanceEnabled) {
+    toolPolicies.push({
+      apiVersion: `${AZURECLAW_GROUP}/${AZURECLAW_VERSION}`,
+      kind: "ToolPolicy",
+      metadata: {
+        name: `${sandboxName}-toolpolicy`,
+        namespace,
+        labels: { [SANDBOX_LABEL_KEY]: sandboxName },
+        annotations: {
+          [PROVENANCE_FROM_KEY]: `${KAGENT_API_VERSION} ${KAGENT_KIND}`,
+          [PROVENANCE_AGENT_KEY]: `${inputNs}/${sandboxName}`,
+        },
+      },
+      spec: {
+        appliesTo: { sandboxName },
+      },
+    });
+    toolPolicies.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
   }
 
   const resourcesOut: KubeResource[] = [

--- a/cli/src/refs.ts
+++ b/cli/src/refs.ts
@@ -1,0 +1,96 @@
+// S13 phase2-config-authority-refs:
+// `ClawSandbox.spec.inferenceRef` → sibling `InferencePolicy` CR (required).
+// `ClawSandbox.spec.governance.toolPolicyRef` → sibling `ToolPolicy` CR
+// (required when governance.enabled). Both are SAME-NAMESPACE refs.
+
+const DNS_LABEL_MAX = 63;
+
+// Truncate a base name + suffix so the result is a valid DNS-1123 subdomain
+// (max 63 chars per label). The suffix already contains a leading hyphen.
+export function kebabRefName(base: string, suffix: string): string {
+  const b = base.toLowerCase().replace(/[^a-z0-9-]/g, "-").replace(/^-+|-+$/g, "");
+  const max = DNS_LABEL_MAX - suffix.length;
+  const trimmed = b.length > max ? b.slice(0, max).replace(/-+$/g, "") : b;
+  return `${trimmed}${suffix}`;
+}
+
+export const inferenceRefName = (sandboxName: string) =>
+  kebabRefName(sandboxName, "-inference");
+
+export const toolPolicyRefName = (sandboxName: string) =>
+  kebabRefName(sandboxName, "-toolpolicy");
+
+export interface InferencePolicyOpts {
+  sandboxName: string;
+  namespace: string;
+  model: string;
+  endpoint?: string;
+  provider?: string;
+  contentSafety?: boolean;
+  promptShields?: boolean;
+  tokenBudgetDaily?: number;
+  tokenBudgetPerRequest?: number;
+}
+
+export function buildInferencePolicy(opts: InferencePolicyOpts): Record<string, unknown> {
+  const spec: Record<string, unknown> = {
+    appliesTo: { sandboxName: opts.sandboxName },
+    modelPreference: {
+      primary: {
+        provider: opts.provider ?? "azure-openai",
+        deployment: opts.model,
+      },
+    },
+    contentSafety: {
+      requirePromptShields: opts.promptShields !== false,
+    },
+  };
+  if (opts.endpoint) {
+    (spec.modelPreference as Record<string, unknown>).primary = {
+      ...(spec.modelPreference as Record<string, { primary: Record<string, unknown> }>).primary,
+      endpoint: opts.endpoint,
+    };
+  }
+  const daily = opts.tokenBudgetDaily ?? 0;
+  const perReq = opts.tokenBudgetPerRequest ?? 0;
+  if (daily > 0 || perReq > 0) {
+    const tb: Record<string, unknown> = {};
+    if (daily > 0) tb.dailyTokens = daily;
+    if (perReq > 0) tb.perRequestTokens = perReq;
+    spec.tokenBudget = tb;
+  }
+  return {
+    apiVersion: "azureclaw.azure.com/v1alpha1",
+    kind: "InferencePolicy",
+    metadata: {
+      name: inferenceRefName(opts.sandboxName),
+      namespace: opts.namespace,
+      labels: { "azureclaw.azure.com/sandbox": opts.sandboxName },
+    },
+    spec,
+  };
+}
+
+export interface ToolPolicyOpts {
+  sandboxName: string;
+  namespace: string;
+  profile?: string;
+}
+
+export function buildToolPolicy(opts: ToolPolicyOpts): Record<string, unknown> {
+  return {
+    apiVersion: "azureclaw.azure.com/v1alpha1",
+    kind: "ToolPolicy",
+    metadata: {
+      name: toolPolicyRefName(opts.sandboxName),
+      namespace: opts.namespace,
+      labels: { "azureclaw.azure.com/sandbox": opts.sandboxName },
+      annotations: opts.profile
+        ? { "azureclaw.azure.com/profile": opts.profile }
+        : undefined,
+    },
+    spec: {
+      appliesTo: { sandboxName: opts.sandboxName },
+    },
+  };
+}

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
     shortname = "claw",
     printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
     printcolumn = r#"{"name":"Runtime","type":"string","jsonPath":".spec.runtime.kind"}"#,
-    printcolumn = r#"{"name":"Model","type":"string","jsonPath":".spec.inference.model"}"#,
+    printcolumn = r#"{"name":"InferencePolicy","type":"string","jsonPath":".spec.inferenceRef.name"}"#,
     printcolumn = r#"{"name":"Isolation","type":"string","jsonPath":".spec.sandbox.isolation"}"#,
     printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
 )]
@@ -45,8 +45,17 @@ pub struct ClawSandboxSpec {
     /// Sandbox security settings
     pub sandbox: Option<SandboxConfig>,
 
-    /// Inference routing
-    pub inference: Option<InferenceConfig>,
+    /// Reference to an `InferencePolicy` CR in the **same namespace** as
+    /// this `ClawSandbox`. The referenced CR is the single source of
+    /// truth for inference guardrails: model preference, content-safety
+    /// floor, prompt-shield requirement, token budgets. The reconciler
+    /// resolves the ref at apply time; if the target is missing the
+    /// sandbox enters `Degraded` with reason `InferencePolicyNotFound`
+    /// (no inline-fallback path post-S13).
+    ///
+    /// Cross-namespace refs are deliberately not supported — would be a
+    /// privilege-escalation vector. See `docs/crd-precedence.md`.
+    pub inference_ref: LocalObjectRef,
 
     /// Network policy
     pub network_policy: Option<NetworkPolicyConfig>,
@@ -655,49 +664,7 @@ impl Default for SandboxConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct InferenceConfig {
-    /// azure-openai | azure-ai-foundry | self-hosted
-    #[serde(default = "default_provider")]
-    pub provider: String,
-    pub endpoint: Option<String>,
-    #[serde(default = "default_model")]
-    pub model: String,
-    pub fallback: Option<FallbackConfig>,
-    #[serde(default = "default_true")]
-    pub content_safety: bool,
-    #[serde(default = "default_true")]
-    pub prompt_shields: bool,
-    pub token_budget: Option<TokenBudgetConfig>,
-}
-
-impl Default for InferenceConfig {
-    fn default() -> Self {
-        Self {
-            provider: "azure-openai".into(),
-            endpoint: None,
-            model: "gpt-4.1".into(),
-            fallback: None,
-            content_safety: true,
-            prompt_shields: true,
-            token_budget: None,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
-pub struct FallbackConfig {
-    pub provider: Option<String>,
-    pub model: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct TokenBudgetConfig {
-    pub daily: Option<i64>,
-    pub per_request: Option<i64>,
-}
+// See `crate::mcp_server::LocalObjectRef` — re-used here for sandbox refs.
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -799,15 +766,27 @@ pub struct AgentConfig {
 }
 
 /// AGT behavioral governance configuration.
+///
+/// **S13:** the `tool_policy` profile name was replaced with
+/// `tool_policy_ref` — a same-namespace reference to a `ToolPolicy` CR.
+/// The dedicated `ToolPolicy` CRD is the single source of truth for
+/// tool-call gating (rate limit, approval, AP2 commerce caps); this
+/// struct keeps only behavior knobs that aren't expressed by `ToolPolicy`
+/// itself (AGT enable flag, trust threshold, trusted peers, registry mode).
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GovernanceConfig {
     /// Enable AGT governance (tool policy, trust, audit).
     #[serde(default)]
     pub enabled: bool,
-    /// Policy profile name (references policies ConfigMap).
-    #[serde(default = "default_policy")]
-    pub tool_policy: String,
+    /// Reference to a `ToolPolicy` CR in the **same namespace** as this
+    /// `ClawSandbox`. Required — the controller resolves the target at
+    /// reconcile time; missing target → `Degraded` with reason
+    /// `ToolPolicyNotFound` (no inline-fallback path post-S13). The
+    /// resolved CR's `metadata.name` doubles as the AGT policy profile
+    /// name carried into the sandbox via `AGT_POLICY_PROFILE`.
+    #[serde(default)]
+    pub tool_policy_ref: LocalObjectRef,
     /// Minimum trust score (0-1000) for inter-agent communication.
     #[serde(default = "default_trust_threshold")]
     pub trust_threshold: i32,
@@ -820,9 +799,6 @@ pub struct GovernanceConfig {
     pub registry_mode: Option<String>,
 }
 
-fn default_policy() -> String {
-    "default".into()
-}
 fn default_trust_threshold() -> i32 {
     500
 }
@@ -876,12 +852,6 @@ fn default_seccomp() -> String {
 fn default_selinux() -> String {
     String::new()
 }
-fn default_provider() -> String {
-    "azure-openai".into()
-}
-fn default_model() -> String {
-    "gpt-4.1".into()
-}
 fn default_true() -> bool {
     true
 }
@@ -918,28 +888,20 @@ mod tests {
     }
 
     #[test]
-    fn default_model_is_gpt_4_1() {
-        let cfg = InferenceConfig::default();
-        assert_eq!(cfg.model, "gpt-4.1");
+    fn local_object_ref_round_trips() {
+        let r = LocalObjectRef {
+            name: "my-policy".into(),
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v.get("name").and_then(|s| s.as_str()), Some("my-policy"));
+        let back: LocalObjectRef = serde_json::from_value(v).unwrap();
+        assert_eq!(back, r);
     }
 
     #[test]
-    fn default_provider_is_azure_openai() {
-        let cfg = InferenceConfig::default();
-        assert_eq!(cfg.provider, "azure-openai");
-    }
-
-    #[test]
-    fn default_inference_enables_content_safety() {
-        let cfg = InferenceConfig::default();
-        assert!(cfg.content_safety);
-        assert!(cfg.prompt_shields);
-    }
-
-    #[test]
-    fn default_inference_has_no_token_budget() {
-        let cfg = InferenceConfig::default();
-        assert!(cfg.token_budget.is_none());
+    fn local_object_ref_default_is_empty_name() {
+        let r = LocalObjectRef::default();
+        assert!(r.name.is_empty());
     }
 
     #[test]
@@ -989,14 +951,14 @@ mod tests {
 
     #[test]
     fn default_governance_config() {
-        // GovernanceConfig derives Default (empty/zero), serde defaults apply on deserialization
         let cfg = GovernanceConfig::default();
         assert!(!cfg.enabled);
-        // Serde default_policy() and default_trust_threshold() are used during deserialization only
+        // S13: tool_policy is now a same-namespace ref to a ToolPolicy CR.
+        // Default is an empty name (a sandbox spec with governance.enabled=true
+        // MUST set toolPolicyRef.name; reconciler degrades on missing ref).
+        assert!(cfg.tool_policy_ref.name.is_empty());
         let cfg_serde: GovernanceConfig = serde_json::from_value(serde_json::json!({})).unwrap();
-        assert_eq!(cfg_serde.tool_policy, "default");
         assert_eq!(cfg_serde.trust_threshold, 500);
-        assert_eq!(cfg.tool_policy, ""); // derive Default gives empty string
     }
 
     #[test]
@@ -1011,19 +973,15 @@ mod tests {
         assert!(spec.runtime.microsoft_agent_framework.is_none());
         assert!(spec.runtime.byo.is_none());
         assert!(spec.sandbox.is_none());
-        assert!(spec.inference.is_none());
+        // S13: `inferenceRef` is a value-type required field. Default is
+        // a `LocalObjectRef` with an empty name; admission CEL rejects
+        // empty-name on apply.
+        assert!(spec.inference_ref.name.is_empty());
         assert!(spec.network_policy.is_none());
         assert!(spec.agent.is_none());
         assert!(spec.governance.is_none());
         assert!(spec.azure_services.is_none());
         assert!(spec.resources.is_none());
-    }
-
-    #[test]
-    fn token_budget_config_defaults_to_none() {
-        let cfg = TokenBudgetConfig::default();
-        assert!(cfg.daily.is_none());
-        assert!(cfg.per_request.is_none());
     }
 
     #[test]
@@ -1071,10 +1029,41 @@ mod tests {
     }
 
     #[test]
-    fn inference_config_default_has_no_fallback() {
-        let cfg = InferenceConfig::default();
-        assert!(cfg.fallback.is_none());
-        assert!(cfg.endpoint.is_none());
+    fn inference_ref_round_trips_via_camel_case() {
+        // Wire-format hygiene: K8s uses camelCase. The ref field on the
+        // ClawSandboxSpec must serialize as `inferenceRef`.
+        let spec = ClawSandboxSpec {
+            inference_ref: LocalObjectRef {
+                name: "my-sandbox-inference".into(),
+            },
+            ..ClawSandboxSpec::default()
+        };
+        let v = serde_json::to_value(&spec).unwrap();
+        assert!(
+            v.get("inferenceRef").is_some(),
+            "must use camelCase inferenceRef"
+        );
+        let ir = v.get("inferenceRef").unwrap();
+        assert_eq!(
+            ir.get("name").and_then(|n| n.as_str()),
+            Some("my-sandbox-inference")
+        );
+    }
+
+    #[test]
+    fn governance_tool_policy_ref_serializes_camel_case() {
+        let g = GovernanceConfig {
+            enabled: true,
+            tool_policy_ref: LocalObjectRef { name: "tp".into() },
+            trust_threshold: 500,
+            trusted_peers: None,
+            registry_mode: None,
+        };
+        let v = serde_json::to_value(&g).unwrap();
+        assert!(
+            v.get("toolPolicyRef").is_some(),
+            "must use camelCase toolPolicyRef"
+        );
     }
 
     // ─── S10.A1 RuntimeSpec tests ────────────────────────────────────

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -221,7 +221,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
 
     let spec = sandbox.spec.clone();
     let sandbox_config = spec.sandbox.unwrap_or_default();
-    let inference_config = spec.inference.unwrap_or_default();
+    let sandbox_self_ns = sandbox.namespace().unwrap_or_default();
     // S10.A2: runtime dispatch flows through `reconciler::runtime` —
     // a `RuntimeDeploymentPlan` flattens the `spec.runtime` discriminated
     // union to the concrete image / command / args / runtime-specific env
@@ -288,10 +288,89 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             format!("invalid sandbox.isolation: {isolation}")
         );
     }
-    if inference_config.model.is_empty() {
-        tracing::error!("ClawSandbox {name} has empty model — skipping reconciliation");
-        degrade!(SPEC_INVALID, "inference.model is empty");
+
+    // ── S13: resolve the sandbox's InferencePolicy ref ───────────────────
+    // ClawSandbox.spec.inferenceRef is the single source of truth for
+    // inference guardrails (model preference, content-safety floor,
+    // prompt-shield requirement, token budgets). The reconciler resolves
+    // the ref against the sandbox's *own* namespace; cross-namespace
+    // refs are deliberately not supported (privilege-escalation vector
+    // — see docs/crd-precedence.md). Missing ref target → Degraded with
+    // reason `InferencePolicyNotFound`; we do not fall through with
+    // defaults.
+    let inference_ref_name = spec.inference_ref.name.clone();
+    if inference_ref_name.is_empty() {
+        tracing::error!(sandbox = %name, "spec.inferenceRef.name is empty");
+        degrade!(SPEC_INVALID, "spec.inferenceRef.name is required");
     }
+    let ip_api: Api<crate::inference_policy::InferencePolicy> =
+        Api::namespaced(client.clone(), &sandbox_self_ns);
+    let inference_policy = match ip_api.get(&inference_ref_name).await {
+        Ok(ip) => ip,
+        Err(kube::Error::Api(ae)) if ae.code == 404 => {
+            tracing::error!(
+                sandbox = %name,
+                ref = %inference_ref_name,
+                ns = %sandbox_self_ns,
+                "InferencePolicy not found in sandbox namespace",
+            );
+            degrade!(
+                crate::status::conditions::reason::INFERENCE_POLICY_NOT_FOUND,
+                format!(
+                    "InferencePolicy `{inference_ref_name}` not found in namespace \
+                     `{sandbox_self_ns}` (cross-namespace refs not supported)"
+                )
+            );
+        }
+        Err(e) => {
+            tracing::error!(error = %e, sandbox = %name, "InferencePolicy lookup failed");
+            return Ok(Action::requeue(Duration::from_secs(15)));
+        }
+    };
+    let inference_policy_spec = inference_policy.spec.clone();
+    // Model is required: it's plumbed into AZURE_OPENAI_DEPLOYMENT and (for
+    // OpenClaw) OPENCLAW_MODEL. Without it the agent container has no
+    // Foundry deployment to call.
+    let inference_model = inference_policy_spec
+        .model_preference
+        .as_ref()
+        .map(|mp| mp.primary.deployment.clone())
+        .unwrap_or_default();
+    if inference_model.is_empty() {
+        tracing::error!(
+            sandbox = %name,
+            ref = %inference_ref_name,
+            "InferencePolicy.modelPreference.primary.deployment is empty",
+        );
+        degrade!(
+            SPEC_INVALID,
+            format!(
+                "InferencePolicy `{inference_ref_name}` is missing \
+                 spec.modelPreference.primary.deployment"
+            )
+        );
+    }
+    // Prompt Shields default-on; opt-out via require_prompt_shields=false.
+    let prompt_shields_enabled = inference_policy_spec
+        .content_safety
+        .as_ref()
+        .and_then(|c| c.require_prompt_shields)
+        .unwrap_or(true);
+    // Content Safety always enabled at the router boundary; the policy
+    // CR's severity floors tighten the router's defaults but do not
+    // disable the feature.
+    let content_safety_enabled = true;
+    let token_budget_daily = inference_policy_spec
+        .token_budget
+        .as_ref()
+        .and_then(|b| b.daily_tokens)
+        .unwrap_or(0) as i64;
+    let token_budget_per_request = inference_policy_spec
+        .token_budget
+        .as_ref()
+        .and_then(|b| b.per_request_tokens)
+        .unwrap_or(0) as i64;
+
     if ctx.foundry_endpoint.is_empty() && ctx.openai_endpoint.is_empty() {
         tracing::error!("No inference endpoint configured");
         degrade!(
@@ -360,6 +439,52 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     // overlay still relies on these.
     let governance_config = spec.governance.clone().unwrap_or_default();
     let blocklist_cm_name = format!("{}-blocklist", &name);
+
+    // ── S13: resolve the sandbox's ToolPolicy ref (if governance enabled) ─
+    // Governance == off ⇒ no ref required. Governance == on ⇒ the ref
+    // is authoritative; missing target → Degraded with reason
+    // `ToolPolicyNotFound`. The resolved CR's `metadata.name` doubles as
+    // the AGT policy profile name carried into the sandbox.
+    let tool_policy_profile: String = if governance_config.enabled {
+        let tp_ref_name = governance_config.tool_policy_ref.name.clone();
+        if tp_ref_name.is_empty() {
+            tracing::error!(sandbox = %name, "spec.governance.toolPolicyRef.name is empty");
+            degrade!(
+                SPEC_INVALID,
+                "spec.governance.toolPolicyRef.name is required when governance.enabled=true"
+            );
+        }
+        let tp_api: Api<crate::tool_policy::ToolPolicy> =
+            Api::namespaced(client.clone(), &sandbox_self_ns);
+        match tp_api.get(&tp_ref_name).await {
+            Ok(_) => tp_ref_name,
+            Err(kube::Error::Api(ae)) if ae.code == 404 => {
+                tracing::error!(
+                    sandbox = %name,
+                    ref = %tp_ref_name,
+                    ns = %sandbox_self_ns,
+                    "ToolPolicy not found in sandbox namespace",
+                );
+                degrade!(
+                    crate::status::conditions::reason::TOOL_POLICY_NOT_FOUND,
+                    format!(
+                        "ToolPolicy `{tp_ref_name}` not found in namespace \
+                         `{sandbox_self_ns}` (cross-namespace refs not supported)"
+                    )
+                );
+            }
+            Err(e) => {
+                tracing::error!(error = %e, sandbox = %name, "ToolPolicy lookup failed");
+                return Ok(Action::requeue(Duration::from_secs(15)));
+            }
+        }
+    } else {
+        // governance off ⇒ no profile is shipped. The reconciler still
+        // needs *some* string for the ConfigMap name when it's referenced;
+        // it never is in this branch (all `tool_policy_profile` reads are
+        // gated by `governance_config.enabled`).
+        String::new()
+    };
 
     // ── Step 1: Create namespace ─────────────────────────────────────────
     let ns_api: Api<Namespace> = Api::all(client.clone());
@@ -688,17 +813,8 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
 
         let deploy_api: Api<Deployment> = Api::namespaced(client.clone(), &sandbox_ns);
 
-        // Token budget values from CRD (0 = unlimited)
-        let token_budget_daily = inference_config
-            .token_budget
-            .as_ref()
-            .and_then(|b| b.daily)
-            .unwrap_or(0);
-        let token_budget_per_request = inference_config
-            .token_budget
-            .as_ref()
-            .and_then(|b| b.per_request)
-            .unwrap_or(0);
+        // Token budget values resolved from the InferencePolicy ref above
+        // (hoisted to the top of `reconcile` after S13). 0 = unlimited.
 
         // S10.A2.b / S10.A3: OpenClaw vs non-OpenClaw branch the *agent
         // container shape*. The router sidecar, init container,
@@ -728,8 +844,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         // ImagePullBackOff-style fail to start.
         let mut openclaw_env: Vec<serde_json::Value> = Vec::new();
         if is_openclaw {
-            openclaw_env
-                .push(json!({"name": "OPENCLAW_MODEL", "value": inference_config.model.clone()}));
+            openclaw_env.push(json!({"name": "OPENCLAW_MODEL", "value": inference_model.clone()}));
         }
         openclaw_env.push(json!({"name": "AZURE_OPENAI_ENDPOINT", "value": &ctx.openai_endpoint}));
         openclaw_env.push(json!({"name": "AZURECLAW_AUTH_MODE", "value": "workload-identity"}));
@@ -805,9 +920,8 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
 
         if governance_config.enabled {
             openclaw_env.push(json!({"name": "AGT_GOVERNANCE_ENABLED", "value": "true"}));
-            openclaw_env.push(
-                json!({"name": "AGT_POLICY_PROFILE", "value": governance_config.tool_policy}),
-            );
+            openclaw_env
+                .push(json!({"name": "AGT_POLICY_PROFILE", "value": tool_policy_profile.clone()}));
             openclaw_env.push(json!({"name": "AGT_TRUST_THRESHOLD", "value": governance_config.trust_threshold.to_string()}));
             // Validate and propagate trusted peers (format: "name:AMID,name:AMID,...")
             let valid_peers = governance_config.trusted_peers.as_deref().filter(|p| {
@@ -835,9 +949,8 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             openclaw_env.push(json!({"name": "AGT_REGISTRY_URL", "value": "http://agentmesh-registry.agentmesh.svc.cluster.local:8080"}));
             // Router needs governance vars too (handoff auth, policy enforcement)
             router_agt_env.push(json!({"name": "AGT_GOVERNANCE_ENABLED", "value": "true"}));
-            router_agt_env.push(
-                json!({"name": "AGT_POLICY_PROFILE", "value": &governance_config.tool_policy}),
-            );
+            router_agt_env
+                .push(json!({"name": "AGT_POLICY_PROFILE", "value": &tool_policy_profile}));
             router_agt_env.push(json!({"name": "AGT_TRUST_THRESHOLD", "value": governance_config.trust_threshold.to_string()}));
             // Behavior-monitor burst threshold: offload workers run long
             // research loops that make many tool/inference calls in short
@@ -845,7 +958,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             // (100/60s) so legitimate research bursts aren't flagged as
             // "abuse" by the self-burst detector. Non-offload profiles keep
             // the router's built-in default.
-            if governance_config.tool_policy == "offload" {
+            if tool_policy_profile == "offload" {
                 router_agt_env
                     .push(json!({"name": "AGT_BEHAVIOR_BURST_THRESHOLD", "value": "1000"}));
             }
@@ -945,10 +1058,10 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             json!({"name": "FOUNDRY_ENDPOINT", "value": &ctx.foundry_endpoint}),
             json!({"name": "FOUNDRY_PROJECT_ENDPOINT", "value": &ctx.foundry_project_endpoint}),
             json!({"name": "IMDS_CLIENT_ID", "value": &ctx.imds_client_id}),
-            json!({"name": "AZURE_OPENAI_DEPLOYMENT", "value": &inference_config.model}),
+            json!({"name": "AZURE_OPENAI_DEPLOYMENT", "value": &inference_model}),
             json!({"name": "AZURECLAW_AUTH_MODE", "value": "workload-identity"}),
-            json!({"name": "CONTENT_SAFETY_ENABLED", "value": inference_config.content_safety.to_string()}),
-            json!({"name": "PROMPT_SHIELDS_ENABLED", "value": inference_config.prompt_shields.to_string()}),
+            json!({"name": "CONTENT_SAFETY_ENABLED", "value": content_safety_enabled.to_string()}),
+            json!({"name": "PROMPT_SHIELDS_ENABLED", "value": prompt_shields_enabled.to_string()}),
             json!({"name": "CONTENT_SAFETY_ENDPOINT", "value": &ctx.content_safety_endpoint}),
             json!({"name": "TOKEN_BUDGET_DAILY", "value": token_budget_daily.to_string()}),
             json!({"name": "TOKEN_BUDGET_PER_REQUEST", "value": token_budget_per_request.to_string()}),
@@ -1182,7 +1295,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
 
         // If AGT governance is enabled, mount the policy ConfigMap into the router
         if governance_config.enabled {
-            let policy_profile = &governance_config.tool_policy;
+            let policy_profile = &tool_policy_profile;
             let cm_name = format!("agt-policy-{}", policy_profile);
 
             // Add policy volume
@@ -1399,7 +1512,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         // Known profiles: "default" (interactive/normal) and "offload" (leaf worker,
         // no spawn/handoff). Unknown profile names fall back to default to preserve
         // backward compatibility — the router will still load whatever YAML key we ship.
-        let policy_profile = &governance_config.tool_policy;
+        let policy_profile = &tool_policy_profile;
         let policy_yaml: &str = match policy_profile.as_str() {
             "offload" => include_str!("../../../cli/policies/azureclaw-offload.yaml"),
             _ => include_str!("../../../cli/policies/azureclaw-default.yaml"),

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -117,6 +117,15 @@ pub mod reason {
     /// cosign signature passed, signer identity matched cluster
     /// SignerPolicy, canonical form re-validated.
     pub const VERIFIED: &str = "Verified";
+    /// Phase 2 S13 — `InferencePolicyNotFound`: the
+    /// `ClawSandbox.spec.inferenceRef.name` did not resolve to an
+    /// `InferencePolicy` CR in the sandbox's namespace. Same-namespace
+    /// constraint is enforced; cross-namespace lookups are not allowed.
+    pub const INFERENCE_POLICY_NOT_FOUND: &str = "InferencePolicyNotFound";
+    /// Phase 2 S13 — `ToolPolicyNotFound`: governance is enabled and
+    /// `spec.governance.toolPolicyRef.name` did not resolve to a
+    /// `ToolPolicy` CR in the sandbox's namespace.
+    pub const TOOL_POLICY_NOT_FOUND: &str = "ToolPolicyNotFound";
 }
 
 /// Build a condition with a freshly-stamped `lastTransitionTime`.
@@ -227,6 +236,8 @@ mod tests {
             reason::SPEC_INVALID,
             reason::DEPENDENCY_MISSING,
             reason::TIMED_OUT,
+            reason::INFERENCE_POLICY_NOT_FOUND,
+            reason::TOOL_POLICY_NOT_FOUND,
         ] {
             assert!(r.chars().next().unwrap().is_uppercase(), "{r}");
             assert!(!r.contains('_'), "{r}");

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -18,7 +18,7 @@ spec:
           properties:
             spec:
               type: object
-              required: ["runtime", "sandbox", "inference"]
+              required: ["runtime", "sandbox", "inferenceRef"]
               properties:
                 runtime:
                   type: object
@@ -315,38 +315,25 @@ spec:
                       items:
                         type: string
                       default: ["/sandbox", "/tmp"]
-                inference:
+                inferenceRef:
                   type: object
+                  description: |
+                    Same-namespace reference to an `InferencePolicy` CR
+                    (S13 config-authority refs). The controller resolves
+                    the target at reconcile time; missing target → status
+                    `Degraded` with reason `InferencePolicyNotFound`.
+                    Cross-namespace refs are not supported (security
+                    invariant — see `docs/crd-precedence.md`).
+                  required: ["name"]
                   properties:
-                    provider:
+                    name:
                       type: string
-                      enum: ["azure-openai", "azure-ai-foundry", "self-hosted"]
-                      default: "azure-openai"
-                    endpoint:
-                      type: string
-                    model:
-                      type: string
-                      default: "gpt-4.1"
-                    fallback:
-                      type: object
-                      properties:
-                        provider:
-                          type: string
-                        model:
-                          type: string
-                    contentSafety:
-                      type: boolean
-                      default: true
-                    promptShields:
-                      type: boolean
-                      default: true
-                    tokenBudget:
-                      type: object
-                      properties:
-                        daily:
-                          type: integer
-                        perRequest:
-                          type: integer
+                      description: "Name of a sibling InferencePolicy CR in the same namespace as this ClawSandbox."
+                      maxLength: 253
+                      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                  x-kubernetes-validations:
+                    - rule: "self.name.size() > 0"
+                      message: "spec.inferenceRef.name must not be empty"
                 agent:
                   type: object
                   description: "Foundry Agent Service configuration — controller creates a prompt agent on reconcile"
@@ -367,15 +354,33 @@ spec:
                 governance:
                   type: object
                   description: "AGT behavioral governance (opt-in for multi-agent)"
+                  x-kubernetes-validations:
+                    - rule: "!has(self.enabled) || !self.enabled || (has(self.toolPolicyRef) && self.toolPolicyRef.name.size() > 0)"
+                      message: "spec.governance.toolPolicyRef.name must be set when governance.enabled=true"
                   properties:
                     enabled:
                       type: boolean
                       default: false
                       description: "Enable AGT governance (tool-level policy, trust, audit)"
-                    toolPolicy:
-                      type: string
-                      default: "default"
-                      description: "Policy profile name (references policies ConfigMap)"
+                    toolPolicyRef:
+                      type: object
+                      description: |
+                        Same-namespace reference to a `ToolPolicy` CR
+                        (S13 config-authority refs). When
+                        `governance.enabled=true`, the controller
+                        resolves the target at reconcile time; missing
+                        target → status `Degraded` with reason
+                        `ToolPolicyNotFound`. The resolved CR's
+                        `metadata.name` doubles as the AGT policy
+                        profile name carried into the sandbox via
+                        `AGT_POLICY_PROFILE`. Cross-namespace refs are
+                        not supported.
+                      properties:
+                        name:
+                          type: string
+                          description: "Name of a sibling ToolPolicy CR in the same namespace as this ClawSandbox."
+                          maxLength: 253
+                          pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
                     trustThreshold:
                       type: integer
                       default: 500
@@ -535,9 +540,9 @@ spec:
         - name: Runtime
           type: string
           jsonPath: .spec.runtime.kind
-        - name: Model
+        - name: InferencePolicy
           type: string
-          jsonPath: .spec.inference.model
+          jsonPath: .spec.inferenceRef.name
         - name: Isolation
           type: string
           jsonPath: .spec.sandbox.isolation

--- a/examples/basic-agent/clawsandbox.yaml
+++ b/examples/basic-agent/clawsandbox.yaml
@@ -1,6 +1,28 @@
 # AzureClaw Example: Basic OpenClaw Agent
 # This creates a sandboxed OpenClaw agent with default security settings.
 
+---
+# S13: ClawSandbox.spec.inferenceRef points at this sibling InferencePolicy.
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: my-assistant-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: my-assistant
+spec:
+  appliesTo:
+    sandboxName: my-assistant
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 500000
+    perRequestTokens: 128000
+---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
@@ -26,14 +48,10 @@ spec:
       - /sandbox
       - /tmp
 
-  inference:
-    provider: "azure-openai"
-    model: "gpt-4.1"
-    contentSafety: true
-    promptShields: true
-    tokenBudget:
-      daily: 500000
-      perRequest: 128000
+  # S13 phase2-config-authority-refs: inline `inference:` is gone — the
+  # spec now references a sibling InferencePolicy CR by name (above).
+  inferenceRef:
+    name: my-assistant-inference
 
   networkPolicy:
     defaultDeny: true

--- a/examples/confidential-agent/clawsandbox.yaml
+++ b/examples/confidential-agent/clawsandbox.yaml
@@ -2,6 +2,27 @@
 # Uses Kata VM isolation for per-pod dedicated kernel.
 # Container escape attacks are trapped inside the VM, not the host.
 
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: confidential-assistant-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: confidential-assistant
+spec:
+  appliesTo:
+    sandboxName: confidential-assistant
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 1000000
+    perRequestTokens: 128000
+---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
@@ -27,14 +48,8 @@ spec:
       - /sandbox
       - /tmp
 
-  inference:
-    provider: "azure-openai"
-    model: "gpt-4.1"
-    contentSafety: true
-    promptShields: true
-    tokenBudget:
-      daily: 1000000
-      perRequest: 128000
+  inferenceRef:
+    name: confidential-assistant-inference
 
   networkPolicy:
     defaultDeny: true

--- a/examples/demo-clawshield/contoso-bank-agent.yaml
+++ b/examples/demo-clawshield/contoso-bank-agent.yaml
@@ -3,6 +3,27 @@
 # Role: Analyzes transaction records, generates compliance reports
 # Allowed egress: GitHub, Contoso internal APIs
 
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: contoso-bank-agent-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: contoso-bank-agent
+spec:
+  appliesTo:
+    sandboxName: contoso-bank-agent
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 500000
+    perRequestTokens: 128000
+---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
@@ -37,14 +58,8 @@ spec:
       - /sandbox
       - /tmp
 
-  inference:
-    provider: "foundry"
-    model: "gpt-4.1"
-    contentSafety: true
-    promptShields: true
-    tokenBudget:
-      daily: 500000
-      perRequest: 128000
+  inferenceRef:
+    name: contoso-bank-agent-inference
 
   networkPolicy:
     defaultDeny: true

--- a/examples/demo-clawshield/fabrikam-legal-agent.yaml
+++ b/examples/demo-clawshield/fabrikam-legal-agent.yaml
@@ -7,6 +7,27 @@
 # target for indirect prompt injection attacks. It runs in a Kata VM
 # with hardware-level isolation to contain any breach.
 
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: fabrikam-legal-agent-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: fabrikam-legal-agent
+spec:
+  appliesTo:
+    sandboxName: fabrikam-legal-agent
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 500000
+    perRequestTokens: 128000
+---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
@@ -44,15 +65,8 @@ spec:
       - /sandbox
       - /tmp
 
-  inference:
-    provider: "foundry"
-    model: "gpt-4.1"
-    contentSafety: true
-    promptShields: true
-    tokenBudget:
-      # Tighter budget — legal reviews don't need high throughput
-      daily: 200000
-      perRequest: 64000
+  inferenceRef:
+    name: fabrikam-legal-agent-inference
 
   networkPolicy:
     defaultDeny: true

--- a/examples/demo-clawshield/northwind-trade-agent.yaml
+++ b/examples/demo-clawshield/northwind-trade-agent.yaml
@@ -3,6 +3,27 @@
 # Role: Validates trade records against compliance frameworks
 # Allowed egress: Northwind APIs, trade data feeds
 
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: northwind-trade-agent-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: northwind-trade-agent
+spec:
+  appliesTo:
+    sandboxName: northwind-trade-agent
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 500000
+    perRequestTokens: 128000
+---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
@@ -37,14 +58,8 @@ spec:
       - /sandbox
       - /tmp
 
-  inference:
-    provider: "foundry"
-    model: "gpt-4.1"
-    contentSafety: true
-    promptShields: true
-    tokenBudget:
-      daily: 300000
-      perRequest: 128000
+  inferenceRef:
+    name: northwind-trade-agent-inference
 
   networkPolicy:
     defaultDeny: true

--- a/examples/telegram-agent/clawsandbox.yaml
+++ b/examples/telegram-agent/clawsandbox.yaml
@@ -15,6 +15,27 @@
 # Or deploy via CLI (creates the secret automatically):
 #   azureclaw add telegram-agent --channels telegram --telegram-token "YOUR_TOKEN"
 
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: telegram-agent-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: telegram-agent
+spec:
+  appliesTo:
+    sandboxName: telegram-agent
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 500000
+    perRequestTokens: 128000
+---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
@@ -42,14 +63,8 @@ spec:
       - /sandbox
       - /tmp
 
-  inference:
-    provider: "azure-openai"
-    model: "gpt-4.1"
-    contentSafety: true
-    promptShields: true
-    tokenBudget:
-      daily: 500000
-      perRequest: 128000
+  inferenceRef:
+    name: telegram-agent-inference
 
   # Egress rules — Telegram Bot API + optional Bing search
   networkPolicy:

--- a/tests/compat/fixtures/null-provider-devonly-ok.yaml
+++ b/tests/compat/fixtures/null-provider-devonly-ok.yaml
@@ -4,6 +4,22 @@
 # admission-null-provider.yaml must ACCEPT this manifest.
 ---
 apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: dev-null-provider-ok-inference
+  namespace: azureclaw-fixtures
+  labels:
+    azureclaw.azure.com/sandbox: dev-null-provider-ok
+spec:
+  appliesTo:
+    sandboxName: dev-null-provider-ok
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+      endpoint: "https://example.openai.azure.com"
+---
+apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
   name: dev-null-provider-ok
@@ -17,8 +33,8 @@ spec:
       version: "0.1"
   sandbox:
     isolation: strict
-  inference:
-    endpoint: "https://example.openai.azure.com"
+  inferenceRef:
+    name: dev-null-provider-ok-inference
   # Forward-compatible with Phase 1 CRD schema; current v1alpha1 has
   # x-kubernetes-preserve-unknown-fields on spec, so this is accepted.
   agt:

--- a/tests/compat/fixtures/null-provider-prod-denied.yaml
+++ b/tests/compat/fixtures/null-provider-prod-denied.yaml
@@ -12,6 +12,22 @@
 # driver strips the dev-only label at apply time.
 ---
 apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: prod-null-provider-denied-inference
+  namespace: azureclaw-fixtures
+  labels:
+    azureclaw.azure.com/sandbox: prod-null-provider-denied
+spec:
+  appliesTo:
+    sandboxName: prod-null-provider-denied
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+      endpoint: "https://example.openai.azure.com"
+---
+apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
   name: prod-null-provider-denied
@@ -29,8 +45,8 @@ spec:
       version: "0.1"
   sandbox:
     isolation: strict
-  inference:
-    endpoint: "https://example.openai.azure.com"
+  inferenceRef:
+    name: prod-null-provider-denied-inference
   agt:
     providers:
       mesh: noop

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -93,16 +93,36 @@ test_controller_running() {
 
 test_create_sandbox() {
     cat <<EOF | kubectl apply -f -
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: e2e-test-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: e2e-test
+spec:
+  appliesTo:
+    sandboxName: e2e-test
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox
 metadata:
   name: e2e-test
   namespace: azureclaw-system
 spec:
+  runtime:
+    kind: OpenClaw
+    openclaw:
+      version: "2026.3.13"
   sandbox:
     isolation: standard
-  inference:
-    model: gpt-4.1
+  inferenceRef:
+    name: e2e-test-inference
 EOF
     sleep 5
 


### PR DESCRIPTION
## S13 `phase2-config-authority-refs`

**BREAKING in-place v1alpha1 schema edit (pre-release; no conversion webhook).**
Inline inference and tool-policy config on `ClawSandbox` is removed; the
spec now carries same-namespace refs to dedicated `InferencePolicy` and
`ToolPolicy` CRDs which become the single source of truth.

### Schema changes

| Before | After |
|---|---|
| `spec.inference: InferenceConfig` (provider/model/contentSafety/promptShields/tokenBudget) | `spec.inferenceRef: { name }` — required, sibling `InferencePolicy` CR |
| `spec.governance.toolPolicy: string` (profile name) | `spec.governance.toolPolicyRef: { name }` — required when `governance.enabled=true` |

- Same-namespace constraint: `Api::namespaced(client, &sandbox_self_ns)`.
  Cross-namespace refs are deliberately not supported — a sandbox author
  must not be able to "borrow" policies from another tenant.
- New status reasons `InferencePolicyNotFound`, `ToolPolicyNotFound`
  emitted on `Degraded` when the referenced CR is missing.
- Printcolumn updated: `Model` → `InferencePolicy` (`.spec.inferenceRef.name`).

### Reconciler

`controller/src/reconciler/mod.rs` resolves `InferencePolicy` after
isolation validation and `ToolPolicy` after the governance block is
parsed. Hoisted vars `inference_model`, `content_safety_enabled`,
`prompt_shields_enabled`, `token_budget_{daily,per_request}`,
`tool_policy_profile` replace the previous inline reads. The
`agt-policy-{profile}` ConfigMap convention and the
`azureclaw-default.yaml` / `azureclaw-offload.yaml` selection are
preserved — the resolved `ToolPolicy`'s `metadata.name` doubles as the
profile identifier.

### CLI

- New `cli/src/refs.ts`: `kebabRefName` helper (DNS-1123 truncated to 63
  chars) + `buildInferencePolicy` / `buildToolPolicy` emitters.
- `azureclaw up` and `azureclaw add` now emit a multi-doc bundle
  (`InferencePolicy` + optional `ToolPolicy` + `ClawSandbox`) applied
  as a single `kubectl apply` of a `v1.List` manifest.
- `azureclaw migrate from-kagent` always emits an
  `<sandbox>-inference` `InferencePolicy` (preserving kagent
  `modelConfig` as a provenance annotation when set) and a synthetic
  `<sandbox>-toolpolicy` aggregator whenever governance is on.
- `attest.ts` recognizes both `inferenceRef` (S13) and the pre-S13
  `inferencePolicyRef` shape during the rollout window.

### Test delta

- **Controller**: 381 tests passing. Removed `default_model_is_gpt_4_1`,
  `default_provider_is_azure_openai`, `default_inference_*` /
  `inference_config_default_has_no_fallback` / `token_budget_config_*`.
  Added `local_object_ref_round_trips`,
  `local_object_ref_default_is_empty_name`,
  `inference_ref_round_trips_via_camel_case`,
  `governance_tool_policy_ref_serializes_camel_case`. Updated
  `default_governance_config` and `sandbox_spec_fields_all_optional`.
  `LocalObjectRef` is reused from the existing
  `crate::mcp_server::LocalObjectRef` (same shape, identical semantics).
- **CLI**: 395 tests passing. `add.test.ts` updated to assert
  `spec.inferenceRef.name === "<sandbox>-inference"` and
  `spec.governance.toolPolicyRef`. `from_kagent.test.ts` updated
  for the always-emit-InferencePolicy and `<sandbox>-toolpolicy`
  aggregator semantics; per-tool `ToolPolicy` count assertions filter
  out the aggregator.

### Pipeline

- `cargo fmt --all` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --all` ✅ (381 controller + 105 router + 26 integration tests)
- `cd cli && npm run lint && npm run typecheck && npm test && npm run build` ✅
- `helm lint deploy/helm/azureclaw` ✅

### Examples and fixtures

All `clawsandbox.yaml` in `examples/` (`basic-agent`,
`confidential-agent`, `telegram-agent`, `demo-clawshield/*`),
`tests/compat/fixtures/null-provider-*.yaml`, and `tests/e2e/run.sh`
updated to the new two-doc-per-sandbox shape (`InferencePolicy` then
`ClawSandbox`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>