### PR TITLE
phase2(post): a2a-gateway Dockerfile must COPY tests/ workspace members

### DIFF
--- a/a2a-gateway/Dockerfile
+++ b/a2a-gateway/Dockerfile
@@ -43,7 +43,9 @@ COPY a2a-gateway/src a2a-gateway/src
 COPY a2a-gateway/testdata a2a-gateway/testdata
 COPY azureclaw-a2a-core/src azureclaw-a2a-core/src
 COPY inference-router/src inference-router/src
+COPY inference-router/benches inference-router/benches
 COPY controller/src controller/src
+COPY controller/benches controller/benches
 COPY tests/chaos/src tests/chaos/src
 COPY tests/cncf-conformance/src tests/cncf-conformance/src
 

--- a/a2a-gateway/Dockerfile
+++ b/a2a-gateway/Dockerfile
@@ -33,6 +33,8 @@ COPY a2a-gateway/Cargo.toml a2a-gateway/Cargo.toml
 COPY azureclaw-a2a-core/Cargo.toml azureclaw-a2a-core/Cargo.toml
 COPY inference-router/Cargo.toml inference-router/Cargo.toml
 COPY controller/Cargo.toml controller/Cargo.toml
+COPY tests/chaos/Cargo.toml tests/chaos/Cargo.toml
+COPY tests/cncf-conformance/Cargo.toml tests/cncf-conformance/Cargo.toml
 
 # Source. Workspace-wide copy is wasteful but keeps the image build
 # context honest with the workspace shape (cargo refuses to build a
@@ -42,6 +44,8 @@ COPY a2a-gateway/testdata a2a-gateway/testdata
 COPY azureclaw-a2a-core/src azureclaw-a2a-core/src
 COPY inference-router/src inference-router/src
 COPY controller/src controller/src
+COPY tests/chaos/src tests/chaos/src
+COPY tests/cncf-conformance/src tests/cncf-conformance/src
 
 RUN cargo build \
         --release \


### PR DESCRIPTION
Post-merge follow-up to PR #125. The a2a-gateway image build (which runs against `main`) failed because a2a-gateway/Dockerfile uses per-member Cargo.toml + src copies (rather than the workspace-wide style of controller/inference-router); after S16 + S17 added `tests/chaos` and `tests/cncf-conformance` to the workspace members list, cargo refuses to load `/work/Cargo.toml` without their manifests.

Fix: add the two `tests/*` Cargo.toml + src copies before the cargo-build invocation. Mirrors the fix already shipped to the other two Rust image Dockerfiles in 23a6614.

No code-behavior change.