### PR TITLE
fix(mesh,governance): vendor patch #11, F6 heartbeat, F7 retry, governance knobs (+ original sandbox stage/mermaid)

### DIFF
--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -586,6 +586,12 @@ export function devCommand(): Command {
           "-e", `SANDBOX_NAME=${options.name}`,
           "-e", "AZURECLAW_DEV_MODE=true",
           "-e", `DOCKER_NETWORK=${AGT_NETWORK}`,
+          // Phase 2/F8 mitigations — env-gated suppression of false-positive
+          // governance findings. Default-on in dev so research/citation
+          // workloads aren't impeded; override with =0 to restore strict mode.
+          "-e", "AZURECLAW_SUPPRESS_EXFIL_URL=1",
+          "-e", "AZURECLAW_SUPPRESS_CONTENT_FLAGS=violence",
+          "-e", "AZURECLAW_CONTENT_FLAG_MIN_SEVERITY=medium",
           ...(creds.foundryProjectEndpoint ? ["-e", `FOUNDRY_PROJECT_ENDPOINT=${creds.foundryProjectEndpoint}`] : []),
           ...(discoveredDeployments ? ["-e", `FOUNDRY_DEPLOYMENTS=${discoveredDeployments}`] : []),
           "-e", `PS1=azureclaw@${options.name}:\\w\\$ `,

--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -402,7 +402,7 @@ sequenceDiagram
         Note over Router,CS: Gate 4: Content Safety Floor
         Router->>CS: Analyze prompt (DefaultV2 policy)<br/>Prompt Shields jailbreak detection
         CS-->>Router: category scores + action
-        Note right of CS: ❌ 400 if threshold breached<br/>(always-on; InferencePolicy can tighten)
+        Note right of CS: ❌ 400 if threshold breached<br/>(always-on — InferencePolicy can tighten)
     end
 
     rect rgb(240, 240, 255)
@@ -972,11 +972,11 @@ stateDiagram-v2
 
     Updated: PolicyEnvelope generation N+1\nNew snapshot (ArcSwap store)\nIn-flight requests hold prior Arc
 
-    Empty --> Loaded: PolicyChange::Upserted\n(first policy)
-    Loaded --> Updated: PolicyChange::Upserted\nor PolicyChange::Deleted
+    Empty --> Loaded: PolicyChange.Upserted\n(first policy)
+    Loaded --> Updated: PolicyChange.Upserted\nor PolicyChange.Deleted
     Updated --> Updated: Additional changes\n(each bumps generation by 1)
-    Loaded --> Empty: PolicyChange::Reset\n(all policies removed)
-    Updated --> Empty: PolicyChange::Reset
+    Loaded --> Empty: PolicyChange.Reset\n(all policies removed)
+    Updated --> Empty: PolicyChange.Reset
 
     note right of Updated
         ArcSwap guarantees:

--- a/docs/security-audits/2026-04-30-dev-stage-perms-and-mermaid.md
+++ b/docs/security-audits/2026-04-30-dev-stage-perms-and-mermaid.md
@@ -1,0 +1,130 @@
+# Dev-mode `/tmp/openclaw-stage` Permissions Fix + Mermaid Diagram Repairs
+
+- **Date:** 2026-04-30
+- **Slice:** post-Phase 2 polish
+- **Author:** Phase 2 train
+
+## Scope
+
+End-to-end test of `azureclaw dev` against a fresh local sandbox surfaced
+two unrelated regressions:
+
+1. The OpenClaw gateway and Node host crashed at startup with `EACCES` on
+   `/tmp/openclaw-stage/openclaw-2026.4.27-<hash>/.openclaw-runtime-deps.lock`,
+   leaving the sandbox alive but with no agent process.
+2. `docs/architecture-diagrams.md` had two diagrams that failed to parse
+   under `mermaid` 11.x — section §6.1 (Inference Router Data Path) and
+   §14.2 (PolicyEnvelope Hot-Reload State Machine).
+
+This change addresses both.
+
+## Fix 1 — `sandbox-images/openclaw/entrypoint.sh` permissions
+
+### Root cause
+
+`/opt/openclaw-stage` is built into the image at build time with mode
+`a+rX` (Dockerfile.base line 101). At container start, the entrypoint
+copies it to the writable `/tmp` tmpfs:
+
+```sh
+cp -r /opt/openclaw-stage /tmp/openclaw-stage
+chmod -R u+w /tmp/openclaw-stage
+```
+
+In **AKS**, the pod's `securityContext.runAsUser=1000` makes the
+entrypoint start as the sandbox user, so `cp -r` produces a
+sandbox-owned tree and `chmod u+w` (owner-write) suffices.
+
+In **dev mode** (Docker, no `USER` directive), the entrypoint runs as
+root, `cp -r` produces a root-owned tree, and `chmod u+w` only adds
+write for root. When the entrypoint later runs OpenClaw via
+`runuser -u sandbox --`, sandbox cannot write the
+`.openclaw-runtime-deps.lock` sentinel that OpenClaw 2026.4.x creates
+on first plugin-runtime resolve — the gateway and Node host both crash
+with `EACCES`.
+
+### Fix
+
+After the `cp`, when running as root, chown the staged tree to
+`sandbox:sandbox` before the `chmod`. The branch is gated on
+`id -u == 0`, so the AKS path is byte-identical to before.
+
+```sh
+if [ -z "${OPENCLAW_PLUGIN_STAGE_DIR:-}" ] && [ -d /opt/openclaw-stage ]; then
+  if [ ! -d /tmp/openclaw-stage ]; then
+    cp -r /opt/openclaw-stage /tmp/openclaw-stage
+    if [ "$(id -u)" = "0" ]; then
+      chown -R sandbox:sandbox /tmp/openclaw-stage 2>/dev/null || true
+    fi
+    chmod -R u+w /tmp/openclaw-stage 2>/dev/null || true
+  fi
+  export OPENCLAW_PLUGIN_STAGE_DIR=/tmp/openclaw-stage
+fi
+```
+
+### Threat-model analysis
+
+| Concern | Outcome |
+|---|---|
+| Does this grant a new privilege to the sandbox user? | **No.** The sandbox UID already executes these `node_modules` at runtime. Making the local copy writable by sandbox does not add capability — you cannot escalate by modifying code you already execute. |
+| Could a router or other UID exploit this? | **No.** `chown sandbox:sandbox` was chosen over `chmod a+w` deliberately: `a+w` would also let the router UID (1001) write, breaking sandbox/router isolation. After the chown, only sandbox (and root, in dev) can write; router retains the read-execute it had via `a+rX`. |
+| Does this affect AKS? | **No.** The new `chown` branch is gated on `id -u == 0`. In AKS, `runAsUser=1000` ⇒ `id -u` is `1000` ⇒ the branch never executes. Production posture is unchanged. |
+| Persistence / supply-chain risk? | **No.** `/tmp` is tmpfs, wiped on container restart. The original `/opt/openclaw-stage` on the read-only rootfs is untouched. |
+| Affect on plugin hardening? | **No.** The `chown -R root:sandbox $PLUGIN_DIR` step (entrypoint.sh:731) operates on `/sandbox/.openclaw/plugins/`, a separate tree. That is still root-owned, read-only for sandbox. |
+
+### Verification
+
+Reproduced the crash before the fix; confirmed clean start after:
+
+```
+Before: ○ OpenClaw gateway (starting...)   — gateway.log: PluginLoadFailureError EACCES
+After:  ✓ OpenClaw gateway (ready)
+        ✓ Inference router (ready)
+```
+
+## Fix 2 — `docs/architecture-diagrams.md` mermaid parse errors
+
+Two diagrams failed `mermaid-cli` 11.14 parsing.
+
+### §6.1 — sequenceDiagram
+
+```
+Note right of CS: ❌ 400 if threshold breached<br/>(always-on; InferencePolicy can tighten)
+                                                              ^
+```
+
+Mermaid sequenceDiagrams treat `;` as an alternative line separator. The
+note text was truncated mid-parenthetical.
+
+**Fix:** replace `;` with em-dash inside the note body. Pure text change,
+no semantic shift.
+
+### §14.2 — stateDiagram-v2
+
+```
+Empty --> Loaded: PolicyChange::Upserted\n(first policy)
+                              ^
+```
+
+Mermaid stateDiagram-v2 splits transition labels on `:`. The
+Rust-style `::` enum-path syntax in the label confused the parser.
+
+**Fix:** replace `::` with `.` (`PolicyChange.Upserted`) inside the
+diagram labels only. Five lines updated. No source code or doc text
+outside the diagram is affected. Surrounding prose still uses the Rust
+`PolicyChange::Upserted` syntax.
+
+### Verification
+
+Lint-passed all 30 mermaid blocks in `docs/architecture-diagrams.md`
+locally with `npx -y -p @mermaid-js/mermaid-cli mmdc`. Zero parse
+errors.
+
+## CI gate considerations
+
+`ci/security-audit-required.sh` flags `sandbox-images/openclaw/entrypoint.sh`
+as a capability-introducing path. This audit document discharges the gate
+for this PR.
+
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>

--- a/docs/security-audits/2026-04-30-dev-stage-perms-and-mermaid.md
+++ b/docs/security-audits/2026-04-30-dev-stage-perms-and-mermaid.md
@@ -120,11 +120,62 @@ Lint-passed all 30 mermaid blocks in `docs/architecture-diagrams.md`
 locally with `npx -y -p @mermaid-js/mermaid-cli mmdc`. Zero parse
 errors.
 
+## Fix 3 — `Dockerfile.base` extension-deps gap-fill
+
+### Root cause
+
+After Fix 1 unblocked the gateway from staring, end-to-end testing surfaced
+a second pre-existing issue: the node-host (`openclaw node`, started at
+entrypoint.sh:978) crashed at startup with
+`Cannot find module '@mariozechner/pi-ai/dist/oauth.js'`. Without the
+node-host, the gateway hosts `agents.list` and accepts WS connections but
+no agent turn ever runs — chat sends silently stall.
+
+The missing module is declared as a dependency in the bundled `xai`
+extension's `package.json`. OpenClaw's own bundled chunks (e.g.
+`dist/oauth-*.js`, loaded by `memory-core` in the node-host) statically
+require it whether or not `xai` is enabled. `openclaw doctor --fix` at
+base-image build time only stages deps for *configured* plugins, so
+`pi-ai` was being skipped — leaving a latent crash that was previously
+masked by Fix 1's EACCES.
+
+### Fix
+
+Add `sandbox-images/openclaw/stage-extension-deps.sh` (build-time helper)
+and invoke it from `Dockerfile.base` immediately after `openclaw doctor`.
+The helper:
+
+1. Walks every bundled extension's `package.json`
+2. Takes the union of declared `dependencies`
+3. Installs anything not already resolvable in the stage tree's
+   `node_modules` via `npm install --no-save --omit=dev`
+
+Then a small assertion fails the build if
+`@mariozechner/pi-ai/dist/oauth.js` is still missing — converting future
+regressions into build failures rather than silent runtime breakage.
+
+### Threat-model analysis
+
+| Concern | Outcome |
+|---|---|
+| New network access at build time? | **No.** The base image already runs `openclaw doctor --fix` and `npm audit fix --force` and several `openclaw skills install` commands. Threat model unchanged: full network at build, frozen-in-image at runtime. |
+| New runtime privileges? | **No.** Helper runs at build time only. Runtime stage tree is still under `OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage` with `chmod -R a+rX` (read+execute for all, write for none). |
+| Extra packages = larger TCB? | **Yes, marginally.** We pull in `@mariozechner/pi-ai@0.70.5` which OpenClaw's own oauth chunk *already requires at runtime*. Either it was getting lazy-installed at first agent turn (worse — runtime npm trust) or the agent was crashing (today). Pre-staging the package OpenClaw already requires reduces runtime trust surface. |
+| Supply-chain pinning? | **Same as upstream.** Versions come from each extension manifest's `dependencies` (committed in OpenClaw's own bundle). We don't introduce new version ranges. |
+
+### Verification
+
+- Without the fix: container starts, gateway "ready", node-host crashes,
+  WebUI connects, chat sends silently stall.
+- With the fix (build-time assertion passes, runtime smoke):
+  `docker logs azureclaw-dev-agent | grep -i "Failed to start CLI"` is
+  empty; `tail /tmp/node-host.log` shows clean plugin registration.
+
 ## CI gate considerations
 
 `ci/security-audit-required.sh` flags `sandbox-images/openclaw/entrypoint.sh`
-as a capability-introducing path. This audit document discharges the gate
-for this PR.
+and `sandbox-images/openclaw/Dockerfile.base` as capability-introducing
+paths. This audit document discharges the gate for this PR.
 
 Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
 Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>

--- a/docs/security-audits/2026-04-30-dev-stage-perms-and-mermaid.md
+++ b/docs/security-audits/2026-04-30-dev-stage-perms-and-mermaid.md
@@ -18,68 +18,96 @@ two unrelated regressions:
 
 This change addresses both.
 
-## Fix 1 — `sandbox-images/openclaw/entrypoint.sh` permissions
+## Fix 1 — `sandbox-images/openclaw/entrypoint.sh` multi-root resolver
 
 ### Root cause
 
 `/opt/openclaw-stage` is built into the image at build time with mode
-`a+rX` (Dockerfile.base line 101). At container start, the entrypoint
-copies it to the writable `/tmp` tmpfs:
+`a+rX` (Dockerfile.base line 101). The previous entrypoint copied it to
+the writable `/tmp` tmpfs because OpenClaw 2026.4.x writes a
+`.openclaw-runtime-deps.lock` sentinel inside the version-hash dir on
+first plugin-runtime resolve, and the rootfs is read-only:
 
 ```sh
 cp -r /opt/openclaw-stage /tmp/openclaw-stage
 chmod -R u+w /tmp/openclaw-stage
 ```
 
-In **AKS**, the pod's `securityContext.runAsUser=1000` makes the
-entrypoint start as the sandbox user, so `cp -r` produces a
-sandbox-owned tree and `chmod u+w` (owner-write) suffices.
+This had two compounding problems:
 
-In **dev mode** (Docker, no `USER` directive), the entrypoint runs as
-root, `cp -r` produces a root-owned tree, and `chmod u+w` only adds
-write for root. When the entrypoint later runs OpenClaw via
-`runuser -u sandbox --`, sandbox cannot write the
-`.openclaw-runtime-deps.lock` sentinel that OpenClaw 2026.4.x creates
-on first plugin-runtime resolve — the gateway and Node host both crash
-with `EACCES`.
+1. **In dev mode** the entrypoint runs as root, `cp -r` produced a
+   root-owned tree, and `chmod u+w` only added write for root. When the
+   entrypoint later switched to `runuser -u sandbox`, sandbox could not
+   write the lock sentinel — gateway and Node host crashed with `EACCES`.
+2. **Independent of the chown bug**, the `cp -r` materializes the
+   *entire* staged tree into tmpfs every container boot — ~600 MiB
+   today, growing with each OpenClaw release. After Fix 3 (gap-fill of
+   missing deps) brought the stage to ~1.8 GiB, the copy started failing
+   with `No space left on device` against the 1 GiB `/tmp` tmpfs.
+3. **Posture compromise**: the `chmod -R u+w` made every bundled JS
+   file writable by the agent UID — bundled TCB became mutable at runtime.
 
 ### Fix
 
-After the `cp`, when running as root, chown the staged tree to
-`sandbox:sandbox` before the `chmod`. The branch is gated on
-`id -u == 0`, so the AKS path is byte-identical to before.
+OpenClaw's bundled-runtime-deps resolver supports a multi-root design
+that the previous entrypoint wasn't using. Verified against
+`dist/bundled-runtime-root-D11Fl_T4.js` in OpenClaw 2026.4.27:
+
+- `OPENCLAW_PLUGIN_STAGE_DIR` is colon-separated (line ~666); all
+  entries become NODE_PATH search roots (line ~1743).
+- `missingSpecs = deps.filter(dep => !hasDependencySentinel(searchRoots, dep))`
+  (line ~1455). With every dep present in *any* search root,
+  `missingSpecs = []` and the install path (lock dir, npm spawn,
+  retained-manifest write) **never executes**.
+- The *last* entry is the install root, used only when something is
+  actually missing (line ~1090: `externalRoots.at(-1)`).
+
+New entrypoint:
 
 ```sh
 if [ -z "${OPENCLAW_PLUGIN_STAGE_DIR:-}" ] && [ -d /opt/openclaw-stage ]; then
-  if [ ! -d /tmp/openclaw-stage ]; then
-    cp -r /opt/openclaw-stage /tmp/openclaw-stage
-    if [ "$(id -u)" = "0" ]; then
-      chown -R sandbox:sandbox /tmp/openclaw-stage 2>/dev/null || true
-    fi
-    chmod -R u+w /tmp/openclaw-stage 2>/dev/null || true
+  mkdir -p /tmp/openclaw-cache 2>/dev/null || true
+  if [ "$(id -u)" = "0" ]; then
+    chown sandbox:sandbox /tmp/openclaw-cache 2>/dev/null || true
   fi
-  export OPENCLAW_PLUGIN_STAGE_DIR=/tmp/openclaw-stage
+  export OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage:/tmp/openclaw-cache
 fi
 ```
+
+Verified at runtime as UID 1000 with `/opt` mounted read-only:
+all 68 bundled plugins load, 0 errors, `/tmp/openclaw-cache` peaks
+at ~27 MiB (NODE_PATH symlinks back into `/opt`, plus a few small
+manifests). No `cp -r`, no chmod-u+w on bundled code, no lock dir
+ever created.
 
 ### Threat-model analysis
 
 | Concern | Outcome |
 |---|---|
-| Does this grant a new privilege to the sandbox user? | **No.** The sandbox UID already executes these `node_modules` at runtime. Making the local copy writable by sandbox does not add capability — you cannot escalate by modifying code you already execute. |
-| Could a router or other UID exploit this? | **No.** `chown sandbox:sandbox` was chosen over `chmod a+w` deliberately: `a+w` would also let the router UID (1001) write, breaking sandbox/router isolation. After the chown, only sandbox (and root, in dev) can write; router retains the read-execute it had via `a+rX`. |
-| Does this affect AKS? | **No.** The new `chown` branch is gated on `id -u == 0`. In AKS, `runAsUser=1000` ⇒ `id -u` is `1000` ⇒ the branch never executes. Production posture is unchanged. |
-| Persistence / supply-chain risk? | **No.** `/tmp` is tmpfs, wiped on container restart. The original `/opt/openclaw-stage` on the read-only rootfs is untouched. |
-| Affect on plugin hardening? | **No.** The `chown -R root:sandbox $PLUGIN_DIR` step (entrypoint.sh:731) operates on `/sandbox/.openclaw/plugins/`, a separate tree. That is still root-owned, read-only for sandbox. |
+| Agent UID can tamper with bundled code? | **No.** `/opt/openclaw-stage` is mounted read-only at runtime (rootfs is read-only). The agent UID has read+execute via `a+rX` baked at build time, and **no write path** — the previous `chmod -R u+w` is gone. Bundled TCB is now genuinely immutable at runtime. |
+| Cache dir poisoning between containers? | **No.** `/tmp` is tmpfs, scoped per-container, wiped on every restart. Each container starts with an empty cache that OpenClaw populates from the read-only stage on first plugin load. |
+| Cross-UID write to cache? | **No.** `chown sandbox:sandbox /tmp/openclaw-cache` runs only in the dev path (`id -u == 0`). In AKS the entrypoint already starts as sandbox so the `mkdir` produces sandbox-owned dirs. Router UID (1001) has no path that writes here. |
+| What if a dep is genuinely missing at runtime (regression)? | **Fail closed.** With egress-guard blocking npm registry on UID 1000, `installBundledRuntimeDepsAsync` would attempt a 403-prone `npm install` and the affected plugin would fail to load. Fix 3's build-time assertion catches this before the image ships, so the runtime path is exercised only for unanticipated regressions. |
+| AKS impact? | **Improved.** Pod `tmp` `emptyDir.sizeLimit` stays at `1Gi` (no bump). Production memory footprint unchanged. The AKS path no longer relies on the `cp -r` working — same multi-root resolver, same ~27 MiB cache. |
 
 ### Verification
 
-Reproduced the crash before the fix; confirmed clean start after:
-
 ```
-Before: ○ OpenClaw gateway (starting...)   — gateway.log: PluginLoadFailureError EACCES
-After:  ✓ OpenClaw gateway (ready)
-        ✓ Inference router (ready)
+$ docker run --rm --user 1000:1000 \
+    -e OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage:/tmp/openclaw-cache \
+    azureclaw-sandbox-base:dev sh -c '
+      mkdir -p /tmp/openclaw-cache
+      openclaw doctor 2>&1 | tail -5
+      du -sh /tmp/openclaw-cache
+      find /tmp/openclaw-cache -name ".openclaw-runtime-deps.lock"
+    '
+
+  Plugins:  Loaded: 68   Errors: 0
+  27M      /tmp/openclaw-cache
+  (no lock dir created)
+
+$ touch /opt/openclaw-stage/probe   # writes correctly denied
+  touch: cannot touch '/opt/openclaw-stage/probe': Permission denied
 ```
 
 ## Fix 2 — `docs/architecture-diagrams.md` mermaid parse errors
@@ -159,8 +187,9 @@ regressions into build failures rather than silent runtime breakage.
 | Concern | Outcome |
 |---|---|
 | New network access at build time? | **No.** The base image already runs `openclaw doctor --fix` and `npm audit fix --force` and several `openclaw skills install` commands. Threat model unchanged: full network at build, frozen-in-image at runtime. |
-| New runtime privileges? | **No.** Helper runs at build time only. Runtime stage tree is still under `OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage` with `chmod -R a+rX` (read+execute for all, write for none). |
-| Extra packages = larger TCB? | **Yes, marginally.** We pull in `@mariozechner/pi-ai@0.70.5` which OpenClaw's own oauth chunk *already requires at runtime*. Either it was getting lazy-installed at first agent turn (worse — runtime npm trust) or the agent was crashing (today). Pre-staging the package OpenClaw already requires reduces runtime trust surface. |
+| New runtime privileges? | **No.** Helper runs at build time only. Runtime stage tree is under `OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage:/tmp/openclaw-cache`; `/opt` is read-only at runtime (Fix 1) and `/tmp/openclaw-cache` is sandbox-owned tmpfs scoped per-container. |
+| Extra packages = larger TCB? | **Larger image, not larger runtime memory.** Union over every bundled extension's manifest brings in heavyweights (e.g. `@openai/codex-linux-arm64`); staged tree grows from ~600 MiB to ~1.8 GiB **on disk in the image**. At runtime, OpenClaw resolves directly from `/opt/openclaw-stage` via NODE_PATH (Fix 1) — nothing is copied, only the ~27 MiB symlink-cache lives in tmpfs. The 1.8 GiB sits cold on the read-only rootfs. |
+| Why not narrow to an allowlist (`pi-ai` only)? | The union approach guarantees that *every* manifest-declared dep is pre-staged and frozen-in-image. Future bundle changes can introduce new transitive `require()`s without warning; the broad pre-stage prevents runtime npm-install fallback (which fails closed under egress-guard). The build-time assertion + multi-root resolver means the only cost is image size on the read-only rootfs. |
 | Supply-chain pinning? | **Same as upstream.** Versions come from each extension manifest's `dependencies` (committed in OpenClaw's own bundle). We don't introduce new version ranges. |
 
 ### Verification
@@ -171,11 +200,145 @@ regressions into build failures rather than silent runtime breakage.
   `docker logs azureclaw-dev-agent | grep -i "Failed to start CLI"` is
   empty; `tail /tmp/node-host.log` shows clean plugin registration.
 
+## Design history (what we tried, what we shipped)
+
+Initial diagnosis pointed at the dev-mode `chown` gap (root-owned
+staged tree). Fixing that unblocked layer 1 (gateway start) and exposed
+layer 2 (`pi-ai/dist/oauth.js` missing → node-host crash → silent chat
+stall). The first cut at Fix 3 used a build-time union helper, which
+grew the stage to ~1.8 GiB and broke the entrypoint's `cp -r` against
+the 1 GiB `/tmp` tmpfs.
+
+We considered four alternatives before landing on the multi-root
+resolver:
+
+| Option | Approach | Cost / blocker |
+|---|---|---|
+| A | Pre-create the `.openclaw-runtime-deps.lock` sentinel at build time | Lock dir is created on-demand only when an install is triggered; pre-creating it would deadlock the resolver (line ~309 fails with `EEXIST`, falls into stale-detection retry loop). |
+| B | overlayfs mount with `/opt/openclaw-stage` lowerdir + tmpfs upperdir | Requires `mount` syscall in entrypoint; doable but adds a CAP_SYS_ADMIN-equivalent step. Defeated by simpler search-roots design. |
+| C | Symlink farm (`cp -rs`) | Cleaner than full copy but still leaves a writable tree path; the multi-root design eliminates the writable-tree requirement entirely. |
+| D | Bump `/tmp` tmpfs `1Gi → 3Gi` (dev + AKS) | Adds +2 GiB memory cgroup pressure per pod in AKS; preserves the writable-stage compromise. Considered, prototyped, **reverted** in favor of Fix 1's multi-root resolver. |
+| **E (shipped)** | **Multi-root `OPENCLAW_PLUGIN_STAGE_DIR` (read-only stage + writable tmpfs cache)** | **Zero compromise: stage stays read-only, cache is ~27 MiB scratch, no tmpfs bump, no mount syscall, no runtime npm trust.** |
+
+The journey is documented for future maintainers who hit similar gaps
+with OpenClaw's plugin-runtime resolver — when in doubt, **check the
+search-roots / install-root distinction in `bundled-runtime-root-*.js`**
+before assuming a writable stage tree is required.
+
 ## CI gate considerations
 
-`ci/security-audit-required.sh` flags `sandbox-images/openclaw/entrypoint.sh`
-and `sandbox-images/openclaw/Dockerfile.base` as capability-introducing
-paths. This audit document discharges the gate for this PR.
+`ci/security-audit-required.sh` flags `sandbox-images/openclaw/entrypoint.sh`,
+`sandbox-images/openclaw/Dockerfile.base`, and `controller/src/reconciler/mod.rs`
+as capability-introducing paths. This audit document discharges the gate
+for this PR.
+
+## Fix 4 — Mesh-send payload guard + `mesh_transfer_file` sub-agent tool + `telegram_status` parent tool
+
+### Root cause
+
+Three demo-day failure modes surfaced in the multimedia-brief run on
+`dev`:
+
+1. **Cross-container path leakage.** `viz` produced a chart on
+   foundry_code_execute and tried to ship it to `writer` by sending
+   `mesh_send(to=writer, content='{"type":"file_transfer", "file_path":"/sandbox/chart.png"}')`.
+   The peer agent runs in its own container and cannot read
+   `viz`'s `/sandbox/`. Result: writer received a JSON envelope with
+   no actual bytes and embedded the literal string
+   `data:image/png;base64,<base64-image-data>` into the brief. The
+   sub-agent tool surface (`agt-task-tools.ts`) had no
+   `mesh_transfer_file` peer of the parent's `azureclaw_mesh_transfer_file`,
+   so the LLM was forced to construct `file_transfer` JSON by hand.
+
+2. **Placeholder bytes in `file_data`.** Other times the LLM built
+   `{"type":"file_transfer", "file_data":"<base64-image-data>"}` —
+   a literal angle-bracketed placeholder rather than real base64.
+   The recipient gateway dutifully tried to decode and got garbage.
+
+3. **Telegram channel routing.** The user prompt referenced "the
+   telegram.dev channel"; the LLM passed `target:"telegram.dev"` to
+   OpenClaw's built-in `message` tool, which rejected with
+   `Unknown target "telegram.dev" for Telegram. Hint: <chatId>`.
+   Half the planned status thread never went out. Parent has Telegram
+   wired (env vars `TELEGRAM_BOT_TOKEN` + `TELEGRAM_ALLOW_FROM`) but
+   the LLM had no tool that took only `text` — every code path
+   required figuring out the channel routing or chat-ID layer.
+
+### Threat model
+
+- **Same-pod data exfiltration:** the new `mesh_transfer_file`
+  sub-agent tool inherits the parent's TOCTOU-safe open/fstat/read
+  pattern, the `/sandbox` confinement check, and the 30 MB max-size
+  cap. It does not widen the per-sandbox FS attack surface.
+- **Mesh peer impersonation:** unchanged — the wire path remains
+  AGT SDK `meshClient.send(targetAmid, ...)` end-to-end, with the
+  same retry/backoff semantics already audited in prior slices. The
+  new tool is a producer of the same `{type:"file_transfer", ...}`
+  envelope the gateway already accepts.
+- **Token / secret leakage in error paths:** `telegram_status`
+  redacts `TELEGRAM_BOT_TOKEN` from any echoed Bot API error body
+  before returning, and from any `fetch()` exception message. Token
+  never leaves the process when delivery fails.
+- **Payload-guard false positives:** the guard parses content as
+  JSON and only inspects `type === "file_transfer"` envelopes
+  AND objects whose keys are in a closed set of artifact-path-style
+  fields (`file_path`, `artifact_path`, `hero_image_path`,
+  `image_path`, `chart_path`, `path`) AND values pointing into
+  local container roots (`/sandbox/`, `/tmp/`, `/mnt/data/`,
+  `/workspace/`). Free-form prose mentioning a path is not parsed
+  as JSON and is allowed through. Plain JSON metadata without the
+  closed-set keys is allowed through. Tested in
+  `runtimes/openclaw/src/index.test.ts`.
+- **Replay / forge:** a hostile sub-agent could already construct
+  any `mesh_send` content. The guard is a *self*-protective rail
+  that catches the LLM's own errors before they hit the wire — it is
+  not a security boundary against an adversarial sub-agent (the
+  AGT SDK's signed envelopes remain the boundary).
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `runtimes/openclaw/src/core/mesh-payload-guard.ts` | **NEW** — pure validator; placeholder/missing/local-path detection. |
+| `runtimes/openclaw/src/core/agt-task-tools.ts` | mesh_send description warns about hand-crafted file_transfer; add `mesh_transfer_file` descriptor; mesh_inbox `mark_read` default doc fixed. |
+| `runtimes/openclaw/src/core/agt-task-loop.ts` | Wire guard into sub-agent `mesh_send`; add `mesh_transfer_file` handler (TOCTOU-safe open/fstat/read, 30 MB cap, /sandbox confinement); decode `file_transfer` inbox entries (gateway-saved + inline forms); update sub-agent system prompt with `mesh_transfer_file` GOOD example replacing the `<base64-bytes>` placeholder. |
+| `runtimes/openclaw/src/core/agt-tools/agt.ts` | Wire guard into parent `azureclaw_mesh_send`; surface `saved_to` + `file_name` + `description` in parent inbox decoder when gateway has rewritten the entry; **register new `telegram_status` tool** with token-redacted error paths. |
+| `runtimes/openclaw/src/index.test.ts` | +12 tests covering placeholder rejection, missing file_data rejection, /sandbox-path rejection, plain-text false-positive prevention, plain-JSON metadata allow-through, valid base64 allow-through, telegram_status registration, missing-config error, empty-text error, chat-ID routing from `TELEGRAM_ALLOW_FROM`, token redaction in error responses, multi-chat-ID fan-out. |
+
+### Verification
+
+```bash
+cd runtimes/openclaw && npx tsc --noEmit && npm test
+# 100 → 112 tests pass
+
+cd cli && npx tsc --noEmit && npm test
+# 451 tests pass
+```
+
+### Why a new tool instead of relying on the guard alone
+
+The rubber-duck pass surfaced this directly: the previous sub-agent
+system prompt contained `mesh_send(...,{type:'file_transfer',
+file_data:'<base64-bytes>'})` as a `✅ GOOD` example. Adding a
+guard but leaving the prompt unchanged would teach the LLM to send
+the rejected pattern, get the error, and try variations. A
+dedicated `mesh_transfer_file` tool that hides the encoding ceremony
+(open/read/base64/envelope construction) is the correct ergonomic
+fix; the guard is the safety net for when the LLM still tries the
+old pattern. Both ship in the same commit.
+
+### Telegram tool design notes
+
+- Bypasses OpenClaw's channel routing entirely — the LLM only has
+  to know the tool name and the message text.
+- Reuses the same Bot API direct-fetch convention already used in
+  `azureclaw_handoff_request` (agt-tools/agt.ts:1156-1167) so
+  parent-side network behavior is unchanged.
+- Multiple chat IDs (`TELEGRAM_ALLOW_FROM=111,222,333`) are
+  fanned out and a per-chat result is returned, allowing the LLM
+  to retry only failed targets.
+- Truncates at 4096 chars (Telegram message ceiling).
+- Token sanitized in any error string before it leaves the tool.
 
 Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
 Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -479,6 +479,15 @@ impl Governance {
 
     /// Scan model response text for threats (prompt injection, exfil URLs, etc.).
     /// Returns the sanitized text and whether any threats were found.
+    ///
+    /// When `AZURECLAW_SUPPRESS_EXFIL_URL=1` is set, the upstream AGT
+    /// `ExfiltrationUrl` finding is downgraded: the threat is still recorded
+    /// (metrics + warn log + audit), but URLs are NOT redacted from the model
+    /// response. Rationale: AGT 3.1.0 / 3.3.0 use a naive substring guard
+    /// (`text.contains("post"|"send"|"upload"|...)`) which over-fires on
+    /// long-form content (e.g. "security posture", "post-mortem") and strips
+    /// legitimate citations. Other threat types (prompt-injection tags,
+    /// imperative phrasing, credential leakage) remain fully enforced.
     pub fn scan_response(&self, text: &str) -> (String, bool) {
         match self.response_scanner.scan_text(text) {
             Ok(result) => {
@@ -517,6 +526,22 @@ impl Governance {
                         &format!("response_threat:{}", types.join(",")),
                         "flagged",
                     );
+
+                    let suppress_exfil = std::env::var("AZURECLAW_SUPPRESS_EXFIL_URL")
+                        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                        .unwrap_or(false);
+                    if suppress_exfil {
+                        let only_exfil = result.findings.iter().all(|f| {
+                            matches!(f.threat_type, McpResponseThreatType::ExfiltrationUrl)
+                        });
+                        if only_exfil {
+                            tracing::warn!(
+                                sandbox = %self.sandbox_name,
+                                "exfiltration_url redaction suppressed (env override); citations retained",
+                            );
+                            return (text.to_string(), false);
+                        }
+                    }
                 }
                 (result.sanitized, !result.findings.is_empty())
             }

--- a/inference-router/src/routes/mesh.rs
+++ b/inference-router/src/routes/mesh.rs
@@ -308,10 +308,11 @@ async fn agt_registry_proxy(
         "registry/capabilities",
         "registry/revocations/bulk",
     ];
-    let is_idempotent =
-        method == axum::http::Method::GET || method == axum::http::Method::HEAD;
+    let is_idempotent = method == axum::http::Method::GET || method == axum::http::Method::HEAD;
     let post_retry = method == axum::http::Method::POST
-        && POST_RETRY_PATHS.iter().any(|p| path == *p || path.starts_with(&format!("{}?", p)));
+        && POST_RETRY_PATHS
+            .iter()
+            .any(|p| path == *p || path.starts_with(&format!("{}?", p)));
     let retry_allowed = is_idempotent || post_retry;
     let max_attempts: u32 = if retry_allowed { 3 } else { 1 };
     let total_budget = std::time::Duration::from_millis(2000);
@@ -323,8 +324,7 @@ async fn agt_registry_proxy(
 
     for attempt in 1..=max_attempts {
         let mut req = state.client.request(
-            reqwest::Method::from_bytes(method.as_str().as_bytes())
-                .unwrap_or(reqwest::Method::GET),
+            reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET),
             &url,
         );
         if let Some(ct) = headers.get("content-type") {
@@ -336,8 +336,8 @@ async fn agt_registry_proxy(
 
         match req.timeout(std::time::Duration::from_secs(10)).send().await {
             Ok(resp) => {
-                let status = StatusCode::from_u16(resp.status().as_u16())
-                    .unwrap_or(StatusCode::BAD_GATEWAY);
+                let status =
+                    StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
                 let resp_body = resp.bytes().await.unwrap_or_default();
 
                 let should_retry = retry_allowed
@@ -387,9 +387,8 @@ async fn agt_registry_proxy(
                     .into_response();
             }
             Err(e) => {
-                let should_retry = retry_allowed
-                    && attempt < max_attempts
-                    && started_at.elapsed() < total_budget;
+                let should_retry =
+                    retry_allowed && attempt < max_attempts && started_at.elapsed() < total_budget;
                 if should_retry {
                     let wait = std::time::Duration::from_millis(
                         100u64.saturating_mul(1u64 << (attempt - 1)),

--- a/inference-router/src/routes/mesh.rs
+++ b/inference-router/src/routes/mesh.rs
@@ -286,56 +286,152 @@ async fn agt_registry_proxy(
         url.push_str(&qs);
     }
 
-    let mut req = state.client.request(
-        reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET),
-        &url,
-    );
+    // Defense-in-depth retry mirror of vendored SDK Patch #12. The plugin's
+    // SDK has a 3-attempt / 2s budget retry, but the router is the
+    // single network egress for sandboxes and benefits from its own retry
+    // for two reasons:
+    //   1. dev port-forward (host.docker.internal:18080) sometimes returns
+    //      502 for the very first connection attempt after a kubectl
+    //      port-forward restart;
+    //   2. the AGT relay's `proxy_relay` path next door already has retry
+    //      semantics, and parity here keeps router behaviour predictable.
+    //
+    // Policy: same as SDK — GET/HEAD always retry; allowlisted POST paths
+    // (idempotent registry endpoints) retry; transient statuses 408/429/
+    // 502/503/504 + network errors. Cap 3 attempts, ~2s elapsed.
+    const RETRY_STATUSES: &[u16] = &[408, 429, 502, 503, 504];
+    const POST_RETRY_PATHS: &[&str] = &[
+        "registry/register",
+        "registry/prekeys",
+        "registry/reputation",
+        "registry/status",
+        "registry/capabilities",
+        "registry/revocations/bulk",
+    ];
+    let is_idempotent =
+        method == axum::http::Method::GET || method == axum::http::Method::HEAD;
+    let post_retry = method == axum::http::Method::POST
+        && POST_RETRY_PATHS.iter().any(|p| path == *p || path.starts_with(&format!("{}?", p)));
+    let retry_allowed = is_idempotent || post_retry;
+    let max_attempts: u32 = if retry_allowed { 3 } else { 1 };
+    let total_budget = std::time::Duration::from_millis(2000);
+    let started_at = std::time::Instant::now();
 
-    // Forward Content-Type
-    if let Some(ct) = headers.get("content-type") {
-        req = req.header("content-type", ct);
-    }
+    let body_clone = body.to_vec();
+    let mut last_err: Option<reqwest::Error> = None;
+    let mut last_response: Option<(StatusCode, axum::body::Bytes)> = None;
 
-    if !body.is_empty() {
-        req = req.body(body.to_vec());
-    }
+    for attempt in 1..=max_attempts {
+        let mut req = state.client.request(
+            reqwest::Method::from_bytes(method.as_str().as_bytes())
+                .unwrap_or(reqwest::Method::GET),
+            &url,
+        );
+        if let Some(ct) = headers.get("content-type") {
+            req = req.header("content-type", ct);
+        }
+        if !body_clone.is_empty() {
+            req = req.body(body_clone.clone());
+        }
 
-    match req.timeout(std::time::Duration::from_secs(10)).send().await {
-        Ok(resp) => {
-            let status =
-                StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
-            let resp_body = resp.bytes().await.unwrap_or_default();
+        match req.timeout(std::time::Duration::from_secs(10)).send().await {
+            Ok(resp) => {
+                let status = StatusCode::from_u16(resp.status().as_u16())
+                    .unwrap_or(StatusCode::BAD_GATEWAY);
+                let resp_body = resp.bytes().await.unwrap_or_default();
 
-            // Log reputation submission failures so we can diagnose why
-            // feedback_count stays 0 (the SDK silently returns false).
-            if path == "registry/reputation"
-                && method == axum::http::Method::POST
-                && !status.is_success()
-            {
-                let error_text = std::str::from_utf8(&resp_body).unwrap_or("<binary>");
-                tracing::warn!(
-                    status = %status,
-                    error = %error_text,
-                    "AGT reputation submission failed"
-                );
+                let should_retry = retry_allowed
+                    && attempt < max_attempts
+                    && RETRY_STATUSES.contains(&status.as_u16())
+                    && started_at.elapsed() < total_budget;
+
+                if should_retry {
+                    let wait = std::time::Duration::from_millis(
+                        100u64.saturating_mul(1u64 << (attempt - 1)),
+                    );
+                    if started_at.elapsed() + wait > total_budget {
+                        last_response = Some((status, resp_body));
+                        break;
+                    }
+                    tracing::warn!(
+                        url = %url,
+                        status = %status,
+                        attempt,
+                        max_attempts,
+                        "AGT registry proxy: retrying transient status"
+                    );
+                    last_response = Some((status, resp_body));
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+
+                // Log reputation submission failures so we can diagnose why
+                // feedback_count stays 0 (the SDK silently returns false).
+                if path == "registry/reputation"
+                    && method == axum::http::Method::POST
+                    && !status.is_success()
+                {
+                    let error_text = std::str::from_utf8(&resp_body).unwrap_or("<binary>");
+                    tracing::warn!(
+                        status = %status,
+                        error = %error_text,
+                        "AGT reputation submission failed"
+                    );
+                }
+
+                return (
+                    status,
+                    [(axum::http::header::CONTENT_TYPE, "application/json")],
+                    resp_body,
+                )
+                    .into_response();
             }
-
-            (
-                status,
-                [(axum::http::header::CONTENT_TYPE, "application/json")],
-                resp_body,
-            )
-                .into_response()
-        }
-        Err(e) => {
-            tracing::warn!(url = %url, error = %e, "AGT registry proxy failed");
-            errors::flat(
-                StatusCode::BAD_GATEWAY,
-                format!("Registry unreachable: {}", e),
-            )
-            .into_response()
+            Err(e) => {
+                let should_retry = retry_allowed
+                    && attempt < max_attempts
+                    && started_at.elapsed() < total_budget;
+                if should_retry {
+                    let wait = std::time::Duration::from_millis(
+                        100u64.saturating_mul(1u64 << (attempt - 1)),
+                    );
+                    if started_at.elapsed() + wait > total_budget {
+                        last_err = Some(e);
+                        break;
+                    }
+                    tracing::warn!(
+                        url = %url,
+                        error = %e,
+                        attempt,
+                        max_attempts,
+                        "AGT registry proxy: retrying network error"
+                    );
+                    last_err = Some(e);
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+                last_err = Some(e);
+                break;
+            }
         }
     }
+
+    if let Some((status, resp_body)) = last_response {
+        return (
+            status,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            resp_body,
+        )
+            .into_response();
+    }
+    let err_msg = last_err
+        .map(|e| e.to_string())
+        .unwrap_or_else(|| "unknown".into());
+    tracing::warn!(url = %url, error = %err_msg, "AGT registry proxy failed");
+    errors::flat(
+        StatusCode::BAD_GATEWAY,
+        format!("Registry unreachable: {}", err_msg),
+    )
+    .into_response()
 }
 
 /// Look up an agent's AMID from the registry by searching for its sandbox name.

--- a/inference-router/src/safety.rs
+++ b/inference-router/src/safety.rs
@@ -168,7 +168,49 @@ pub fn parse_streaming_prompt_filter(chunk_text: &str) -> ContentFlags {
 }
 
 /// Check individual filter results and populate flags.
+///
+/// Two optional env-var knobs (default behaviour unchanged when unset):
+/// * `AZURECLAW_CONTENT_FLAG_MIN_SEVERITY` (`safe|low|medium|high`, default
+///   `low`) — minimum Foundry severity that raises a category flag. `filtered:
+///   true` from Foundry always wins regardless of this threshold.
+/// * `AZURECLAW_SUPPRESS_CONTENT_FLAGS` (comma-separated, e.g.
+///   `violence,sexual`) — listed categories never raise a flag (no trust
+///   penalty, no audit). Useful where Foundry's `violence` heuristic
+///   over-fires on legitimate security/research content (e.g. "exploit",
+///   "attack", "compromise"). Affects only the four severity-graded
+///   categories; `jailbreak` and `indirect_attack` cannot be suppressed.
 fn check_filter_results(results: &ContentFilterResults, flags: &mut ContentFlags) {
+    let min_sev_level: u8 = match std::env::var("AZURECLAW_CONTENT_FLAG_MIN_SEVERITY")
+        .ok()
+        .map(|s| s.to_lowercase())
+        .as_deref()
+    {
+        Some("medium") => 2,
+        Some("high") => 3,
+        Some("safe") => 0,
+        _ => 1, // low (default)
+    };
+    let suppressed: std::collections::HashSet<String> =
+        std::env::var("AZURECLAW_SUPPRESS_CONTENT_FLAGS")
+            .ok()
+            .map(|v| {
+                v.split(',')
+                    .map(|s| s.trim().to_lowercase())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
+    let sev_meets = |sev: Option<&str>| -> bool {
+        let level = match sev {
+            Some("safe") => 0u8,
+            Some("low") => 1,
+            Some("medium") => 2,
+            Some("high") => 3,
+            _ => 0,
+        };
+        level > 0 && level >= min_sev_level
+    };
+
     if let Some(ref jb) = results.jailbreak {
         if jb.detected.unwrap_or(false) || jb.filtered {
             flags.jailbreak_detected = true;
@@ -190,7 +232,7 @@ fn check_filter_results(results: &ContentFilterResults, flags: &mut ContentFlags
         }
     }
     if let Some(ref h) = results.hate {
-        if h.filtered || h.severity.as_deref().is_some_and(|s| s != "safe") {
+        if !suppressed.contains("hate") && (h.filtered || sev_meets(h.severity.as_deref())) {
             flags.hate_detected = true;
             if h.filtered {
                 flags.filtered_categories.push("hate".into());
@@ -200,7 +242,7 @@ fn check_filter_results(results: &ContentFilterResults, flags: &mut ContentFlags
         }
     }
     if let Some(ref sh) = results.self_harm {
-        if sh.filtered || sh.severity.as_deref().is_some_and(|s| s != "safe") {
+        if !suppressed.contains("self_harm") && (sh.filtered || sev_meets(sh.severity.as_deref())) {
             flags.self_harm_detected = true;
             if sh.filtered {
                 flags.filtered_categories.push("self_harm".into());
@@ -210,7 +252,7 @@ fn check_filter_results(results: &ContentFilterResults, flags: &mut ContentFlags
         }
     }
     if let Some(ref sx) = results.sexual {
-        if sx.filtered || sx.severity.as_deref().is_some_and(|s| s != "safe") {
+        if !suppressed.contains("sexual") && (sx.filtered || sev_meets(sx.severity.as_deref())) {
             flags.sexual_detected = true;
             if sx.filtered {
                 flags.filtered_categories.push("sexual".into());
@@ -220,7 +262,7 @@ fn check_filter_results(results: &ContentFilterResults, flags: &mut ContentFlags
         }
     }
     if let Some(ref vi) = results.violence {
-        if vi.filtered || vi.severity.as_deref().is_some_and(|s| s != "safe") {
+        if !suppressed.contains("violence") && (vi.filtered || sev_meets(vi.severity.as_deref())) {
             flags.violence_detected = true;
             if vi.filtered {
                 flags.filtered_categories.push("violence".into());

--- a/mesh-plugin/src/connection.ts
+++ b/mesh-plugin/src/connection.ts
@@ -79,9 +79,28 @@ export interface ConnectionConfig {
 }
 
 interface InboxMessage {
+  /** Stable id for this message — used by mesh_inbox to mark-read and dedupe. */
+  id: string;
   from: string;
   content: unknown;
   timestamp: string;
+  /**
+   * ISO timestamp set when the LLM-facing `mesh_inbox` tool returned this
+   * entry with `mark_read=true`. Untouched by `consumeInbox` / `waitForMessage`
+   * because those paths *remove* the entry from the array entirely.
+   */
+  read_at?: string;
+}
+
+export interface MeshDiagnostics {
+  build_hash: string;
+  received_total: number;
+  consumed_by_waiter: number;
+  consumed_by_predicate: number;
+  fifo_dropped: number;
+  read_total: number;
+  last_received_at: string | null;
+  last_read_at: string | null;
 }
 
 interface PendingTransfer {
@@ -116,6 +135,21 @@ export class MeshConnection implements IMeshTransport {
   private pendingTransfers = new Map<string, PendingTransfer>();
   private transferCleanupTimer: ReturnType<typeof setInterval> | null = null;
   private connectInFlight: Promise<void> | null = null;
+
+  // Inbox + lifecycle counters. Surfaced by `getDiagnostics()` for the
+  // mesh_inbox tool so operators can distinguish "never received" from
+  // "already consumed" without re-running the demo. Bumped from the only
+  // four sites that mutate `inbox`: pushInbox, deliverToWaiters (claimed
+  // path), consumeInbox, waitForMessage.
+  private stats = {
+    received_total: 0,
+    consumed_by_waiter: 0,
+    consumed_by_predicate: 0,
+    fifo_dropped: 0,
+    read_total: 0,
+    last_received_at: null as string | null,
+    last_read_at: null as string | null,
+  };
 
   // Lazily loaded SDK client + the wsFactory's current CONNECT tunnel socket.
   // The SDK owns the WebSocket, auth, prekey upload, Signal E2E, and reconnect.
@@ -379,12 +413,16 @@ export class MeshConnection implements IMeshTransport {
       } catch (err) {
         this.waiters.delete(waiter);
         waiter.resolve(err);
+        if (waiter.consume) this.stats.consumed_by_waiter += 1;
         return waiter.consume;
       }
       if (result !== null && result !== undefined) {
         this.waiters.delete(waiter);
         waiter.resolve(result);
-        if (waiter.consume) return true;
+        if (waiter.consume) {
+          this.stats.consumed_by_waiter += 1;
+          return true;
+        }
       }
     }
     return false;
@@ -392,7 +430,12 @@ export class MeshConnection implements IMeshTransport {
 
   private pushInbox(msg: InboxMessage): void {
     this.inbox.push(msg);
-    while (this.inbox.length > this.maxInboxSize) this.inbox.shift();
+    this.stats.received_total += 1;
+    this.stats.last_received_at = msg.timestamp;
+    while (this.inbox.length > this.maxInboxSize) {
+      this.inbox.shift();
+      this.stats.fifo_dropped += 1;
+    }
   }
 
   /**
@@ -426,7 +469,12 @@ export class MeshConnection implements IMeshTransport {
 
     const claimed = this.deliverToWaiters(from, final);
     if (!claimed) {
-      this.pushInbox({ from, content: final, timestamp: ts });
+      this.pushInbox({
+        id: `mesh-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`,
+        from,
+        content: final,
+        timestamp: ts,
+      });
     }
   }
 
@@ -744,8 +792,55 @@ export class MeshConnection implements IMeshTransport {
     return msgs;
   }
 
+  /**
+   * Mark the given message ids as read (in-place). Used by the mesh_inbox
+   * tool when called with `mark_read=true` so subsequent `unread_only`
+   * queries don't re-list the same entries. Entries themselves stay in
+   * the inbox until `consumeInbox` / `waitForMessage` claims them or the
+   * FIFO cap evicts them.
+   */
+  markRead(ids: string[]): number {
+    if (ids.length === 0) return 0;
+    const idSet = new Set(ids);
+    const now = new Date().toISOString();
+    let count = 0;
+    for (const m of this.inbox) {
+      if (idSet.has(m.id) && !m.read_at) {
+        m.read_at = now;
+        count += 1;
+      }
+    }
+    if (count > 0) {
+      this.stats.read_total += count;
+      this.stats.last_read_at = now;
+    }
+    return count;
+  }
+
+  /** Number of inbox entries with no `read_at` timestamp. */
+  getUnreadCount(): number {
+    let n = 0;
+    for (const m of this.inbox) if (!m.read_at) n += 1;
+    return n;
+  }
+
+  /** Snapshot of inbox + lifecycle counters for diagnostics. */
+  getDiagnostics(): MeshDiagnostics {
+    return {
+      build_hash: BUILD_HASH,
+      received_total: this.stats.received_total,
+      consumed_by_waiter: this.stats.consumed_by_waiter,
+      consumed_by_predicate: this.stats.consumed_by_predicate,
+      fifo_dropped: this.stats.fifo_dropped,
+      read_total: this.stats.read_total,
+      last_received_at: this.stats.last_received_at,
+      last_read_at: this.stats.last_read_at,
+    };
+  }
+
   drainInbox(): InboxMessage[] {
     const msgs = [...this.inbox];
+    this.stats.consumed_by_predicate += msgs.length;
     this.inbox = [];
     return msgs;
   }
@@ -762,7 +857,10 @@ export class MeshConnection implements IMeshTransport {
       if (predicate(m)) claimed.push(m);
       else kept.push(m);
     }
-    if (claimed.length > 0) this.inbox = kept;
+    if (claimed.length > 0) {
+      this.inbox = kept;
+      this.stats.consumed_by_predicate += claimed.length;
+    }
     return claimed;
   }
 
@@ -779,7 +877,10 @@ export class MeshConnection implements IMeshTransport {
       const msg = this.inbox[i];
       const result = predicate(msg.content, msg.from);
       if (result !== null && result !== undefined) {
-        if (consume) this.inbox.splice(i, 1);
+        if (consume) {
+          this.inbox.splice(i, 1);
+          this.stats.consumed_by_waiter += 1;
+        }
         return result;
       }
     }

--- a/mesh-plugin/src/index.ts
+++ b/mesh-plugin/src/index.ts
@@ -39,10 +39,55 @@ import * as crypto from "node:crypto";
 // State
 // ---------------------------------------------------------------------------
 
-let connection: MeshConnection | null = null;
-let meshIdentity: MeshIdentity | null = null;
-let activePairing: StoredPairing | null = null;
-let initialized = false;
+// ---------------------------------------------------------------------------
+// Plugin state — singleton via process-keyed Symbol.
+//
+// OpenClaw's plugin loader runs through this module twice in some setups
+// (tool-registry pass + agent-session pass), and a hot-reload during dev
+// re-imports it again. Without a singleton, each pass would build its own
+// `MeshConnection`, upload its own prekeys, and open its own WebSocket —
+// exactly the duplicate-message / "session already exists" bug pattern
+// documented in `vendor/agentmesh-sdk/README.md` patch #10.
+//
+// `Symbol.for(...)` lookups are process-global so all imports share the
+// same state object. Module-level `let`s mirror the singleton for the
+// common read path; `ensureInitialized()` is the only writer and syncs
+// both sides.
+// ---------------------------------------------------------------------------
+
+interface MeshPluginState {
+  connection: MeshConnection | null;
+  meshIdentity: MeshIdentity | null;
+  activePairing: StoredPairing | null;
+  initialized: boolean;
+  /** In-flight init promise — prevents racey concurrent ensureInitialized calls. */
+  initPromise: Promise<string | null> | null;
+}
+
+const STATE_KEY = Symbol.for("azureclaw.mesh-plugin.state");
+const state: MeshPluginState = (() => {
+  const proc = process as unknown as Record<symbol, MeshPluginState | undefined>;
+  let s = proc[STATE_KEY];
+  if (!s) {
+    s = {
+      connection: null,
+      meshIdentity: null,
+      activePairing: null,
+      initialized: false,
+      initPromise: null,
+    };
+    proc[STATE_KEY] = s;
+  }
+  return s;
+})();
+
+// Local view onto the singleton. Reads only — writes go through `state.*`
+// inside ensureInitialized (and are mirrored back here so legacy reads
+// see the same connection on subsequent invocations).
+let connection: MeshConnection | null = state.connection;
+let meshIdentity: MeshIdentity | null = state.meshIdentity;
+let activePairing: StoredPairing | null = state.activePairing;
+let initialized: boolean = state.initialized;
 
 /**
  * Offload state. Updated by the background orchestrator; read by
@@ -374,18 +419,22 @@ export function definePluginEntry() {
       api.registerTool({
         name: "mesh_inbox",
         description:
-          "Read incoming messages from the E2E encrypted mesh inbox. " +
-          "Call this whenever the user asks you to check the inbox, check " +
-          "for replies, or see if a peer/cloud agent has responded. It is " +
-          "safe to call at any time, including during an active cloud " +
-          "offload — the user may ask you to peek at raw mesh traffic.",
+          "Read messages received via the E2E encrypted AGT mesh. ALWAYS call " +
+          "this tool when the user asks about inbox, replies, or peer messages — " +
+          "do NOT rely on what you remember from earlier turns, because new " +
+          "messages may have arrived since then. Default behaviour is *peek-only* " +
+          "and shows only entries you haven't read yet; messages stay in the " +
+          "inbox so you can re-read them. Pass mark_read=true once you have " +
+          "acted on the contents to flag them as seen, or unread_only=false to " +
+          "also see entries from previous turns. The response includes a " +
+          "`diagnostics` block with lifecycle counters so you can tell apart " +
+          "'never received' from 'already consumed by an offload waiter'.",
         parameters: {
           type: "object",
           properties: {
-            limit: {
-              type: "number",
-              description: "Max messages to return (default: 10)",
-            },
+            limit: { type: "number", description: "Max messages to return (default: 10)" },
+            mark_read: { type: "boolean", description: "When true, flag returned entries as read." },
+            unread_only: { type: "boolean", description: "Default true. Set false to include entries you already read." },
           },
         },
         handler: meshInboxHandler,
@@ -502,32 +551,67 @@ export function definePluginEntry() {
 // ---------------------------------------------------------------------------
 
 async function ensureInitialized(): Promise<string | null> {
-  if (initialized) return null;
-
-  meshIdentity = await loadOrCreateIdentity();
-  activePairing = getDefaultPairing();
-
-  if (activePairing) {
-    try {
-      connection = new MeshConnection({
-        relayUrl: activePairing.relayUrl,
-        registryUrl: activePairing.registryUrl,
-        identity: meshIdentity,
-        // The controller speaks legacy base64(JSON), not Signal E2E — route
-        // its traffic through the plaintext-compat bypass in the SDK.
-        plaintextPeers: activePairing.controllerAmid
-          ? [activePairing.controllerAmid]
-          : undefined,
-      });
-      await connection.connect();
+  // Fast path — singleton already initialized by a prior plugin load.
+  if (state.initialized) {
+    if (!initialized) {
+      // This module copy hasn't synced yet (re-import after hot-reload or
+      // second plugin pass). Mirror the canonical state into our locals.
+      connection = state.connection;
+      meshIdentity = state.meshIdentity;
+      activePairing = state.activePairing;
       initialized = true;
-    } catch (err: any) {
-      return `Failed to connect to mesh: ${err.message}`;
     }
+    return null;
   }
 
-  initialized = true;
-  return null;
+  // Coalesce concurrent callers onto a single in-flight init.
+  if (state.initPromise) return state.initPromise;
+
+  state.initPromise = (async (): Promise<string | null> => {
+    try {
+      const id = await loadOrCreateIdentity();
+      const pairing = getDefaultPairing();
+      let conn: MeshConnection | null = null;
+
+      if (pairing) {
+        try {
+          conn = new MeshConnection({
+            relayUrl: pairing.relayUrl,
+            registryUrl: pairing.registryUrl,
+            identity: id,
+            // The controller speaks legacy base64(JSON), not Signal E2E — route
+            // its traffic through the plaintext-compat bypass in the SDK.
+            plaintextPeers: pairing.controllerAmid
+              ? [pairing.controllerAmid]
+              : undefined,
+          });
+          await conn.connect();
+        } catch (err: any) {
+          // Reset the gate so a later retry can try again instead of
+          // permanently caching a failed init promise.
+          state.initPromise = null;
+          return `Failed to connect to mesh: ${err.message}`;
+        }
+      }
+
+      // Commit to the singleton AND mirror locally.
+      state.meshIdentity = id;
+      state.activePairing = pairing;
+      state.connection = conn;
+      state.initialized = true;
+      meshIdentity = id;
+      activePairing = pairing;
+      connection = conn;
+      initialized = true;
+      return null;
+    } finally {
+      // Drop the promise reference once resolved so reads don't hold it
+      // forever. A failed init already cleared it above before returning.
+      if (state.initialized) state.initPromise = null;
+    }
+  })();
+
+  return state.initPromise;
 }
 
 // ---------------------------------------------------------------------------
@@ -1506,25 +1590,56 @@ async function meshSendHandler(...args: any[]): Promise<string> {
 }
 
 async function meshInboxHandler(...args: any[]): Promise<string> {
-  const params = extractParams(args) as { limit?: number };
+  const params = extractParams(args) as {
+    limit?: number;
+    mark_read?: boolean;
+    unread_only?: boolean;
+  };
   const err = await ensureInitialized();
   if (err) return `❌ ${err}`;
   if (!connection) return "❌ Mesh client not connected.";
 
-  const limit = params.limit || 10;
-  const messages = connection.getInbox(limit);
+  const markRead = params.mark_read === true;
+  const unreadOnly = params.unread_only !== false; // default true
+  const limit = typeof params.limit === "number" && params.limit > 0
+    ? Math.floor(params.limit)
+    : 10;
 
-  if (messages.length === 0) return "📭 Inbox empty.";
+  // getInbox is peek-only — does not mutate the underlying array.
+  // Filtering/limit happens here so the LLM can ask for unread-only or all.
+  const all = connection.getInbox();
+  const visible = unreadOnly ? all.filter((m) => !m.read_at) : all;
+  const slice = visible.slice(-limit);
 
-  const lines = messages.map((m, i) => {
+  if (markRead && slice.length > 0) {
+    connection.markRead(slice.map((m) => m.id));
+  }
+
+  const diag = connection.getDiagnostics();
+  const unreadCount = connection.getUnreadCount();
+  const totalInbox = all.length;
+
+  if (slice.length === 0) {
+    // Empty inbox → still return diagnostics so operators / the LLM can
+    // distinguish "never received" from "already consumed by an offload
+    // waiter / mesh_send reply waiter / earlier mark_read".
+    const summary = unreadOnly && unreadCount === 0 && totalInbox > 0
+      ? `📭 No unread messages (${totalInbox} already read; pass unread_only=false to re-read).`
+      : "📭 Inbox empty.";
+    return `${summary}\n\nDiagnostics: ${JSON.stringify(diag)}`;
+  }
+
+  const lines = slice.map((m, i) => {
     const content =
       typeof m.content === "string"
         ? m.content.slice(0, 200)
         : JSON.stringify(m.content).slice(0, 200);
-    return `  ${i + 1}. [${m.from}] ${content}`;
+    const tag = m.read_at ? "·read" : "·new";
+    return `  ${i + 1}. [${m.from}] (${tag}) ${content}`;
   });
 
-  return `📬 ${messages.length} message(s):\n${lines.join("\n")}`;
+  const header = `📬 ${slice.length} of ${totalInbox} message(s) (${unreadCount} unread${markRead ? `, ${slice.length} now marked read` : ""}):`;
+  return `${header}\n${lines.join("\n")}\n\nDiagnostics: ${JSON.stringify(diag)}`;
 }
 
 async function discoverHandler(...args: any[]): Promise<string> {

--- a/runtimes/openclaw/src/core/agt-handoff.ts
+++ b/runtimes/openclaw/src/core/agt-handoff.ts
@@ -41,6 +41,21 @@ export interface AgtInboxEntry {
   timestamp: string;
   id: string;
   message_type?: string;
+  /**
+   * ISO timestamp of when this entry was first surfaced to the LLM via
+   * azureclaw_mesh_inbox. Undefined while still unread. Used by the inbox
+   * tool to:
+   *   1. show "📬 N new / M total" diagnostics so the LLM knows which
+   *      messages it has already seen on prior turns;
+   *   2. stop draining on every read — entries persist across calls so a
+   *      later "what's in your inbox?" reply is still grounded in the
+   *      actual receive history (fixes the demo "viz says inbox empty"
+   *      after auto-reply already consumed the splice-based drain).
+   * Internal protocol/handshake messages and entries claimed by the
+   * mesh_send reply-wait loop are removed from the array immediately and
+   * never get a read_at value.
+   */
+  read_at?: string;
 }
 
 export interface HandoffDeps {

--- a/runtimes/openclaw/src/core/agt-heartbeat.test.ts
+++ b/runtimes/openclaw/src/core/agt-heartbeat.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { startTaskProgressHeartbeat } from "./agt-heartbeat.js";
+
+describe("startTaskProgressHeartbeat", () => {
+  let log: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    log = { info: vi.fn(), warn: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires an initial 'started' ping synchronously", () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const cancel = startTaskProgressHeartbeat(
+      "did:mesh:parent",
+      { send },
+      "sub-agent-x",
+      log,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [amid, msg] = send.mock.calls[0];
+    expect(amid).toBe("did:mesh:parent");
+    expect(msg.type).toBe("task_progress");
+    expect(msg.stage).toBe("started");
+    expect(msg.from_agent).toBe("sub-agent-x");
+    expect(msg.tick).toBe(0);
+    expect(typeof msg.elapsed_seconds).toBe("number");
+    expect(typeof msg.timestamp).toBe("string");
+
+    cancel();
+  });
+
+  it("fires periodic 'executing' pings on the configured interval", () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const cancel = startTaskProgressHeartbeat(
+      "did:mesh:parent",
+      { send },
+      "sub-agent-x",
+      log,
+      5_000, // 5s for the test
+    );
+
+    expect(send).toHaveBeenCalledTimes(1); // initial 'started'
+
+    vi.advanceTimersByTime(5_000);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[1][1].stage).toBe("executing");
+    expect(send.mock.calls[1][1].tick).toBe(1);
+
+    vi.advanceTimersByTime(5_000);
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send.mock.calls[2][1].tick).toBe(2);
+
+    cancel();
+  });
+
+  it("stops firing after cancel()", () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const cancel = startTaskProgressHeartbeat(
+      "did:mesh:parent",
+      { send },
+      "sub-agent-x",
+      log,
+      5_000,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    cancel();
+
+    vi.advanceTimersByTime(60_000);
+    expect(send).toHaveBeenCalledTimes(1); // never increased
+  });
+
+  it("is no-op when meshClient is null", () => {
+    const cancel = startTaskProgressHeartbeat(
+      "did:mesh:parent",
+      null,
+      "sub-agent-x",
+      log,
+      5_000,
+    );
+
+    vi.advanceTimersByTime(20_000);
+    // Nothing thrown, no logs about send failures.
+    cancel();
+  });
+
+  it("swallows send errors and continues firing on the next tick", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ratchet broken"))
+      .mockResolvedValue(undefined);
+
+    const cancel = startTaskProgressHeartbeat(
+      "did:mesh:parent",
+      { send },
+      "sub-agent-x",
+      log,
+      5_000,
+    );
+
+    // Initial fire produced a rejecting promise; flush microtasks.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(log.warn).toHaveBeenCalled();
+
+    // Still ticks afterwards.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(send).toHaveBeenCalledTimes(2);
+
+    cancel();
+  });
+
+  it("cancel() is idempotent", () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const cancel = startTaskProgressHeartbeat(
+      "did:mesh:parent",
+      { send },
+      "sub-agent-x",
+      log,
+      5_000,
+    );
+    cancel();
+    cancel();
+    cancel();
+    vi.advanceTimersByTime(20_000);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/runtimes/openclaw/src/core/agt-heartbeat.ts
+++ b/runtimes/openclaw/src/core/agt-heartbeat.ts
@@ -117,6 +117,78 @@ export async function agtReconnect(
 }
 
 /**
+ * Start a periodic `task_progress` heartbeat to `originatorAmid` while a
+ * `task_request` is being processed by the in-process LLM tool-call loop.
+ *
+ * Why: the in-process task-loop path (sub-agent receives `task_request`,
+ * runs `processTaskWithTools`, replies with `task_response`) used to leave
+ * the parent silently waiting on a fixed 60s timeout. Long-running tool
+ * sequences (e.g. multiple `foundry_web_search` calls) routinely exceeded
+ * this and the parent gave up *before* the actual reply arrived. The
+ * offload path (`agt-offload.ts`) already solved this with periodic
+ * `offload_progress` pings; this is the in-process equivalent so the
+ * parent's wait loop can extend the idle clock as long as the sub-agent
+ * keeps signalling progress.
+ *
+ * Returns a cancel function that MUST be called from a `finally` block
+ * when the task completes (success, failure, or interrupt). All sends are
+ * fire-and-forget — a transient ratchet failure on the heartbeat must
+ * never crash the wrapper task.
+ */
+export function startTaskProgressHeartbeat(
+  originatorAmid: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  meshClient: { send: (amid: string, msg: any) => Promise<unknown> } | null,
+  fromAgent: string,
+  log: MeshLogger,
+  intervalMs: number = 20_000,
+): () => void {
+  const startedAt = Date.now();
+  let tick = 0;
+  let cancelled = false;
+
+  const fire = (stage: "started" | "executing"): void => {
+    if (cancelled || !meshClient) return;
+    const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+    try {
+      meshClient.send(originatorAmid, {
+        type: "task_progress",
+        stage,
+        tick,
+        elapsed_seconds: elapsedSec,
+        from_agent: fromAgent,
+        timestamp: new Date().toISOString(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }).catch((e: any) => {
+        // Best-effort heartbeat — log once at debug-equivalent then swallow.
+        log.warn(`AGT relay: task_progress heartbeat send failed (tick=${tick}): ${e?.message || e}`);
+      });
+    } catch (e: any) {
+      log.warn(`AGT relay: task_progress heartbeat threw (tick=${tick}): ${e?.message || e}`);
+    }
+  };
+
+  // Initial ping — tells the parent "I started" so its wait loop sees a
+  // progress hit even for fast tasks (avoids the race where the reply
+  // arrives between the "started" tick and the first interval fire).
+  fire("started");
+
+  const timer = setInterval(() => {
+    tick += 1;
+    fire("executing");
+  }, intervalMs);
+  // Don't keep the event loop alive solely for this interval — when the
+  // wrapper task finishes its finally block runs the cancel returned below.
+  if (typeof timer.unref === "function") timer.unref();
+
+  return () => {
+    if (cancelled) return;
+    cancelled = true;
+    clearInterval(timer);
+  };
+}
+
+/**
  * Rewrite the AGT_INBOX_START..AGT_INBOX_END section of MEMORY.md so the
  * wrapped LLM sees pending peer messages without an explicit mesh_inbox
  * call. Best-effort — silently no-ops if the file isn't present.

--- a/runtimes/openclaw/src/core/agt-task-loop.ts
+++ b/runtimes/openclaw/src/core/agt-task-loop.ts
@@ -13,9 +13,11 @@
 // plugin.ts singletons. Pure imports (TASK_TOOLS, routerUrl, resolveAmidByName,
 // sanitizeLog) are pulled directly from sibling core modules.
 
+import type { AgtInboxEntry } from "./agt-handoff.js";
 import { TASK_TOOLS } from "./agt-task-tools.js";
 import { resolveAmidByName } from "./amid-cache.js";
 import { sanitizeLog } from "./log-redact.js";
+import { validateMeshPayload } from "./mesh-payload-guard.js";
 import { routerUrl } from "./router-client.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -31,6 +33,21 @@ export interface TaskLoopDeps {
   interruptReason: () => string;
   /** Mark the interrupt as latched (so we do not re-fire on the next round). */
   setInterrupt: (requested: boolean, reason: string) => void;
+  /**
+   * Shared AGT inbox buffer (same array as parent-tools' deps.inbox in
+   * agt-tools/agt.ts). Direct reference — pushInbox mutates it in place.
+   * The sub-agent task-loop's `mesh_inbox` reads from this so messages
+   * received between sub-agent boot and the start of a task_request
+   * session are visible to the LLM. Without this, two concurrent
+   * processTaskWithTools sessions could not exchange peer artifacts.
+   */
+  inbox?: AgtInboxEntry[];
+  /**
+   * Notify diagnostics that entries were marked read. Mirrors
+   * AgtToolsDeps.markRead so inboxStats.read_total stays in sync
+   * regardless of which tool path consumed the messages.
+   */
+  markRead?: (ids: string[]) => void;
 }
 
 export async function processTaskWithTools(
@@ -51,7 +68,7 @@ export async function processTaskWithTools(
       role: "system",
       content: process.env.OFFLOAD_REQUEST_ID
         ? "You are an AzureClaw OFFLOAD WORKER — a short-lived sandboxed agent executing ONE task on behalf of a remote parent agent. Always identify as an AzureClaw offload worker. Your tools:\n- file_write: write text content directly to a file (USE THIS for all artifacts — never use shell redirection)\n- exec_command: run shell commands (read-only ops are fine; DO NOT use `>`, `>>`, `<<`, `<<<` — the shell policy blocks redirection. Use file_write instead.)\n- http_fetch: HTTP requests through security proxy (egress-controlled)\n- foundry_web_search: real-time web search via Bing grounding\n- foundry_code_execute: run Python code server-side (pandas, numpy, matplotlib)\n- foundry_image_generation: generate images from text prompts (gpt-image-1)\n- foundry_file_search: search documents in vector stores\n- foundry_memory: persistent memory store — 'search' to recall, 'update' to remember\n- mesh_send: send E2E encrypted message to PARENT (to_agent is locked to 'parent')\n- mesh_inbox: check for incoming messages from the parent\n- discover: list agents in the mesh network (informational only)\n\nHARD RULES (offload mode):\n1. ALL outbound mesh messages go to 'parent'. You CANNOT route to siblings — the mesh_send tool will rewrite any other to_agent to 'parent'. Messages to peers will NOT reach the requester.\n2. ALL artifacts (markdown, JSON, CSV, HTML, PDF, PNG, TXT) MUST be written to /sandbox/.openclaw/workspace/ using the `file_write` tool so they are automatically harvested and shipped back to parent at offload_done time. DO NOT use `cat > file <<EOF` or `echo > file` — those are blocked by the shell policy.\n3. foundry_code_execute writes to Foundry's EPHEMERAL /mnt/data/ sandbox — that storage is destroyed when the offload ends. If you use foundry_code_execute to generate content, IMMEDIATELY copy it into /sandbox/.openclaw/workspace/ by calling file_write with the content. Do NOT claim a file is 'saved to the workspace' unless file_write has returned OK for it at /sandbox/.openclaw/workspace/.\n4. Execute the task immediately — do not announce, just act. Be concise, report results."
-        : "You are an AzureClaw sub-agent — a governed, sandboxed AI worker in the AzureClaw multi-agent platform on Azure. Always identify as an AzureClaw agent. Your tools:\n- file_write: write text content directly to a file (use this for all artifacts — shell redirection is blocked)\n- exec_command: run shell commands (no `>`, `>>`, `<<`, `<<<` — use file_write instead)\n- http_fetch: HTTP requests through security proxy (egress-controlled)\n- foundry_web_search: real-time web search via Bing grounding\n- foundry_code_execute: run Python code server-side (pandas, numpy, matplotlib)\n- foundry_image_generation: generate images from text prompts (gpt-image-1)\n- foundry_file_search: search documents in vector stores\n- foundry_memory: persistent memory store — 'search' to recall, 'update' to remember\n- mesh_send: send E2E encrypted messages to ANY agent (parent, siblings, or others) — auto-discovers the target\n- mesh_inbox: check for incoming messages from any agent\n- discover: list agents in the mesh network with status and trust scores\n\nPEER-TO-PEER MESH: You can message any agent directly — not just your parent. To forward data to a sibling agent (e.g. 'writer'), just call mesh_send with to_agent='writer'. Discovery is automatic. After sending, the recipient can reply via mesh_send back to you — check mesh_inbox for replies.\n\nExecute tasks immediately — do not announce, just act. When asked to forward results to another agent, DO IT directly with mesh_send. Chain tool calls as needed. Be concise, report results.",
+        : "You are an AzureClaw sub-agent — a governed, sandboxed AI worker in the AzureClaw multi-agent platform on Azure. Always identify as an AzureClaw agent. Your tools:\n- file_write: write text content directly to a file (use this for all artifacts — shell redirection is blocked)\n- exec_command: run shell commands (no `>`, `>>`, `<<`, `<<<` — use file_write instead)\n- http_fetch: HTTP requests through security proxy (egress-controlled)\n- foundry_web_search: real-time web search via Bing grounding\n- foundry_code_execute: run Python code server-side (pandas, numpy, matplotlib)\n- foundry_image_generation: generate images from text prompts (gpt-image-1)\n- foundry_file_search: search documents in vector stores\n- foundry_memory: persistent memory store — 'search' to recall, 'update' to remember\n- mesh_send: send E2E encrypted TEXT/JSON messages to ANY agent (parent, siblings, or others) — auto-discovers the target\n- mesh_transfer_file: ship a FILE / IMAGE / BINARY to another agent (handles base64 + chunking for you)\n- mesh_inbox: check for incoming messages from any agent\n- discover: list agents in the mesh network with status and trust scores\n\nPEER-TO-PEER MESH: You can message any agent directly — not just your parent. To forward data to a sibling agent (e.g. 'writer'), just call mesh_send with to_agent='writer'. Discovery is automatic. After sending, the recipient can reply via mesh_send back to you — check mesh_inbox for replies.\n\n🚨 ISOLATED FILESYSTEMS — CRITICAL: Each sub-agent runs in its OWN isolated container with its OWN /sandbox AND its own /tmp filesystem. Sibling agents CANNOT read your local files. NEVER send a sibling a file path, /tmp/ path, /sandbox path, or URL pointing into your container — they cannot resolve it.\n  • For TEXT / JSON artifacts → call `mesh_send` with the FULL stringified content in the `message` field. The SDK auto-chunks large messages.\n  • For FILES / IMAGES / BINARIES (PNG, JPG, PDF, …) → ALWAYS call `mesh_transfer_file(to_agent, file_path)`. It reads the bytes, base64-encodes them, and ships them via the chunked transfer protocol. The recipient's gateway auto-writes the file to /sandbox/.openclaw/workspace/incoming/ and they see the saved path in their mesh_inbox.\n  • DO NOT hand-craft `{type:'file_transfer', file_path:'/sandbox/...'}` envelopes through `mesh_send` — they will be REJECTED. The peer cannot read your filesystem.\n  • DO NOT use placeholder strings like `<base64-image-data>` or `<base64-bytes>` in `file_data` — they will be REJECTED.\n❌ BAD:  `mesh_send(to=writer, msg={hero_image_path:'/tmp/img.png'})`           ← peer cannot read /tmp\n❌ BAD:  `mesh_send(to=viz, msg={artifact_path:'/sandbox/data.json'})`           ← peer cannot read /sandbox\n❌ BAD:  `mesh_send(to=writer, msg={type:'file_transfer', file_data:'<base64-bytes>'})` ← placeholder, not real bytes\n✅ GOOD: `mesh_transfer_file(to_agent='writer', file_path='/sandbox/.openclaw/workspace/hero.png', description='hero image 1024x1024')`\n✅ GOOD: `mesh_send(to=viz, msg=JSON.stringify({trends:[...real data...], metrics:[...]}))`\n\n📥 INBOX-FIRST RULE — MANDATORY: Whenever your task description says you should already have data from a sibling, your VERY FIRST action MUST be `mesh_inbox` (no arguments). Sibling messages always arrive before you process them — the inbox is your buffer. Sibling artifacts appear with `message_type:'peer_message'` (text/JSON via mesh_send) or `message_type:'file_transfer'` (files via mesh_transfer_file — read the file at `saved_to` to get the bytes). NEVER reply 'BLOCKED' or 'no data received' without first checking mesh_inbox in the current turn — the data is almost always sitting there waiting. mesh_inbox is peek-only by default; calling it does not consume the messages, so concurrent task sessions all see the same data.\n\nExecute tasks immediately — do not announce, just act. When asked to forward results to another agent, DO IT directly (mesh_send for text/JSON, mesh_transfer_file for files). Chain tool calls as needed. Be concise, report results.",
     },
     {
       role: "user",
@@ -135,7 +152,7 @@ export async function processTaskWithTools(
     if (msg.tool_calls && msg.tool_calls.length > 0) {
       messages.push(msg);
       for (const tc of msg.tool_calls) {
-        let result: string;
+        let result: string = "";
         try {
           const args = JSON.parse(tc.function.arguments);
           const fnName = tc.function.name;
@@ -409,6 +426,14 @@ export async function processTaskWithTools(
               toAgent = "parent";
             }
             const meshMsg = args.message as string;
+            // Guard: reject malformed file_transfer envelopes / cross-container
+            // path references before they hit the wire. Peer agents cannot
+            // read this container's filesystem.
+            const guardErr = validateMeshPayload(meshMsg, { transferToolName: "mesh_transfer_file" });
+            if (guardErr) {
+              log.warn(`AGT sub-agent mesh_send: payload guard rejected — ${guardErr.slice(0, 160)}`);
+              result = guardErr;
+            } else {
             log.info(`AGT sub-agent mesh_send: to=${toAgent} msg=${(meshMsg || "").slice(0, 100)}`);
             try {
               let targetAmid = await resolveAmidByName(toAgent, routerUrl);
@@ -458,6 +483,116 @@ export async function processTaskWithTools(
             } catch (meshErr: any) {
               result = `mesh_send failed: ${meshErr.message}`;
             }
+            }
+          } else if (fnName === "mesh_transfer_file") {
+            let toAgent = args.to_agent as string;
+            if (process.env.OFFLOAD_REQUEST_ID && toAgent !== "parent") {
+              log.warn(`AGT sub-agent mesh_transfer_file: offload mode — rewriting to_agent '${toAgent}' → 'parent'`);
+              toAgent = "parent";
+            }
+            const filePath = String(args.file_path || "");
+            const desc = typeof args.description === "string" ? args.description : "";
+            log.info(`AGT sub-agent mesh_transfer_file: to=${toAgent} file=${filePath}`);
+            try {
+              const fs = await import("node:fs");
+              const path = await import("node:path");
+
+              // Resolve relative paths under the workspace; absolutes must
+              // stay inside /sandbox to prevent escape via .. traversal.
+              const workspaceRoot = "/sandbox/.openclaw/workspace";
+              const resolvedPath = path.isAbsolute(filePath)
+                ? path.resolve(filePath)
+                : path.resolve(workspaceRoot, filePath);
+
+              if (!resolvedPath.startsWith("/sandbox")) {
+                result = `mesh_transfer_file failed: path must be within /sandbox (got: ${resolvedPath})`;
+              } else {
+                const MAX_FILE_SIZE = 30 * 1024 * 1024;
+                let fd: number;
+                try {
+                  fd = fs.openSync(resolvedPath, "r");
+                } catch (openErr: any) {
+                  result = `mesh_transfer_file failed: cannot open ${filePath}: ${openErr.message}`;
+                  fd = -1;
+                }
+                if (fd >= 0) {
+                  let fileData: Buffer | null = null;
+                  let finalSize = 0;
+                  let openErrMsg = "";
+                  try {
+                    const fstat = fs.fstatSync(fd);
+                    if (!fstat.isFile()) {
+                      openErrMsg = `not a regular file: ${filePath}`;
+                    } else if (fstat.size > MAX_FILE_SIZE) {
+                      openErrMsg = `file too large: ${(fstat.size / 1024 / 1024).toFixed(1)} MB (max 30MB)`;
+                    } else {
+                      finalSize = fstat.size;
+                      fileData = Buffer.alloc(finalSize);
+                      fs.readSync(fd, fileData, 0, finalSize, 0);
+                    }
+                  } finally {
+                    fs.closeSync(fd);
+                  }
+                  if (openErrMsg || !fileData) {
+                    result = `mesh_transfer_file failed: ${openErrMsg || "read failed"}`;
+                  } else {
+                    const b64Data = fileData.toString("base64");
+                    const fileName = path.basename(resolvedPath);
+
+                    let targetAmid = await resolveAmidByName(toAgent, routerUrl);
+                    for (let attempt = 1; attempt < 8 && !targetAmid; attempt++) {
+                      log.info(`AGT sub-agent mesh_transfer_file: waiting for '${toAgent}' to register (${attempt}/7)...`);
+                      await new Promise(r => setTimeout(r, 2000));
+                      targetAmid = await resolveAmidByName(toAgent, routerUrl, { bypassCache: true });
+                    }
+
+                    const meshClient = deps.meshClient();
+                    if (!targetAmid) {
+                      result = `Agent '${toAgent}' not found in registry after retries. It may not be running yet.`;
+                    } else if (!meshClient) {
+                      result = `Mesh client not available — cannot send to ${toAgent}`;
+                    } else {
+                      const fileMsg = {
+                        type: "file_transfer",
+                        file_name: fileName,
+                        file_path: filePath,
+                        file_data: b64Data,
+                        size_bytes: finalSize,
+                        description: desc,
+                        from_agent: process.env.SANDBOX_NAME || "unknown",
+                        timestamp: new Date().toISOString(),
+                      };
+                      let sendErr: Error | null = null;
+                      for (let attempt = 0; attempt < 5; attempt++) {
+                        try {
+                          await meshClient.send(targetAmid, fileMsg);
+                          sendErr = null;
+                          break;
+                          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        } catch (e: any) {
+                          sendErr = e;
+                          if (e.message?.includes("prekey")) {
+                            log.info(`AGT sub-agent mesh_transfer_file: waiting for prekeys from '${toAgent}' (${attempt + 1}/5)...`);
+                            await new Promise(r => setTimeout(r, 1000));
+                          } else {
+                            break;
+                          }
+                        }
+                      }
+                      const sizeHuman = finalSize < 1024 ? `${finalSize}B`
+                        : finalSize < 1024 * 1024 ? `${(finalSize / 1024).toFixed(1)}KB`
+                        : `${(finalSize / 1024 / 1024).toFixed(1)}MB`;
+                      result = sendErr
+                        ? `mesh_transfer_file to ${toAgent} failed: ${sendErr.message}`
+                        : `File '${fileName}' (${sizeHuman}) sent to ${toAgent} via E2E encrypted mesh relay. The recipient's gateway will auto-save it under /sandbox/.openclaw/workspace/incoming/.`;
+                    }
+                  }
+                }
+              }
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (transferErr: any) {
+              result = `mesh_transfer_file failed: ${transferErr.message}`;
+            }
           } else if (fnName === "discover") {
             const pattern = (args.pattern as string) || "*";
             log.info(`AGT sub-agent discover: pattern=${pattern}`);
@@ -478,19 +613,147 @@ export async function processTaskWithTools(
           } else if (fnName === "mesh_inbox") {
             log.info("AGT sub-agent mesh_inbox check");
             try {
-              const meshClient = deps.meshClient();
-              if (meshClient && typeof meshClient.drain === "function") {
-                const messages = await meshClient.drain();
-                result = messages.length > 0
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  ? JSON.stringify(messages.map((m: any) => ({ from: m.from_agent || m.sender, content: m.content || m.text, timestamp: m.timestamp })))
-                  : "No pending messages";
+              const inbox = deps.inbox;
+              if (!inbox) {
+                // Defensive: deps.inbox should always be wired by index.ts.
+                // If absent, surface clearly rather than silently returning empty.
+                result = "mesh_inbox unavailable: gateway buffer not wired";
               } else {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const agtInbox = (globalThis as any).__agtInbox || [];
-                result = agtInbox.length > 0
-                  ? JSON.stringify(agtInbox)
-                  : "No pending messages";
+                // Match parent azureclaw_mesh_inbox semantics: hide internal
+                // handoff/transfer protocol traffic. Peer-to-peer payloads
+                // arrive as `type: "task_request"` (see agt-task-loop.ts:432
+                // and agt-tools/agt.ts:417/557 — that's the single wire
+                // format for sibling and parent->sibling artifacts), so we
+                // SURFACE entries whose message_type is "task_request" and
+                // expose them to the LLM as `peer_message`.
+                const HIDDEN_TYPES = new Set([
+                  "handoff_transfer", "handoff_verification", "handoff_ready",
+                  "handoff:interrupt", "handoff:interrupt_ack",
+                  "handoff:workspace_request", "handoff:workspace_response",
+                  "handoff:workspace_inject", "handoff:workspace_inject_ack",
+                  "handoff:resume", "handoff:resume_ack",
+                  "file_transfer_ack",
+                ]);
+                const markRead = args.mark_read === true; // default false — match parent peek-only semantics
+                const unreadOnly = args.unread_only !== false; // default true
+                const limit = typeof args.limit === "number" && (args.limit as number) > 0
+                  ? Math.floor(args.limit as number)
+                  : 50;
+
+                const visible = inbox.filter((m) => {
+                  if (m.message_type && HIDDEN_TYPES.has(m.message_type)) return false;
+                  // Also hide entries whose JSON content advertises an internal type
+                  try {
+                    const parsed = typeof m.content === "string" ? JSON.parse(m.content) : m.content;
+                    if (parsed?.type && HIDDEN_TYPES.has(parsed.type)) return false;
+                  } catch { /* not JSON — keep */ }
+                  return true;
+                });
+
+                const filtered = unreadOnly ? visible.filter((m) => !m.read_at) : visible;
+                const slice = filtered.slice(-limit);
+
+                // Pre-import fs once so the synchronous .map() below can
+                // optionally inline-read small text payloads when the
+                // gateway has saved a file_transfer to disk.
+                const fsForInline = await import("node:fs");
+
+                const decoded = slice.map((m) => {
+                  // Peer-to-peer artifacts: entry.content already holds the
+                  // INNER payload string (the JSON / text the sibling sent),
+                  // because the gateway extracts message.content into
+                  // entry.content (index.ts:612). Just surface it.
+                  //
+                  // Special case: file_transfer messages are auto-saved by
+                  // the gateway (index.ts:824-882) which rewrites
+                  // entry.content to {type, file_name, saved_to,
+                  // size_bytes, description, from_agent}. Lift those
+                  // fields to the top level so the LLM sees the local
+                  // path it can read with `cat <saved_to>`. For small
+                  // text files we additionally inline the content
+                  // (matches parent decoder semantics at agt-tools/agt.ts:680).
+                  let parsed: any = null;
+                  try {
+                    parsed = typeof m.content === "string" ? JSON.parse(m.content) : m.content;
+                  } catch { /* not JSON */ }
+
+                  if (parsed?.type === "file_transfer") {
+                    // (a) Gateway-rewritten form: saved_to + file_name
+                    if (parsed.saved_to && parsed.file_name) {
+                      const sizeBytes = typeof parsed.size_bytes === "number" ? parsed.size_bytes : 0;
+                      let inlined: string | null = null;
+                      if (sizeBytes > 0 && sizeBytes < 100 * 1024) {
+                        try {
+                          const buf = fsForInline.readFileSync(parsed.saved_to);
+                          if (!buf.some((b: number) => b === 0)) {
+                            inlined = buf.toString("utf-8");
+                          }
+                        } catch { /* fall through */ }
+                      }
+                      return {
+                        id: m.id,
+                        from: m.from_agent,
+                        from_amid: m.from_amid,
+                        timestamp: m.timestamp,
+                        message_type: "file_transfer",
+                        file_name: parsed.file_name,
+                        saved_to: parsed.saved_to,
+                        size_bytes: sizeBytes,
+                        description: parsed.description || "",
+                        content: inlined != null
+                          ? inlined
+                          : `[binary or large file: ${parsed.file_name}, ${sizeBytes} bytes — read with: cat ${parsed.saved_to}]`,
+                      };
+                    }
+                    // (b) Inline file_data form (gateway hadn't rewritten yet,
+                    //     or sender used the raw API). Decode locally.
+                    if (typeof parsed.file_data === "string" && parsed.file_name) {
+                      try {
+                        const buf = Buffer.from(parsed.file_data, "base64");
+                        const isText = !buf.some((b: number) => b === 0);
+                        return {
+                          id: m.id,
+                          from: m.from_agent,
+                          from_amid: m.from_amid,
+                          timestamp: m.timestamp,
+                          message_type: "file_transfer",
+                          file_name: parsed.file_name,
+                          size_bytes: buf.length,
+                          description: parsed.description || "",
+                          content: isText
+                            ? buf.toString("utf-8")
+                            : `[binary file: ${parsed.file_name}, ${buf.length} bytes — auto-save in progress; re-check mesh_inbox for saved_to path]`,
+                        };
+                      } catch { /* fall through to default */ }
+                    }
+                  }
+
+                  return {
+                    id: m.id,
+                    from: m.from_agent,
+                    from_amid: m.from_amid,
+                    timestamp: m.timestamp,
+                    message_type: m.message_type === "task_request" ? "peer_message" : (m.message_type || "message"),
+                    content: m.content,
+                  };
+                });
+
+                if (markRead) {
+                  const now = new Date().toISOString();
+                  const returnedIds = new Set(decoded.map((d) => d.id));
+                  const newlyRead: string[] = [];
+                  for (const m of inbox) {
+                    if (returnedIds.has(m.id) && !m.read_at) {
+                      m.read_at = now;
+                      newlyRead.push(m.id);
+                    }
+                  }
+                  if (newlyRead.length > 0) {
+                    try { deps.markRead?.(newlyRead); } catch { /* best effort */ }
+                  }
+                }
+
+                result = decoded.length > 0 ? JSON.stringify(decoded) : "No pending messages";
               }
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (inboxErr: any) {

--- a/runtimes/openclaw/src/core/agt-task-loop.ts
+++ b/runtimes/openclaw/src/core/agt-task-loop.ts
@@ -15,7 +15,7 @@
 
 import type { AgtInboxEntry } from "./agt-handoff.js";
 import { TASK_TOOLS } from "./agt-task-tools.js";
-import { resolveAmidByName } from "./amid-cache.js";
+import { resolveAmidByName, getStaleAmid } from "./amid-cache.js";
 import { sanitizeLog } from "./log-redact.js";
 import { validateMeshPayload } from "./mesh-payload-guard.js";
 import { routerUrl } from "./router-client.js";
@@ -441,10 +441,27 @@ export async function processTaskWithTools(
                 log.info(`AGT sub-agent mesh_send: resolved AMID for '${toAgent}' (${targetAmid.slice(0, 12)}...)`);
               }
 
-              for (let attempt = 1; attempt < 8 && !targetAmid; attempt++) {
-                log.info(`AGT sub-agent mesh_send: waiting for '${toAgent}' to register (${attempt}/7)...`);
-                await new Promise(r => setTimeout(r, 2000));
+              // F7: Exponential backoff (1s..10s, ~50s total budget) instead of
+              // 7 × 2s = 14s flat. Registry 502 bursts can outlast 14s; with
+              // backoff we keep the upper bound bounded but give registry time
+              // to recover.
+              const F7_BACKOFFS_MS = [1000, 1500, 2000, 3000, 4500, 6500, 8000, 10000, 10000, 10000, 10000];
+              for (let attempt = 0; attempt < F7_BACKOFFS_MS.length && !targetAmid; attempt++) {
+                log.info(`AGT sub-agent mesh_send: waiting for '${toAgent}' to register (${attempt + 1}/${F7_BACKOFFS_MS.length})...`);
+                await new Promise(r => setTimeout(r, F7_BACKOFFS_MS[attempt]));
                 targetAmid = await resolveAmidByName(toAgent, routerUrl, { bypassCache: true });
+              }
+
+              // F7: Last-known-good fallback. If registry retries exhausted but
+              // we previously knew this peer's AMID, try it — the meshClient.send
+              // will fail fast if the peer is genuinely dead, and we surface that
+              // error. Better than dropping a real send during a registry blip.
+              if (!targetAmid) {
+                const stale = getStaleAmid(toAgent);
+                if (stale) {
+                  log.warn(`AGT sub-agent mesh_send: registry exhausted for '${toAgent}' — falling back to last-known-good AMID (${stale.slice(0, 12)}...)`);
+                  targetAmid = stale;
+                }
               }
 
               const meshClient = deps.meshClient();
@@ -540,10 +557,20 @@ export async function processTaskWithTools(
                     const fileName = path.basename(resolvedPath);
 
                     let targetAmid = await resolveAmidByName(toAgent, routerUrl);
-                    for (let attempt = 1; attempt < 8 && !targetAmid; attempt++) {
-                      log.info(`AGT sub-agent mesh_transfer_file: waiting for '${toAgent}' to register (${attempt}/7)...`);
-                      await new Promise(r => setTimeout(r, 2000));
+                    // F7: Exponential backoff + last-known-good fallback (see
+                    // mesh_send branch above for rationale).
+                    const F7_BACKOFFS_MS = [1000, 1500, 2000, 3000, 4500, 6500, 8000, 10000, 10000, 10000, 10000];
+                    for (let attempt = 0; attempt < F7_BACKOFFS_MS.length && !targetAmid; attempt++) {
+                      log.info(`AGT sub-agent mesh_transfer_file: waiting for '${toAgent}' to register (${attempt + 1}/${F7_BACKOFFS_MS.length})...`);
+                      await new Promise(r => setTimeout(r, F7_BACKOFFS_MS[attempt]));
                       targetAmid = await resolveAmidByName(toAgent, routerUrl, { bypassCache: true });
+                    }
+                    if (!targetAmid) {
+                      const stale = getStaleAmid(toAgent);
+                      if (stale) {
+                        log.warn(`AGT sub-agent mesh_transfer_file: registry exhausted for '${toAgent}' — falling back to last-known-good AMID (${stale.slice(0, 12)}...)`);
+                        targetAmid = stale;
+                      }
                     }
 
                     const meshClient = deps.meshClient();

--- a/runtimes/openclaw/src/core/agt-task-tools.ts
+++ b/runtimes/openclaw/src/core/agt-task-tools.ts
@@ -136,14 +136,30 @@ export const TASK_TOOLS: any[] = [
     type: "function" as const,
     function: {
       name: "mesh_send",
-      description: "Send an E2E encrypted message to any agent in the mesh — siblings, parent, or any discovered agent. Auto-discovers the target by name (no need to call discover first). Use for peer-to-peer communication between agents.",
+      description: "Send an E2E encrypted TEXT/JSON message to any agent in the mesh — siblings, parent, or any discovered agent. Auto-discovers the target by name. Use for peer-to-peer text or JSON. To send a FILE / IMAGE / BINARY, use `mesh_transfer_file` instead — peer agents run in separate containers and cannot read your /sandbox or /tmp paths, so a file_transfer envelope must contain real base64 bytes. Plain JSON metadata is accepted; envelopes with placeholder file_data (e.g. `<base64-image-data>`) are rejected.",
       parameters: {
         type: "object",
         properties: {
           to_agent: { type: "string", description: "Name of the target agent" },
-          message: { type: "string", description: "The message to send" },
+          message: { type: "string", description: "The message body — text or stringified JSON. Do NOT hand-craft `{type:'file_transfer', file_data:'<base64-bytes>'}` here; use `mesh_transfer_file` for files." },
         },
         required: ["to_agent", "message"],
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "mesh_transfer_file",
+      description: "Send a FILE / IMAGE / BINARY to another mesh agent. Reads the file from your local container, base64-encodes it, and ships it to the recipient via the chunked E2E encrypted transfer protocol (files up to ~30 MB). The recipient's gateway auto-saves it under /sandbox/.openclaw/workspace/incoming/<file_name> and the recipient sees the saved path in their mesh_inbox. Use this for any file you want to ship — never hand-craft a `file_transfer` JSON envelope through `mesh_send`.",
+      parameters: {
+        type: "object",
+        properties: {
+          to_agent: { type: "string", description: "Name of the target agent" },
+          file_path: { type: "string", description: "Path to the file to send (relative to /sandbox/.openclaw/workspace, or absolute under /sandbox)" },
+          description: { type: "string", description: "Optional human-readable description for the recipient" },
+        },
+        required: ["to_agent", "file_path"],
       },
     },
   },
@@ -164,10 +180,14 @@ export const TASK_TOOLS: any[] = [
     type: "function" as const,
     function: {
       name: "mesh_inbox",
-      description: "Check for incoming messages from other agents via the AGT E2E encrypted mesh relay. Returns pending messages.",
+      description: "Check for incoming messages from peer agents via the AGT E2E encrypted mesh relay. Returns peer messages received since boot. Internal protocol traffic (handoff/file_transfer ack) and the seeding task itself are filtered out — you only see real peer-to-peer payloads. file_transfer messages are auto-decoded: small text files inline; binaries surface `saved_to` (the local path your container has, written by the gateway) plus `file_name` and `size_bytes`. By default returns unread messages only and PEEKS without marking them read so concurrent sessions all see the same data; set mark_read=true to mark returned entries as read.",
       parameters: {
         type: "object",
-        properties: {},
+        properties: {
+          unread_only: { type: "boolean", description: "If true (default) return only entries not yet marked read." },
+          mark_read: { type: "boolean", description: "If true mark returned entries as read so subsequent calls don't repeat them. Defaults to false (peek-only)." },
+          limit: { type: "number", description: "Maximum number of entries to return (default 50, most recent kept)." },
+        },
       },
     },
   },

--- a/runtimes/openclaw/src/core/agt-tools/agt.ts
+++ b/runtimes/openclaw/src/core/agt-tools/agt.ts
@@ -95,7 +95,7 @@ export interface AgtToolsDeps {
    * transfer ack handler). Index sites that do `agtInbox.splice(...)`
    * bypass `pushInbox` so counters would otherwise drift.
    */
-  notifyConsumed?: (kind: "send_wait" | "protocol_drain", count: number) => void;
+  notifyConsumed?: (kind: "send_wait" | "protocol_drain" | "progress_drain", count: number) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   meshClient: () => any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -487,28 +487,42 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
           // To recover from rolling deploys (parent's cached/registered AMID is for
           // the previous pod incarnation), we retry ONCE on reply timeout: clear
           // the cache, re-resolve, and if the AMID actually changed, resend.
-          const waitMaxMs = 60_000; // 60 seconds — prevents blocking the agent loop too long
-          const pollIntervalMs = 500; // 500ms — fast polling for responsive feel
+          //
+          // Heartbeat-aware timeout (added 2026-04-30 fix-pass F6): the
+          // sub-agent emits periodic `task_progress` pings while running its
+          // in-process LLM tool-loop (see `index.ts` task_request handler +
+          // `core/agt-heartbeat.ts::startTaskProgressHeartbeat`). Each
+          // progress drain resets the idle clock so long-running tool
+          // sequences no longer time out at a fixed 60s. A hard ceiling
+          // bounds the total wait absolutely — even continuous heartbeats
+          // cannot keep a stuck tool call running forever.
+          const idleTimeoutMs = 60_000;       // reset on each task_progress
+          const hardCeilingMs = 600_000;      // absolute upper bound (10 min)
+          const pollIntervalMs = 500;
           let replyContent: string | null = null;
           let retriedAfterTimeout = false;
+          const overallStart = Date.now();
 
           // eslint-disable-next-line no-constant-condition
           while (true) {
-            const replyWaitStart = Date.now();
-            log.info(`AGT relay: waiting up to ${waitMaxMs / 1000}s for reply from '${agentName}'...`);
+            let replyWaitStart = Date.now();
+            log.info(`AGT relay: waiting up to ${idleTimeoutMs / 1000}s idle / ${hardCeilingMs / 1000}s total for reply from '${agentName}'...`);
 
-            while (Date.now() - replyWaitStart < waitMaxMs) {
+            while (
+              Date.now() - replyWaitStart < idleTimeoutMs &&
+              Date.now() - overallStart < hardCeilingMs
+            ) {
               // Check inbox for a reply from this target, skipping protocol messages
               const replyIdx = agtInbox.findIndex((m) => {
                 if (m.from_amid !== targetAmid && m.from_agent !== agentName) return false;
-                // Skip Signal Protocol handshake messages (ACCEPT, KNOCK, KEY_EXCHANGE)
+                // Skip Signal Protocol handshake + heartbeat messages
                 const mt = m.message_type || "";
-                if (mt === "ACCEPT" || mt === "KNOCK" || mt === "KEY_EXCHANGE") return false;
+                if (mt === "ACCEPT" || mt === "KNOCK" || mt === "KEY_EXCHANGE" || mt === "task_progress") return false;
                 // Also check content for JSON protocol messages
                 if (typeof m.content === "string") {
                   try {
                     const parsed = JSON.parse(m.content);
-                    if (parsed.type === "ACCEPT" || parsed.type === "KNOCK" || parsed.type === "KEY_EXCHANGE") return false;
+                    if (parsed.type === "ACCEPT" || parsed.type === "KNOCK" || parsed.type === "KEY_EXCHANGE" || parsed.type === "task_progress") return false;
                   } catch { /* not JSON, treat as real content */ }
                 }
                 return true;
@@ -519,7 +533,7 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
                 replyContent = typeof reply.content === "string"
                   ? reply.content
                   : JSON.stringify(reply.content);
-                log.info(`AGT relay: got reply from '${agentName}' after ${((Date.now() - replyWaitStart) / 1000).toFixed(1)}s`);
+                log.info(`AGT relay: got reply from '${agentName}' after ${((Date.now() - overallStart) / 1000).toFixed(1)}s`);
                 break;
               }
               // Drain protocol messages to keep inbox clean
@@ -533,6 +547,46 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
                 }
               }
               if (drained > 0) deps.notifyConsumed?.("protocol_drain", drained);
+
+              // Drain task_progress heartbeats and reset the idle clock for
+              // every one we see — sub-agent is signalling "still working".
+              let progressDrained = 0;
+              let lastProgressStage: string | undefined;
+              let lastProgressElapsed: number | undefined;
+              for (let i = agtInbox.length - 1; i >= 0; i--) {
+                const m = agtInbox[i];
+                if (m.from_amid !== targetAmid && m.from_agent !== agentName) continue;
+                let isProgress = m.message_type === "task_progress";
+                let parsed: any = null;
+                if (typeof m.content === "string") {
+                  try {
+                    parsed = JSON.parse(m.content);
+                    if (parsed?.type === "task_progress") isProgress = true;
+                  } catch { /* not JSON */ }
+                } else if (typeof m.content === "object" && m.content !== null) {
+                  parsed = m.content;
+                  if (parsed?.type === "task_progress") isProgress = true;
+                }
+                if (!isProgress) continue;
+                if (parsed) {
+                  lastProgressStage = String(parsed.stage ?? "");
+                  if (typeof parsed.elapsed_seconds === "number") {
+                    lastProgressElapsed = parsed.elapsed_seconds;
+                  }
+                }
+                agtInbox.splice(i, 1);
+                progressDrained++;
+              }
+              if (progressDrained > 0) {
+                deps.notifyConsumed?.("progress_drain", progressDrained);
+                replyWaitStart = Date.now();
+                log.info(
+                  `AGT relay: '${agentName}' still working ` +
+                  `(stage=${lastProgressStage ?? "?"}, ` +
+                  `elapsed=${lastProgressElapsed ?? "?"}s, ` +
+                  `progress_pings=${progressDrained}) — extending idle wait`,
+                );
+              }
               await new Promise((r) => setTimeout(r, pollIntervalMs));
             }
 
@@ -546,7 +600,7 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
             // race where parent's discovery happened during the gap between old
             // pod terminating and new pod re-registering its identity.
             const previousAmid = targetAmid!;
-            log.warn(`AGT relay: no reply from '${agentName}' within ${waitMaxMs / 1000}s — clearing cache and re-discovering (target may have been recycled during a rollout)`);
+            log.warn(`AGT relay: no reply from '${agentName}' within ${idleTimeoutMs / 1000}s idle (or ${hardCeilingMs / 1000}s ceiling) — clearing cache and re-discovering (target may have been recycled during a rollout)`);
             nameToAmid.delete(agentName);
             amidToName.delete(previousAmid);
             let freshAmid: string | undefined;
@@ -672,6 +726,8 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
           "handoff:workspace_inject", "handoff:workspace_inject_ack",
           "handoff:resume", "handoff:resume_ack",
           "file_transfer_ack",
+          // Heartbeats — drained by mesh_send wait loop; never user-visible.
+          "task_progress", "offload_progress",
         ]);
 
         const visible = agtInbox.filter((m) => {

--- a/runtimes/openclaw/src/core/agt-tools/agt.ts
+++ b/runtimes/openclaw/src/core/agt-tools/agt.ts
@@ -38,6 +38,7 @@ import {
   resolveAmidByName as _resolveAmidByName,
 } from "../amid-cache.js";
 import { safeJson } from "../safe-json.js";
+import { validateMeshPayload } from "../mesh-payload-guard.js";
 import type { HandoffProgress, AgtInboxEntry } from "../agt-handoff.js";
 
 // Re-suppress unused warnings for imports retained for symmetry with plugin.ts.
@@ -67,6 +68,34 @@ export interface AgtToolsDeps {
   log: { info: (m: string) => void; warn: (m: string) => void };
   bannerAlreadyPrinted: boolean;
   inbox: AgtInboxEntry[];
+  /**
+   * Inbox + gateway diagnostics. Surfaced inside `azureclaw_mesh_inbox`
+   * responses so the LLM (and operators triaging "inbox empty"-style
+   * reports) can distinguish a never-arrived message from one that the
+   * agent already received and consumed on a prior turn, vs a gateway
+   * restart that wiped the in-memory buffer. Mutated by sites that
+   * remove entries directly from `inbox` (mesh_send reply waiter,
+   * protocol-message scrubber); read-only here.
+   */
+  diagnostics?: () => {
+    gateway_instance_id: string;
+    gateway_started_at: string;
+    received_total: number;
+    consumed_by_send_wait: number;
+    consumed_by_protocol_drain: number;
+    read_total: number;
+    last_received_at: string | null;
+    last_read_at: string | null;
+  };
+  /** Mark all currently-unread inbox entries as read, bumping read_total. */
+  markRead?: (ids: string[]) => void;
+  /**
+   * Notify diagnostics that entries were removed from the inbox by an
+   * internal consumer (mesh_send reply waiter, protocol scrubber, file
+   * transfer ack handler). Index sites that do `agtInbox.splice(...)`
+   * bypass `pushInbox` so counters would otherwise drift.
+   */
+  notifyConsumed?: (kind: "send_wait" | "protocol_drain", count: number) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   meshClient: () => any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -296,7 +325,7 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
   api.registerTool({
     name: "azureclaw_mesh_send",
     label: "Send Mesh Task",
-    description: "Send a task to a sub-agent via AGT mesh (E2E encrypted relay). Sub-agents have isolated filesystems — include any file contents the agent needs directly in the message body. Ask the agent to return its output as text in the reply. You can also instruct sub-agents to forward results to each other directly (they have peer-to-peer mesh access). Automatically retries registry discovery and prekey exchange for as long as the sub-agent pod is alive; aborts only if the pod reaches Failed/Terminating/Exited, the sandbox is deleted, or meshSend returns a non-transient error. Then waits up to 5.5 minutes for the reply. If no reply arrives, check azureclaw_mesh_inbox later.",
+    description: "Send a TEXT/JSON task to a sub-agent via AGT mesh (E2E encrypted relay). Sub-agents have isolated filesystems — include any data the agent needs directly in the message body. To send a FILE / IMAGE / BINARY, use `azureclaw_mesh_transfer_file` instead — peer agents cannot read your /sandbox or /tmp paths, so a hand-crafted file_transfer envelope with placeholder file_data will be rejected by the payload guard. Plain JSON metadata and free-form text are accepted. Automatically retries registry discovery and prekey exchange for as long as the sub-agent pod is alive; aborts only if the pod reaches Failed/Terminating/Exited, the sandbox is deleted, or meshSend returns a non-transient error. Then waits up to 5.5 minutes for the reply. If no reply arrives, check azureclaw_mesh_inbox later.",
     parameters: {
       type: "object",
       properties: {
@@ -315,6 +344,18 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
       if (process.env.OFFLOAD_REQUEST_ID && agentName !== "parent") {
         log.warn(`azureclaw_mesh_send: offload mode — rewriting to_agent '${agentName}' → 'parent'`);
         agentName = "parent";
+      }
+
+      // Guard: reject malformed file_transfer envelopes / cross-container
+      // path references before they hit the wire. The peer agent runs in a
+      // separate container and cannot read this filesystem.
+      const guardErr = validateMeshPayload(msgContent, { transferToolName: "azureclaw_mesh_transfer_file" });
+      if (guardErr) {
+        log.warn(`azureclaw_mesh_send: payload guard rejected — ${guardErr.slice(0, 160)}`);
+        return { content: [{ type: "text", text: safeJson({
+          error: guardErr,
+          to_agent: agentName,
+        }) }] };
       }
 
       // ── Primary path: AGT SDK relay (E2E encrypted) ──
@@ -474,6 +515,7 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
               });
               if (replyIdx >= 0) {
                 const reply = agtInbox.splice(replyIdx, 1)[0];
+                deps.notifyConsumed?.("send_wait", 1);
                 replyContent = typeof reply.content === "string"
                   ? reply.content
                   : JSON.stringify(reply.content);
@@ -481,13 +523,16 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
                 break;
               }
               // Drain protocol messages to keep inbox clean
+              let drained = 0;
               for (let i = agtInbox.length - 1; i >= 0; i--) {
                 const m = agtInbox[i];
                 if ((m.from_amid === targetAmid || m.from_agent === agentName) &&
                     (m.message_type === "ACCEPT" || m.message_type === "KNOCK" || m.message_type === "KEY_EXCHANGE")) {
                   agtInbox.splice(i, 1);
+                  drained++;
                 }
               }
+              if (drained > 0) deps.notifyConsumed?.("protocol_drain", drained);
               await new Promise((r) => setTimeout(r, pollIntervalMs));
             }
 
@@ -580,15 +625,173 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
   api.registerTool({
     name: "azureclaw_mesh_inbox",
     label: "Check Mesh Inbox",
-    description: "Check your AGT mesh inbox for responses from sub-agents. Returns messages received via the E2E encrypted AGT relay and any router-level messages.",
-    parameters: { type: "object", properties: {} },
-    async execute(_id: string, _params: Record<string, unknown>) {
+    description:
+      "Read messages received via the E2E encrypted AGT mesh inbox. ALWAYS call " +
+      "this tool whenever you need to know whether a peer has sent you anything — " +
+      "do NOT rely on what you remember from previous turns, because new messages " +
+      "may have arrived since then. By default the tool is *peek-only* and shows " +
+      "only unread entries; messages stay in the inbox so you can read them again. " +
+      "Pass mark_read=true once you have acted on the contents to flag them as " +
+      "seen, or unread_only=false to also show entries you have already read on " +
+      "earlier turns. The response includes a `diagnostics` block with the " +
+      "gateway instance id and counters so you can tell apart 'no message has " +
+      "ever arrived' from 'I already consumed the message earlier'.",
+    parameters: {
+      type: "object",
+      properties: {
+        mark_read: {
+          type: "boolean",
+          description: "When true, flag the returned entries as read so the next call (with default unread_only=true) won't re-list them. The entries themselves stay in the inbox.",
+        },
+        unread_only: {
+          type: "boolean",
+          description: "Default true — only return entries with no read_at timestamp. Set false to also see entries you already read on earlier turns.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of entries to return. Default 50.",
+        },
+      },
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
       try {
-        // Collect messages from both sources
-        const agtMessages = agtInbox.splice(0, agtInbox.length); // drain AGT buffer
+        const markRead = params.mark_read === true;
+        const unreadOnly = params.unread_only !== false; // default true
+        const limit = typeof params.limit === "number" && params.limit > 0
+          ? Math.floor(params.limit)
+          : 50;
 
-        // Clear the MEMORY.md inbox notification since we've drained messages
-        if (agtMessages.length > 0) {
+        // ── 1. Filter out internal protocol/handshake messages from the
+        //      view. They stay in the array (the mesh_send reply waiter
+        //      and handoff orchestration scrub them on their own cadence)
+        //      but the LLM never needs to see them.
+        const INTERNAL_TYPES = new Set([
+          "handoff_transfer", "handoff_verification", "handoff_ready",
+          "handoff:interrupt", "handoff:interrupt_ack",
+          "handoff:workspace_request", "handoff:workspace_response",
+          "handoff:workspace_inject", "handoff:workspace_inject_ack",
+          "handoff:resume", "handoff:resume_ack",
+          "file_transfer_ack",
+        ]);
+
+        const visible = agtInbox.filter((m) => {
+          try {
+            const parsed = typeof m.content === "string" ? JSON.parse(m.content) : m.content;
+            if (INTERNAL_TYPES.has(parsed?.type)) return false;
+          } catch { /* not JSON — keep */ }
+          if (m.message_type && INTERNAL_TYPES.has(m.message_type)) return false;
+          return true;
+        });
+
+        const filtered = unreadOnly ? visible.filter((m) => !m.read_at) : visible;
+
+        // Take the most recent `limit` entries (chronological order kept).
+        const slice = filtered.slice(-limit);
+
+        // Auto-decode file_transfer messages so the LLM sees a readable
+        // representation. The original entry retains its raw content.
+        // Two forms are handled:
+        //   (a) Gateway-rewritten: {type, file_name, saved_to, size_bytes, ...}
+        //       — the gateway has already base64-decoded and written the
+        //       file to /sandbox/.openclaw/workspace/incoming/. Lift the
+        //       saved path so the LLM can `cat` it; inline small text.
+        //   (b) Inline file_data: legacy/raw form before gateway rewrite.
+        const decoded = slice.map((m) => {
+          try {
+            const parsed = typeof m.content === "string" ? JSON.parse(m.content) : m.content;
+            if (parsed?.type === "file_transfer" && parsed?.saved_to && parsed?.file_name) {
+              const sizeBytes = typeof parsed.size_bytes === "number" ? parsed.size_bytes : 0;
+              let inlined: string | null = null;
+              if (sizeBytes > 0 && sizeBytes < 100 * 1024) {
+                try {
+                  // eslint-disable-next-line @typescript-eslint/no-require-imports
+                  const fs = require("node:fs");
+                  const buf = fs.readFileSync(parsed.saved_to);
+                  if (!buf.some((b: number) => b === 0)) {
+                    inlined = buf.toString("utf-8");
+                  }
+                } catch { /* fall through */ }
+              }
+              return {
+                id: m.id,
+                from_amid: m.from_amid,
+                from_agent: m.from_agent,
+                timestamp: m.timestamp,
+                read_at: m.read_at,
+                source: "agt_relay_e2e",
+                message_type: "file_transfer",
+                file_name: parsed.file_name,
+                saved_to: parsed.saved_to,
+                file_size_bytes: sizeBytes,
+                description: parsed.description || "",
+                content: inlined != null
+                  ? inlined
+                  : `[binary or large file: ${parsed.file_name}, ${sizeBytes} bytes — read with: cat ${parsed.saved_to}]`,
+              };
+            }
+            if (parsed?.type === "file_transfer" && parsed?.file_data && parsed?.file_name) {
+              const buf = Buffer.from(parsed.file_data, "base64");
+              const isText = !buf.some((b: number) => b === 0);
+              return {
+                id: m.id,
+                from_amid: m.from_amid,
+                from_agent: m.from_agent,
+                timestamp: m.timestamp,
+                read_at: m.read_at,
+                source: "agt_relay_e2e",
+                message_type: "file_transfer",
+                file_name: parsed.file_name,
+                file_size_bytes: buf.length,
+                content: isText
+                  ? buf.toString("utf-8")
+                  : `[binary file: ${parsed.file_name}, ${buf.length} bytes — auto-save pending; re-check mesh_inbox for saved_to path]`,
+              };
+            }
+          } catch { /* fall through */ }
+          return {
+            id: m.id,
+            from_amid: m.from_amid,
+            from_agent: m.from_agent,
+            timestamp: m.timestamp,
+            read_at: m.read_at,
+            source: "agt_relay_e2e",
+            message_type: m.message_type || "message",
+            content: m.content,
+          };
+        });
+
+        // ── 2. Optional router-level inbox merge (best effort).
+        let routerMessages: any[] = [];
+        try {
+          const routerResult = await routerCall("GET", "/agt/mesh/inbox");
+          routerMessages = routerResult.messages || [];
+        } catch {
+          // router inbox unavailable — AGT-only view is fine
+        }
+
+        // ── 3. Mark returned AGT entries as read (in-place). We only
+        //      flip read_at for entries that were actually returned and
+        //      currently have no read_at, so a subsequent unread_only
+        //      query becomes empty rather than re-listing the same items.
+        if (markRead) {
+          const now = new Date().toISOString();
+          const returnedIds = new Set(decoded.map((d) => d.id));
+          const newlyRead: string[] = [];
+          for (const m of agtInbox) {
+            if (returnedIds.has(m.id) && !m.read_at) {
+              m.read_at = now;
+              newlyRead.push(m.id);
+            }
+          }
+          if (deps.markRead && newlyRead.length > 0) {
+            try { deps.markRead(newlyRead); } catch { /* best effort */ }
+          }
+        }
+
+        // ── 4. Tidy MEMORY.md inbox banner once the LLM has acknowledged
+        //      receipt by calling the tool. Was previously gated on a
+        //      drain-everything path; now also covers peek+mark_read.
+        if (markRead && decoded.length > 0) {
           try {
             const fs = await import("node:fs/promises");
             const memPath = process.env.MEMORY_FILE_PATH || "/home/user/MEMORY.md";
@@ -603,71 +806,26 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
           } catch { /* best effort */ }
         }
 
-        // Also get any router-level messages (fallback / auto-reply)
-        let routerMessages: any[] = [];
-        try {
-          const routerResult = await routerCall("GET", "/agt/mesh/inbox");
-          routerMessages = routerResult.messages || [];
-        } catch {
-          // Router inbox unavailable — use AGT only
-        }
-
-        // Merge and deduplicate (prefer AGT source)
-        // Filter out internal protocol messages — only show human-readable content
-        const INTERNAL_TYPES = new Set([
-          "handoff_transfer", "handoff_verification", "handoff_ready",
-          "handoff:interrupt", "handoff:interrupt_ack",
-          "handoff:workspace_request", "handoff:workspace_response",
-          "handoff:workspace_inject", "handoff:workspace_inject_ack",
-          "handoff:resume", "handoff:resume_ack",
-          "file_transfer_ack",
-        ]);
-
-        const userMessages = agtMessages.filter((m: any) => {
-          try {
-            const parsed = typeof m.content === "string" ? JSON.parse(m.content) : m.content;
-            return !INTERNAL_TYPES.has(parsed?.type);
-          } catch { return true; } // If can't parse, keep it
-        });
-
-        // Auto-decode file_transfer messages so LLM sees readable content
-        const decoded = userMessages.map((m: any) => {
-          try {
-            const parsed = typeof m.content === "string" ? JSON.parse(m.content) : m.content;
-            if (parsed?.type === "file_transfer" && parsed?.file_data && parsed?.file_name) {
-              const buf = Buffer.from(parsed.file_data, "base64");
-              const isText = !buf.some((b: number) => b === 0); // null bytes → binary
-              return {
-                ...m,
-                source: "agt_relay_e2e",
-                message_type: "file_transfer",
-                file_name: parsed.file_name,
-                file_size_bytes: buf.length,
-                content: isText
-                  ? buf.toString("utf-8")
-                  // Binary file still carries raw bytes here, meaning the
-                  // auto-save handler (plugin.ts ~2152) hasn't overwritten
-                  // this entry yet — so we intentionally do NOT claim a
-                  // save path. The next mesh_inbox call will reflect the
-                  // real `saved_to` once the handler finishes.
-                  : `[binary file: ${parsed.file_name}, ${buf.length} bytes — auto-save pending; re-check mesh_inbox for saved_to path]`,
-              };
-            }
-          } catch { /* fall through */ }
-          return { ...m, source: "agt_relay_e2e" };
-        });
+        // Snapshot diagnostics last so counters reflect this call too.
+        const diag = deps.diagnostics ? deps.diagnostics() : undefined;
 
         const allMessages = [
           ...decoded,
           ...routerMessages.map((m: any) => ({ ...m, source: "router_http" })),
         ];
 
+        const unreadCount = visible.filter((m) => !m.read_at).length;
+        const totalVisible = visible.length;
+
         return { content: [{ type: "text", text: JSON.stringify({
           count: allMessages.length,
+          unread_count: unreadCount,
+          total_in_inbox: totalVisible,
           agt_relay_count: decoded.length,
           router_count: routerMessages.length,
-          filtered_protocol_messages: agtMessages.length - userMessages.length,
+          filter: { unread_only: unreadOnly, limit, mark_read: markRead },
           messages: allMessages,
+          diagnostics: diag,
         }, null, 2) }] };
       } catch (e: any) {
         return { content: [{ type: "text", text: `Inbox check failed: ${e.message}` }] };
@@ -812,6 +970,7 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
                 ackError = ackMsg?.error || "";
               } catch { ackReceived = true; }
               agtInbox.splice(ackIdx, 1);
+              deps.notifyConsumed?.("protocol_drain", 1);
               break;
             }
             await new Promise(r => setTimeout(r, 500));
@@ -841,6 +1000,68 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
           error: `File transfer failed: ${e.message}`,
         }, null, 2) }] };
       }
+    },
+  });
+
+  api.registerTool({
+    name: "telegram_status",
+    label: "Send Telegram Status",
+    description: "Send a short status update to the user's Telegram chat configured for this sandbox. Use this for live progress pings during long-running multi-agent tasks (e.g. 'analyst done — 8 sources, 4 platforms scored'). Takes only the text — the chat ID is read from the sandbox's TELEGRAM_ALLOW_FROM env var (configured at `azureclaw up` time). No need to specify channel routing or chat IDs. Returns delivery status without leaking the bot token.",
+    parameters: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "The status message to send (≤4096 chars). Plain text or simple emoji are fine." },
+      },
+      required: ["text"],
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const text = String(params.text || "").trim();
+      if (!text) {
+        return { content: [{ type: "text", text: safeJson({ error: "telegram_status: empty text" }) }] };
+      }
+      const tgToken = process.env.TELEGRAM_BOT_TOKEN;
+      const tgAllowFrom = process.env.TELEGRAM_ALLOW_FROM;
+      if (!tgToken || !tgAllowFrom) {
+        return { content: [{ type: "text", text: safeJson({
+          error: "telegram_status: Telegram is not configured for this sandbox",
+          hint: "Run `azureclaw credentials update <name> --telegram-token <token> --telegram-chat-id <id>` to enable.",
+        }) }] };
+      }
+      const chatIds = tgAllowFrom.split(",").map((s: string) => s.trim()).filter(Boolean);
+      if (chatIds.length === 0) {
+        return { content: [{ type: "text", text: safeJson({ error: "telegram_status: TELEGRAM_ALLOW_FROM is empty" }) }] };
+      }
+      const truncated = text.length > 4096 ? text.slice(0, 4093) + "..." : text;
+      const results: Array<{ chat_id: string; ok: boolean; status?: number; error?: string }> = [];
+      for (const chatId of chatIds) {
+        try {
+          const tgResp = await fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ chat_id: chatId, text: truncated }),
+          });
+          if (tgResp.ok) {
+            results.push({ chat_id: chatId, ok: true });
+          } else {
+            // Sanitize: strip the token from any echoed body before surfacing.
+            const body = await tgResp.text().catch(() => "");
+            const sanitized = body.replace(tgToken, "[REDACTED]").slice(0, 200);
+            results.push({ chat_id: chatId, ok: false, status: tgResp.status, error: sanitized });
+            log.warn(`telegram_status: HTTP ${tgResp.status} for chat ${chatId}`);
+          }
+        } catch (e: any) {
+          const msg = String(e?.message || e).replace(tgToken, "[REDACTED]");
+          results.push({ chat_id: chatId, ok: false, error: msg });
+          log.warn(`telegram_status: send error for chat ${chatId}: ${msg}`);
+        }
+      }
+      const okCount = results.filter((r) => r.ok).length;
+      return { content: [{ type: "text", text: safeJson({
+        status: okCount === results.length ? "delivered" : okCount > 0 ? "partial" : "failed",
+        delivered: okCount,
+        total: results.length,
+        results,
+      }) }] };
     },
   });
 

--- a/runtimes/openclaw/src/core/amid-cache.ts
+++ b/runtimes/openclaw/src/core/amid-cache.ts
@@ -46,6 +46,15 @@ export function getCachedAmid(name: string): string | undefined {
   return nameToAmid.get(name);
 }
 
+// F7: Last-known-good fallback. Returns the cached AMID for `name` even if
+// the TTL has expired. Used by send/transfer paths after the registry retry
+// budget is exhausted: if the peer was reachable recently, try its last AMID
+// rather than failing the tool call. If the peer truly died, meshClient.send
+// will fail fast and the caller surfaces the error to the LLM.
+export function getStaleAmid(name: string): string | undefined {
+  return nameToAmid.get(name);
+}
+
 export function setCachedAmid(name: string, amid: string): void {
   nameToAmid.set(name, amid);
   nameToAmidTs.set(name, Date.now());

--- a/runtimes/openclaw/src/core/mesh-payload-guard.ts
+++ b/runtimes/openclaw/src/core/mesh-payload-guard.ts
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Mesh-send payload guard.
+//
+// Demo-day failure mode: the LLM constructs a `mesh_send` content that
+// either (a) advertises a `file_transfer` with placeholder text where
+// real base64 should be (`<base64-image-data>`, `<base64-bytes>`,
+// `<base64>`), (b) advertises a `file_transfer` with no `file_data` at
+// all, or (c) sends a JSON object whose only file reference is a local
+// container path the peer cannot resolve (`/sandbox/...`, `/tmp/...`)
+// without inlining the bytes.
+//
+// Recipient agents run in their own containers — they cannot read
+// `/sandbox/<peer>/...` no matter what the path string says. The right
+// path is the `mesh_transfer_file` tool (sub-agent) or
+// `azureclaw_mesh_transfer_file` (parent), which read-and-base64-encode
+// the file and send a proper `file_transfer` envelope.
+//
+// `validateMeshPayload(content, hint)` returns `null` when the payload
+// looks safe to send and an error string (with the hint to point at
+// the right tool) otherwise. The caller should surface the error
+// string back to the LLM verbatim so the next round corrects course.
+
+const PLACEHOLDERS = new Set([
+  "<base64>",
+  "<base64-data>",
+  "<base64-bytes>",
+  "<base64-image-data>",
+  "<base64-bytes-here>",
+  "<file_data>",
+  "<your-base64-here>",
+]);
+
+const LOCAL_PATH_KEYS = new Set([
+  "file_path",
+  "filepath",
+  "artifact_path",
+  "hero_image_path",
+  "image_path",
+  "chart_path",
+  "path",
+]);
+
+const LOCAL_PATH_PREFIXES = ["/sandbox/", "/tmp/", "/mnt/data/", "/workspace/"];
+
+function looksLikeLocalPath(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  return LOCAL_PATH_PREFIXES.some((p) => value.startsWith(p));
+}
+
+function isPlaceholder(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const lower = value.trim().toLowerCase();
+  if (PLACEHOLDERS.has(lower)) return true;
+  // Generic catch — angle-bracketed token where real base64 cannot have <>.
+  return /^<[a-z0-9_\- ]+>$/i.test(lower);
+}
+
+function decodesAsBase64(value: string): boolean {
+  if (!value) return false;
+  // Reject angle brackets — base64 alphabet is A-Za-z0-9+/=.
+  if (/[<>]/.test(value)) return false;
+  try {
+    const buf = Buffer.from(value, "base64");
+    return buf.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export interface MeshGuardOptions {
+  /** Tool name to suggest in the error message (varies parent vs sub-agent). */
+  transferToolName: string;
+}
+
+/**
+ * Validate a mesh_send payload string.
+ *
+ * Returns `null` when the payload looks safe to send across containers,
+ * or an error string (with remediation hint) otherwise.
+ *
+ * @param content - the mesh_send `content` / `message` string the LLM produced.
+ * @param opts.transferToolName - which file-transfer tool to point at.
+ */
+export function validateMeshPayload(
+  content: unknown,
+  opts: MeshGuardOptions,
+): string | null {
+  if (typeof content !== "string" || content.length === 0) {
+    return null; // empty / non-string handled elsewhere
+  }
+
+  // Cheap early exit — if it doesn't look like JSON, it's free-form text
+  // (status / prose) which we explicitly do NOT want to false-reject.
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return null;
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null; // malformed JSON — let the receiver deal with it
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  // ── 1. Explicit file_transfer envelope ────────────────────────────
+  if (parsed.type === "file_transfer") {
+    const fileData = parsed.file_data;
+
+    if (fileData == null || (typeof fileData === "string" && fileData.length === 0)) {
+      return (
+        "REJECTED: file_transfer envelope is missing file_data. " +
+        "Peer agents run in separate containers — they cannot read " +
+        `your local /sandbox or /tmp paths. Use the \`${opts.transferToolName}\` ` +
+        "tool to send a real file (it will read and base64-encode the bytes for you), " +
+        "or inline the actual base64 in `file_data` if you produced the bytes in-memory."
+      );
+    }
+
+    if (typeof fileData !== "string") {
+      return (
+        "REJECTED: file_transfer.file_data must be a base64 string. " +
+        `Use the \`${opts.transferToolName}\` tool instead of constructing this envelope by hand.`
+      );
+    }
+
+    if (isPlaceholder(fileData)) {
+      return (
+        "REJECTED: file_transfer.file_data contains a placeholder " +
+        `(\`${fileData}\`) instead of real base64 bytes. The recipient cannot ` +
+        `decode this. Use the \`${opts.transferToolName}\` tool to send the actual ` +
+        "file — it reads the bytes and base64-encodes them for you."
+      );
+    }
+
+    if (!decodesAsBase64(fileData)) {
+      return (
+        "REJECTED: file_transfer.file_data is not valid base64. " +
+        `Use the \`${opts.transferToolName}\` tool instead of constructing the envelope by hand.`
+      );
+    }
+
+    // size_bytes sanity check (best effort — non-fatal mismatch is OK).
+    return null;
+  }
+
+  // ── 2. Plain JSON metadata referencing a local container path ────
+  // Only reject when the value clearly points into the sender's
+  // container filesystem AND there is no inlined data the peer could
+  // use instead. Plain JSON like {"summary":"see /sandbox/xyz"} that
+  // doesn't use a known *_path key is accepted (user prose).
+  for (const [k, v] of Object.entries(parsed)) {
+    if (LOCAL_PATH_KEYS.has(k) && looksLikeLocalPath(v)) {
+      const hasInline =
+        typeof parsed.file_data === "string" && parsed.file_data.length > 0;
+      const hasContent =
+        typeof parsed.content === "string" && parsed.content.length > 0;
+      if (!hasInline && !hasContent) {
+        return (
+          `REJECTED: payload references a local container path (\`${k}: ${v}\`) ` +
+          "but contains no inlined data. Peer agents cannot read your filesystem. " +
+          `Use the \`${opts.transferToolName}\` tool to send the file, or inline ` +
+          "the bytes/text directly in the message."
+        );
+      }
+    }
+  }
+
+  return null;
+}

--- a/runtimes/openclaw/src/index.test.ts
+++ b/runtimes/openclaw/src/index.test.ts
@@ -1307,3 +1307,214 @@ describe("post-handoff sub-agent restore logic", () => {
     expect(toolResponse.display).toContain("Telegram");
   });
 });
+
+// ---------------------------------------------------------------------------
+// N. Mesh-send payload guard (rejects cross-container path references and
+//    placeholder file_transfer envelopes — see mesh-payload-guard.ts)
+// ---------------------------------------------------------------------------
+
+describe("mesh-payload-guard via azureclaw_mesh_send", () => {
+  let plugin: any;
+  let tools: Map<string, any>;
+
+  beforeEach(async () => {
+    process.env.AGT_SKIP_INIT = "1";
+    const mod = await import("./index.js");
+    plugin = mod.default;
+    const mock = createMockApi();
+    tools = mock.tools;
+    plugin.register(mock.api);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterEach(() => {
+    delete process.env.AGT_SKIP_INIT;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects file_transfer envelope with placeholder file_data", async () => {
+    const tool = tools.get("azureclaw_mesh_send")!;
+    const result = await tool.execute("id", {
+      to_agent: "writer",
+      content: JSON.stringify({
+        type: "file_transfer",
+        file_name: "hero.png",
+        file_data: "<base64-image-data>",
+      }),
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toContain("placeholder");
+    expect(parsed.error).toContain("azureclaw_mesh_transfer_file");
+  });
+
+  it("rejects file_transfer envelope with missing file_data", async () => {
+    const tool = tools.get("azureclaw_mesh_send")!;
+    const result = await tool.execute("id", {
+      to_agent: "writer",
+      content: JSON.stringify({ type: "file_transfer", file_name: "chart.png" }),
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toContain("missing file_data");
+  });
+
+  it("rejects payload referencing /sandbox/ path with no inlined data", async () => {
+    const tool = tools.get("azureclaw_mesh_send")!;
+    const result = await tool.execute("id", {
+      to_agent: "writer",
+      content: JSON.stringify({ artifact_path: "/sandbox/data.json" }),
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toContain("local container path");
+    expect(parsed.error).toContain("azureclaw_mesh_transfer_file");
+  });
+
+  it("does NOT reject plain text mentioning /sandbox/ path", async () => {
+    const tool = tools.get("azureclaw_mesh_send")!;
+    // Plain text — not a JSON object — must be allowed even when it
+    // mentions a /sandbox/... path. The downstream "AGT mesh not
+    // initialized" error proves the guard let the call through.
+    const result = await tool.execute("id", {
+      to_agent: "writer",
+      content: "I saved the chart to /sandbox/.openclaw/workspace/chart.png and will follow up.",
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    // The guard allowed it through — what we get back is the AGT-init
+    // error (no mesh client in this test), NOT a guard rejection.
+    expect(parsed.error).toContain("AGT mesh not initialized");
+  });
+
+  it("does NOT reject plain JSON metadata without local-path artifact keys", async () => {
+    const tool = tools.get("azureclaw_mesh_send")!;
+    const result = await tool.execute("id", {
+      to_agent: "viz",
+      content: JSON.stringify({ trends: ["a", "b"], metrics: { foo: 1 } }),
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toContain("AGT mesh not initialized");
+  });
+
+  it("accepts a valid file_transfer envelope (real base64)", async () => {
+    const tool = tools.get("azureclaw_mesh_send")!;
+    const realB64 = Buffer.from("hello world", "utf-8").toString("base64");
+    const result = await tool.execute("id", {
+      to_agent: "writer",
+      content: JSON.stringify({
+        type: "file_transfer",
+        file_name: "note.txt",
+        file_data: realB64,
+        size_bytes: 11,
+      }),
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    // Guard allowed it through; the AGT-init error proves we got past.
+    expect(parsed.error).toContain("AGT mesh not initialized");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// N+1. telegram_status tool
+// ---------------------------------------------------------------------------
+
+describe("telegram_status tool", () => {
+  let plugin: any;
+  let tools: Map<string, any>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    process.env.AGT_SKIP_INIT = "1";
+    originalFetch = globalThis.fetch;
+    const mod = await import("./index.js");
+    plugin = mod.default;
+    const mock = createMockApi();
+    tools = mock.tools;
+    plugin.register(mock.api);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterEach(() => {
+    delete process.env.AGT_SKIP_INIT;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_ALLOW_FROM;
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("is registered as a tool", () => {
+    expect(tools.has("telegram_status")).toBe(true);
+    const tool = tools.get("telegram_status")!;
+    expect(tool.parameters.required).toEqual(["text"]);
+  });
+
+  it("returns config error when TELEGRAM_BOT_TOKEN is missing", async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_ALLOW_FROM;
+    const tool = tools.get("telegram_status")!;
+    const result = await tool.execute("id", { text: "hello" });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toContain("not configured");
+  });
+
+  it("returns empty-text error for blank input", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "T";
+    process.env.TELEGRAM_ALLOW_FROM = "1";
+    const tool = tools.get("telegram_status")!;
+    const result = await tool.execute("id", { text: "  " });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toContain("empty text");
+  });
+
+  it("uses TELEGRAM_ALLOW_FROM as the chat ID and posts to Telegram Bot API", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "BOT_TOKEN_SECRET_123";
+    process.env.TELEGRAM_ALLOW_FROM = "999111";
+    const calls: Array<{ url: string; body: any }> = [];
+    globalThis.fetch = (async (url: string, init: any) => {
+      calls.push({ url, body: JSON.parse(init.body) });
+      return { ok: true, status: 200 } as any;
+    }) as any;
+
+    const tool = tools.get("telegram_status")!;
+    const result = await tool.execute("id", { text: "🔍 analyst: searching" });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.status).toBe("delivered");
+    expect(parsed.delivered).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain("/sendMessage");
+    expect(calls[0].body.chat_id).toBe("999111");
+    expect(calls[0].body.text).toBe("🔍 analyst: searching");
+  });
+
+  it("redacts the bot token from error responses", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "BOT_TOKEN_SECRET_456";
+    process.env.TELEGRAM_ALLOW_FROM = "42";
+    globalThis.fetch = (async () => {
+      // Return a body that echoes the token back (Bot API does sometimes do this on 4xx)
+      return {
+        ok: false,
+        status: 401,
+        text: async () => "Unauthorized: token BOT_TOKEN_SECRET_456 invalid",
+      } as any;
+    }) as any;
+
+    const tool = tools.get("telegram_status")!;
+    const result = await tool.execute("id", { text: "test" });
+    const text = result.content[0].text;
+    expect(text).not.toContain("BOT_TOKEN_SECRET_456");
+    expect(text).toContain("[REDACTED]");
+    const parsed = JSON.parse(text);
+    expect(parsed.status).toBe("failed");
+  });
+
+  it("supports multiple chat IDs separated by commas", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "T";
+    process.env.TELEGRAM_ALLOW_FROM = "111,222,333";
+    const calls: any[] = [];
+    globalThis.fetch = (async (_url: string, init: any) => {
+      calls.push(JSON.parse(init.body));
+      return { ok: true, status: 200 } as any;
+    }) as any;
+
+    const tool = tools.get("telegram_status")!;
+    await tool.execute("id", { text: "x" });
+    expect(calls.map((c) => c.chat_id)).toEqual(["111", "222", "333"]);
+  });
+});

--- a/runtimes/openclaw/src/index.ts
+++ b/runtimes/openclaw/src/index.ts
@@ -139,7 +139,30 @@ let agtIdentity: any = null;
 let agtInitialized = false; // Module-level guard (supplemented by process-level guard below)
 
 // AGT message buffer — filled by onMessage handler, drained by mesh_inbox tool
-const agtInbox: Array<{ from_amid: string; from_agent: string; content: any; timestamp: string; id: string; message_type?: string }> = [];
+const agtInbox: Array<{ from_amid: string; from_agent: string; content: any; timestamp: string; id: string; message_type?: string; read_at?: string }> = [];
+
+// Inbox + gateway diagnostics. Surface in azureclaw_mesh_inbox responses so
+// the LLM (and operators triaging "inbox empty" reports) can distinguish:
+//   - never received   → received_total === 0
+//   - already consumed → received_total > 0 && current array is small/empty
+//   - gateway restart  → uptime small but received_total > 0 may be 0 anew
+// gatewayInstanceId regenerates per process; counters reset with it. Receivers
+// upstream (waitForMessage / mesh_send reply loop) MUST increment the
+// matching counter when they remove entries from the array directly.
+const gatewayInstanceId: string = (() => {
+  try { return crypto.randomUUID(); } catch { return `gw-${Date.now().toString(36)}`; }
+})();
+const gatewayStartedAt: string = new Date().toISOString();
+const inboxStats = {
+  received_total: 0,
+  consumed_by_send_wait: 0,
+  consumed_by_protocol_drain: 0,
+  read_total: 0,
+  // ISO timestamp of last successful agtInbox.push (any source)
+  last_received_at: null as string | null,
+  // ISO timestamp of last successful azureclaw_mesh_inbox tool invocation
+  last_read_at: null as string | null,
+};
 
 // AGT reconnect & heartbeat state
 let agtReconnectTimer: ReturnType<typeof setInterval> | null = null;
@@ -147,6 +170,24 @@ let agtInboxNotifyTimer: ReturnType<typeof setInterval> | null = null;
 let agtConnected = false;
 let agtReconnectFailures = 0;
 const AGT_RECONNECT_MAX_BACKOFF = 300_000; // 5 min cap
+
+// Centralised inbox push: keep counters in lockstep with array growth so
+// the inbox tool can report meaningful diagnostics without scanning every
+// entry. All onMessage / error / handoff sites must call this instead of
+// agtInbox.push directly.
+function pushInbox(entry: {
+  from_amid: string;
+  from_agent: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any;
+  timestamp: string;
+  id: string;
+  message_type?: string;
+}): void {
+  agtInbox.push(entry);
+  inboxStats.received_total += 1;
+  inboxStats.last_received_at = entry.timestamp;
+}
 
 // Offload request IDs currently being processed (either env-driven proactive
 // start or inbound offload_task). Prevents double-execution if the external
@@ -247,6 +288,13 @@ async function processTaskWithTools(
     setInterrupt: (req, reason) => {
       handoffInterruptRequested = req;
       handoffInterruptReason = reason;
+    },
+    inbox: agtInbox,
+    markRead: (ids) => {
+      if (ids.length > 0) {
+        inboxStats.read_total += ids.length;
+        inboxStats.last_read_at = new Date().toISOString();
+      }
     },
   }, log);
 }
@@ -458,7 +506,7 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
       const fromName = amidToName.get(fromAmid) || fromAmid.slice(0, 12);
       if (type === 'knock_rejected') {
         log.warn(`⛔ Message blocked from '${fromName}': KNOCK not accepted — ${detail}`);
-        agtInbox.push({
+        pushInbox({
           from_amid: fromAmid,
           from_agent: fromName,
           content: `⛔ MESSAGE BLOCKED: ${fromName} attempted to send a message but has no accepted KNOCK session. The message was rejected and not delivered.`,
@@ -469,7 +517,7 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
       } else {
         log.warn(`AGT E2E ${type} from '${fromName}' (${fromAmid.slice(0, 12)}): ${detail}`);
         pushTrustToRouter(fromName, -0.5);
-        agtInbox.push({
+        pushInbox({
           from_amid: fromAmid,
           from_agent: fromName,
           content: `⚠️ E2E DECRYPTION FAILURE: ${type} — ${detail}. Message was REJECTED (not delivered). This may indicate a session mismatch or tampering.`,
@@ -549,7 +597,7 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
                 log.warn(`Ed25519 signature INVALID from '${fromName}' — message accepted but trust penalized`);
                 pushSigningCounter("rejected");
                 pushTrustToRouter(fromName, -0.5);
-                agtInbox.push({
+                pushInbox({
                   from_amid: fromAmid,
                   from_agent: fromName,
                   content: `⚠️ SIGNATURE INVALID: Message from '${fromName}' has invalid Ed25519 signature. Possible tampering.`,
@@ -577,7 +625,7 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
         timestamp: new Date().toISOString(),
         id: `agt-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`,
       };
-      agtInbox.push(entry);
+      pushInbox(entry);
       log.info(`AGT relay message from ${sanitizeLog(fromName, 50)} (${fromAmid.slice(0, 12)}...): ${sanitizeLog(JSON.stringify(content), 200)}`);
 
       // ── mesh:ping — lightweight reachability probe used by mesh-plugin
@@ -2426,6 +2474,24 @@ const azureClawPlugin = definePluginEntry({
       log,
       bannerAlreadyPrinted,
       inbox: agtInbox,
+      diagnostics: () => ({
+        gateway_instance_id: gatewayInstanceId,
+        gateway_started_at: gatewayStartedAt,
+        received_total: inboxStats.received_total,
+        consumed_by_send_wait: inboxStats.consumed_by_send_wait,
+        consumed_by_protocol_drain: inboxStats.consumed_by_protocol_drain,
+        read_total: inboxStats.read_total,
+        last_received_at: inboxStats.last_received_at,
+        last_read_at: inboxStats.last_read_at,
+      }),
+      markRead: (ids) => {
+        inboxStats.read_total += ids.length;
+        inboxStats.last_read_at = new Date().toISOString();
+      },
+      notifyConsumed: (kind, count) => {
+        if (kind === "send_wait") inboxStats.consumed_by_send_wait += count;
+        else if (kind === "protocol_drain") inboxStats.consumed_by_protocol_drain += count;
+      },
       meshClient: () => agtMeshClient,
       identity: () => agtIdentity,
       sandboxName: () => agtSandboxName,

--- a/runtimes/openclaw/src/index.ts
+++ b/runtimes/openclaw/src/index.ts
@@ -157,6 +157,7 @@ const inboxStats = {
   received_total: 0,
   consumed_by_send_wait: 0,
   consumed_by_protocol_drain: 0,
+  consumed_by_progress_drain: 0,
   read_total: 0,
   // ISO timestamp of last successful agtInbox.push (any source)
   last_received_at: null as string | null,
@@ -259,7 +260,7 @@ import { discoverFoundryProject, type FoundryProjectInfo } from "./core/foundry-
 import { delegateToNativeAgent } from "./core/agt-task-delegate.js";
 import { meshSendWithIdentity, meshHandleTransportMessage, pendingTransfers, MESH_CHUNK_THRESHOLD, MESH_CHUNK_SIZE, MESH_MAX_CHUNKS, MESH_TRANSFER_TTL, type PendingMeshTransfer } from "./core/mesh-transport.js";
 import { TASK_TOOLS } from "./core/agt-task-tools.js";
-import { recordMeshSession as _recordMeshSession, agtReconnect as _agtReconnect, notifyInboxToMemory as _notifyInboxToMemory } from "./core/agt-heartbeat.js";
+import { recordMeshSession as _recordMeshSession, agtReconnect as _agtReconnect, notifyInboxToMemory as _notifyInboxToMemory, startTaskProgressHeartbeat } from "./core/agt-heartbeat.js";
 import { runOffloadTask as _runOffloadTask, startProactiveOffloadIfNeeded as _startProactiveOffloadIfNeeded } from "./core/agt-offload.js";
 import { processTaskWithTools as _processTaskWithTools } from "./core/agt-task-loop.js";
 import { runHandoffOrchestration as _runHandoffOrchestrationCore } from "./core/agt-handoff.js";
@@ -513,6 +514,19 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
           message_type: "security_event",
           timestamp: new Date().toISOString(),
           id: `agt-knock-${Date.now().toString(36)}`,
+        });
+      } else if (type === 'session_desync') {
+        // Vendor patch #11: ratchet desync is recoverable — local session was
+        // cleared, next mesh_send to this peer will trigger a fresh KNOCK.
+        // Do NOT penalize trust (this is a protocol issue, not a security event).
+        log.warn(`AGT session_desync with '${fromName}' (${fromAmid.slice(0, 12)}): ${detail} — session cleared, next send will rekey`);
+        pushInbox({
+          from_amid: fromAmid,
+          from_agent: fromName,
+          content: `⚠️ AGT session with ${fromName} was cleared due to ratchet desync (${detail}). The previous in-flight message was lost. Next mesh_send to this peer will re-establish a fresh encrypted session — please retry the message if it was important.`,
+          message_type: "session_event",
+          timestamp: new Date().toISOString(),
+          id: `agt-desync-${Date.now().toString(36)}`,
         });
       } else {
         log.warn(`AGT E2E ${type} from '${fromName}' (${fromAmid.slice(0, 12)}): ${detail}`);
@@ -777,7 +791,24 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
         try {
           // In-process tool-calling loop only. See offload path above for why
           // we deliberately skip `delegateToNativeAgent` here.
-          const llmResponse: string = await processTaskWithTools(taskContent, log);
+          //
+          // Heartbeat: send periodic `task_progress` pings to the originator
+          // so its mesh_send wait loop can extend the idle timer as long as
+          // we're making progress. Mirrors the offload path's
+          // `offload_progress` pings (`core/agt-offload.ts`). Cancel in
+          // finally — must run on success, failure, or thrown error.
+          const cancelHeartbeat = startTaskProgressHeartbeat(
+            fromAmid,
+            agtMeshClient,
+            agtSandboxName,
+            log,
+          );
+          let llmResponse: string;
+          try {
+            llmResponse = await processTaskWithTools(taskContent, log);
+          } finally {
+            cancelHeartbeat();
+          }
 
           // Send the response back via E2E encrypted relay
           await agtMeshClient.send(fromAmid, {
@@ -2480,6 +2511,7 @@ const azureClawPlugin = definePluginEntry({
         received_total: inboxStats.received_total,
         consumed_by_send_wait: inboxStats.consumed_by_send_wait,
         consumed_by_protocol_drain: inboxStats.consumed_by_protocol_drain,
+        consumed_by_progress_drain: inboxStats.consumed_by_progress_drain,
         read_total: inboxStats.read_total,
         last_received_at: inboxStats.last_received_at,
         last_read_at: inboxStats.last_read_at,
@@ -2491,6 +2523,7 @@ const azureClawPlugin = definePluginEntry({
       notifyConsumed: (kind, count) => {
         if (kind === "send_wait") inboxStats.consumed_by_send_wait += count;
         else if (kind === "protocol_drain") inboxStats.consumed_by_protocol_drain += count;
+        else if (kind === "progress_drain") inboxStats.consumed_by_progress_drain += count;
       },
       meshClient: () => agtMeshClient,
       identity: () => agtIdentity,

--- a/sandbox-images/openclaw/Dockerfile.base
+++ b/sandbox-images/openclaw/Dockerfile.base
@@ -95,15 +95,35 @@ ENV OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage
 # Use bash with pipefail so the `openclaw doctor … | tail -40` pipe surfaces
 # a non-zero exit code from doctor instead of being masked by tail's success.
 # Scoped to this RUN only — subsequent stages re-default to /bin/sh.
+COPY sandbox-images/openclaw/stage-extension-deps.sh /usr/local/bin/stage-extension-deps.sh
+RUN chmod +x /usr/local/bin/stage-extension-deps.sh
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /opt/openclaw-stage && \
     openclaw doctor --fix --non-interactive --yes 2>&1 | tail -40 && \
+    # Belt-and-suspenders: doctor pre-stages deps for *configured* plugins,
+    # but OpenClaw's own bundled chunks (e.g. dist/oauth-*.js, loaded by
+    # memory-core in the node-host) have static require chains into deps
+    # declared only by *unconfigured* extension manifests (e.g. xai →
+    # @mariozechner/pi-ai). Without this step the node-host crashes with
+    # "Cannot find module '@mariozechner/pi-ai/dist/oauth.js'" → no agent
+    # runs in either gateway or webchat. The helper takes the union of
+    # every bundled extension's declared dependencies and force-installs
+    # the missing ones into the stage tree.
+    /usr/local/bin/stage-extension-deps.sh && \
     chmod -R a+rX /opt/openclaw-stage && \
     staged_count=$(find /opt/openclaw-stage -mindepth 2 -maxdepth 2 -type d -name node_modules 2>/dev/null | wc -l) && \
     if [ "$staged_count" -gt 0 ]; then \
       echo "OpenClaw bundled-runtime-deps pre-staged: $(du -sh /opt/openclaw-stage | cut -f1) (${staged_count} version dirs)"; \
     else \
       echo "OpenClaw doctor completed cleanly with no staging required"; \
+    fi && \
+    # Verify the canonical missing-module case so future regressions fail
+    # the build instead of silently breaking the runtime.
+    stage_dir=$(find /opt/openclaw-stage -mindepth 1 -maxdepth 1 -type d | head -n1) && \
+    if [ -n "$stage_dir" ] && [ ! -f "$stage_dir/node_modules/@mariozechner/pi-ai/dist/oauth.js" ]; then \
+      echo "FATAL: @mariozechner/pi-ai/dist/oauth.js missing from stage tree after doctor + extension-deps fill"; \
+      exit 1; \
     fi
 SHELL ["/bin/sh", "-c"]
 

--- a/sandbox-images/openclaw/entrypoint.sh
+++ b/sandbox-images/openclaw/entrypoint.sh
@@ -12,37 +12,46 @@
 
 set -e
 
-# Make pre-staged OpenClaw bundled-runtime-deps discoverable. The base image
-# stages all bundled channel/plugin deps into /opt/openclaw-stage at build time
-# (full network); at runtime UID 1000 cannot reach npm registry directly because
-# of egress-guard, so we point OpenClaw's `installBundledRuntimeDeps` resolver at
-# the pre-populated tree. Set BEFORE any `openclaw …` invocation in this script
-# (parent gateway, sub-agent `openclaw agent --local`, doctor checks, etc.) so
-# they all hit the cached deps instead of attempting a 403-prone npm install.
+# Make pre-staged OpenClaw bundled-runtime-deps discoverable at runtime.
 #
-# The image rootfs is read-only, but OpenClaw 2026.4.x writes a
-# `.openclaw-runtime-deps.lock` sentinel inside the version-hash dir on first
-# resolve, so we mirror the staged tree onto the writable /tmp tmpfs and point
-# the env var there. /tmp is a 1GiB tmpfs (see pod spec); the staged tree is
-# ~500MiB so it fits with room to spare. cp -r is ~3-5s on tmpfs and only runs
-# once at container start.
+# Background. The base image bakes all bundled channel/plugin deps into
+# /opt/openclaw-stage at build time (full network); at runtime UID 1000
+# cannot reach npm directly because of egress-guard, so OpenClaw must
+# resolve every `require()` from local disk.
+#
+# Design contract (verified against OpenClaw 2026.4.27
+# dist/bundled-runtime-root-D11Fl_T4.js):
+#
+#   * `OPENCLAW_PLUGIN_STAGE_DIR` is a colon-separated *list* of base
+#     dirs (line ~666 of bundled-runtime-root: splits on `path.delimiter`).
+#   * All entries become NODE_PATH search roots (line ~1743:
+#     `registerBundledRuntimeDependencyNodePath`). Deps resolve from
+#     whichever root has them — read-only is fine.
+#   * The *last* entry is the install root: where the lock dir + retained
+#     manifest are written if (and only if) something is actually
+#     missing from the search roots (line ~1090: `externalRoots.at(-1)`).
+#   * `missingSpecs = deps.filter(dep => !hasDependencySentinel(searchRoots, dep))`
+#     (line ~1455). With everything pre-staged, `missingSpecs = []` and
+#     the install path (lock, npm spawn, manifest write) **never executes**.
+#
+# What this gives us:
+#   * /opt/openclaw-stage stays read-only at runtime — agent UID cannot
+#     tamper with bundled code (security posture: bundled TCB is immutable).
+#   * /tmp/openclaw-cache is a tiny tmpfs scratch area (~27 MiB observed:
+#     symlinks back into /opt + a few small NODE_PATH manifests). Fits in
+#     the 1 GiB /tmp tmpfs with a 36× safety margin.
+#   * No `cp -r` of the staged tree (saves 3-5 s of boot, ~1.8 GiB of
+#     tmpfs, and removes the previous "chmod -R u+w on stage" compromise).
+#
+# Order matters: read-only stage first, writable cache last.
 if [ -z "${OPENCLAW_PLUGIN_STAGE_DIR:-}" ] && [ -d /opt/openclaw-stage ]; then
-  if [ ! -d /tmp/openclaw-stage ]; then
-    cp -r /opt/openclaw-stage /tmp/openclaw-stage
-    # OpenClaw writes a `.openclaw-runtime-deps.lock` sentinel inside the
-    # version-hash dir on first plugin resolve. The agent process runs as the
-    # sandbox UID (1000 in AKS, 1000 via runuser in dev), so the staged tree
-    # must be writable by that UID. cp -r preserves the source mode (a+rX)
-    # and makes the new tree owned by whoever ran cp (root in dev,
-    # sandbox in AKS), so a `chmod u+w` alone is insufficient in dev mode.
-    # In dev mode chown to sandbox; in AKS the entrypoint already runs as
-    # sandbox so cp produced sandbox-owned files and chmod -R u+w suffices.
-    if [ "$(id -u)" = "0" ]; then
-      chown -R sandbox:sandbox /tmp/openclaw-stage 2>/dev/null || true
-    fi
-    chmod -R u+w /tmp/openclaw-stage 2>/dev/null || true
+  mkdir -p /tmp/openclaw-cache 2>/dev/null || true
+  # In dev mode entrypoint starts as root; in AKS it starts as sandbox.
+  # Ensure the cache dir is owned by the agent UID either way.
+  if [ "$(id -u)" = "0" ]; then
+    chown sandbox:sandbox /tmp/openclaw-cache 2>/dev/null || true
   fi
-  export OPENCLAW_PLUGIN_STAGE_DIR=/tmp/openclaw-stage
+  export OPENCLAW_PLUGIN_STAGE_DIR=/opt/openclaw-stage:/tmp/openclaw-cache
 fi
 
 # Default SANDBOX_NAME to a clean agent name (strip pod suffix from hostname)

--- a/sandbox-images/openclaw/entrypoint.sh
+++ b/sandbox-images/openclaw/entrypoint.sh
@@ -29,6 +29,17 @@ set -e
 if [ -z "${OPENCLAW_PLUGIN_STAGE_DIR:-}" ] && [ -d /opt/openclaw-stage ]; then
   if [ ! -d /tmp/openclaw-stage ]; then
     cp -r /opt/openclaw-stage /tmp/openclaw-stage
+    # OpenClaw writes a `.openclaw-runtime-deps.lock` sentinel inside the
+    # version-hash dir on first plugin resolve. The agent process runs as the
+    # sandbox UID (1000 in AKS, 1000 via runuser in dev), so the staged tree
+    # must be writable by that UID. cp -r preserves the source mode (a+rX)
+    # and makes the new tree owned by whoever ran cp (root in dev,
+    # sandbox in AKS), so a `chmod u+w` alone is insufficient in dev mode.
+    # In dev mode chown to sandbox; in AKS the entrypoint already runs as
+    # sandbox so cp produced sandbox-owned files and chmod -R u+w suffices.
+    if [ "$(id -u)" = "0" ]; then
+      chown -R sandbox:sandbox /tmp/openclaw-stage 2>/dev/null || true
+    fi
     chmod -R u+w /tmp/openclaw-stage 2>/dev/null || true
   fi
   export OPENCLAW_PLUGIN_STAGE_DIR=/tmp/openclaw-stage

--- a/sandbox-images/openclaw/stage-extension-deps.sh
+++ b/sandbox-images/openclaw/stage-extension-deps.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Ensure every dependency declared by every bundled OpenClaw extension is
+# resolvable in the pre-staged node_modules tree.
+#
+# Background. OpenClaw's `openclaw doctor --fix` pre-stages plugin runtime
+# deps for the *configured* extensions. But OpenClaw's own bundled chunks
+# (e.g. dist/oauth-*.js, used by `memory-core`) have static `require()`
+# chains into deps that are only declared by an *unconfigured* extension's
+# manifest (e.g. the `xai` plugin declares `@mariozechner/pi-ai`, and the
+# OpenClaw oauth chunk transitively needs it whether xai is enabled or
+# not). When `memory-core` loads in the node-host process, the require
+# chain fails with `Cannot find module '@mariozechner/pi-ai/dist/oauth.js'`
+# and the node-host crashes.
+#
+# Fix. After `openclaw doctor`, scan every bundled extension's
+# package.json, take the union of declared `dependencies`, and `npm
+# install --no-save` anything that isn't already present in the stage
+# tree's node_modules. Idempotent: missing-set is empty on a clean run.
+#
+# This runs at base-image build time only. The threat model is identical
+# to the existing `npm install` steps in Dockerfile.base — full network
+# at build, frozen-in-image at runtime.
+#
+# SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+EXT_DIR="${1:-/usr/local/lib/node_modules/openclaw/dist/extensions}"
+STAGE_ROOT="${2:-/opt/openclaw-stage}"
+
+if [ ! -d "$EXT_DIR" ]; then
+  echo "stage-extension-deps: no extensions dir at $EXT_DIR — skipping"
+  exit 0
+fi
+
+# Pick the (single) staged version dir. Doctor produces one per OpenClaw
+# version; we only support one OpenClaw per image.
+stage_dir=$(find "$STAGE_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -n1 || true)
+if [ -z "$stage_dir" ]; then
+  echo "stage-extension-deps: no version dir under $STAGE_ROOT — doctor staged nothing, skipping"
+  exit 0
+fi
+mkdir -p "$stage_dir/node_modules"
+
+# Compute missing deps: union of all extension manifest `dependencies`,
+# minus what's already resolvable in the stage tree.
+missing=$(node -e '
+  const fs = require("fs");
+  const path = require("path");
+  const extDir = process.argv[1];
+  const stageNm = process.argv[2];
+  const want = new Map();
+  for (const d of fs.readdirSync(extDir)) {
+    const pj = path.join(extDir, d, "package.json");
+    if (!fs.existsSync(pj)) continue;
+    let manifest;
+    try { manifest = JSON.parse(fs.readFileSync(pj, "utf8")); }
+    catch (e) { continue; }
+    const deps = manifest.dependencies || {};
+    for (const [name, range] of Object.entries(deps)) {
+      // Last writer wins; differing ranges across manifests are rare and
+      // npm will pick a satisfying version.
+      want.set(name, range);
+    }
+  }
+  const out = [];
+  for (const [name, range] of want) {
+    if (!fs.existsSync(path.join(stageNm, name, "package.json"))) {
+      out.push(name + "@" + range);
+    }
+  }
+  process.stdout.write(out.join("\n"));
+' "$EXT_DIR" "$stage_dir/node_modules")
+
+if [ -z "$missing" ]; then
+  echo "stage-extension-deps: all extension manifest deps already resolvable"
+  exit 0
+fi
+
+echo "stage-extension-deps: filling gaps in $stage_dir/node_modules:"
+echo "$missing" | sed 's/^/  - /'
+
+# Install into the existing stage tree without writing a package.json.
+# npm install with no package.json creates one transparently and removes
+# it after we move the deps out... actually it keeps it. We accept a
+# minimal package.json artifact in the stage dir — it doesn't affect
+# resolution.
+cd "$stage_dir"
+[ -f package.json ] || echo '{"name":"openclaw-stage","private":true}' > package.json
+
+# shellcheck disable=SC2086
+xargs -r npm install --no-save --no-audit --no-fund --no-progress --omit=dev <<<"$missing"
+
+echo "stage-extension-deps: completed; stage size $(du -sh "$stage_dir" | cut -f1)"

--- a/vendor/agentmesh-sdk/README.md
+++ b/vendor/agentmesh-sdk/README.md
@@ -103,11 +103,49 @@ The SDK's relay transport `receive` events are not wired to
 
 This is an upstream SDK issue (transport→client message routing not implemented).
 
+## Patch #12 — Registry fetch retry (April 2026)
+
+**Files:** `dist/chunk-NMOWWZKF.js`, `dist/chunk-UBUGIENK.cjs` (dist-only overlay)
+
+`RegistryClient.fetch()` used to do a single `fetch()` call with timeout
+and no retry. Brief 502/503 blips during kubectl port-forward restarts
+(`host.docker.internal:18080`) and AKS ingress rolls caused
+`submitReputation` (and other registry calls) to silently return `false`
+— indistinguishable from "registry rejected the score".
+
+The fix wraps `fetch()` with an endpoint-aware retry policy:
+
+- **GET / HEAD**: always retried (idempotent).
+- **POST on idempotent registry endpoints** — `/registry/register`,
+  `/registry/prekeys`, `/registry/reputation`, `/registry/status`,
+  `/registry/capabilities`, `/registry/revocations/bulk`,
+  `/auth/oauth/authorize`: retried.
+- **All other POSTs**: not retried (caller decides).
+- **Triggers**: status 408/429/502/503/504 or any thrown network error.
+- **Cap**: up to 3 attempts, total elapsed budget 2s, exponential backoff
+  starting at 100 ms; honours `Retry-After` header up to 1.5s.
+
+`submitReputation` (patch #7) already logs final-failure with target
+AMID prefix so operators can correlate "feedback_count stays 0" with
+concrete registry responses.
+
+The router (`inference-router/src/routes/mesh.rs::agt_registry_proxy`)
+mirrors the same retry policy as a defense-in-depth layer because it is
+the single network egress for sandboxes.
+
+> **Maintainer note:** This patch is a **dist-only overlay**, applied
+> directly to the published bundles like patches #5, #7, and #8. **Do
+> not run `npm run build` on this package** — the build regenerates
+> `dist/` from `src/` and silently drops every dist-only patch. To
+> modify any dist-only patch, hand-edit the chunk files and update this
+> README.
+
 ## Build
 
-```sh
-npm ci && npm run build
-```
+> ⚠️ **Do not run `npm run build`.** Several patches (#5, #7, #8, #12)
+> live exclusively in `dist/`. Running the build regenerates `dist/`
+> from `src/` and erases them. The Dockerfile copies `dist/` directly,
+> so the committed bundles are the source of truth for those patches.
 
 TypeScript SDK for AgentMesh - a decentralized, end-to-end encrypted messaging protocol for AI agents.
 

--- a/vendor/agentmesh-sdk/dist/chunk-NMOWWZKF.js
+++ b/vendor/agentmesh-sdk/dist/chunk-NMOWWZKF.js
@@ -796,24 +796,64 @@ var RegistryClient = class {
     }
   }
   /**
-   * Internal fetch helper with timeout.
+   * Internal fetch helper with timeout + retry-with-backoff (vendor patch #12).
+   * Retries transient registry failures (5xx, 408, 429, network errors) for
+   * idempotent or allowlisted requests. Hard cap: 3 attempts / ~2s budget.
    */
   async fetch(path2, options = {}) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
-    try {
-      const response = await fetch(`${this.baseUrl}${path2}`, {
-        ...options,
-        headers: {
-          "Content-Type": "application/json",
-          ...options.headers
-        },
-        signal: controller.signal
-      });
-      return response;
-    } finally {
-      clearTimeout(timeoutId);
+    const method = (options.method || "GET").toUpperCase();
+    const isIdempotent = method === "GET" || method === "HEAD";
+    const POST_RETRY_ALLOWLIST = [
+      "/registry/register", "/registry/prekeys", "/registry/reputation",
+      "/registry/status", "/registry/capabilities", "/registry/revocations/bulk",
+      "/auth/oauth/authorize"
+    ];
+    const isAllowlistedPost = method === "POST" && POST_RETRY_ALLOWLIST.some((p) => path2.startsWith(p));
+    const retryEligible = isIdempotent || isAllowlistedPost;
+    const RETRY_STATUSES = new Set([408, 429, 502, 503, 504]);
+    const MAX_ATTEMPTS = 3;
+    const BUDGET_MS = 2000;
+    const BASE_BACKOFF_MS = 100;
+    const RETRY_AFTER_CAP_MS = 1500;
+    const startedAt = Date.now();
+    let lastErr;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+      try {
+        const response = await fetch(`${this.baseUrl}${path2}`, {
+          ...options,
+          headers: {
+            "Content-Type": "application/json",
+            ...options.headers
+          },
+          signal: controller.signal
+        });
+        if (!retryEligible || !RETRY_STATUSES.has(response.status) || attempt === MAX_ATTEMPTS) {
+          return response;
+        }
+        let waitMs = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
+        const retryAfter = response.headers.get("retry-after");
+        if (retryAfter) {
+          const ra = Number(retryAfter);
+          if (Number.isFinite(ra) && ra > 0) waitMs = Math.min(ra * 1000, RETRY_AFTER_CAP_MS);
+        }
+        if (Date.now() - startedAt + waitMs > BUDGET_MS) return response;
+        try { await response.body?.cancel?.(); } catch { /* ignore */ }
+        console.warn(`[agentmesh-sdk] retry ${attempt}/${MAX_ATTEMPTS} ${method} ${path2} status=${response.status} wait=${waitMs}ms`);
+        await new Promise((r) => setTimeout(r, waitMs));
+      } catch (err) {
+        lastErr = err;
+        if (!retryEligible || attempt === MAX_ATTEMPTS) throw err;
+        const waitMs = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
+        if (Date.now() - startedAt + waitMs > BUDGET_MS) throw err;
+        console.warn(`[agentmesh-sdk] retry ${attempt}/${MAX_ATTEMPTS} ${method} ${path2} err=${err?.message || err} wait=${waitMs}ms`);
+        await new Promise((r) => setTimeout(r, waitMs));
+      } finally {
+        clearTimeout(timeoutId);
+      }
     }
+    throw lastErr ?? new Error("registry fetch retry budget exhausted");
   }
   /**
    * Parse agent info from API response.

--- a/vendor/agentmesh-sdk/dist/chunk-UBUGIENK.cjs
+++ b/vendor/agentmesh-sdk/dist/chunk-UBUGIENK.cjs
@@ -820,24 +820,64 @@ var RegistryClient = class {
     }
   }
   /**
-   * Internal fetch helper with timeout.
+   * Internal fetch helper with timeout + retry-with-backoff (vendor patch #12).
+   * Retries transient registry failures (5xx, 408, 429, network errors) for
+   * idempotent or allowlisted requests. Hard cap: 3 attempts / ~2s budget.
    */
   async fetch(path2, options = {}) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
-    try {
-      const response = await fetch(`${this.baseUrl}${path2}`, {
-        ...options,
-        headers: {
-          "Content-Type": "application/json",
-          ...options.headers
-        },
-        signal: controller.signal
-      });
-      return response;
-    } finally {
-      clearTimeout(timeoutId);
+    const method = (options.method || "GET").toUpperCase();
+    const isIdempotent = method === "GET" || method === "HEAD";
+    const POST_RETRY_ALLOWLIST = [
+      "/registry/register", "/registry/prekeys", "/registry/reputation",
+      "/registry/status", "/registry/capabilities", "/registry/revocations/bulk",
+      "/auth/oauth/authorize"
+    ];
+    const isAllowlistedPost = method === "POST" && POST_RETRY_ALLOWLIST.some((p) => path2.startsWith(p));
+    const retryEligible = isIdempotent || isAllowlistedPost;
+    const RETRY_STATUSES = new Set([408, 429, 502, 503, 504]);
+    const MAX_ATTEMPTS = 3;
+    const BUDGET_MS = 2000;
+    const BASE_BACKOFF_MS = 100;
+    const RETRY_AFTER_CAP_MS = 1500;
+    const startedAt = Date.now();
+    let lastErr;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+      try {
+        const response = await fetch(`${this.baseUrl}${path2}`, {
+          ...options,
+          headers: {
+            "Content-Type": "application/json",
+            ...options.headers
+          },
+          signal: controller.signal
+        });
+        if (!retryEligible || !RETRY_STATUSES.has(response.status) || attempt === MAX_ATTEMPTS) {
+          return response;
+        }
+        let waitMs = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
+        const retryAfter = response.headers.get("retry-after");
+        if (retryAfter) {
+          const ra = Number(retryAfter);
+          if (Number.isFinite(ra) && ra > 0) waitMs = Math.min(ra * 1000, RETRY_AFTER_CAP_MS);
+        }
+        if (Date.now() - startedAt + waitMs > BUDGET_MS) return response;
+        try { await response.body?.cancel?.(); } catch { /* ignore */ }
+        console.warn(`[agentmesh-sdk] retry ${attempt}/${MAX_ATTEMPTS} ${method} ${path2} status=${response.status} wait=${waitMs}ms`);
+        await new Promise((r) => setTimeout(r, waitMs));
+      } catch (err) {
+        lastErr = err;
+        if (!retryEligible || attempt === MAX_ATTEMPTS) throw err;
+        const waitMs = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
+        if (Date.now() - startedAt + waitMs > BUDGET_MS) throw err;
+        console.warn(`[agentmesh-sdk] retry ${attempt}/${MAX_ATTEMPTS} ${method} ${path2} err=${err?.message || err} wait=${waitMs}ms`);
+        await new Promise((r) => setTimeout(r, waitMs));
+      } finally {
+        clearTimeout(timeoutId);
+      }
     }
+    throw lastErr ?? new Error("registry fetch retry budget exhausted");
   }
   /**
    * Parse agent info from API response.

--- a/vendor/agentmesh-sdk/dist/index.cjs
+++ b/vendor/agentmesh-sdk/dist/index.cjs
@@ -2911,6 +2911,21 @@ var AgentMeshClient = class _AgentMeshClient {
       const msgType = data.message_type;
       try {
         const parsed = JSON.parse(rawPayload);
+        // Vendor patch #11: peer-initiated session close (ratchet desync recovery).
+        if (msgType === "close" || parsed?.type === "close") {
+          const reason = parsed?.reason || "unknown";
+          console.warn(`[AGT] peer ${fromAmid} signalled session close (reason=${reason}) \u2014 clearing local session`);
+          const localSessionId = this.activeSessions.get(fromAmid);
+          if (localSessionId) {
+            try { this.sessionManager.closeSession(localSessionId); } catch {}
+            this.activeSessions.delete(fromAmid);
+          }
+          try { this.sessionCache?.clearByAmid?.(fromAmid); } catch {}
+          for (const handler of this.errorHandlers) {
+            try { handler("session_desync", fromAmid, `peer_close:${reason}`); } catch {}
+          }
+          return;
+        }
         if (msgType === "knock") {
           const request = parsed.request || parsed;
           // PATCH: Track this KNOCK as pending so concurrent messages wait
@@ -3027,6 +3042,27 @@ var AgentMeshClient = class _AgentMeshClient {
               }
             } catch (decErr) {
               console.error("[AGT] E2E decrypt failed for existing session \u2014 message REJECTED:", decErr?.message || decErr);
+              // Vendor patch #11: ratchet desync recovery.
+              try {
+                this.sessionManager.closeSession(sessionId);
+              } catch {}
+              this.activeSessions.delete(fromAmid);
+              try { this.sessionCache?.clearByAmid?.(fromAmid); } catch {}
+              if (this.isConnected) {
+                try {
+                  await this.transport.send(
+                    fromAmid,
+                    JSON.stringify({ type: "close", reason: "ratchet_desync" }),
+                    "close",
+                  );
+                } catch {}
+              }
+              for (const handler of this.errorHandlers) {
+                try {
+                  handler("session_desync", fromAmid, decErr?.message || "ratchet_desync");
+                } catch {
+                }
+              }
               for (const handler of this.errorHandlers) {
                 try {
                   handler("decrypt_failed", fromAmid, decErr?.message || "unknown");

--- a/vendor/agentmesh-sdk/dist/index.js
+++ b/vendor/agentmesh-sdk/dist/index.js
@@ -2956,6 +2956,23 @@ var AgentMeshClient = class _AgentMeshClient {
       }
       try {
         const parsed = JSON.parse(rawPayload);
+        // Vendor patch #11: handle peer-initiated session close (e.g. ratchet desync).
+        // Clear our local session so the next outbound send to that peer triggers
+        // a fresh KNOCK + X3DH handshake.
+        if (msgType === "close" || parsed?.type === "close") {
+          const reason = parsed?.reason || "unknown";
+          console.warn(`[AGT] peer ${fromAmid} signalled session close (reason=${reason}) \u2014 clearing local session`);
+          const localSessionId = this.activeSessions.get(fromAmid);
+          if (localSessionId) {
+            try { this.sessionManager.closeSession(localSessionId); } catch {}
+            this.activeSessions.delete(fromAmid);
+          }
+          try { this.sessionCache?.clearByAmid?.(fromAmid); } catch {}
+          for (const handler of this.errorHandlers) {
+            try { handler("session_desync", fromAmid, `peer_close:${reason}`); } catch {}
+          }
+          return;
+        }
         if (msgType === "knock") {
           const request = parsed.request || parsed;
           // PATCH: Track this KNOCK as pending so concurrent messages wait
@@ -3072,6 +3089,32 @@ var AgentMeshClient = class _AgentMeshClient {
               }
             } catch (decErr) {
               console.error("[AGT] E2E decrypt failed for existing session \u2014 message REJECTED:", decErr?.message || decErr);
+              // Vendor patch #11: ratchet desync recovery.
+              // The local session is now unusable (Double Ratchet keys are
+              // out of sync — typical causes: post-KNOCK message reordering,
+              // duplicate KNOCK, or stale session from earlier exchange).
+              // Clear local state so the next outbound mesh_send triggers a
+              // fresh KNOCK + X3DH. Best-effort notify peer to clear too.
+              try {
+                this.sessionManager.closeSession(sessionId);
+              } catch {}
+              this.activeSessions.delete(fromAmid);
+              try { this.sessionCache?.clearByAmid?.(fromAmid); } catch {}
+              if (this.isConnected) {
+                try {
+                  await this.transport.send(
+                    fromAmid,
+                    JSON.stringify({ type: "close", reason: "ratchet_desync" }),
+                    "close",
+                  );
+                } catch {}
+              }
+              for (const handler of this.errorHandlers) {
+                try {
+                  handler("session_desync", fromAmid, decErr?.message || "ratchet_desync");
+                } catch {
+                }
+              }
               for (const handler of this.errorHandlers) {
                 try {
                   handler("decrypt_failed", fromAmid, decErr?.message || "unknown");


### PR DESCRIPTION
## Summary

This PR was originally scoped to sandbox plugin-stage chown + mermaid syntax fixes. It has since accumulated mesh and governance improvements verified live against the multi-sub-agent demo. Merging together to ride a single image rebuild.

## What's in this PR

### 🔧 Original scope
- `6744c68` — sandbox plugin-stage chown + mermaid doc fix
- `0141667` — pre-stage bundled extension deps (fixes node-host crash)
- `b657d74` — payload guard, sub-agent `mesh_transfer_file` tool, `telegram_status`, inbox peek-only + SDK retry

### 🆕 New (this push)

**`747fb04`** `style(inference-router): cargo fmt mesh.rs` — fixes the `cargo fmt --check` CI gate failure that was blocking the previous run.

**`fa5a15d`** `fix(mesh): vendor patch #11 — auto-recover from Double Ratchet desync`
Two-sided recovery for the `wrong secret key for the given ciphertext` class of failures. Receiver closes locally + notifies peer with `{type:'close', reason:'ratchet_desync'}`; peer's dispatcher catches the close at the top of the try block and clears its session. App handler differentiates `session_desync` (no trust penalty, recoverable) from real `decrypt_failed` (-0.5 trust). Verified live: writer↔viz cleared a broken session and resumed traffic.

> 📝 Chunked file transfers still need F8 (chunk-level resume) for true at-least-once delivery — queued separately.

**`98b345f`** `feat(mesh,heartbeat): F6 task-progress heartbeat protocol + cosmetic log fix`
- New `agt-heartbeat.ts` module + 6 unit tests
- Cosmetic fix in parent `mesh_send` wait loop: capture `parsed.stage` and `parsed.elapsed_seconds` even when message arrives already typed as `task_progress`
- Verified live: log lines now show `stage=executing, elapsed=60s`

**`b11a73a`** `fix(mesh): F7 — exponential backoff + last-known-good fallback for registry discovery`
Replaces flat 7×2s = 14s registry-resolution loop with exponential backoff (~57s total). Adds `getStaleAmid(name)` returning last-known-good AMID without TTL, used as fallback when registry retries exhaust. `meshClient.send` fails fast against a dead peer; registry blips no longer drop real calls.

**`878e124`** `feat(governance,safety): env-gated suppression knobs for false-positive findings`
- `AZURECLAW_SUPPRESS_EXFIL_URL=1` — suppress AGT McpResponseScanner ExfiltrationUrl redaction when it's the sole finding (upstream uses unanchored `contains("post")` substring match, fires on "posture", "post-mortem", etc., no config knobs in 3.1.0 or 3.3.0).
- `AZURECLAW_CONTENT_FLAG_MIN_SEVERITY=safe|low|medium|high` (default `low`).
- `AZURECLAW_SUPPRESS_CONTENT_FLAGS=hate,self_harm,sexual,violence` (csv). `jailbreak` and `indirect_attack` are non-suppressible.
- `cli/src/commands/dev.ts` defaults the three vars on for dev. AKS controller env injection is queued.

## Validation

- ✅ `cargo build --release` — clean
- ✅ `cargo clippy --all-targets --release -- -D warnings` — clean
- ✅ `cargo fmt --all --check` — clean
- ✅ `npx tsc --noEmit` — clean (runtimes/openclaw + cli)
- ✅ `npm test` — 118/118 runtime tests pass
- ✅ Live multi-sub-agent demo — vendor patch #11 cascade verified, F6 stage/elapsed logging verified

## Queued follow-ups

- **F8** — `mesh_transfer_file` chunk-level resume protocol
- **F9** — wire `session_desync` into parent's `mesh_send` wait loop to break early
- **InferencePolicy CRD field** — replaces the env-only hack on AKS
- **Controller reconciler env injection** — 3 lines at `controller/src/reconciler/mod.rs:1127` so AKS sandboxes pick up the vars until the CRD lands