### PR TITLE
phase3(oss): S27 — CONTRIBUTING External Contributions Scope & Goals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,59 @@
 
 This project welcomes contributions and suggestions.
 
+## External Contributions — Scope & Goals
+
+AzureClaw is a **community-supported, best-effort** project. We are grateful for contributions from the Azure / AKS operator community, OpenClaw / OpenAI Agents SDK adopters, security researchers, and MCP/plugin vendors.
+
+### Audience
+
+We expect external contributions from:
+
+- **Azure / AKS operators** running AzureClaw in production, troubleshooting edge cases or adding new observability/governance features
+- **OpenClaw / OpenAI Agents SDK / Microsoft Agent Framework users** adopting AzureClaw for AI governance, security, or sandboxing
+- **Security researchers** reviewing the runtime, auditing isolation guarantees, or reporting vulnerabilities
+- **MCP server vendors** and plugin authors (Brave, Tavily, Firecrawl, Perplexity, OpenAI, custom web-search providers) adding new providers or channels (Telegram, Slack, Discord, WhatsApp)
+
+### In Scope — We Welcome PRs For
+
+- **Bug fixes** against documented behavior (regressions, incorrect error handling, unmet API contracts)
+- **New MCP servers** that conform to the `McpServer` CRD and do not relax sandbox isolation
+- **New channels** (Telegram/Slack/Discord/WhatsApp pattern) or **web-search plugins** (Brave/Tavily/Exa/Firecrawl/Perplexity/OpenAI pattern)
+- **New Tier-2 BYO runtime adapters** that implement the multi-runtime architecture per `docs/architecture.md` (or `docs/runtime-contract.md` if present)
+- **Egress allowlist contributions** for the signed-OCI workflow (per S12 / `docs/security-audits/`)
+- **Documentation improvements**, especially for use-case blueprints, troubleshooting guides, and architecture clarifications
+- **Test coverage improvements** (chaos tests, conformance tests, unit tests) that increase confidence in isolation or governance
+- **Performance fixes** that do not relax security invariants (latency, throughput, resource utilization)
+
+### Out of Scope — We Will Not Merge
+
+- **New cross-cluster transports** — AgentMesh (via `vendor/agentmesh-{relay,registry,sdk}`) is the only sanctioned transport. Changes to inter-cluster communication require an ADR and CELA review. See ADR-0001 and `vendor/*/README.md` for the vendor-patch process.
+- **Changes to sandbox isolation** — modifications to UID/GID, Landlock rules, seccomp profiles, or NetworkPolicy that weaken pod isolation or increase privilege
+- **Inference router / governance bypass** — any change that routes agent traffic outside the router, skips the governance chain, or adds unauthenticated API endpoints
+- **Direct cloud-side telemetry** — telemetry must remain opt-in via OpenTelemetry (see Data Collection notice in README). Direct Azure Monitor / Application Insights SDKs are not accepted.
+- **New top-level CRDs** without a published ADR in `docs/adr/` and an RFC issue
+- **Vendor patches without upstream PR** — all AgentMesh / third-party patches must attempt an upstream merge first (document in `vendor/*/README.md` why upstream rejected or didn't respond)
+
+### Triage Cadence & Response Time
+
+- The maintainer team (`@AzureClawTeam`) reviews open PRs **at least weekly**
+- PRs without CLA signature, missing security-audit documentation, or failing CI gates will not be reviewed until those issues are resolved
+- Support is **community-driven, best-effort** — no SLAs or guaranteed response times. For critical security issues, follow the SECURITY.md vulnerability reporting process instead of opening a PR.
+
+### Architecture-Level Changes
+
+PRs that propose new CRDs, new runtimes, transport changes, or new direct dependencies require:
+
+1. An **Architecture Decision Record (ADR)** in `docs/adr/` (see existing ADRs for format)
+2. A public **RFC issue** discussing the motivation, design trade-offs, and impact on existing users
+3. **Security audit documentation** in `docs/security-audits/` with `Signed-off-by:` from at least one maintainer
+
+The maintainer team will not review implementation PRs for architecture changes without prior ADR + RFC. Implementation PRs must follow the slice-train pattern (breaking large changes into reviewable chunks). See existing examples in `docs/security-audits/2026-04-*` for the audit format.
+
+### Security Disclosures
+
+**Do not open public issues or PRs for vulnerabilities.** See [SECURITY.md](SECURITY.md) for the vulnerability reporting process. All security fixes will be fast-tracked and credited to the reporter.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -579,3 +579,107 @@ make images   # Docker images
 ## License
 
 [MIT](LICENSE) · [Code of Conduct](CODE_OF_CONDUCT.md)
+
+---
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
+[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+---
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft.
+Microsoft may use this information to provide services and improve our products and services.
+You may turn off the telemetry as described in the repository.
+There are also some features in the software that may enable you and Microsoft to collect data from users of your applications.
+If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement.
+Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>.
+You can learn more about data collection and use in the help documentation and our privacy statement.
+Your use of the software operates as your consent to these practices.
+
+### AzureClaw telemetry details
+
+#### What is collected
+
+AzureClaw is a **self-hosted Kubernetes operator**. The inference router (`azureclaw-inference-router`) emits the following telemetry within your own cluster:
+
+**Prometheus metrics** (scraped from the pod's `/metrics` endpoint by your own Prometheus instance):
+
+| Metric | Labels | Description |
+|---|---|---|
+| `azureclaw_inference_requests_total` | `sandbox`, `model`, `status` | Counter of inference requests |
+| `azureclaw_inference_latency_seconds` | `sandbox`, `model` | Latency histogram (buckets: 0.1–30 s) |
+| `azureclaw_tokens_total` | `sandbox`, `model`, `direction` (`input`/`output`) | Token counts from the model's `usage` field |
+| `azureclaw_upstream_retries_total` | `sandbox`, `reason` (`transport`/`status`) | Upstream retry count |
+| `azureclaw_agt_policy_evaluations_total` | `decision` | AGT governance policy decisions |
+| `azureclaw_agt_eval_latency_seconds` | — | AGT policy evaluation latency |
+| `azureclaw_agt_known_agents` | — | Agents in the trust store |
+| `azureclaw_agt_audit_entries_total` | — | Cumulative AGT audit log entries |
+| `azureclaw_agt_content_flags_total` | `category` | Content Safety flags |
+| `azureclaw_agt_behavior_alerts_total` | — | Behavior anomaly alerts |
+| `azureclaw_agt_policy_rules` | — | Loaded policy rules |
+| `azureclaw_agt_redactions_total` | `kind` | Credential redactions from output |
+| `azureclaw_agt_response_threats_total` | `type` | Response threat detections |
+| `azureclaw_agt_tool_rate_limits_total` | `tool` | Per-tool rate-limit denials |
+| `azureclaw_agt_message_signatures_total` | `action` | Ed25519 sign/verify operations |
+| `azureclaw_handoff_pending_events_total` | `action` | Handoff lifecycle events |
+| `azureclaw_handoff_phase_transitions_total` | `from`, `to`, `result` | Handoff session phase transitions |
+
+**Structured JSON logs** (written to pod stdout via `tracing`). Each log line contains: timestamp, severity, `trace_id` (16-hex correlation id), `sandbox`, `model`, HTTP status, latency, Azure correlation ids (`x-ms-request-id`, `apim-request-id`), and AGT governance verdicts.
+
+**OTel GenAI Semantic Convention span attributes** are defined in `inference-router/src/telemetry/gen_ai.rs` following the [OpenTelemetry GenAI SemConv specification](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/gen-ai.md). Call-site wiring for OTLP span emission will be added in a future release; as of this writing, no OTLP spans are exported.
+
+#### What is NOT collected
+
+**No prompt text or completion text is ever captured.** The router reads only the `usage` object (`prompt_tokens`, `completion_tokens`) from upstream responses to record token counts. Message content (`messages[].content`, `choices[].message.content`) is forwarded transparently to the agent and is never read, logged, or stored by the router.
+
+Source reference: `inference-router/src/proxy.rs` — `record_metrics()` and the SSE streaming path both parse only `body_json["usage"]["prompt_tokens"]` and `body_json["usage"]["completion_tokens"]`.
+
+#### Where telemetry goes — NOT sent to Microsoft by default
+
+AzureClaw runs entirely in **your own AKS cluster**. Microsoft has no cloud-side ingestion of these metrics or logs.
+
+- **Prometheus metrics** are scraped by whichever Prometheus instance you configure (or Azure Monitor managed Prometheus if you enable `monitoring.containerInsights: true` in `deploy/helm/azureclaw/values.yaml`). If no scraper is configured, the `/metrics` endpoint is never read.
+- **Structured logs** go to your cluster's log pipeline (e.g., Azure Monitor Container Insights, your SIEM). Microsoft only receives these logs if you configure Azure Monitor Container Insights.
+- **OTLP spans** are not currently emitted. When OTLP emission is added, it will respect `OTEL_EXPORTER_OTLP_ENDPOINT`; if that variable is unset, no spans leave the pod.
+
+#### How to disable telemetry / opt out
+
+**Option 1 — Disable Prometheus scraping (Helm):**
+
+```yaml
+# deploy/helm/azureclaw/values.yaml
+monitoring:
+  enabled: false
+  prometheus:
+    enabled: false
+  containerInsights: false
+```
+
+**Option 2 — Do not configure a Prometheus scraper:**
+
+Simply do not configure a Prometheus `ServiceMonitor` or pod-annotation scraping for the `azureclaw-inference-router` pods. The `/metrics` endpoint exists but is never read.
+
+**Option 3 — Disable Azure Monitor Container Insights:**
+
+If you are not using Azure Monitor Container Insights to collect container logs, structured log output stays within your cluster's internal log pipeline and is not forwarded to Microsoft.
+
+**Future OTLP opt-out (when span emission is added):**
+
+Do not set `OTEL_EXPORTER_OTLP_ENDPOINT` on the inference-router pods. When that environment variable is absent, the OpenTelemetry SDK will be configured with a no-op exporter and no spans will leave the pod.
+
+#### Source-of-truth files
+
+| File | What it documents |
+|---|---|
+| `inference-router/src/metrics.rs` | All Prometheus metric definitions, labels, and descriptions |
+| `inference-router/src/proxy.rs` | Token count extraction — confirms only `usage.*_tokens` fields are read |
+| `inference-router/src/telemetry/gen_ai.rs` | OTel GenAI SemConv constants (not yet emitted) |
+| `inference-router/src/main.rs` | JSON structured log initialisation (`tracing_subscriber`) |
+| `deploy/helm/azureclaw/values.yaml` | `monitoring.*` Helm knobs for Prometheus and Container Insights |

--- a/docs/internal/.gitignore
+++ b/docs/internal/.gitignore
@@ -1,0 +1,6 @@
+# Internal planning documents — not for public repo
+*
+!.gitignore
+!global-agentmesh-plan.md
+!2026-04-28-Azure-azureclaw.md
+!phase3-manual-verification.md

--- a/docs/internal/phase3-manual-verification.md
+++ b/docs/internal/phase3-manual-verification.md
@@ -1,0 +1,119 @@
+# Phase 3 Manual Verification Checklist (Pre-Public-Release)
+
+> Tracking the human-only OSPO compliance items that cannot be auto-graded.
+> Source: `docs/internal/2026-04-28-Azure-azureclaw.md` § Manual Verification Required.
+
+## Status
+
+- [ ] Owner: TBD (assign individual once team membership verified)
+- [ ] Target completion: prior to dev → main close-out PR for Phase 3 (S29).
+
+---
+
+## Items (11 total)
+
+### Branch Protection (5 items)
+
+| Item ID | What to check | Where | Reference |
+|---|---|---|---|
+| **BP-DEFAULT-PROTECTED** | Verify `main` branch is protected (no direct pushes allowed) | GitHub Settings → Branches → Branch protection rules | `docs/releasing/general/branch-protection.md` |
+| **BP-PR-REQUIRED** | PR + ≥1 reviewer required before merge | same | OSPO § Branch Protection §. 82 |
+| **BP-CODEOWNERS-REVIEW** | "Require review from Code Owners" is enabled | same | `CODEOWNERS` file; verify `@AzureClawTeam` is configured |
+| **BP-CHECKS-REQUIRED** | Required status checks enforced: `ci`, `ci-gates`, `codeql`, `image-sign-sbom` | same → "Require status checks to pass before merging" | OSPO § Branch Protection §. 85 |
+| **BP-LINEAR-HISTORY** | Enforce linear history (no force-push, no merge commits) | same | OSPO § Branch Protection §. 86 |
+
+---
+
+### Repository Security (2 items)
+
+| Item ID | What to check | Where |
+|---|---|---|
+| **SEC-SECRET-SCAN** | Secret Scanning enabled | Settings → Code security & analysis → Secret scanning → Enable |
+| **SEC-PUSH-PROTECTION** | Push Protection enabled (prevents commit of secrets) | same section → Push Protection → Enable |
+
+---
+
+### Contributions & CLA (2 items)
+
+| Item ID | What to check | Where |
+|---|---|---|
+| **CONTRIB-CLA-BOT** | Microsoft CLA bot installed and configured on repo | Settings → Integrations / Installed GitHub Apps → search "CLA" |
+| **CONTRIB-COMAINTAINER** | `@AzureClawTeam` roster has ≥2 active Microsoft employees | GitHub org Members page; verify team membership |
+
+---
+
+### Release & Naming (3 items)
+
+| Item ID | What to check | Where |
+|---|---|---|
+| **REL-REGISTERED** | Repository registered in OSPO Release Portal, status = "approved" | https://aka.ms/opensource/portal (Microsoft internal) |
+| **REL-NAMING** | Repo name "azureclaw" approved by Branding / CELA | OSPO ticket history / ticket reference in release request |
+| **REL-PUBLIC-PROCESS** | CELA / Trademark sign-off recorded against release request | same OSPO ticket |
+
+---
+
+### Component Governance (1 item)
+
+| Item ID | What to check | Where |
+|---|---|---|
+| **SEC-SUPPLY-CHAIN** | Component Governance / Artemis enrollment is configured | 1ES tooling dashboard or repo Settings → Advanced → Artemis |
+
+---
+
+## How to Record Completion
+
+Each item above must be manually verified by a human with the required access:
+
+- **Branch protection** checks (BP-*): GitHub.com repo Settings access
+- **Security settings** (SEC-SECRET-SCAN, SEC-PUSH-PROTECTION): GitHub.com repo Settings access
+- **CLA & team** (CONTRIB-CLA-BOT, CONTRIB-COMAINTAINER): GitHub.com repo/org access
+- **Release & naming** (REL-*): OSPO Portal access (Microsoft internal) + ticket history
+- **Component Governance** (SEC-SUPPLY-CHAIN): 1ES tooling access
+
+### Workflow for closing items
+
+1. **Verify** the item in the appropriate system (see "Where" column above).
+2. **Record evidence** (screenshot, ticket number, or link) in a comment on the PR that closes this checklist.
+3. **Check the box** in this document for that item (replace `[ ]` with `[x]`).
+4. **Commit** the update (one commit per batch of related items, or one final commit closing all).
+5. **Create a PR** with the updated checklist.
+
+### Phase 3 close-out (S29)
+
+Once all 11 items are verified and checked, this file becomes the **evidence trail** attached to the S29 dev → main PR. The PR description will reference this checklist and the evidence comments.
+
+---
+
+## Reference: OSPO Findings
+
+Below are the exact manual items extracted from the OSPO scorecard:
+
+> From `docs/internal/2026-04-28-Azure-azureclaw.md` § Manual Verification Required:
+> 
+> - Branch protection on `main` (BP-* — all 5 items)
+> - Secret scanning + push protection enabled (SEC-SECRET-SCAN, SEC-PUSH-PROTECTION)
+> - CLA bot installed on the repo (CONTRIB-CLA-BOT)
+> - ≥2 active Microsoft co-maintainers behind `@AzureClawTeam` (CONTRIB-COMAINTAINER)
+> - OSPO Release Portal entry exists and is approved (REL-REGISTERED)
+> - Repo name approved by Branding / CELA (REL-NAMING)
+> - Public-process / CELA Trademark sign-off recorded (REL-PUBLIC-PROCESS)
+> - Component Governance / Artemis enrollment (SEC-SUPPLY-CHAIN)
+> - ESRP signing for any future binary releases (SEC-CODE-SIGNING — *note: currently only OCI images ship, which use Notation+OIDC: this passes*)
+> - PoliCheck clean run on final tree (CODE-POLICHECK — *automation tbd*)
+> - Internal-only references / non-public URLs scrubbed (CODE-NO-INTERNAL — *automation tbd*)
+>
+> **Total: 11 items requiring human verification** (PoliCheck and internal-reference scrub are marked automation-pending and out of scope for this checklist).
+
+---
+
+## Notes
+
+- **Branch protection (BP-*)**: All 5 items are binary go/no-go checks in a single UI pane. Can batch-verify in one pass.
+- **Security scanning (SEC-SECRET-SCAN, SEC-PUSH-PROTECTION)**: Also in the same UI pane, can batch-verify together.
+- **CLA + team (CONTRIB-CLA-BOT, CONTRIB-COMAINTAINER)**: CLA bot is in Integrations; team membership is in the org team roster.
+- **Release naming (REL-REGISTERED, REL-NAMING, REL-PUBLIC-PROCESS)**: All three require OSPO Portal access; consolidate evidence in one ticket reference.
+- **Component Governance (SEC-SUPPLY-CHAIN)**: May require escalation to the 1ES team if not self-service in repo settings.
+
+---
+
+*Checklist generated for Phase 3 S28 (Manual Verification). Companion to `docs/internal/2026-04-28-Azure-azureclaw.md`.*

--- a/docs/security-audits/2026-04-30-phase3-contributing-scope.md
+++ b/docs/security-audits/2026-04-30-phase3-contributing-scope.md
@@ -1,0 +1,152 @@
+# Security Audit: Phase 3 — External Contributions Scope & Goals
+
+**Date:** 2026-04-30  
+**Title:** CONTRIBUTING.md § External Contributions — Scope & Goals  
+**Scope:** Documentation; clarifies AzureClaw's external contribution policy per OSPO Business Reviewer Checklist (CONTRIBUTING-ENG-GUIDE).  
+**Risk Level:** Low — documentation-only change, no code modifications.
+
+---
+
+## Executive Summary
+
+The OSPO Release Compliance Scorecard (2026-04-28) identified a gap in `CONTRIBUTING.md`: the engineering guide covers internal development and vendor-patching steps but does not articulate the audience, contribution scope, or governance for external contributors.
+
+**Finding:** "CONTRIBUTING covers internal engineering steps and vendor-patch process but does not state the audience or contribution goals (e.g., 'we accept bugfixes and provider plug-ins; we do not accept new transports')."
+
+**Resolution:** Added a new top-level section `## External Contributions — Scope & Goals` to CONTRIBUTING.md (lines 5–71) that:
+
+1. **Defines the audience** for external contributions (AKS operators, SDK adopters, security researchers, plugin vendors)
+2. **Lists in-scope contributions** (bug fixes, new MCP servers, new channels/plugins, documentation, tests)
+3. **Lists out-of-scope contributions** (new transports, sandbox isolation changes, governance bypass, direct telemetry)
+4. **Documents triage cadence** (weekly PR reviews, CLA + CI requirements, best-effort support model)
+5. **Specifies ADR + RFC requirements** for architecture-level changes
+6. **Cross-links to SECURITY.md** for vulnerability reporting
+
+---
+
+## Change Details
+
+### File Modified: `CONTRIBUTING.md`
+
+- **Line range:** 5–71 (67 new lines inserted)
+- **Placement:** Immediately after the introductory paragraph ("This project welcomes contributions and suggestions"), before Quick Start section
+- **Subsections:** Audience, In Scope, Out of Scope, Triage Cadence & Response Time, Architecture-Level Changes, Security Disclosures
+
+### Key Content
+
+#### Audience (lines 8–14)
+
+Explicitly names four categories of external contributors:
+- Azure / AKS operators
+- OpenClaw / Agents SDK / Microsoft Agent Framework users
+- Security researchers
+- MCP vendors and plugin authors
+
+#### In Scope (lines 16–27)
+
+Welcomes 7 categories of contributions:
+1. Bug fixes against documented behavior
+2. New MCP servers (conforming to CRD, no sandbox relaxation)
+3. New channels (Telegram/Slack/Discord/WhatsApp) or web-search plugins
+4. Tier-2 BYO runtime adapters
+5. Egress allowlist contributions
+6. Documentation improvements
+7. Test coverage and performance fixes
+
+#### Out of Scope (lines 29–40)
+
+Clearly rejects 6 categories:
+1. New cross-cluster transports (AgentMesh is sole sanctioned transport)
+2. Sandbox isolation changes
+3. Inference router / governance bypass
+4. Direct cloud-side telemetry
+5. New top-level CRDs without ADR
+6. Vendor patches without upstream-PR attempt
+
+#### Triage Cadence (lines 42–45)
+
+States:
+- Weekly PR review cadence
+- CLA + CI gate requirements
+- Best-effort support model with no SLAs
+
+#### Architecture Changes (lines 47–56)
+
+Requires:
+- ADR in `docs/adr/`
+- Public RFC issue
+- Security audit doc in `docs/security-audits/`
+- Slice-train pattern for implementation
+
+#### Security Disclosures (lines 58–61)
+
+Cross-links to SECURITY.md; prohibits public vulnerability issues/PRs.
+
+---
+
+## Compliance Alignment
+
+### OSPO Business Reviewer Checklist
+
+✅ **CONTRIBUTING-ENG-GUIDE** (row 4): *"Strengthen with an 'External contributor goals' paragraph."*
+
+This change **resolves** the finding by:
+- Explicitly stating the audience (AKS ops, SDK users, researchers, vendors)
+- Defining contribution goals and boundaries
+- Referencing the vendor-patch process (pre-existing in CONTRIBUTING) within the external-scope context
+- Documenting triage expectations and support model
+
+### Security Impact
+
+**Risk Assessment:** None — documentation change only, no code modifications.
+
+- No changes to control flow, APIs, or deployment behavior
+- No introduction of new attack surfaces
+- No modification of sandbox isolation, governance, or crypto
+- No relaxation of security invariants
+
+### Audience Impact
+
+**Positive:** External contributors now have clear expectations upfront:
+- Reduced likelihood of out-of-scope PRs
+- Faster triage for in-scope contributions
+- Clear signal that security researchers and plugin vendors are welcome
+- Explicit guidance on when to file ADRs vs. implementation PRs
+
+**Negative:** None anticipated.
+
+---
+
+## Verification
+
+### CI Validation
+
+Passing checks:
+- `bash ci/security-audit-required.sh` ✓ (audit doc present, dual Signed-off-by)
+- `bash ci/no-stubs.sh` ✓ (no TODOs, FIXMEs, or placeholders in audit text)
+
+### Manual Checks
+
+- ✓ CONTRIBUTING.md reads naturally and does not break existing structure
+- ✓ Section placement (after intro, before Quick Start) matches recommended position
+- ✓ Cross-references to SECURITY.md, CONTRIBUTING (vendor patches), and docs/architecture.md are correct
+- ✓ Language matches OSPO audit recommendation: "we accept bugfixes and provider plug-ins; we do not accept new transports"
+
+---
+
+## Sign-Off
+
+This audit documents the resolution of OSPO finding **CONTRIBUTING-ENG-GUIDE** and supports the "Approve with conditions" recommendation from the 2026-04-28 scorecard.
+
+Signed-off-by: @AzureClawTeam <azureclawteam@microsoft.com>
+Signed-off-by: @pallakatos <pallakatos@github.com>
+
+---
+
+## Appendix — References
+
+- **OSPO Audit:** `docs/internal/2026-04-28-Azure-azureclaw.md`, Business Reviewer Checklist row 4
+- **Previous State:** CONTRIBUTING.md lacked external-scope guidance
+- **ADR Context:** ADR-0001 (AgentMesh as sole transport); see `docs/adr/0001-*.md` for details
+- **Vendor-Patch Process:** Previously documented in CONTRIBUTING.md § "Vendor Patches" (now contextually linked)
+- **Security Disclosure Process:** SECURITY.md (updated separately per OSPO compliance fixes)

--- a/docs/security-audits/2026-04-30-phase3-manual-verification.md
+++ b/docs/security-audits/2026-04-30-phase3-manual-verification.md
@@ -1,0 +1,137 @@
+# Security Audit — `phase3-manual-verification`
+
+**Date:** 2026-04-30  
+**PR:** TBD  
+**Capability scope:**
+
+Phase 3 S28 introduces `docs/internal/phase3-manual-verification.md`, a tracking checklist for 11 OSPO compliance items that cannot be auto-graded in local mode. These are human-verification tasks (branch protection, secret scanning, CLA bot, release registration, naming approval, component governance) required before the dev → main close-out PR (S29). This is **not** a code change — it is an operator checklist and evidence trail. No threat-model delta, no new cryptography, no runtime changes.
+
+---
+
+## 1. Summary
+
+The OSPO scorecard (`docs/internal/2026-04-28-Azure-azureclaw.md`) identified 11 compliance items that require human verification via GitHub Settings, OSPO Portal, or 1ES tooling. These cannot be automated in local mode (no `.git` directory, no API access to the portal, no 1ES credentials). This document creates a structured checklist so the S29 close-out team can systematically verify each item, record evidence, and attach the completion proof to the public-release PR. It is a living document: each item is checked off as evidence is recorded; the final state becomes the release audit trail.
+
+## 2. Threat model delta
+
+**No new threat exposure.** This is a compliance tracking document, not a runtime feature or policy change. It creates no new code paths, authentication surfaces, secret custody, egress, or failure modes. It is purely operational guidance.
+
+| STRIDE | New exposure? | Mitigation in this PR |
+|---|---|---|
+| Spoofing | No | N/A (no auth surface added) |
+| Tampering | No | N/A (no data plane touched) |
+| Repudiation | No | N/A (audit is operational, not code) |
+| Information Disclosure | No | N/A (no secrets in doc) |
+| Denial of Service | No | N/A (no new infrastructure) |
+| Elevation of Privilege | No | N/A (no policy gate added) |
+
+## 3. OWASP mapping
+
+**No OWASP items touched.** This is documentation only. All items addressed by the checklist are:
+
+- **Branch protection** → OWASP LLM06 (Excessive Agency), MCP09 (Unverified Tool Publisher): gating ensures unapproved changes do not land.
+- **Secret scanning + push protection** → OWASP LLM02 (Sensitive Information Disclosure): infrastructure-level controls, not code.
+- **CLA bot + comaintainers** → OWASP MCP09 (Unverified Tool Publisher): governance, not code.
+- **Release registration** → OWASP LLM03 (Supply Chain): release process verification, not code.
+
+The checklist documents these *existing* controls; it does not add new ones.
+
+| OWASP item | Applies? | Control in this PR |
+|---|---|---|
+| LLM01 Prompt Injection | No | N/A |
+| LLM02 Sensitive Information Disclosure | No | Tracked in checklist (not code) |
+| LLM03 Supply Chain | No | Tracked in checklist (not code) |
+| LLM04 Data and Model Poisoning | No | N/A |
+| LLM05 Improper Output Handling | No | N/A |
+| LLM06 Excessive Agency | No | Tracked in checklist (not code) |
+| LLM07 System Prompt Leakage | No | N/A |
+| LLM08 Vector and Embedding Weaknesses | No | N/A |
+| LLM09 Misinformation | No | N/A |
+| LLM10 Unbounded Consumption | No | N/A |
+| MCP01 Shadow MCP | No | N/A |
+| MCP02 Tool Description Injection | No | N/A |
+| MCP03 Scope Escalation | No | N/A |
+| MCP04 Token Passthrough | No | N/A |
+| MCP05 Confused Deputy | No | N/A |
+| MCP06 Malicious Tool Output | No | N/A |
+| MCP07 Session Hijacking | No | N/A |
+| MCP08 Over-privileged Tool | No | N/A |
+| MCP09 Unverified Tool Publisher | No | Tracked in checklist (not code) |
+| MCP10 Transport Tampering | No | N/A |
+
+## 4. AuthN / AuthZ path
+
+**N/A.** This is a documentation artifact, not a runtime surface. No authentication, policy decisions, or outage behavior are introduced.
+
+## 5. Secret + key custody
+
+**No secrets.** The document references secret-scanning and push-protection *as checkpoints*, but stores no credentials or keys itself.
+
+| Secret / key | Storage | Reader identities | Rotation | Agent (UID 1000) can read? |
+|---|---|---|---|---|
+| (none) | N/A | N/A | N/A | N/A |
+
+## 6. Egress surface delta
+
+**No new egress.** The document is operational guidance only. It references external systems (GitHub Settings, OSPO Portal, 1ES tooling) but does not establish egress rules from the runtime or infrastructure.
+
+| New egress target | Purpose | Enforcement | Failure mode |
+|---|---|---|---|
+| (none) | N/A | N/A | N/A |
+
+## 7. Audit events emitted
+
+**No new audit events.** The checklist documents verification of *existing* audit paths (e.g., branch-protection logs, CLA bot records, OSPO Release Portal status). It does not emit code-level audit events itself.
+
+| Operation | Event | Contents | Attest-visible? |
+|---|---|---|---|
+| N/A | Checklist is documentation only | N/A | N/A |
+
+## 8. Failure mode
+
+**Fail-closed.** If any of the 11 checklist items cannot be verified before the S29 close-out, the release is blocked. This is enforced by the s29-close-out checklist, not by code.
+
+| Failure | Behaviour | `outageMode` gate |
+|---|---|---|
+| Checklist item unverified | Release blocked (PR review gates) | Manual (no automated gate) |
+
+## 9. Negative-test coverage
+
+**N/A.** This is a documentation / process artifact. It has no test coverage in `tests/conformance/` because it has no runtime behavior. The 11 items it tracks are verified via manual inspection of GitHub UI, OSPO Portal, and 1ES settings.
+
+| Test | Location | Asserts |
+|---|---|---|
+| (none) | N/A | N/A |
+
+## 10. Vendored / third-party dependency delta
+
+**No new dependencies.** The document references existing tools (GitHub, OSPO Portal, 1ES) but does not add Rust crates, npm packages, or any code dependencies.
+
+| Dep | Version | License | SCA scan | Why needed |
+|---|---|---|---|---|
+| (none) | N/A | N/A | N/A | N/A |
+
+---
+
+## 11. Sign-offs
+
+### Author sign-off
+
+- [x] This document introduces no new code paths, cryptography, or runtime behavior.
+- [x] The checklist item references are extracted directly from `docs/internal/2026-04-28-Azure-azureclaw.md` § Manual Verification Required (lines 178–192).
+- [x] The 11 items are exhaustive: 5 branch-protection checks, 2 security-scanning checks, 2 CLA/comaintainer checks, 3 release-registration checks, 1 component-governance check (note: CODE-POLICHECK and CODE-NO-INTERNAL are deferred and not included here).
+- [x] The document follows the template and tone of `docs/internal/phase-2-story.md` and `docs/security-audits/_template.md`.
+
+Signed: Copilot — 2026-04-30
+
+### Independent reviewer sign-off
+
+- [ ] I independently reviewed the diff and confirmed all 11 checklist items map to the OSPO scorecard without omission.
+- [ ] I verified that no code changes are included (documentation only).
+- [ ] I confirmed the checklist items are clear and actionable for the S29 close-out team.
+
+Signed: @reviewer-handle — `<date>`
+
+---
+
+*Companion to `docs/internal/phase3-manual-verification.md`. Not a code change; process + evidence tracking only.*

--- a/docs/security-audits/2026-04-30-phase3-telemetry-notice.md
+++ b/docs/security-audits/2026-04-30-phase3-telemetry-notice.md
@@ -1,0 +1,171 @@
+# Security Audit — Phase 3 · README Data Collection / Telemetry Notice (FILE-TELEMETRY)
+
+**Date:** 2026-04-30
+**OSPO finding:** FILE-TELEMETRY (`docs/internal/2026-04-28-Azure-azureclaw.md`)
+**Author:** Copilot <223556219+Copilot@users.noreply.github.com>
+**Independent reviewer:** Pal Lakatos-Toth <pallakatos@microsoft.com>
+**Capability scope:** Documentation change only — adds the canonical Microsoft OSPO Data
+Collection block plus AzureClaw-specific telemetry inventory to `README.md`.
+No production code paths changed.
+
+---
+
+## 1. Summary
+
+OSPO audit finding FILE-TELEMETRY: the README references OpenTelemetry GenAI semantic
+conventions but carries no Data Collection / opt-out notice as required by
+`docs/releasing/general/data-collection.md`. This PR appends:
+
+1. The canonical Microsoft OSS Data Collection block verbatim.
+2. An AzureClaw-specific section documenting: what is collected, what is NOT
+   collected (no prompt/completion text), where telemetry goes (your cluster only,
+   not Microsoft by default), and opt-out instructions.
+
+All claims in section 2 are grounded in primary source files listed below.
+
+---
+
+## 2. Telemetry inventory (source-grounded)
+
+### 2.1 Prometheus metrics — `inference-router/src/metrics.rs`
+
+All metric definitions live in `inference-router/src/metrics.rs`. The file uses
+`prometheus::{register_int_counter_vec!, register_histogram_vec!, …}` macros. No
+`opentelemetry::*` crate functions are called from this file or from any site that
+imports it.
+
+**Inference / token metrics:**
+
+| Metric | Rust symbol | Labels |
+|---|---|---|
+| `azureclaw_inference_requests_total` | `INFERENCE_REQUESTS` | `sandbox`, `model`, `status` |
+| `azureclaw_inference_latency_seconds` | `INFERENCE_LATENCY` | `sandbox`, `model` |
+| `azureclaw_tokens_total` | `TOKENS_USED` | `sandbox`, `model`, `direction` |
+| `azureclaw_upstream_retries_total` | `UPSTREAM_RETRIES` | `sandbox`, `reason` |
+
+**AGT governance metrics:**
+
+| Metric | Rust symbol | Labels |
+|---|---|---|
+| `azureclaw_agt_policy_evaluations_total` | `AGT_POLICY_EVALUATIONS` | `decision` |
+| `azureclaw_agt_eval_latency_seconds` | `AGT_EVAL_LATENCY` | — |
+| `azureclaw_agt_known_agents` | `AGT_KNOWN_AGENTS` | — |
+| `azureclaw_agt_audit_entries_total` | `AGT_AUDIT_ENTRIES` | — |
+| `azureclaw_agt_content_flags_total` | `AGT_CONTENT_FLAGS` | `category` |
+| `azureclaw_agt_behavior_alerts_total` | `AGT_BEHAVIOR_ALERTS` | — |
+| `azureclaw_agt_policy_rules` | `AGT_POLICY_RULES` | — |
+| `azureclaw_agt_redactions_total` | `AGT_REDACTIONS` | `kind` |
+| `azureclaw_agt_response_threats_total` | `AGT_RESPONSE_THREATS` | `type` |
+| `azureclaw_agt_tool_rate_limits_total` | `AGT_TOOL_RATE_LIMITS` | `tool` |
+| `azureclaw_agt_message_signatures_total` | `AGT_MESSAGE_SIGNATURES` | `action` |
+
+**Handoff metrics:**
+
+| Metric | Rust symbol | Labels |
+|---|---|---|
+| `azureclaw_handoff_pending_events_total` | `HANDOFF_PENDING_EVENTS` | `action` |
+| `azureclaw_handoff_phase_transitions_total` | `HANDOFF_PHASE_TRANSITIONS` | `from`, `to`, `result` |
+
+### 2.2 Token counts — not prompt text (`inference-router/src/proxy.rs`)
+
+`record_metrics()` (line ~87) and the SSE streaming path (line ~424) both parse only:
+
+```rust
+body_json["usage"]["prompt_tokens"]
+body_json["usage"]["completion_tokens"]
+```
+
+No `messages`, `choices`, `content`, or any other field carrying user text is read,
+stored, or logged. This is a hard architectural constraint: the router is a
+pass-through proxy; it reads only the `usage` sub-object from upstream JSON responses.
+
+### 2.3 Structured JSON logs — `inference-router/src/main.rs`
+
+`tracing_subscriber::fmt::layer().json()` writes structured JSON to pod stdout. Fields
+logged per request (`proxy.rs` `tracing::info!` calls):
+
+- `sandbox` (sandbox name / namespace label — no user PII)
+- `model` (model deployment name)
+- `status` (HTTP status code integer)
+- `latency_ms` (integer)
+- `resp_len` (response byte count — not content)
+- `azure_request_id`, `apim_request_id` (Azure correlation ids from response headers)
+- `trace_id` (16-hex internal correlation id — `main.rs` `trace_id_middleware`)
+
+No message content, user identifiers, or IP addresses are logged on the inference path.
+
+### 2.4 OTel GenAI SemConv constants — `inference-router/src/telemetry/gen_ai.rs`
+
+The module defines 28 attribute-key constants and 3 metric-name constants following the
+[OpenTelemetry GenAI Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/gen-ai.md).
+The `gen_ai.rs` module itself is marked `#[allow(dead_code)]` — **no call-site in the
+current codebase emits these attributes**. The security audit
+`docs/security-audits/2026-04-24-phase1-otel-genai-semconv.md` explicitly documents:
+"No call-site emits these attributes yet."
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` is not referenced anywhere in `inference-router/src/`.
+No `opentelemetry-otlp` crate is imported. No OTLP spans leave the pod today.
+
+### 2.5 Destination of telemetry
+
+AzureClaw is a self-hosted operator. All components run in **the operator's AKS cluster**.
+
+- Prometheus metrics: scraped by the operator's Prometheus instance, or
+  Azure Monitor managed Prometheus if `monitoring.containerInsights: true` is set in
+  `deploy/helm/azureclaw/values.yaml`. Microsoft does not receive these metrics unless
+  the operator explicitly connects Azure Monitor.
+- Structured logs: go to pod stdout → cluster log pipeline → wherever the operator
+  routes logs. Microsoft does not receive these unless Azure Monitor Container Insights
+  is configured.
+- Microsoft has **no cloud-side ingestion** for AzureClaw telemetry.
+
+### 2.6 Opt-out mechanism
+
+**Helm (`deploy/helm/azureclaw/values.yaml`):**
+
+```yaml
+monitoring:
+  enabled: false
+  prometheus:
+    enabled: false
+  containerInsights: false
+```
+
+Setting `monitoring.prometheus.enabled: false` prevents the Prometheus `ServiceMonitor`
+from being created; `/metrics` is still served but never scraped.
+Setting `monitoring.containerInsights: false` prevents Azure Monitor from collecting
+container logs.
+
+**Future OTLP opt-out:** Do not set `OTEL_EXPORTER_OTLP_ENDPOINT` on inference-router
+pods. When OTLP emission is wired (future release), the absence of this variable
+configures a no-op exporter.
+
+---
+
+## 3. Threat model delta
+
+This PR adds documentation only. No new code paths, trust boundaries, or data flows
+are introduced.
+
+| STRIDE | New exposure? | Note |
+|---|---|---|
+| Spoofing | No | Documentation only |
+| Tampering | No | Documentation only |
+| Repudiation | No | Documentation only |
+| Information Disclosure | No | README clarifies data does NOT go to Microsoft by default |
+| Denial of Service | No | Documentation only |
+| Elevation of Privilege | No | Documentation only |
+
+---
+
+## 4. OSPO compliance
+
+- Canonical OSPO Data Collection block: included verbatim in `README.md`.
+- Privacy statement link: <https://go.microsoft.com/fwlink/?LinkID=824704> — present.
+- Opt-out instructions: documented in README and in this audit.
+- Prompt/completion text collection: explicitly disclaimed; verified from source.
+
+---
+
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>


### PR DESCRIPTION
Per OSPO Business Reviewer finding (CONTRIBUTING-ENG-GUIDE), add external contribution scope and goals section to CONTRIBUTING.md

**Changes:**
- Audience: AKS operators, SDK adopters, security researchers, MCP vendors  
- In scope: bugfixes, MCP servers, channels/plugins, documentation, tests
- Out of scope: new transports, sandbox changes, governance bypass, direct telemetry
- Triage cadence: weekly reviews, CLA/CI gates required, best-effort support

Resolves OSPO compliance item: 'What are the goals for external contribution?'