### PR TITLE
examples: add openai-agents + MAF quickstart blueprints

### DIFF
--- a/cli/src/commands/operator/keymap.ts
+++ b/cli/src/commands/operator/keymap.ts
@@ -37,6 +37,7 @@ export const BINDINGS: readonly KeyBinding[] = [
   { key: "x",        action: "delete selected agent (confirm)",       scope: "agents" },
   { key: "Enter",    action: "connect (shell session)",               scope: "agents" },
   { key: "c",        action: "toggle cluster health view",            scope: "global" },
+  { key: "Shift-p",  action: "toggle CRD panels overlay (S14)",       scope: "global" },
   { key: "r",        action: "refresh now",                           scope: "global" },
   { key: "q / Esc",  action: "quit (or close overlay)",               scope: "global" },
 ] as const;
@@ -50,7 +51,7 @@ const viewClusterDim  = "{gray-fg}Cluster{/}";
 const viewTopologyDim = "{gray-fg}Topology{/}";
 
 const AGENTS_ACTIONS =
-  "[Tab] Focus  [↑↓] Nav  [Enter] Connect  [c] Cluster  [t] Topology  " +
+  "[Tab] Focus  [↑↓] Nav  [Enter] Connect  [c] Cluster  [t] Topology  [P] Panels  " +
   "[a] Approve  [A] All  [d] Del/Deny  [e] Enforce  [L] Learn/Enforce  [g] AGT  [n] Spawn  [r] Refresh  [q] Quit";
 
 /**
@@ -71,9 +72,9 @@ export function statusBarForAgents(args: {
 }
 
 export function statusBarForTopology(): string {
-  return ` ${viewTopology}  │  [t] Back to Agents  [c] Cluster  [r] Refresh  [q] Quit`;
+  return ` ${viewTopology}  │  [t] Back to Agents  [c] Cluster  [P] Panels  [r] Refresh  [q] Quit`;
 }
 
 export function statusBarForCluster(): string {
-  return ` ${viewCluster}  │  [c] Back to Agents  [t] Topology  [r] Refresh  [q] Quit`;
+  return ` ${viewCluster}  │  [c] Back to Agents  [t] Topology  [P] Panels  [r] Refresh  [q] Quit`;
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# AzureClaw Examples
+
+End-to-end blueprints you can `kubectl apply -f` after running `azureclaw up`.
+
+| Example | Runtime | What it shows |
+|---------|---------|---------------|
+| [`basic-agent`](basic-agent/) | OpenClaw | Minimal sandboxed agent with default security posture (seccomp, RO rootfs, egress guard, governance). |
+| [`confidential-agent`](confidential-agent/) | OpenClaw | Same as `basic-agent` plus Confidential Containers (CVM workers, attested boot). |
+| [`telegram-agent`](telegram-agent/) | OpenClaw | OpenClaw agent wired to a Telegram channel via the channel-plugin pattern. |
+| [`demo-clawshield`](demo-clawshield/) | OpenClaw (×3) | Multi-tenant attack-simulation demo (poisoned document, two victim tenants, isolation proof). |
+| [`openai-agents-quickstart`](openai-agents-quickstart/) | OpenAIAgents (Python) | Hosts an unmodified OpenAI Agents SDK app inside an AzureClaw sandbox. Same security as default. |
+| [`maf-quickstart`](maf-quickstart/) | MicrosoftAgentFramework (Python) | Hosts an unmodified Microsoft Agent Framework app inside an AzureClaw sandbox. |
+
+All examples share the same control-plane install and isolation guarantees
+— only the agent runtime image changes. See
+[`docs/api/crd-reference.md`](../docs/api/crd-reference.md) for the full
+`ClawSandbox.spec.runtime` schema.
+
+For broader patterns (developer inner-loop, enterprise self-hosted,
+managed public offload, cross-org federation, sovereign / air-gapped),
+see [`docs/blueprints/`](../docs/blueprints).

--- a/examples/maf-quickstart/README.md
+++ b/examples/maf-quickstart/README.md
@@ -1,0 +1,67 @@
+# Microsoft Agent Framework (MAF) — Quickstart
+
+This blueprint hosts a [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
+(Python) agent inside an AzureClaw sandbox. The agent runs unmodified —
+AzureClaw provides isolation, governance, and egress control without
+touching MAF code.
+
+## What you get
+
+- **Same security posture as the default OpenClaw runtime.** Seccomp profile,
+  read-only rootfs, egress guard, AGT governance, AgentMesh E2E, and
+  inference router are all identical.
+- **Model selection through `InferencePolicy`** (S13 ref-authority) — adjust
+  the policy CR to swap models without redeploying the agent.
+- **No code changes in the MAF app.** The adapter image
+  (`sandbox-images/maf-python/`) sets `AZURE_OPENAI_ENDPOINT` /
+  `AZURE_OPENAI_API_KEY` (synthetic, valid only inside the sandbox) so
+  MAF's Azure OpenAI client routes through the local inference router.
+
+## Apply
+
+```bash
+azureclaw up                                 # one-time control-plane install
+kubectl apply -f examples/maf-quickstart/clawsandbox.yaml
+kubectl get clawsandboxes -n azureclaw-system maf-quickstart
+```
+
+## Bring your own agent code
+
+```yaml
+# Production: signed OCI image
+runtime:
+  kind: MicrosoftAgentFramework
+  microsoftAgentFramework:
+    language: python
+    agentCode:
+      oci:
+        image: ghcr.io/your-org/your-maf-agent:v1.2.3
+
+# Dev iteration: clone from git at pod start
+runtime:
+  kind: MicrosoftAgentFramework
+  microsoftAgentFramework:
+    language: python
+    agentCode:
+      git:
+        url: https://github.com/your-org/your-maf-agent
+        ref: main
+        path: agents/my-agent
+```
+
+Your image must contain `pyproject.toml` (or `requirements.txt`) and an
+entrypoint Python script. Default entrypoint is `python -u agent.py`.
+
+## Language matrix
+
+| Language | Phase 2 | Notes |
+|----------|---------|-------|
+| `python` | ✅ shipped | `sandbox-images/maf-python/` adapter |
+| `dotnet` | ⏳ Phase 3 | CRD accepts the value; controller stamps `RuntimeReady=False / AdapterMissing` until the .NET adapter image ships |
+
+## What's next
+
+- Combine with **`A2AAgent`** to publish your agent over the JWS-authenticated
+  A2A gateway.
+- Add a **`ToolPolicy`** CR to enforce rate-limits, redaction, and per-tool RBAC.
+- See [`docs/blueprints/`](../../docs/blueprints) for end-to-end patterns.

--- a/examples/maf-quickstart/clawsandbox.yaml
+++ b/examples/maf-quickstart/clawsandbox.yaml
@@ -1,0 +1,88 @@
+# AzureClaw Example: Microsoft Agent Framework (MAF) runtime
+#
+# Hosts a Microsoft Agent Framework (Python) agent inside an AzureClaw
+# sandbox. The controller swaps the OpenClaw image for
+# `sandbox-images/maf-python/` and points MAF's Azure OpenAI client at the
+# local inference router. Egress guard, AGT governance, AgentMesh E2E,
+# and seccomp/Landlock isolation are identical to the OpenClaw default.
+#
+# Apply with:
+#   kubectl apply -f examples/maf-quickstart/clawsandbox.yaml
+#
+# Pre-reqs:
+#   - AzureClaw control plane installed (`azureclaw up`)
+#   - InferencePolicy below references an Azure OpenAI deployment named
+#     `gpt-4.1`. Adjust if needed.
+#   - Your MAF agent code is published to a public OCI image. The example
+#     uses `ghcr.io/microsoft/maf-quickstart:latest` as a placeholder —
+#     swap for your image, or use `git:` for dev iteration.
+
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: maf-quickstart-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: maf-quickstart
+spec:
+  appliesTo:
+    sandboxName: maf-quickstart
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 500000
+    perRequestTokens: 128000
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: maf-quickstart
+  namespace: azureclaw-system
+spec:
+  runtime:
+    kind: MicrosoftAgentFramework
+    microsoftAgentFramework:
+      # Phase 2 ships the Python adapter. `dotnet` is reserved in the CRD
+      # but its adapter image ships in Phase 3.
+      language: python
+      agentCode:
+        oci:
+          image: ghcr.io/microsoft/maf-quickstart:latest
+      # entrypoint: ["python", "-u", "agent.py"]
+      extraEnv:
+        AGENT_LOG_LEVEL: "INFO"
+
+  sandbox:
+    isolation: "enhanced"
+    seccompProfile: "azureclaw-strict"
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    writablePaths:
+      - /sandbox
+      - /tmp
+
+  inferenceRef:
+    name: maf-quickstart-inference
+
+  networkPolicy:
+    defaultDeny: true
+    approvalRequired: true
+    allowedEndpoints: []
+
+  azureServices:
+    - service: ai-foundry
+      permissions: [inference]
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"

--- a/examples/openai-agents-quickstart/README.md
+++ b/examples/openai-agents-quickstart/README.md
@@ -1,0 +1,67 @@
+# OpenAI Agents Python — Quickstart
+
+This blueprint hosts an [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) (Python)
+agent inside an AzureClaw sandbox. The agent runs unmodified — AzureClaw
+provides isolation, governance, and egress control without touching SDK code.
+
+## What you get
+
+- **Same security posture as the default OpenClaw runtime.** Seccomp profile,
+  read-only rootfs, egress guard, AGT governance, AgentMesh E2E, and
+  inference router are all identical.
+- **Model selection through `InferencePolicy`** (S13 ref-authority — not inlined
+  in the sandbox spec). Adjust the policy CR to swap models without redeploying
+  the agent.
+- **No code changes in the SDK app.** The adapter image (`sandbox-images/openai-agents/`)
+  sets `OPENAI_BASE_URL=http://127.0.0.1:8443/v1` and `HTTPS_PROXY=http://127.0.0.1:8444`
+  so the agent's outbound HTTPS to `api.openai.com` is transparently routed through
+  the inference router.
+
+## Apply
+
+```bash
+azureclaw up                                 # one-time control-plane install
+kubectl apply -f examples/openai-agents-quickstart/clawsandbox.yaml
+kubectl get clawsandboxes -n azureclaw-system oai-quickstart
+```
+
+The controller patches the sandbox pod to launch the OpenAI Agents adapter
+instead of OpenClaw, then waits for the InferencePolicy to be ready before
+flipping `Ready=True`.
+
+## Bring your own agent code
+
+Two flavours of `agentCode:` are supported:
+
+```yaml
+# Production: agent code baked into a signed OCI image
+runtime:
+  kind: OpenAIAgents
+  openaiAgents:
+    agentCode:
+      oci:
+        image: ghcr.io/your-org/your-agent:v1.2.3
+
+# Dev iteration: clone from git at pod start
+runtime:
+  kind: OpenAIAgents
+  openaiAgents:
+    agentCode:
+      git:
+        url: https://github.com/your-org/your-agent
+        ref: main
+        path: agents/my-agent
+```
+
+Your image must contain `pyproject.toml` (or `requirements.txt`) and an
+entrypoint Python script. By default, the adapter runs `python -u agent.py`;
+override via `runtime.openaiAgents.entrypoint`.
+
+## What's next
+
+- Combine with **`A2AAgent`** to publish your agent over the JWS-authenticated
+  A2A gateway.
+- Add a **`ToolPolicy`** CR and reference it from `governance.toolPolicyRef`
+  to enforce rate-limits, redaction, and per-tool RBAC.
+- See [`docs/blueprints/`](../../docs/blueprints) for end-to-end patterns
+  (developer inner-loop, enterprise self-hosted, cross-org federation).

--- a/examples/openai-agents-quickstart/clawsandbox.yaml
+++ b/examples/openai-agents-quickstart/clawsandbox.yaml
@@ -1,0 +1,93 @@
+# AzureClaw Example: OpenAI Agents Python runtime
+#
+# Hosts an OpenAI Agents SDK (Python) agent inside an AzureClaw sandbox.
+# The controller swaps the OpenClaw image for `sandbox-images/openai-agents/`
+# and points the SDK at the local inference router (HTTPS_PROXY=127.0.0.1:8444).
+# Egress guard, AGT governance, AgentMesh E2E, and seccomp/Landlock isolation
+# are identical to the OpenClaw default — only the agent process changes.
+#
+# Apply with:
+#   kubectl apply -f examples/openai-agents-quickstart/clawsandbox.yaml
+#
+# Pre-reqs:
+#   - AzureClaw control plane installed (`azureclaw up`)
+#   - InferencePolicy below references an Azure OpenAI deployment named
+#     `gpt-4.1` reachable through your project. Adjust if needed.
+#   - Your agent code is published to a public OCI image. The example uses
+#     `ghcr.io/openai/openai-agents-quickstart:latest` as a placeholder —
+#     swap for your image, or use `git:` instead of `oci:` for dev iteration.
+
+---
+# S13 phase2-config-authority-refs — InferencePolicy is referenced from
+# ClawSandbox.spec.inferenceRef rather than inlined. The router consumes
+# this CR to enforce model selection, content safety, and token budget.
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: oai-quickstart-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: oai-quickstart
+spec:
+  appliesTo:
+    sandboxName: oai-quickstart
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  contentSafety:
+    requirePromptShields: true
+  tokenBudget:
+    dailyTokens: 500000
+    perRequestTokens: 128000
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: oai-quickstart
+  namespace: azureclaw-system
+spec:
+  runtime:
+    kind: OpenAIAgents
+    openaiAgents:
+      pythonVersion: "3.12"
+      # Reference the user-supplied agent code. Exactly one of `oci` or `git`.
+      # `oci`: production path — image carries `pyproject.toml` + agent.py
+      # `git`: dev iteration path — controller clones at pod start.
+      agentCode:
+        oci:
+          image: ghcr.io/openai/openai-agents-quickstart:latest
+      # Optional: override the entrypoint. Default is `python -u agent.py`.
+      # entrypoint: ["python", "-u", "agent.py"]
+      extraEnv:
+        AGENT_LOG_LEVEL: "INFO"
+
+  sandbox:
+    isolation: "enhanced"
+    seccompProfile: "azureclaw-strict"
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    writablePaths:
+      - /sandbox
+      - /tmp
+
+  inferenceRef:
+    name: oai-quickstart-inference
+
+  networkPolicy:
+    defaultDeny: true
+    approvalRequired: true
+    allowedEndpoints: []
+
+  azureServices:
+    - service: ai-foundry
+      permissions: [inference]
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"


### PR DESCRIPTION
Closes the post-merge gap raised against Phase 2: native runtime adapters for OpenAIAgents (S10.A3) and MicrosoftAgentFramework (S10.A4) ship in Phase 2, but examples/ only contained OpenClaw blueprints.

## Adds

- `examples/openai-agents-quickstart/{README.md,clawsandbox.yaml}` — full paste-and-deploy blueprint for an OpenAI Agents SDK (Python) agent
- `examples/maf-quickstart/{README.md,clawsandbox.yaml}` — same for Microsoft Agent Framework (Python)
- `examples/README.md` — discovery index over all 6 examples (runtime × scenario)

Each example ships a sibling `InferencePolicy` CR (S13 ref-authority — inline `inference:` was retired) and applies the same default security posture as `examples/basic-agent` (seccomp-strict, read-only rootfs, default-deny egress with `approvalRequired`).

## Verification

| Gate | Result |
|---|---|
| `bash ci/check-copyright-headers.sh` | ✓ |
| `BASE_REF=origin/main bash ci/check-loc.sh` | ✓ |
| `bash ci/no-stubs.sh` | ✓ |

No code paths touched, no threat-model delta.