### PR TITLE
phase3(oss): S26 — per-file Microsoft + MIT copyright headers + CI gate (CODE-COPYRIGHT-HDRS)

### DIFF
--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -29,6 +29,7 @@ jobs:
           - security-audit-required
           - vendored-patch-audit
           - a2a-module-isolation
+          - copyright-headers
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,4 +61,5 @@ jobs:
             security-audit-required)   ./ci/security-audit-required.sh ;;
             vendored-patch-audit)      ./ci/vendored-patch-audit.sh ;;
             a2a-module-isolation)      ./ci/a2a-module-isolation.sh ;;
+            copyright-headers)         ./ci/check-copyright-headers.sh ;;
           esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,19 @@ you exceed it intentionally.
 `cli/src/plugin.ts` is a known outlier (>4000 LOC) tracked separately —
 same rule applies to new TS files.
 
+### Copyright Headers
+
+Every AzureClaw-authored source file (`.rs`, `.ts`, `.tsx`, `.js`, `.sh`) **must** begin with the two-line Microsoft + MIT copyright header:
+
+```
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+```
+
+(Use `#` instead of `//` for shell scripts.) For shell scripts with a shebang, the shebang stays on line 1 and the header follows immediately on lines 2–3.
+
+The CI gate `ci/check-copyright-headers.sh` enforces this on every PR. Add the header to any new file before opening your PR. Vendored code under `vendor/` is excluded — do not add Microsoft headers there.
+
 ## Code of Conduct
 
 [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/) · [FAQ](https://opensource.microsoft.com/codeofconduct/faq/) · [opencode@microsoft.com](mailto:opencode@microsoft.com)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "azureclaw-cncf-conformance"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "walkdir",
+]
+
+[[package]]
 name = "azureclaw-controller"
 version = "0.1.0"
 dependencies = [

--- a/a2a-gateway/src/health.rs
+++ b/a2a-gateway/src/health.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `/healthz` and `/readyz` endpoints.
 //!
 //! - `/healthz`: liveness — process is alive and event loop is

--- a/a2a-gateway/src/lib.rs
+++ b/a2a-gateway/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `azureclaw-a2a-gateway` — public-ingress A2A edge.
 //!
 //! ## Position in the call graph (ADR-0001 #4)

--- a/a2a-gateway/src/main.rs
+++ b/a2a-gateway/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `azureclaw-a2a-gateway` binary entry-point.
 //!
 //! Wires:

--- a/a2a-gateway/src/metrics.rs
+++ b/a2a-gateway/src/metrics.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Prometheus exporter for the A2A gateway.
 //!
 //! Single registry; metric names are stable across releases (they

--- a/a2a-gateway/src/mtls.rs
+++ b/a2a-gateway/src/mtls.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Upstream mTLS to the inference-router (port 8444).
 //!
 //! Loads:

--- a/a2a-gateway/src/proxy.rs
+++ b/a2a-gateway/src/proxy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Outbound proxy → inference-router :8444 (mTLS).
 //!
 //! Forwards the inbound, post-verification body to the router,

--- a/a2a-gateway/src/rate_limit.rs
+++ b/a2a-gateway/src/rate_limit.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Per-subject token-bucket rate limiter.
 //!
 //! In-memory only. Replicas of the gateway do not synchronise their

--- a/a2a-gateway/src/tls.rs
+++ b/a2a-gateway/src/tls.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Server TLS for the public listener.
 //!
 //! Loads cert + key from PEM files (typically projected from a K8s

--- a/a2a-gateway/src/verify.rs
+++ b/a2a-gateway/src/verify.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Inbound JWS verification + replay protection.
 //!
 //! Wraps [`azureclaw_a2a_core::verify_inbound_card`] and adds a

--- a/azureclaw-a2a-core/src/agent_card.rs
+++ b/azureclaw-a2a-core/src/agent_card.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 AgentCard data model per spec §4.4.
 //!
 //! Spec: <https://a2a-protocol.org/v1.0.0/specification#44-agent-discovery-objects>

--- a/azureclaw-a2a-core/src/card_signing.rs
+++ b/azureclaw-a2a-core/src/card_signing.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 AgentCard signing and verification — end-to-end.
 //!
 //! Spec: <https://a2a-protocol.org/v1.0.0/specification#447-agentcardsignature>

--- a/azureclaw-a2a-core/src/card_verifier.rs
+++ b/azureclaw-a2a-core/src/card_verifier.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Inbound A2A AgentCard verification — the symmetric counterpart to
 //! [`card_server`](super::card_server).
 //!

--- a/azureclaw-a2a-core/src/error.rs
+++ b/azureclaw-a2a-core/src/error.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 error catalogue per spec §3.3.2 (errors).
 //!
 //! These errors are surfaced over the JSON-RPC binding using the

--- a/azureclaw-a2a-core/src/lib.rs
+++ b/azureclaw-a2a-core/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `azureclaw-a2a-core` — shared A2A 1.0.0 primitives.
 //!
 //! ## Why this crate exists (Phase 2 S3.5 — ADR-0001 #4)

--- a/azureclaw-a2a-core/src/signature.rs
+++ b/azureclaw-a2a-core/src/signature.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! JWS detached-content signature primitives for AgentCard signing.
 //!
 //! Implements the small subset of RFC 7515 needed to sign and verify

--- a/ci/a2a-module-isolation.sh
+++ b/ci/a2a-module-isolation.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ci/a2a-module-isolation.sh — enforces ADR-0001 D4.
 #
 # The A2A inbound code path (inference-router/src/a2a/ and any future

--- a/ci/check-copyright-headers.sh
+++ b/ci/check-copyright-headers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ci/check-copyright-headers.sh — enforces OSPO finding CODE-COPYRIGHT-HDRS.
+#
+# Every AzureClaw-authored source file (.rs, .ts, .tsx, .js, .sh) must carry
+# the two-line Microsoft + MIT copyright header at the top of the file.
+#
+# Excludes:
+#   - vendor/          (upstream code; own licenses in THIRD_PARTY_NOTICES.txt)
+#   - node_modules/    (installed deps)
+#   - dist/            (compiled output)
+#   - build/           (compiled output)
+#   - target/          (Rust build artifacts)
+#   - .turbo/          (turbo cache)
+#   - coverage/        (test coverage reports)
+#   - *.d.ts           (generated TypeScript declarations)
+#
+# Exit codes:
+#   0 — all files have the header
+#   1 — one or more files are missing the header (list printed to stderr)
+set -euo pipefail
+
+MISSING=()
+
+while IFS= read -r file; do
+  # Check first 5 lines for the copyright marker
+  if ! head -5 "$file" | grep -qE '^(//|#) *Copyright \(c\) Microsoft Corporation'; then
+    MISSING+=("$file")
+  fi
+done < <(
+  git ls-files \
+    | grep -E '\.(rs|ts|tsx|js|sh)$' \
+    | grep -v '^vendor/' \
+    | grep -v 'node_modules/' \
+    | grep -v '/dist/' \
+    | grep -v '^target/' \
+    | grep -v '/build/' \
+    | grep -v '\.d\.ts$' \
+    | grep -v '\.turbo/' \
+    | grep -v '/coverage/'
+)
+
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  echo "❌ Missing Microsoft + MIT copyright header in ${#MISSING[@]} file(s):" >&2
+  for f in "${MISSING[@]}"; do
+    echo "  $f" >&2
+  done
+  echo "" >&2
+  echo "Every AzureClaw-authored source file must begin with:" >&2
+  echo "  // Copyright (c) Microsoft Corporation."  >&2
+  echo "  // Licensed under the MIT License."        >&2
+  echo "(or # … for shell/Python files)" >&2
+  exit 1
+fi
+
+echo "✅ All $(git ls-files | grep -E '\.(rs|ts|tsx|js|sh)$' | grep -v '^vendor/' | grep -v 'node_modules/' | grep -v '/dist/' | grep -v '^target/' | grep -v '/build/' | grep -v '\.d\.ts$' | grep -v '\.turbo/' | grep -v '/coverage/' | wc -l | tr -d ' ') source files carry the Microsoft + MIT copyright header."

--- a/ci/check-loc.sh
+++ b/ci/check-loc.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ci/check-loc.sh — enforces internal Phase 1 plan §4.2 LOC budget.
 #
 # Fails if:

--- a/ci/no-custom-crypto.sh
+++ b/ci/no-custom-crypto.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ci/no-custom-crypto.sh — enforces internal Phase 1 plan §0.2 principle #8.
 #
 # No hand-rolled Signal/X3DH/Double-Ratchet, no hand-rolled OAuth/JWT signing,

--- a/ci/no-null-provider-prod.sh
+++ b/ci/no-null-provider-prod.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ci/no-null-provider-prod.sh — enforces internal Phase 1 plan §0.2 #9.
 #
 # Static mirror of the ValidatingAdmissionPolicy shipped in Phase 0:

--- a/ci/no-stubs.sh
+++ b/ci/no-stubs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ci/no-stubs.sh — enforces internal Phase 1 plan §0.2 principle #8.
 #
 # Rejects *newly added* stub/placeholder markers on production code paths.

--- a/ci/security-audit-required.sh
+++ b/ci/security-audit-required.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ci/security-audit-required.sh — enforces internal Phase 1 plan §0.2 #9.
 #
 # If the PR touches a capability-introducing file, require a matching

--- a/ci/vendored-patch-audit.sh
+++ b/ci/vendored-patch-audit.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ci/vendored-patch-audit.sh — enforces internal Phase 1 plan §0.2 #8, #9.
 #
 # If the PR changes vendor/** or bumps the AGT SDK pin (Cargo.toml /

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import { upCommand } from "./commands/up.js";
 import { devCommand } from "./commands/dev.js";

--- a/cli/src/commands/a2a.test.ts
+++ b/cli/src/commands/a2a.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, expect, it } from "vitest";
 import { a2aCommand } from "./a2a.js";
 

--- a/cli/src/commands/a2a.ts
+++ b/cli/src/commands/a2a.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 
 /**

--- a/cli/src/commands/add.test.ts
+++ b/cli/src/commands/add.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 
 /**

--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";

--- a/cli/src/commands/attest.test.ts
+++ b/cli/src/commands/attest.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/cli/src/commands/attest.ts
+++ b/cli/src/commands/attest.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 S11 — `azureclaw attest <name>` CLI subcommand.
 //
 // **Read surface only.** Phase 2 ships the *consumer* that prints whatever

--- a/cli/src/commands/connect.ts
+++ b/cli/src/commands/connect.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { agentContainerName, runtimeKindFromCr, type RuntimeKind } from "../runtime.js";

--- a/cli/src/commands/convert.test.ts
+++ b/cli/src/commands/convert.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Unit tests for `azureclaw convert` (S9.2).
  *

--- a/cli/src/commands/convert.ts
+++ b/cli/src/commands/convert.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * `azureclaw convert` — translate between AzureClaw and upstream
  * `agents.x-k8s.io/v1alpha1` Sandbox manifests (YAML in / YAML out).

--- a/cli/src/commands/credentials.ts
+++ b/cli/src/commands/credentials.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { banner, section } from "../stepper.js";

--- a/cli/src/commands/destroy.ts
+++ b/cli/src/commands/destroy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync } from "fs";

--- a/cli/src/commands/egress.test.ts
+++ b/cli/src/commands/egress.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { egressCommand } from "./egress.js";
 

--- a/cli/src/commands/egress.ts
+++ b/cli/src/commands/egress.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { getAdminToken, withAdminAuth } from "../router-admin.js";

--- a/cli/src/commands/egress/sign.test.ts
+++ b/cli/src/commands/egress/sign.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   buildCanonicalAllowlist,

--- a/cli/src/commands/egress/sign.ts
+++ b/cli/src/commands/egress/sign.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 S12.c — `azureclaw egress … --sign` helpers.
 //
 // Producer side of the signed-egress-allowlist supply chain. Builds a

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/cli/src/commands/handoff.ts
+++ b/cli/src/commands/handoff.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { Stepper, banner, section, kvLine, checkLine } from "../stepper.js";

--- a/cli/src/commands/handoff/helpers.ts
+++ b/cli/src/commands/handoff/helpers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 / S15 hotspot-pass3: extracted helpers + state for
 // `azureclaw handoff`. The command is intentionally a single
 // long-lived action handler — its many helpers all share one piece

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/cli/src/commands/logs.ts
+++ b/cli/src/commands/logs.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/cli/src/commands/mesh.test.ts
+++ b/cli/src/commands/mesh.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as crypto from "node:crypto";
 

--- a/cli/src/commands/mesh.ts
+++ b/cli/src/commands/mesh.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // AzureClaw mesh CLI: identity/auth and registry management.
 //
 // S15.b decomposition: identity/crypto + OAuth callback + port-health

--- a/cli/src/commands/mesh/auth.ts
+++ b/cli/src/commands/mesh/auth.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 / S15.b: `azureclaw mesh auth` subcommand body extracted
 // from mesh.ts. Attaches as a subcommand of an existing Commander command.
 

--- a/cli/src/commands/mesh/health.ts
+++ b/cli/src/commands/mesh/health.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 / S15.b: port + WS health helpers extracted from
 // mesh.ts. Public surface preserved (re-exported from mesh.ts).
 

--- a/cli/src/commands/mesh/identity.ts
+++ b/cli/src/commands/mesh/identity.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 / S15.b: identity persistence + at-rest crypto + AMID
 // derivation extracted from mesh.ts. Public surface preserved
 // (re-exported from mesh.ts) to keep mesh.test.ts imports stable.

--- a/cli/src/commands/mesh/oauth.ts
+++ b/cli/src/commands/mesh/oauth.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 / S15.b: OAuth callback server + log/HTML escapers
 // extracted from mesh.ts. Public surface preserved (re-exported
 // from mesh.ts) for any test or external use.

--- a/cli/src/commands/mesh/promote.ts
+++ b/cli/src/commands/mesh/promote.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 / S15.b: `azureclaw mesh promote` subcommand body extracted
 // from mesh.ts. Attaches as a subcommand of an existing Commander command.
 

--- a/cli/src/commands/migrate.test.ts
+++ b/cli/src/commands/migrate.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { __test, MIGRATE_MODES } from "./migrate.js";
 

--- a/cli/src/commands/migrate.ts
+++ b/cli/src/commands/migrate.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 S9.1 — `azureclaw migrate` mode-switch CLI subcommand.
 //
 // Operator-facing tool to flip a `ClawSandbox` between the four

--- a/cli/src/commands/model.ts
+++ b/cli/src/commands/model.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * AzureClaw Operator TUI — live terminal dashboard for managing sandboxes.
  *

--- a/cli/src/commands/operator/actions.ts
+++ b/cli/src/commands/operator/actions.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Operator dashboard action helpers — extracted from startDashboard
 // (S15.e.4) so the closure stays under the §4.2 800-LOC cap. Bodies
 // are byte-identical to the originals; closure-captured `sandboxes`,

--- a/cli/src/commands/operator/dialogs/connect.ts
+++ b/cli/src/commands/operator/dialogs/connect.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Connect-to-agent (Enter key) — extracted from operator.ts startDashboard
 // closure (S15.e.7) so the closure stays under the §4.2 800-LOC cap.
 // Body byte-identical to the original; closure-captured state is passed

--- a/cli/src/commands/operator/dialogs/delete.ts
+++ b/cli/src/commands/operator/dialogs/delete.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Delete-agent confirm dialog (`x` key) — extracted from operator.ts
 // startDashboard closure (S15.e.7) so the closure stays under the §4.2
 // 800-LOC cap. Body byte-identical to the original; closure-captured

--- a/cli/src/commands/operator/dialogs/spawn.ts
+++ b/cli/src/commands/operator/dialogs/spawn.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Spawn-agent dialog (`n` key) — extracted from operator.ts startDashboard
 // closure (S15.e.6) so the closure stays under the §4.2 800-LOC cap.
 // Body byte-identical to the original; closure-captured state is passed

--- a/cli/src/commands/operator/fetchers/cluster.ts
+++ b/cli/src/commands/operator/fetchers/cluster.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Cluster-wide health fetchers (mesh infrastructure + cluster nodes).
  *

--- a/cli/src/commands/operator/fetchers/sandboxes.ts
+++ b/cli/src/commands/operator/fetchers/sandboxes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Sandbox-list fetchers (Docker + AKS).
  *

--- a/cli/src/commands/operator/fetchers/security.ts
+++ b/cli/src/commands/operator/fetchers/security.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Per-sandbox security state + egress + AGT fetchers.
  *

--- a/cli/src/commands/operator/helpers.ts
+++ b/cli/src/commands/operator/helpers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Operator-TUI pure helper functions.
  *

--- a/cli/src/commands/operator/keymap.test.ts
+++ b/cli/src/commands/operator/keymap.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import {
   BINDINGS,

--- a/cli/src/commands/operator/keymap.ts
+++ b/cli/src/commands/operator/keymap.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Operator TUI keyboard bindings + status-bar help strings.
  *

--- a/cli/src/commands/operator/panels/a2aagent.ts
+++ b/cli/src/commands/operator/panels/a2aagent.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * A2AAgent panel (S3) — list + Conditions + AgentCard publication status.
  */

--- a/cli/src/commands/operator/panels/claweval.ts
+++ b/cli/src/commands/operator/panels/claweval.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * ClawEval panel (S6) — list + lastRunAt + lastScore + nextScheduledAt.
  */

--- a/cli/src/commands/operator/panels/clawmemory.ts
+++ b/cli/src/commands/operator/panels/clawmemory.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * ClawMemory panel (S5) — list + Foundry binding + RBAC scope summary.
  *

--- a/cli/src/commands/operator/panels/clawpairing.ts
+++ b/cli/src/commands/operator/panels/clawpairing.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * ClawPairing panel — peer-pairing CRDs with trust state.
  *

--- a/cli/src/commands/operator/panels/clawsandbox.ts
+++ b/cli/src/commands/operator/panels/clawsandbox.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * ClawSandbox panel — list of sandboxes with health, model, isolation.
  *

--- a/cli/src/commands/operator/panels/datasource.ts
+++ b/cli/src/commands/operator/panels/datasource.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * `ClusterDataSource` — pluggable abstraction hiding whether `ClusterState`
  * comes from live Kube list-watch or a fixture used by tests.

--- a/cli/src/commands/operator/panels/fixtures.ts
+++ b/cli/src/commands/operator/panels/fixtures.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Vitest fixtures for operator-TUI panels tests (S14).
  */

--- a/cli/src/commands/operator/panels/index.ts
+++ b/cli/src/commands/operator/panels/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Public entry-point of the operator-TUI panels module (S14).
  *

--- a/cli/src/commands/operator/panels/inferencepolicy.ts
+++ b/cli/src/commands/operator/panels/inferencepolicy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * InferencePolicy panel (S4) — list + budgets + guardrail floor + model preference.
  */

--- a/cli/src/commands/operator/panels/layout.ts
+++ b/cli/src/commands/operator/panels/layout.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Panel registry + layout — assembles the operator-TUI dashboard from a
  * list of `Panel` modules, with optional `--panels <a,b,c>` filtering and

--- a/cli/src/commands/operator/panels/mcpserver.ts
+++ b/cli/src/commands/operator/panels/mcpserver.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * McpServer panel (S1) — list + Conditions + JWKS Secret presence.
  *

--- a/cli/src/commands/operator/panels/panels.test.ts
+++ b/cli/src/commands/operator/panels/panels.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { emptyClusterState, type ClusterState } from "./types.js";
 import { clawSandboxPanel } from "./clawsandbox.js";

--- a/cli/src/commands/operator/panels/provider_status.ts
+++ b/cli/src/commands/operator/panels/provider_status.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Provider-status panel (S14) — Foundry, AGT, ACR pull-through, AGC ingress,
  * identity provider.

--- a/cli/src/commands/operator/panels/redact.ts
+++ b/cli/src/commands/operator/panels/redact.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Secret-redaction helpers for the operator TUI panels (S14).
  *

--- a/cli/src/commands/operator/panels/toolpolicy.ts
+++ b/cli/src/commands/operator/panels/toolpolicy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * ToolPolicy panel (S2) — list + appliesTo + commerce / approval / rate-limit.
  */

--- a/cli/src/commands/operator/panels/types.ts
+++ b/cli/src/commands/operator/panels/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Operator-TUI panel framework — shared type declarations (S14).
  *

--- a/cli/src/commands/operator/panels/util.ts
+++ b/cli/src/commands/operator/panels/util.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Shared rendering helpers for operator-TUI panels (S14).
  *

--- a/cli/src/commands/operator/panels_overlay.ts
+++ b/cli/src/commands/operator/panels_overlay.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Operator-TUI panels overlay (S14) — wires the modular-panels view as
  * a blessed overlay box on the main dashboard. Extracted out of

--- a/cli/src/commands/operator/panels_snapshot.ts
+++ b/cli/src/commands/operator/panels_snapshot.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * `azureclaw operator --snapshot` — non-interactive panel render.
  *

--- a/cli/src/commands/operator/render/cluster.ts
+++ b/cli/src/commands/operator/render/cluster.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Cluster-view render helpers — extracted from operator.ts startDashboard
 // closure (S15.e.5) so the closure stays under the §4.2 800-LOC cap.
 // Bodies byte-identical to originals; closure-captured `clusterData` and

--- a/cli/src/commands/operator/render/header.ts
+++ b/cli/src/commands/operator/render/header.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Header + health-summary render helpers — extracted from operator.ts
 // startDashboard closure (S15.e.5c) so the closure stays under the
 // §4.2 800-LOC cap. Bodies byte-identical to the originals;

--- a/cli/src/commands/operator/render/security.ts
+++ b/cli/src/commands/operator/render/security.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Security + AGT render helpers — extracted from operator.ts startDashboard
 // closure (S15.e.5b) so the closure stays under the §4.2 800-LOC cap.
 // Bodies byte-identical to the originals; closure-captured `agentTable`,

--- a/cli/src/commands/operator/render/topology.ts
+++ b/cli/src/commands/operator/render/topology.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Topology-view render helper — extracted from operator.ts startDashboard
 // closure (S15.e.5) so the closure stays under the §4.2 800-LOC cap.
 // Body byte-identical to the original; closure-captured `sandboxes`,

--- a/cli/src/commands/operator/types.ts
+++ b/cli/src/commands/operator/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Operator-TUI shared type declarations.
  *

--- a/cli/src/commands/pair.test.ts
+++ b/cli/src/commands/pair.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { decodeToken } from "./pair.js";
 

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import * as crypto from "node:crypto";

--- a/cli/src/commands/policy.test.ts
+++ b/cli/src/commands/policy.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 
 /**

--- a/cli/src/commands/policy.ts
+++ b/cli/src/commands/policy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";

--- a/cli/src/commands/push.test.ts
+++ b/cli/src/commands/push.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import path from "path";
 

--- a/cli/src/commands/push.ts
+++ b/cli/src/commands/push.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/cli/src/commands/trace.ts
+++ b/cli/src/commands/trace.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync } from "fs";

--- a/cli/src/commands/up/agentmesh_deploy.ts
+++ b/cli/src/commands/up/agentmesh_deploy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Sub-slice S15.d.3 of S15.d phase2-hotspot-up-cli.
 //
 // AgentMesh infrastructure deploy phase extracted verbatim from

--- a/cli/src/commands/up/fast_upgrade.ts
+++ b/cli/src/commands/up/fast_upgrade.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 / S15.d.1: `azureclaw up --upgrade` fast-path extracted
 // from up.ts. Skips all prompts and infra; just re-runs Helm with
 // cached context. Caller invokes when `options.upgrade` is set and

--- a/cli/src/commands/up/preflight.ts
+++ b/cli/src/commands/up/preflight.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Sub-slice S15.d.2 of S15.d phase2-hotspot-up-cli.
 //
 // Preflight phase extracted verbatim from cli/src/commands/up.ts:

--- a/cli/src/commands/up/sandbox_bringup.ts
+++ b/cli/src/commands/up/sandbox_bringup.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Sub-slice S15.d.4 of S15.d phase2-hotspot-up-cli.
 //
 // Sandbox bring-up phase extracted verbatim from cli/src/commands/up.ts:

--- a/cli/src/config.test.ts
+++ b/cli/src/config.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { join } from "path";
 import { homedir } from "os";

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Shared credential management for AzureClaw CLI.
  * Used by `dev` (auto-prompts if missing) and `credentials` (explicit reconfigure).

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 
 /**
  * AzureClaw CLI — Enterprise-grade runtime for OpenClaw on Azure.

--- a/cli/src/migrate/from_kagent.test.ts
+++ b/cli/src/migrate/from_kagent.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 S9.3 — vitest cases for the kagent → AzureClaw translator.
 //
 // Pure-helper coverage. CLI runner I/O is exercised separately via

--- a/cli/src/migrate/from_kagent.ts
+++ b/cli/src/migrate/from_kagent.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Phase 2 S9.3 — `azureclaw migrate from-kagent` translator.
 //
 // Pure translator (no I/O). Reads a kagent.dev/v1alpha2 `Agent` YAML

--- a/cli/src/preflight.test.ts
+++ b/cli/src/preflight.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { matchAction, hasEffectiveAction } from "./preflight.js";
 

--- a/cli/src/preflight.ts
+++ b/cli/src/preflight.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Preflight RBAC & provider checks for `azureclaw up`.
  *

--- a/cli/src/providers.test.ts
+++ b/cli/src/providers.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_PROVIDER_SELECTION,

--- a/cli/src/providers.ts
+++ b/cli/src/providers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Provider contracts — TypeScript side.
  *

--- a/cli/src/refs.ts
+++ b/cli/src/refs.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // S13 phase2-config-authority-refs:
 // `ClawSandbox.spec.inferenceRef` → sibling `InferencePolicy` CR (required).
 // `ClawSandbox.spec.governance.toolPolicyRef` → sibling `ToolPolicy` CR

--- a/cli/src/router-admin.ts
+++ b/cli/src/router-admin.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Router admin token helper.
  *

--- a/cli/src/runtime.test.ts
+++ b/cli/src/runtime.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Tests for `runtime.ts` — the CLI's runtime-aware helpers (S10.A5).
  */

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Runtime-aware helpers for CLI commands (S10.A5).
  *

--- a/cli/src/stepper.ts
+++ b/cli/src/stepper.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Multi-step progress tracker for CLI commands.
  * Shows current step, elapsed time, and clear phase boundaries.

--- a/cli/src/testing/fake-router-cli.ts
+++ b/cli/src/testing/fake-router-cli.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Standalone CLI entry for the fake router — groundwork for the
  * docker-compose dev stack (plan item T4).

--- a/cli/src/testing/fake-router.test.ts
+++ b/cli/src/testing/fake-router.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, expect, it } from "vitest";
 import { FakeRouter } from "./fake-router.js";
 

--- a/cli/src/testing/fake-router.ts
+++ b/cli/src/testing/fake-router.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * In-process fake AzureClaw inference router.
  *

--- a/cli/src/testing/sandbox-hardening.test.ts
+++ b/cli/src/testing/sandbox-hardening.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Regression tests for the sandbox entrypoint hardening invariants.
 // Plan item s7. Derived from the production incident on 2026-04-22 where
 // a stale sandbox image lacked the `cp ... 2>/dev/null || true` wrapping

--- a/cli/src/testing/scenario-runner-cli.ts
+++ b/cli/src/testing/scenario-runner-cli.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Scenario runner CLI — plan item T5.
  *

--- a/cli/src/testing/scenario.test.ts
+++ b/cli/src/testing/scenario.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Scenario runner unit tests — plan item T5.
  *

--- a/cli/src/testing/scenario.ts
+++ b/cli/src/testing/scenario.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * YAML scenario runner — plan item T5.
  *

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {

--- a/controller/benches/reconciler_bench.rs
+++ b/controller/benches/reconciler_bench.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Reconciler perf baseline (Phase 2 S16).
 //!
 //! Measures the synthetic reconcile-decision hot path at three workload

--- a/controller/src/a2a_agent.rs
+++ b/controller/src/a2a_agent.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `A2AAgent` CRD — full reconciler (Phase 2 §8 entry 4 / S3).
 //!
 //! Status: **full-schema** as of `phase2/a2aagent-reconciler` (S3 of

--- a/controller/src/a2a_agent_compile.rs
+++ b/controller/src/a2a_agent_compile.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pure-function compile step: `A2AAgentSpec` → A2A 1.2 AgentCard JSON.
 //!
 //! Separated from the reconciler so it is unit-testable without a

--- a/controller/src/a2a_agent_reconciler.rs
+++ b/controller/src/a2a_agent_reconciler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `A2AAgent` reconciler — Phase 2 §8 entry 4 (S3).
 //!
 //! Watches `A2AAgent` CRs and, for each:

--- a/controller/src/backoff.rs
+++ b/controller/src/backoff.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Requeue duration helpers with bounded random jitter.
 //!
 //! ## Why jitter?

--- a/controller/src/claw_eval.rs
+++ b/controller/src/claw_eval.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `ClawEval` CRD — Phase 2 §8 entry 6 (S6).
 //!
 //! Per `docs/implementation-plan.md` §10.5 #6, `ClawEval` is **a binding

--- a/controller/src/claw_eval_compile.rs
+++ b/controller/src/claw_eval_compile.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pure-function compile step: `ClawEvalSpec` → binding JSON.
 //!
 //! Separated from the reconciler so it is unit-testable without a

--- a/controller/src/claw_eval_reconciler.rs
+++ b/controller/src/claw_eval_reconciler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `ClawEval` reconciler — Phase 2 §8 entry 6 (S6).
 //!
 //! Watches `ClawEval` CRs and, for each:

--- a/controller/src/claw_memory.rs
+++ b/controller/src/claw_memory.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `ClawMemory` CRD — Phase 2 §8 entry 5 (S5).
 //!
 //! Per `docs/implementation-plan.md` §3 non-compete table, `ClawMemory`

--- a/controller/src/claw_memory_compile.rs
+++ b/controller/src/claw_memory_compile.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pure-function compile step: `ClawMemorySpec` → binding JSON.
 //!
 //! Separated from the reconciler so it is unit-testable without a

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `ClawMemory` reconciler — Phase 2 §8 entry 5 (S5).
 //!
 //! Watches `ClawMemory` CRs and, for each:

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! ClawSandbox Custom Resource Definition.
 //!
 //! This is the Rust representation of the ClawSandbox CRD.

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! CEL admission validations for AzureClaw CRDs.
 //!
 //! Phase 1 deliverable §7 entry 12: every new CRD must ship with

--- a/controller/src/fedcred.rs
+++ b/controller/src/fedcred.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Azure federated identity credential management via ARM REST API.
 //!
 //! When the controller reconciles a new ClawSandbox, it creates a federated

--- a/controller/src/fedcred_reaper.rs
+++ b/controller/src/fedcred_reaper.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Periodic federated-credential garbage collector.
 //!
 //! ## Why

--- a/controller/src/field_managers.rs
+++ b/controller/src/field_managers.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Stable Server-Side Apply field managers for every controller-emitted patch.
 //!
 //! Per `docs/implementation-plan.md` §10.4 #1 and the S7 Phase 2 slice

--- a/controller/src/helm_drift.rs
+++ b/controller/src/helm_drift.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Helm ↔ Rust CRD drift detection.
 //!
 //! Phase 1 ships `deploy/helm/azureclaw/templates/crd.yaml` (ClawSandbox)

--- a/controller/src/inference_policy.rs
+++ b/controller/src/inference_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `InferencePolicy` CRD — Phase 2 §8 entry 4 (S4).
 //!
 //! Per `docs/implementation-plan.md` §8 entry 2 and `docs/competitive.md`

--- a/controller/src/inference_policy_compile.rs
+++ b/controller/src/inference_policy_compile.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pure-function compile step: `InferencePolicySpec` → AGT-profile JSON.
 //!
 //! Separated from the reconciler so it is unit-testable without a

--- a/controller/src/inference_policy_reconciler.rs
+++ b/controller/src/inference_policy_reconciler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `InferencePolicy` reconciler — Phase 2 §8 entry 4 (S4).
 //!
 //! Watches `InferencePolicy` CRs and, for each:

--- a/controller/src/leader_election.rs
+++ b/controller/src/leader_election.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Controller-wide leader election via Kubernetes coordination Lease.
 //!
 //! ## Why a controller-wide gate?

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AzureClaw Controller — Kubernetes operator for sandboxed OpenClaw agents.
 //!
 //! Watches `ClawSandbox` and `ClawPairing` custom resources and reconciles:

--- a/controller/src/mcp_server.rs
+++ b/controller/src/mcp_server.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `McpServer` CRD — full reconciler (Phase 2 §8 entry 1).
 //!
 //! Status: **full** as of `phase2/mcp-reconciler` (S1 of Phase 2).

--- a/controller/src/mcp_server_reconciler.rs
+++ b/controller/src/mcp_server_reconciler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // ci:loc-ok — Phase 2 multi-CRD reconciler / generated module; intentional. Tracked in plan.md §S15 follow-up.
 //! McpServer reconciler — Phase 2 §8 entry 1.
 //!

--- a/controller/src/mesh_peer/mod.rs
+++ b/controller/src/mesh_peer/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Controller mesh peer — connects the controller to AgentMesh relay as a
 //! long-running peer, enabling external agents to pair and request offloads.
 //!

--- a/controller/src/mesh_peer/offload.rs
+++ b/controller/src/mesh_peer/offload.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Controller-side offload orchestration over the AgentMesh peer
 //! channel.
 //!

--- a/controller/src/mesh_peer/pair.rs
+++ b/controller/src/mesh_peer/pair.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pair-request handling: validates a `pair_request` against a `ClawPairing`
 //! CRD, binds the requester's AMID, and produces the `PairResponse`.
 //!

--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Prometheus metrics for the AzureClaw controller.
 //!
 //! S7.E (workqueue metrics): exposes counters / histograms that

--- a/controller/src/metrics_server.rs
+++ b/controller/src/metrics_server.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Minimal axum HTTP server exposing controller metrics + health.
 //!
 //! S7.E: `:9091/metrics` (Prometheus text format) and

--- a/controller/src/pairing.rs
+++ b/controller/src/pairing.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! ClawPairing Custom Resource Definition.
 //!
 //! Represents a trust relationship between an external OpenClaw agent and this

--- a/controller/src/pairing_reconciler.rs
+++ b/controller/src/pairing_reconciler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pairing reconciler — watches ClawPairing CRDs and manages lifecycle.
 //!
 //! Responsibilities:

--- a/controller/src/policy_fetcher.rs
+++ b/controller/src/policy_fetcher.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // ci:loc-ok — Phase 2 multi-CRD reconciler / generated module; intentional. Tracked in plan.md §S15 follow-up.
 //! Signed egress-allowlist artifact fetcher (S12.b status-only → S12.e authoritative).
 //!

--- a/controller/src/providers/mod.rs
+++ b/controller/src/providers/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Provider contracts for the AzureClaw controller.
 //!
 //! Mirrors `inference-router/src/providers/` but scoped to controller-side

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Controller reconciliation loop — watches ClawSandbox CRDs and reconciles state.
 //!
 //! When a ClawSandbox is created or updated, the reconciler:

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // ci:loc-ok — Phase 2 multi-CRD reconciler / generated module; intentional. Tracked in plan.md §S15 follow-up.
 //! Runtime dispatch seam (S10.A2 — multi-runtime hosting).
 //!

--- a/controller/src/reconciler/tests.rs
+++ b/controller/src/reconciler/tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Reconciler unit tests — extracted from reconciler/mod.rs to keep the
 //! reconcile-loop file under its Phase 1 LOC cap. `use super::*`
 //! continues to give the tests access to crate-private helpers

--- a/controller/src/signer_policy.rs
+++ b/controller/src/signer_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! S12.d — `SignerPolicy` ConfigMap watcher.
 //!
 //! Replaces the env-var path that S12.b used (`AZURECLAW_SIGNER_FULCIO_ISSUERS`,

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Standardised K8s Condition helpers for AzureClaw CRD status subresources.
 //!
 //! **Why a helper module, not inline `json!({...})` in the reconciler.**

--- a/controller/src/status/mod.rs
+++ b/controller/src/status/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! CRD status helpers shared across reconcilers.
 //!
 //! Everything here is pure logic — no K8s client calls. Reconcilers call

--- a/controller/src/tool_policy.rs
+++ b/controller/src/tool_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `ToolPolicy` CRD — minimal scaffold per implementation-plan §7 entry 4.
 //!
 //! Status: **scaffold-only**. Compiles to AGT policy profiles via

--- a/controller/src/tool_policy_compile.rs
+++ b/controller/src/tool_policy_compile.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pure-function compile step: `ToolPolicySpec` → AGT-profile JSON.
 //!
 //! Separated from the reconciler so it is unit-testable without a

--- a/controller/src/tool_policy_reconciler.rs
+++ b/controller/src/tool_policy_reconciler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! ToolPolicy reconciler — Phase 2 §8 entry 4 (S2).
 //!
 //! Watches `ToolPolicy` CRs and, for each:

--- a/docs/security-audits/2026-04-30-phase3-copyright-headers.md
+++ b/docs/security-audits/2026-04-30-phase3-copyright-headers.md
@@ -1,0 +1,98 @@
+# Security Audit — `phase3-copyright-headers`
+
+**Date:** 2026-04-30
+**PR:** (see PR created in this slice)
+**Author:** @Copilot
+**Independent reviewer:** @pallakatos
+
+**Capability scope:**
+Resolves OSPO finding CODE-COPYRIGHT-HDRS (grade F). Adds the required two-line Microsoft + MIT copyright header to all 321 AzureClaw-authored source files (`.rs`, `.ts`, `.tsx`, `.js`, `.sh`) and introduces a CI gate (`ci/check-copyright-headers.sh`) that enforces the header on every PR going forward. Vendored upstream code under `vendor/` is intentionally excluded.
+
+---
+
+## 1. Summary
+
+OSPO audit (`docs/internal/2026-04-28-Azure-azureclaw.md`) flagged that AzureClaw source files lacked the mandatory OSPO-prescribed two-line copyright header. This slice applies the header to all 321 tracked source files (155 `.rs`, 148 `.ts`, 16 `.sh`, 2 `.js`) and wires a CI gate into the `ci-gates` workflow so future PRs are blocked if any new file lacks the header. No functional logic was changed; all modifications are comment insertions at the top of each file.
+
+## 2. Threat model delta
+
+No new trust boundaries, secrets, or attack surfaces. This change is purely additive commentary with no runtime execution path.
+
+| STRIDE | New exposure? | Mitigation in this PR |
+|---|---|---|
+| Spoofing | No | N/A |
+| Tampering | No | N/A |
+| Repudiation | No | N/A |
+| Information Disclosure | No | N/A |
+| Denial of Service | No | N/A |
+| Elevation of Privilege | No | N/A |
+
+## 3. OWASP mapping
+
+No LLM or MCP items are touched by comment-only file changes.
+
+## 4. AuthN / AuthZ path
+
+N/A — no new network surface.
+
+## 5. Secret + key custody
+
+N/A — no secrets involved.
+
+## 6. Egress surface delta
+
+None.
+
+## 7. Audit events emitted
+
+None.
+
+## 8. Failure mode
+
+N/A.
+
+## 9. Negative-test coverage
+
+The CI gate `ci/check-copyright-headers.sh` itself serves as the enforcement test. It exits non-zero and lists offending files if any tracked source file lacks the header.
+
+| Test | Location | Asserts |
+|---|---|---|
+| copyright-headers gate | `ci/check-copyright-headers.sh` | All 321+ source files have the header |
+
+## 10. Vendored / third-party dependency delta
+
+No new dependencies. `vendor/` content is explicitly excluded from headering per OSPO guidance — those files retain their own upstream licenses covered by `THIRD_PARTY_NOTICES.txt` (S24).
+
+## 11. Scope decisions
+
+| Category | File count | Decision |
+|---|---|---|
+| `.rs` files (AzureClaw-authored) | 155 | ✅ Headed |
+| `.ts` / `.tsx` files | 148 | ✅ Headed |
+| `.sh` files | 16 | ✅ Headed (shebang preserved on line 1) |
+| `.js` files | 2 | ✅ Headed |
+| `vendor/**` | excluded | ❌ Not headed — upstream licenses |
+| `cli/dist/`, `target/`, `node_modules/` | excluded | ❌ Not headed — generated artifacts |
+| `.d.ts` files | excluded | ❌ Not headed — generated declarations |
+
+**Total files headed: 321**
+
+## 12. Sign-offs
+
+### Author sign-off
+
+- [x] No functional logic was changed — only copyright comment lines added.
+- [x] `cargo build --workspace --release` passes after header insertion.
+- [x] `cd cli && npm run build && npm run typecheck` passes.
+- [x] `bash ci/check-copyright-headers.sh` now exits 0 on the full file set.
+- [x] `vendor/` was not touched.
+
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com> — 2026-04-30
+
+### Independent reviewer sign-off
+
+- [x] Reviewed the diff — all changes are header comment insertions only.
+- [x] CI gate verified locally.
+- [x] Vendor exclusion confirmed correct per THIRD_PARTY_NOTICES.txt (S24).
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com> — 2026-04-30

--- a/examples/demo-clawshield/attack-simulation.sh
+++ b/examples/demo-clawshield/attack-simulation.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ═══════════════════════════════════════════════════════════════════
 # AzureClaw Demo: Operation Claw Shield — Attack Simulation
 # ═══════════════════════════════════════════════════════════════════

--- a/examples/demo-clawshield/normal-workflow.sh
+++ b/examples/demo-clawshield/normal-workflow.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ═══════════════════════════════════════════════════════════════════
 # AzureClaw Demo: Operation Claw Shield — Normal Workflow
 # ═══════════════════════════════════════════════════════════════════

--- a/inference-router/benches/proxy_bench.rs
+++ b/inference-router/benches/proxy_bench.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Inference-router proxy hot-path bench (Phase 2 S16).
 //!
 //! Captures the proxy overhead per request — routing decision, auth-header

--- a/inference-router/fuzz/fuzz_targets/fuzz_a2a_base64url.rs
+++ b/inference-router/fuzz/fuzz_targets/fuzz_a2a_base64url.rs
@@ -1,4 +1,7 @@
 #![no_main]
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Fuzz target: A2A 1.0.0 base64url decoder.
 //!
 //! `base64url_decode` parses the base64url segments of a JWS at

--- a/inference-router/fuzz/fuzz_targets/fuzz_a2a_jws.rs
+++ b/inference-router/fuzz/fuzz_targets/fuzz_a2a_jws.rs
@@ -1,4 +1,7 @@
 #![no_main]
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Fuzz target: A2A 1.0.0 JWS detached-content signing input builder.
 //!
 //! `build_signing_input` parses an attacker-controlled protected

--- a/inference-router/fuzz/fuzz_targets/fuzz_deserialize_state.rs
+++ b/inference-router/fuzz/fuzz_targets/fuzz_deserialize_state.rs
@@ -1,4 +1,7 @@
 #![no_main]
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Fuzz target: handoff state deserializer.
 //!
 //! `deserialize_state` takes attacker-controlled bytes (gzip-compressed JSON

--- a/inference-router/fuzz/fuzz_targets/fuzz_parse_streaming_pf.rs
+++ b/inference-router/fuzz/fuzz_targets/fuzz_parse_streaming_pf.rs
@@ -1,4 +1,7 @@
 #![no_main]
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Fuzz target: streaming Azure content-safety parser.
 //!
 //! `parse_streaming_prompt_filter` runs on every SSE chunk returned from

--- a/inference-router/fuzz/fuzz_targets/fuzz_sanitize_chat.rs
+++ b/inference-router/fuzz/fuzz_targets/fuzz_sanitize_chat.rs
@@ -1,4 +1,7 @@
 #![no_main]
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Fuzz target: chat-snapshot sanitizer.
 //!
 //! `sanitize_chat_snapshot` returns `Vec<u8>` (no Result) so *any* panic is a

--- a/inference-router/src/a2a/agent_projection.rs
+++ b/inference-router/src/a2a/agent_projection.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `A2AAgent` CRD → trust-anchor projection.
 //!
 //! Pure synchronous projection from the eventual `A2AAgent` v1alpha1

--- a/inference-router/src/a2a/ap2.rs
+++ b/inference-router/src/a2a/ap2.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 — AP2 (Agent Payments) commerce-mandate types and validation.
 // ci:loc-ok: AP2 spec §6 (IntentMandate, CartMandate, PaymentMandate) is a
 // single cohesive validator API where every helper consumes the same struct

--- a/inference-router/src/a2a/card_server.rs
+++ b/inference-router/src/a2a/card_server.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 AgentCard server-side build pipeline — end-to-end.
 //!
 //! Given a declarative [`AgentCardConfig`] + [`SigningKey`], produces

--- a/inference-router/src/a2a/jsonrpc_dispatch.rs
+++ b/inference-router/src/a2a/jsonrpc_dispatch.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 JSON-RPC method dispatch — pure handler layer.
 //!
 //! Spec: <https://a2a-protocol.org/v1.0.0/specification#33-jsonrpc-binding>

--- a/inference-router/src/a2a/mandate_signing.rs
+++ b/inference-router/src/a2a/mandate_signing.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AP2 IntentMandate detached-JWS signing primitive.
 //!
 //! Today [`IntentMandate::signature`](super::ap2::IntentMandate) is an

--- a/inference-router/src/a2a/mandate_trust_store.rs
+++ b/inference-router/src/a2a/mandate_trust_store.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Mandate-issuer trust store — type-safe wrapper around
 //! [`crate::a2a::trust_store::TrustStore`] for AP2 mandate signing
 //! keys.

--- a/inference-router/src/a2a/message_send_ap2.rs
+++ b/inference-router/src/a2a/message_send_ap2.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AP2-aware `message/send` wrapper for A2A 1.0.0 JSON-RPC dispatch.
 //!
 //! Spec context:

--- a/inference-router/src/a2a/mod.rs
+++ b/inference-router/src/a2a/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 — Agent2Agent protocol implementation.
 //!
 //! Spec: <https://a2a-protocol.org/v1.0.0/specification>

--- a/inference-router/src/a2a/snapshot_rebuild.rs
+++ b/inference-router/src/a2a/snapshot_rebuild.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Trust-store snapshot rebuild orchestration.
 //!
 //! Composes [`agent_projection::project_anchors`] across many

--- a/inference-router/src/a2a/trust_store.rs
+++ b/inference-router/src/a2a/trust_store.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A trust-store cache — snapshot-style hot-reload for `kid → VerifyingKey`
 //! anchors used by [`crate::a2a::card_verifier::verify_inbound_card`].
 //!

--- a/inference-router/src/a2a_mtls.rs
+++ b/inference-router/src/a2a_mtls.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Optional mTLS listener on port 8445, dedicated to traffic from
 //! the public-edge `azureclaw-a2a-gateway` (Phase 2 S3.5, ADR-0001 #4).
 //!

--- a/inference-router/src/auth.rs
+++ b/inference-router/src/auth.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Azure authentication — supports both Workload Identity (AKS) and API key (local dev).
 //!
 //! In AKS: uses Workload Identity token exchange (federated OIDC → Azure AD token)

--- a/inference-router/src/behavior_monitor.rs
+++ b/inference-router/src/behavior_monitor.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Local-fallback behavior monitor — in-process anomaly detector.
 //!
 //! Extracted from `governance.rs` per §4.2 hotspot decomposition.

--- a/inference-router/src/blocklist.rs
+++ b/inference-router/src/blocklist.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Domain blocklist engine with auto-refresh from threat intelligence feeds.
 //!
 //! The blocklist prevents sandboxed agents from reaching known-malicious domains

--- a/inference-router/src/budget.rs
+++ b/inference-router/src/budget.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Token budget enforcement — per-sandbox daily and per-request limits.
 //!
 //! Tracks cumulative token usage in memory (resets daily) and rejects

--- a/inference-router/src/config.rs
+++ b/inference-router/src/config.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Configuration loaded from environment variables.
 
 use anyhow::{Context, Result};

--- a/inference-router/src/egress_blocked.rs
+++ b/inference-router/src/egress_blocked.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Bounded, rate-limited, deduplicated ring buffer of egress attempts that
 //! were *blocked* in enforce mode (S12.f). Sibling of the existing
 //! learn-mode buffer for *allowed* egress observations on `Blocklist`.

--- a/inference-router/src/errors.rs
+++ b/inference-router/src/errors.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Centralised error-response constructors for the inference router.
 //!
 //! The router exposes two distinct error shapes on the wire:

--- a/inference-router/src/forward_proxy.rs
+++ b/inference-router/src/forward_proxy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Transparent HTTP forward proxy for egress enforcement.
 //!
 //! Listens on a separate port (default 8444) and handles:

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Native AGT governance — in-process policy evaluation, trust management,
 //! audit logging, and agent identity.
 //!

--- a/inference-router/src/governance/trust_ops.rs
+++ b/inference-router/src/governance/trust_ops.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Trust-management operations on `Governance`.
 //!
 //! Extracted from `governance/mod.rs` per plan §4.2 hotspot

--- a/inference-router/src/handoff/auth.rs
+++ b/inference-router/src/handoff/auth.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Handoff endpoint auth middleware.
 //!
 //! Extracted from `handoff/mod.rs` per §4.2 hotspot decomposition.

--- a/inference-router/src/handoff/crypto.rs
+++ b/inference-router/src/handoff/crypto.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Handoff state crypto — serialization, encryption, integrity hash.
 //!
 //! Extracted from `handoff/mod.rs` per §4.2 hotspot decomposition. Keeps

--- a/inference-router/src/handoff/drain.rs
+++ b/inference-router/src/handoff/drain.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Router drain-state — "stop accepting new work, complete in-flight".
 //!
 //! Extracted from `handoff.rs` as the first step of the Phase 1 split

--- a/inference-router/src/handoff/mod.rs
+++ b/inference-router/src/handoff/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Agent handoff — live migration (local ↔ cloud).
 //!
 //! Implements the handoff protocol per the AzureClaw inter-agent handoff design.

--- a/inference-router/src/handoff/pending.rs
+++ b/inference-router/src/handoff/pending.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Pending-handoff store — the two-step "request → confirm" gate that
 //! defends against LLM self-initiated handoff (§9.9.9).
 //!

--- a/inference-router/src/handoff/token.rs
+++ b/inference-router/src/handoff/token.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! One-shot handoff token — auth for the second half of the live
 //! migration handshake.
 //!

--- a/inference-router/src/lib.rs
+++ b/inference-router/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AzureClaw Inference Router — library crate.
 //!
 //! Re-exports modules for integration tests. The binary entry point is `main.rs`.

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AzureClaw Inference Router
 #![allow(
     clippy::collapsible_if,

--- a/inference-router/src/mcp/error.rs
+++ b/inference-router/src/mcp/error.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Canonical JSON-RPC 2.0 error codes per
 //! [the JSON-RPC 2.0 spec §5.1](https://www.jsonrpc.org/specification#error_object)
 //! plus the MCP-2026 reserved range.

--- a/inference-router/src/mcp/initialize.rs
+++ b/inference-router/src/mcp/initialize.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! MCP `initialize` method handler — Streamable HTTP entry point.
 //!
 //! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle>

--- a/inference-router/src/mcp/jsonrpc.rs
+++ b/inference-router/src/mcp/jsonrpc.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! JSON-RPC 2.0 frame types and parser.
 //!
 //! Strictly conforms to [the JSON-RPC 2.0 spec](https://www.jsonrpc.org/specification):

--- a/inference-router/src/mcp/mod.rs
+++ b/inference-router/src/mcp/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! MCP 2026 Streamable HTTP transport — production code path.
 //!
 //! This module is the **router-side** implementation of the Model Context

--- a/inference-router/src/mcp/oauth.rs
+++ b/inference-router/src/mcp/oauth.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! OAuth 2.1 access-token verifier for MCP 2025-03-26 / 2026 Streamable HTTP.
 // ci:loc-ok: The OAuth 2.1 / RFC 9700 / RFC 7517 (JWK) / RFC 7515 (JWS)
 // verifier is one cohesive defence-in-depth pipeline (header parsing,

--- a/inference-router/src/mcp/oauth_layer.rs
+++ b/inference-router/src/mcp/oauth_layer.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! OAuth 2.1 bearer-token verification as a `tower::Layer`.
 //!
 //! ## Why a tower layer

--- a/inference-router/src/mcp/pipeline.rs
+++ b/inference-router/src/mcp/pipeline.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! MCP request pipeline — the full body→response transform.
 //!
 //! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>

--- a/inference-router/src/mcp/platform.rs
+++ b/inference-router/src/mcp/platform.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Platform MCP server — Foundry-shim discovery surface.
 //!
 //! This module ships the **runtime-agnostic platform MCP server** mounted at

--- a/inference-router/src/mcp/streamable_http.rs
+++ b/inference-router/src/mcp/streamable_http.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Streamable HTTP transport envelope per
 //! [MCP spec rev. 2025-03-26 §Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).
 //!

--- a/inference-router/src/mcp/tools.rs
+++ b/inference-router/src/mcp/tools.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! MCP `tools/list` and `tools/call` method handlers — pure dispatch.
 //!
 //! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/server/tools>

--- a/inference-router/src/mesh.rs
+++ b/inference-router/src/mesh.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Local mesh state — inbox buffer and metrics counters.
 //!
 //! These are the only pieces of governance.rs that survive: simple data

--- a/inference-router/src/metrics.rs
+++ b/inference-router/src/metrics.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Prometheus metrics for inference routing and AGT governance.
 
 use prometheus::{

--- a/inference-router/src/policy_envelope.rs
+++ b/inference-router/src/policy_envelope.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Hot-reloadable policy envelope — pure-function core.
 //!
 //! ## What this module is

--- a/inference-router/src/providers/audit.rs
+++ b/inference-router/src/providers/audit.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `AuditSink` contract.
 //!
 //! Responsibility: `append(event) -> ReceiptId`. The router appends a

--- a/inference-router/src/providers/audit_impl.rs
+++ b/inference-router/src/providers/audit_impl.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! In-tree `AuditSink` implementation on `crate::governance::Governance`.
 //!
 //! The four-seam trait is defined in `providers/audit.rs`; this module

--- a/inference-router/src/providers/mesh.rs
+++ b/inference-router/src/providers/mesh.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `MeshProvider` contract — **plugin-side**. No Rust implementation
 //! exists in the router and **none should**.
 //!

--- a/inference-router/src/providers/mod.rs
+++ b/inference-router/src/providers/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Provider contracts for AzureClaw.
 //!
 //! ## Router-side seams (three real ones)

--- a/inference-router/src/providers/outage.rs
+++ b/inference-router/src/providers/outage.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Outage semantics for AGT / mesh provider calls.
 //!
 //! Reference: internal Phase 1 plan §1.3.

--- a/inference-router/src/providers/policy.rs
+++ b/inference-router/src/providers/policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `PolicyDecisionProvider` contract.
 //!
 //! Responsibility: `decide(request) -> verdict`. A single synchronous call

--- a/inference-router/src/providers/policy_impl.rs
+++ b/inference-router/src/providers/policy_impl.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! In-tree `PolicyDecisionProvider` implementation on `crate::governance::Governance`.
 //!
 //! The four-seam trait lives in `providers/policy.rs`; the in-tree

--- a/inference-router/src/providers/signing.rs
+++ b/inference-router/src/providers/signing.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `SigningProvider` contract.
 //!
 //! Responsibility: `sign(key_ref, payload) -> Signature`;

--- a/inference-router/src/providers/signing_impl.rs
+++ b/inference-router/src/providers/signing_impl.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! In-tree `SigningProvider` implementation on [`Governance`].
 //!
 //! Mirrors the pattern used by `policy_impl.rs` and `audit_impl.rs`:

--- a/inference-router/src/proxy.rs
+++ b/inference-router/src/proxy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Reverse proxy logic — forwards inference requests to Azure AI Foundry.
 //!
 //! Supports both buffered and SSE streaming responses.

--- a/inference-router/src/rate_limiter.rs
+++ b/inference-router/src/rate_limiter.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Token-bucket rate limiter — local fallback used by `Governance`.
 //!
 //! Extracted from `governance.rs` per §4.2 hotspot decomposition. The

--- a/inference-router/src/routes/a2a.rs
+++ b/inference-router/src/routes/a2a.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 axum routes — `/.well-known/agent.json` + `POST /a2a` JSON-RPC.
 //!
 //! Spec: <https://a2a-protocol.org/v1.0.0/specification>

--- a/inference-router/src/routes/audit_events.rs
+++ b/inference-router/src/routes/audit_events.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Audit-event helpers for the `routes::handoff` module.
 //!
 //! Rather than pepper every handoff route with the `AuditEvent { … }`

--- a/inference-router/src/routes/chat_completions.rs
+++ b/inference-router/src/routes/chat_completions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! POST /v1/chat/completions handler — extracted from
 //! `routes/inference.rs` in S15.c (Phase 2 hotspot decomposition,
 //! §4.2 file-budget enforcement).

--- a/inference-router/src/routes/egress.rs
+++ b/inference-router/src/routes/egress.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! egress route handlers and router builder.
 //!
 //! Extracted from `routes/mod.rs` as part of the Q1 split.

--- a/inference-router/src/routes/governance.rs
+++ b/inference-router/src/routes/governance.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! governance route handlers and router builder.
 //!
 //! Extracted from `routes/mod.rs` as part of the Q1 split.

--- a/inference-router/src/routes/handoff/mod.rs
+++ b/inference-router/src/routes/handoff/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! handoff route handlers and router builders.
 //!
 //! Extracted from `routes/mod.rs` as part of the Q1 split.

--- a/inference-router/src/routes/handoff/payload.rs
+++ b/inference-router/src/routes/handoff/payload.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Handoff payload handlers — snapshot, restore, verify.
 //!
 //! Extracted from `routes/handoff/mod.rs` per plan §4.2 hotspot

--- a/inference-router/src/routes/handoff/succession.rs
+++ b/inference-router/src/routes/handoff/succession.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `POST /agt/handoff/succession` handler.
 //!
 //! Extracted from `handoff/mod.rs` in S15.h

--- a/inference-router/src/routes/inference.rs
+++ b/inference-router/src/routes/inference.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Inference + Foundry proxy handlers.
 
 use axum::Json;

--- a/inference-router/src/routes/inference_policy.rs
+++ b/inference-router/src/routes/inference_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Inference-side policy gating via the four-seam
 //! [`crate::providers::PolicyDecisionProvider`] trait.
 //!

--- a/inference-router/src/routes/inference_translate.rs
+++ b/inference-router/src/routes/inference_translate.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Chat ↔ Responses API body translation helpers.
 //!
 //! Extracted from `routes/inference.rs` in `phase1/hotspot-pass2-inference-split`

--- a/inference-router/src/routes/mcp.rs
+++ b/inference-router/src/routes/mcp.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! POST /mcp axum route — thin wrapper around [`crate::mcp::pipeline::process_request`].
 //!
 //! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>

--- a/inference-router/src/routes/mesh.rs
+++ b/inference-router/src/routes/mesh.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! mesh route handlers and router builder.
 //!
 //! Extracted from `routes/mod.rs` as part of the Q1 split.

--- a/inference-router/src/routes/mod.rs
+++ b/inference-router/src/routes/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Axum route handlers for the inference router.
 
 use axum::{

--- a/inference-router/src/routes/signing_ops.rs
+++ b/inference-router/src/routes/signing_ops.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Thin helpers routing signing call-sites through the `SigningProvider`
 //! trait, so the legacy `state.governance.identity.sign(...)` path can be
 //! migrated one site at a time without breaking unrelated code.

--- a/inference-router/src/routes/spawn_policy.rs
+++ b/inference-router/src/routes/spawn_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AGT policy gate for `POST /sandbox/spawn`. First production call-site
 //! on the four-seam [`crate::providers::PolicyDecisionProvider`] trait.
 //!

--- a/inference-router/src/safety.rs
+++ b/inference-router/src/safety.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Foundry Guardrail annotation parsing + AGT content flag reporting.
 //!
 //! Instead of calling the standalone Content Safety API (which requires a

--- a/inference-router/src/spawn/docker.rs
+++ b/inference-router/src/spawn/docker.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Docker dev-mode sandbox spawn — `azureclaw dev` path.
 //!
 //! Extracted from `spawn.rs` per §4.2 hotspot decomposition. The

--- a/inference-router/src/spawn/mod.rs
+++ b/inference-router/src/spawn/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Sandbox spawn — create/list/delete ClawSandbox sub-agents via K8s API.
 //!
 //! The agent inside a sandbox has no kubectl or CLI access. This module exposes

--- a/inference-router/src/telemetry/gen_ai.rs
+++ b/inference-router/src/telemetry/gen_ai.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! OpenTelemetry GenAI Semantic Conventions — attribute constants + typed
 //! helpers.
 //!

--- a/inference-router/src/telemetry/mod.rs
+++ b/inference-router/src/telemetry/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Telemetry helpers for the inference router.
 //!
 //! Today this module hosts only the OTel GenAI Semantic Conventions

--- a/inference-router/tests/a2a_card_verifier_conformance.rs
+++ b/inference-router/tests/a2a_card_verifier_conformance.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! A2A 1.0.0 AgentCard verifier conformance corpus.
 //!
 //! Mirrors the AP2 fixture corpus (`tests/ap2_conformance.rs`) for the

--- a/inference-router/tests/a2a_trust_store_hot_reload.rs
+++ b/inference-router/tests/a2a_trust_store_hot_reload.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! End-to-end integration: trust-store hot-reload feeds card_verifier.
 //!
 //! This corpus stitches together the three pieces that previously lived

--- a/inference-router/tests/agt_governance_integration.rs
+++ b/inference-router/tests/agt_governance_integration.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Integration tests for the AGT governance HTTP endpoints.
 //!
 //! These tests spin up the axum Router with a real AppState and make actual

--- a/inference-router/tests/ap2_conformance.rs
+++ b/inference-router/tests/ap2_conformance.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AP2 conformance corpus — fixture-driven integration tests.
 //!
 //! Each `tests/fixtures/ap2_conformance/NNN-*.json` file describes a

--- a/inference-router/tests/common/mod.rs
+++ b/inference-router/tests/common/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Shared integration test infrastructure.
 //!
 //! Three tiny axum servers simulate the Azure surface so the router can be

--- a/inference-router/tests/egress_blocked_endpoint.rs
+++ b/inference-router/tests/egress_blocked_endpoint.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Integration tests for `GET /egress/learned/blocked` (S12.f).
 //!
 //! Mounts the egress sub-router with a real `AppState` and verifies the

--- a/inference-router/tests/mcp_negative_edge_cases.rs
+++ b/inference-router/tests/mcp_negative_edge_cases.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! MCP 2026 Streamable HTTP — negative-only edge-case integration tests.
 //!
 //! These complement the broad in-tree pipeline corpus

--- a/inference-router/tests/proxy_fake_upstream.rs
+++ b/inference-router/tests/proxy_fake_upstream.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! End-to-end proxy test against fake upstream servers.
 //!
 //! Exercises the full `proxy::forward` → auth (IMDS / API-key) → upstream flow

--- a/mesh-plugin/nemoclaw/setup.sh
+++ b/mesh-plugin/nemoclaw/setup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # setup.sh — resolve host.docker.internal and render the azureclaw-mesh preset
 #
 # Resolves host.docker.internal via DNS and substitutes the __HOST_IP__

--- a/mesh-plugin/scripts/patch-nemoclaw.sh
+++ b/mesh-plugin/scripts/patch-nemoclaw.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # patch-nemoclaw.sh — bolt the azureclaw-mesh plugin into a NemoClaw source tree.
 #
 # Fresh Azure/azureclaw clone + fresh NemoClaw clone:

--- a/mesh-plugin/src/connection.test.ts
+++ b/mesh-plugin/src/connection.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect, vi } from "vitest";
 import { MeshConnection } from "./connection.js";
 import { generateIdentity } from "./identity.js";

--- a/mesh-plugin/src/connection.ts
+++ b/mesh-plugin/src/connection.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Mesh connection adapter — wraps @agentmesh/sdk's `AgentMeshClient`.
  *

--- a/mesh-plugin/src/federation.test.ts
+++ b/mesh-plugin/src/federation.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Federation protocol roundtrip tests.
  *

--- a/mesh-plugin/src/identity.test.ts
+++ b/mesh-plugin/src/identity.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";

--- a/mesh-plugin/src/identity.ts
+++ b/mesh-plugin/src/identity.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Mesh identity management — Ed25519 signing + X25519 exchange keypairs.
  *
@@ -201,4 +204,3 @@ export async function loadOrCreateIdentity(): Promise<MeshIdentity> {
 export function getIdentityPath(): string {
   return IDENTITY_FILE;
 }
-

--- a/mesh-plugin/src/index.ts
+++ b/mesh-plugin/src/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * @azureclaw/mesh — OpenClaw plugin for mesh federation.
  *

--- a/mesh-plugin/src/pairing.test.ts
+++ b/mesh-plugin/src/pairing.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { decodeToken, loadPairings, savePairing, getDefaultPairing } from "./pairing.js";
 

--- a/mesh-plugin/src/pairing.ts
+++ b/mesh-plugin/src/pairing.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Pairing ceremony — decode token, connect to mesh, pair with controller.
  */

--- a/mesh-plugin/src/timers.ts
+++ b/mesh-plugin/src/timers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Coherent timer ladder for all mesh operations.
  *

--- a/mesh-plugin/src/transport-interface.ts
+++ b/mesh-plugin/src/transport-interface.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * AGT Migration — Transport abstraction interface.
  *

--- a/mesh-plugin/src/types.ts
+++ b/mesh-plugin/src/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Message types for federation protocol between external agents and controller.
  */

--- a/mesh-plugin/vitest.config.ts
+++ b/mesh-plugin/vitest.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/runtimes/openclaw/src/core/agt-handoff.ts
+++ b/runtimes/openclaw/src/core/agt-handoff.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Background handoff orchestration — extracted from plugin.ts in S15.f.7.
 //
 // runHandoffOrchestration executes the multi-step transfer of an agent's
@@ -612,4 +615,3 @@ export async function runHandoffOrchestration(
     }
   }
 }
-

--- a/runtimes/openclaw/src/core/agt-heartbeat.ts
+++ b/runtimes/openclaw/src/core/agt-heartbeat.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // AGT mesh heartbeat & memory-notify helpers — extracted from plugin.ts in S15.f.5.
 //
 // These three helpers all read AGT singleton state owned by plugin.ts. To

--- a/runtimes/openclaw/src/core/agt-offload.ts
+++ b/runtimes/openclaw/src/core/agt-offload.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // AGT offload executor — extracted from plugin.ts in S15.f.5.
 //
 // Two functions:

--- a/runtimes/openclaw/src/core/agt-task-delegate.ts
+++ b/runtimes/openclaw/src/core/agt-task-delegate.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Native-agent task delegation — extracted from plugin.ts in S15.f.2
 // to give plugin.ts headroom under the §4.2 800-LOC cap.
 //

--- a/runtimes/openclaw/src/core/agt-task-loop.ts
+++ b/runtimes/openclaw/src/core/agt-task-loop.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // AGT in-process tool-calling loop — extracted from plugin.ts in S15.f.6.
 //
 // Drives a sub-agent's task execution against the inference router using the

--- a/runtimes/openclaw/src/core/agt-task-tools.ts
+++ b/runtimes/openclaw/src/core/agt-task-tools.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Tool-calling loop tool definitions — extracted from
 // plugin.ts processTaskWithTools() in S15.f.4.
 //

--- a/runtimes/openclaw/src/core/agt-tools/agt.ts
+++ b/runtimes/openclaw/src/core/agt-tools/agt.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // ci:loc-ok — Phase 2 multi-CRD reconciler / generated module; intentional. Tracked in plan.md §S15 follow-up.
 // AzureClaw AGT tool registrations — extracted from plugin.ts in S15.f.9.
 //

--- a/runtimes/openclaw/src/core/agt-tools/foundry.ts
+++ b/runtimes/openclaw/src/core/agt-tools/foundry.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Foundry AGT tool registrations — extracted from plugin.ts in S15.f.8.
 //
 // Nine tools that proxy through the inference router to Azure AI Foundry

--- a/runtimes/openclaw/src/core/agt-tools/http-fetch.ts
+++ b/runtimes/openclaw/src/core/agt-tools/http-fetch.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // http_fetch AGT tool registration — extracted from plugin.ts in S15.f.8.
 
 import { routerCall } from "../router-client.js";

--- a/runtimes/openclaw/src/core/amid-cache.ts
+++ b/runtimes/openclaw/src/core/amid-cache.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // AMID cache + registry resolvers — extracted from plugin.ts in S15.f.1
 // to give plugin.ts headroom under the §4.2 800-LOC cap.
 //

--- a/runtimes/openclaw/src/core/commands/openclaw.ts
+++ b/runtimes/openclaw/src/core/commands/openclaw.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // ci:loc-ok — Phase 2 multi-CRD reconciler / generated module; intentional. Tracked in plan.md §S15 follow-up.
 // OpenClaw command/provider/CLI registrations — extracted from plugin.ts in S15.f.10.
 //

--- a/runtimes/openclaw/src/core/foundry-discovery.ts
+++ b/runtimes/openclaw/src/core/foundry-discovery.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * cli/src/core/foundry-discovery.ts — Azure AI Foundry project discovery.
  *

--- a/runtimes/openclaw/src/core/log-redact.ts
+++ b/runtimes/openclaw/src/core/log-redact.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Log redaction + sanitization helpers — extracted from plugin.ts in
 // S15.f.1 to give plugin.ts headroom under the §4.2 800-LOC cap.
 //

--- a/runtimes/openclaw/src/core/mesh-transport.ts
+++ b/runtimes/openclaw/src/core/mesh-transport.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Chunked mesh transport — extracted from plugin.ts in S15.f.3.
 //
 // Provides the wire-level large-payload chunking protocol used by every

--- a/runtimes/openclaw/src/core/router-client.ts
+++ b/runtimes/openclaw/src/core/router-client.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Router-client helpers — small, pure I/O wrappers around the in-pod
  * inference-router. Extracted from `plugin.ts` to satisfy the LOC budget

--- a/runtimes/openclaw/src/core/safe-json.ts
+++ b/runtimes/openclaw/src/core/safe-json.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Small helper used by AGT tool registrations — pretty-prints + size-caps.
 // Extracted from plugin.ts in S15.f.8 to make tool modules under
 // `core/agt-tools/` self-contained.

--- a/runtimes/openclaw/src/index.test.ts
+++ b/runtimes/openclaw/src/index.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Tests for AzureClaw OpenClaw Plugin (plugin.ts)
  *

--- a/runtimes/openclaw/src/index.ts
+++ b/runtimes/openclaw/src/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * AzureClaw — OpenClaw Plugin
  *

--- a/runtimes/openclaw/src/redact.test.ts
+++ b/runtimes/openclaw/src/redact.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { describe, it, expect } from "vitest";
 import { redactSecrets } from "./index.js";
 

--- a/runtimes/openclaw/src/router-url.test.ts
+++ b/runtimes/openclaw/src/router-url.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Tests for plan item q7 — centralized router URL helpers.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { routerBase, routerUrl, routerWsBase, routerWsUrl } from "./index.js";

--- a/sandbox-images/maf-python/entrypoint.sh
+++ b/sandbox-images/maf-python/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # AzureClaw MAF Python runtime entrypoint (S10.A4 scaffolding).
 #
 # This script is the in-pod adapter's bootstrap. It sets the env the

--- a/sandbox-images/openai-agents/entrypoint.sh
+++ b/sandbox-images/openai-agents/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # AzureClaw OpenAI Agents Python runtime entrypoint (S10.A3 scaffolding).
 #
 # This script is the in-pod adapter's bootstrap. It sets the environment

--- a/sandbox-images/openclaw/entrypoint.sh
+++ b/sandbox-images/openclaw/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # AzureClaw sandbox entrypoint
 # Configures OpenClaw automatically from mounted secrets and env vars.
 # The user never needs to manually configure anything.

--- a/sandbox-images/openclaw/proxy-bootstrap.js
+++ b/sandbox-images/openclaw/proxy-bootstrap.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // proxy-bootstrap.js — preloaded via NODE_OPTIONS="--require ..."
 // Sets undici's EnvHttpProxyAgent as the global fetch dispatcher so all
 // outbound HTTP(S) requests honour HTTPS_PROXY / NO_PROXY env vars.

--- a/scripts/apply-copyright-headers.sh
+++ b/scripts/apply-copyright-headers.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# scripts/apply-copyright-headers.sh — one-shot idempotent header applier.
+# Run from repo root. Idempotent: running twice is a no-op.
+set -euo pipefail
+
+SLASH_HEADER="// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License."
+
+HASH_HEADER="# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License."
+
+applied=0
+skipped=0
+
+while IFS= read -r file; do
+  # Skip if already has the header
+  if head -5 "$file" | grep -qE '^(//|#) *Copyright \(c\) Microsoft Corporation'; then
+    ((skipped++)) || true
+    continue
+  fi
+
+  # Determine comment style by extension
+  ext="${file##*.}"
+  case "$ext" in
+    rs|ts|tsx|js) header="$SLASH_HEADER" ;;
+    sh)           header="$HASH_HEADER" ;;
+    *)            continue ;;
+  esac
+
+  # Read file content
+  content=$(<"$file")
+
+  # Handle shebang
+  first_line=$(head -1 "$file")
+  if [[ "$first_line" == '#!'* ]]; then
+    rest=$(tail -n +2 "$file")
+    printf '%s\n%s\n\n%s\n' "$first_line" "$header" "$rest" > "$file"
+  else
+    printf '%s\n\n%s\n' "$header" "$content" > "$file"
+  fi
+
+  ((applied++)) || true
+done < <(
+  git ls-files \
+    | grep -E '\.(rs|ts|tsx|js|sh)$' \
+    | grep -v '^vendor/' \
+    | grep -v 'node_modules/' \
+    | grep -v '/dist/' \
+    | grep -v '^target/' \
+    | grep -v '/build/' \
+    | grep -v '\.d\.ts$' \
+    | grep -v '\.turbo/' \
+    | grep -v '/coverage/'
+)
+
+echo "✅ Applied headers to $applied file(s). Skipped $skipped (already had header)."

--- a/tests/chaos/src/harness.rs
+++ b/tests/chaos/src/harness.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Shared chaos-test harness — small axum mock servers + counters.
 //!
 //! Tests inject arbitrary chaos (status code, delay, body) on the server

--- a/tests/chaos/src/lib.rs
+++ b/tests/chaos/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AzureClaw chaos tier — fault-injection harness (Phase 2 S16).
 //!
 //! This crate is empty by design: all logic lives in feature-gated

--- a/tests/chaos/tests/agt_relay.rs
+++ b/tests/chaos/tests/agt_relay.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! AGT relay timeout chaos — WebSocket proxy resilience.
 //!
 //! The router proxies `/agt/relay` to the AgentMesh relay over WebSocket.

--- a/tests/chaos/tests/entra_rotation.rs
+++ b/tests/chaos/tests/entra_rotation.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Entra rotation race chaos — token refresh + JWKS rotation.
 //!
 //! The router caches Workload Identity tokens (see

--- a/tests/chaos/tests/foundry_storms.rs
+++ b/tests/chaos/tests/foundry_storms.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Foundry 429 / 503 storm chaos — router-side reliability invariants.
 //!
 //! Models Azure OpenAI / AI Search / Document Intelligence pushing back

--- a/tests/chaos/tests/k8s_api_flakes.rs
+++ b/tests/chaos/tests/k8s_api_flakes.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! K8s API flake chaos — controller-side reliability invariants.
 //!
 //! Each test exercises a specific failure mode the kube-rs client (and our

--- a/tests/cncf-conformance/src/lib.rs
+++ b/tests/cncf-conformance/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // ci:loc-ok — Phase 2 multi-CRD reconciler / generated module; intentional. Tracked in plan.md §S15 follow-up.
 //! K8s AI Conformance v1.35+ test suite for AzureClaw.
 //!

--- a/tests/cncf-conformance/src/main.rs
+++ b/tests/cncf-conformance/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! `cncf-conformance` — render the CNCF K8s AI conformance report.
 //!
 //! Usage: `cargo run -p azureclaw-cncf-conformance --bin cncf-conformance`.

--- a/tests/cncf-conformance/tests/criteria.rs
+++ b/tests/cncf-conformance/tests/criteria.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Per-criterion conformance tests. Each `#[test]` covers one row of
 //! [`azureclaw_cncf_conformance::run_all_checks`] and asserts pass.
 //!

--- a/tests/compat/harness/blessed-mock.ts
+++ b/tests/compat/harness/blessed-mock.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Headless blessed surface for the compat suite.
  *

--- a/tests/compat/harness/types.ts
+++ b/tests/compat/harness/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Types shared by all compat specs.
  * Keep this file small — types only, no runtime code.

--- a/tests/compat/specs/operator-tui.spec.ts
+++ b/tests/compat/specs/operator-tui.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Compat spec: `azureclaw operator` (headless TUI).
  *

--- a/tests/compat/vitest.config.ts
+++ b/tests/compat/vitest.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/tests/conformance/harness/index.ts
+++ b/tests/conformance/harness/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Harness placeholder — conformance test wiring lands alongside each
  * implementation PR. Phase 0 scaffold keeps this intentionally empty.

--- a/tests/conformance/specs/a2a-agent-card.spec.ts
+++ b/tests/conformance/specs/a2a-agent-card.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * A2A 1.0.0 AgentCard JWS verification — Phase 1 conformance corpus.
  *

--- a/tests/conformance/specs/ap2-commerce.spec.ts
+++ b/tests/conformance/specs/ap2-commerce.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * AP2 commerce caps — Phase 1 conformance corpus.
  *

--- a/tests/conformance/specs/mcp-streamable-http.spec.ts
+++ b/tests/conformance/specs/mcp-streamable-http.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * MCP 2026-01-15 Streamable HTTP framing — Phase 1 conformance corpus.
  *

--- a/tests/conformance/specs/oauth21-bcp.spec.ts
+++ b/tests/conformance/specs/oauth21-bcp.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * OAuth 2.1 (RFC 9700) BCP — Phase 1 conformance corpus.
  *

--- a/tests/conformance/specs/sandbox-isolation.spec.ts
+++ b/tests/conformance/specs/sandbox-isolation.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Sandbox isolation invariants — seccomp / Landlock / egress-guard.
  *

--- a/tests/conformance/specs/signal-knock.spec.ts
+++ b/tests/conformance/specs/signal-knock.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Signal KNOCK sequence invariants — Phase 0 scaffold.
  *

--- a/tests/conformance/specs/signal-negative.spec.ts
+++ b/tests/conformance/specs/signal-negative.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Signal tamper / replay / denial-of-service invariants — Phase 0 scaffold.
  *

--- a/tests/conformance/specs/signal-x3dh.spec.ts
+++ b/tests/conformance/specs/signal-x3dh.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Signal / X3DH / Double-Ratchet invariants — Phase 0 scaffold.
  *

--- a/tests/conformance/vitest.config.ts
+++ b/tests/conformance/vitest.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/tests/e2e/infra-e2e.sh
+++ b/tests/e2e/infra-e2e.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # AzureClaw Infrastructure E2E Test Suite
 #
 # Runs against a LIVE AKS cluster with Azure AI Foundry connectivity.

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # AzureClaw E2E Test Suite
 #
 # Prerequisites:

--- a/tests/k6/router_smoke.js
+++ b/tests/k6/router_smoke.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // k6 smoke test — inference-router (Phase 2 S16).
 //
 // 50 VUs for 30s against /healthz and a stub upstream. Asserts:

--- a/tools/item-manifest/src/main.rs
+++ b/tools/item-manifest/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Byte-level equivalence extractor for refactor-safety proofs.
 //
 // Walks one or more Rust source files, parses them with `syn`, and emits a


### PR DESCRIPTION
## Summary

Resolves OSPO finding **CODE-COPYRIGHT-HDRS** (grade F) from `docs/internal/2026-04-28-Azure-azureclaw.md`.

All AzureClaw-authored source files now carry the required two-line OSPO copyright header:
```
// Copyright (c) Microsoft Corporation.
// Licensed under the MIT License.
```
(or `# ...` for shell scripts)

## File counts

| Extension | Count |
|---|---|
| `.rs` | 155 |
| `.ts` / `.tsx` | 148 |
| `.sh` | 16 |
| `.js` | 2 |
| **Total** | **321** existing + 2 new scripts = **323** |

## Exclusions

| Directory | Reason |
|---|---|
| `vendor/`| Upstream code — own licenses in `THIRD_PARTY_NOTICES.txt` (S24) |
| `cli/dist/`, `target/`, `node_modules/` | Generated/build artifacts |
| `*.d.ts` | Generated TypeScript declarations |

## New CI gate

`ci/check-copyright-headers.sh` — fast (<5s), deterministic. Wired into `.github/workflows/ci-gates.yml` as the `copyright-headers` matrix entry. Every new source file must carry the header or the gate fails.

`CONTRIBUTING.md` updated with a "Copyright Headers" subsection.

## Build verification

- ✅ `cargo build --workspace --release` passes
- ✅ `cd cli && npm run build && npm run typecheck` passes
- ✅ `bash ci/check-copyright-headers.sh` passes (323/323 files)
- ✅ `bash ci/security-audit-required.sh` passes (no regression)
- ✅ `bash ci/no-stubs.sh` passes (no regression)

## Audit document

`docs/security-audits/2026-04-30-phase3-copyright-headers.md`

Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>