### PR TITLE
fix(ci): copyright headers + scorecard private-repo gate

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,10 +1,10 @@
 name: OpenSSF Scorecard
 
+# NOTE: OpenSSF Scorecard requires public repository access (the action
+# clones via the public GitHub API and fails with "Repository not found"
+# on private repos). This workflow is manually-triggerable only and is
+# kept for completeness; it is not part of required CI.
 on:
-  push:
-    branches: [main]
-  schedule:
-    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 permissions: read-all

--- a/mesh-plugin/src/did.test.ts
+++ b/mesh-plugin/src/did.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 import { describe, it, expect } from "vitest";
 import * as crypto from "node:crypto";
 import {

--- a/mesh-plugin/src/did.ts
+++ b/mesh-plugin/src/did.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * DID canonicalization — deterministic derivation of AGT-compatible DIDs
  * from Ed25519 signing keys.

--- a/sandbox-images/openclaw/stage-extension-deps.sh
+++ b/sandbox-images/openclaw/stage-extension-deps.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Ensure every dependency declared by every bundled OpenClaw extension is
 # resolvable in the pre-staged node_modules tree.
 #


### PR DESCRIPTION
Fixes ci-gates **copyright-headers** failure on main (3 files from #58 and #152) and disables OpenSSF Scorecard pushes (action cannot clone private repos).

- `mesh-plugin/src/did.{ts,test.ts}` — from #58
- `sandbox-images/openclaw/stage-extension-deps.sh` — from #152
- `scorecard.yml` — gated to `workflow_dispatch` only (was failing with "Repository not found")

Verified locally: `./ci/check-copyright-headers.sh` passes (328/328 files).