### PR TITLE
feat(mcp): bump protocolVersion to 2025-11-25 with backward-compat negotiation

### DIFF
--- a/docs/security-audits/2026-05-02-mcp-2025-11-25.md
+++ b/docs/security-audits/2026-05-02-mcp-2025-11-25.md
@@ -1,0 +1,103 @@
+# Security Audit — `mcp-2025-11-25-bump`
+
+**Date:** 2026-05-02
+**PR:** #167
+**Author:** @copilot-cli
+**Independent reviewer:** TBD (router-data-plane)
+**Capability scope:**
+Bumps the MCP Streamable-HTTP `protocolVersion` advertised by the
+inference-router from `2025-03-26` to `2025-11-25` (the current
+upstream revision) while keeping `2025-06-18` and `2025-03-26` in the
+server's supported-versions list so legacy clients continue to
+negotiate successfully. Touches `inference-router/src/mcp/{streamable_http.rs,
+initialize.rs, mod.rs, oauth.rs, pipeline.rs, tools.rs}` and
+`inference-router/src/routes/mcp.rs` (doc-comment URLs only, plus the
+new `SUPPORTED_MCP_PROTOCOL_VERSIONS` constant + `InitializeConfig`
+default that carries all three versions).
+
+---
+
+## 1. Summary
+
+The MCP working group released revision `2025-11-25` of the spec.
+Compared to `2025-03-26`, the changes that intersect AzureClaw are
+purely additive — new optional capabilities (icons, OIDC discovery
+metadata, URL elicitation, tasks, OAuth 2.0 Client ID Metadata
+documents, tool calling within sampling, default values for
+elicitation, JSON Schema 2020-12), plus one transport clarification
+(servers MUST respond `403 Forbidden` to requests carrying a
+disallowed `Origin` header). No mandatory protocol surface is removed
+or renamed. We adopt the new version string, advertise multi-version
+support so 2025-03-26 and 2025-06-18 clients continue to interoperate,
+and update doc-comment URLs.
+
+## 2. Threat model delta
+
+No new trust boundary, no new auth surface, no new egress path.
+Behaviour for `Origin`-restricted clients was already conservative
+(rejected at the axum layer); the spec's tightened wording matches
+what we shipped. Version negotiation is data-plane: a malicious
+client cannot escalate by requesting a different version because the
+server only echoes back values from the server's own allow-list (see
+`initialize.rs:233-239`).
+
+| STRIDE | New exposure? | Mitigation in this PR |
+|---|---|---|
+| Spoofing | No | Negotiated version is always one of the server's allow-list values. |
+| Tampering | No | No new write path; default config is constructed from the const slice. |
+| Repudiation | No | All initialize calls remain audit-loggable via existing pipeline. |
+| Information Disclosure | No | No new fields are returned; `serverInfo` is unchanged. |
+| Denial of Service | No | No new resource allocations; `SUPPORTED_MCP_PROTOCOL_VERSIONS` is a `&'static [&'static str]`. |
+| Elevation of Privilege | No | OAuth 2.1 verifier and Origin gate are unchanged. |
+
+## 3. OWASP mapping
+
+| OWASP item | Applies? | Control in this PR |
+|---|---|---|
+| LLM01 Prompt Injection | No | Out of scope for transport version. |
+| MCP01 Tool poisoning | Indirect | Tool-listing pipeline unchanged; new spec text on icons/metadata is opt-in and not advertised by us. |
+| MCP08 Insecure transport defaults | Yes | Spec's tightened `Origin` wording matches our existing axum layer; no behavioural change required. |
+
+## 4. Fail-closed analysis
+
+If the version-negotiation path encounters an unknown client version,
+existing logic falls back to the **first** entry of
+`supported_protocol_versions`, which after this bump is
+`2025-11-25`. This preserves the prior fail-safe behaviour (clients
+must opt into a version we support) and hardens it (we now also
+explicitly accept the two intermediate revisions). A misconfiguration
+that empties the list would panic-via-index in test only; production
+default cannot reach that state because the const slice is
+non-empty.
+
+## 5. Tests
+
+### Unit (rust)
+- `inference-router/src/mcp/streamable_http.rs::tests::protocol_version_pinned`
+  — pins the constant to `2025-11-25`.
+- `inference-router/src/mcp/streamable_http.rs::tests::supported_versions_newest_first_and_includes_legacy`
+  — ensures the slice ordering and contents.
+- `inference-router/src/mcp/initialize.rs::tests::legacy_2025_03_26_client_negotiates_against_default_config`
+  — backward-compat regression guard.
+- `inference-router/src/mcp/initialize.rs::tests::legacy_2025_06_18_client_negotiates_against_default_config`
+  — intermediate revision guard.
+- `inference-router/src/mcp/initialize.rs::tests::current_2025_11_25_client_negotiates_against_default_config`
+  — happy-path for current revision.
+
+### E2E (`tests/e2e/run.sh`)
+- `test_mcp_initialize_version_negotiation` — spins up a router pod
+  in `azureclaw-e2e-mcp` (PSS-restricted-compliant), POSTs three
+  `initialize` requests (2025-11-25, 2025-06-18, 2025-03-26) and
+  asserts the response carries the same version each time. Cleans up
+  its namespace.
+
+## 6. Rollback
+
+Revert the squashed PR. Constants are pure-data; no state migration,
+no on-disk format change.
+
+## 7. References
+
+- MCP spec 2025-11-25: <https://modelcontextprotocol.io/specification/2025-11-25>
+- MCP changelog (2025-06-18 → 2025-11-25): upstream `CHANGELOG.md`
+- AzureClaw threat model: `docs/threat-model.md` §MCP transport

--- a/inference-router/src/mcp/initialize.rs
+++ b/inference-router/src/mcp/initialize.rs
@@ -3,7 +3,7 @@
 
 //! MCP `initialize` method handler — Streamable HTTP entry point.
 //!
-//! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle>
+//! Spec: <https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle>
 //!
 //! The first request a client makes on a fresh MCP connection is the
 //! `initialize` JSON-RPC request. The server MUST respond with:
@@ -43,7 +43,9 @@ use serde_json::{Value, json};
 
 use super::error::{ErrorCode, JsonRpcError};
 use super::jsonrpc::{Id, Request, Response};
-use super::streamable_http::{MCP_PROTOCOL_VERSION, SessionId};
+#[cfg(test)]
+use super::streamable_http::MCP_PROTOCOL_VERSION;
+use super::streamable_http::{SUPPORTED_MCP_PROTOCOL_VERSIONS, SessionId};
 
 /// Outcome of handling an `initialize` request: the JSON-RPC response
 /// to send to the client *and* the session id the server is assigning.
@@ -105,7 +107,10 @@ impl Default for InitializeConfig {
             },
             capabilities: ServerCapabilities::default(),
             instructions: None,
-            supported_protocol_versions: vec![MCP_PROTOCOL_VERSION.to_string()],
+            supported_protocol_versions: SUPPORTED_MCP_PROTOCOL_VERSIONS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
         }
     }
 }
@@ -400,6 +405,45 @@ mod tests {
         let out = handle_initialize(&r, &cfg, &FixedMinter("test-session-003"));
         let result = out.response.result.unwrap();
         assert_eq!(result["protocolVersion"], json!("2024-11-05"));
+    }
+
+    #[test]
+    fn legacy_2025_03_26_client_negotiates_against_default_config() {
+        // Phase B: a client pinned to the 2025-03-26 revision must
+        // continue to negotiate successfully against the default
+        // server configuration (which now advertises 2025-11-25 first
+        // but keeps 2025-06-18 + 2025-03-26 in the supported list).
+        let cfg = InitializeConfig::default();
+        let mut p = ok_init_params();
+        p["protocolVersion"] = json!("2025-03-26");
+        let r = req("initialize", Some(p));
+        let out = handle_initialize(&r, &cfg, &FixedMinter("legacy-session"));
+        let result = out.response.result.unwrap();
+        assert_eq!(result["protocolVersion"], json!("2025-03-26"));
+        assert!(out.session_id.is_some());
+    }
+
+    #[test]
+    fn legacy_2025_06_18_client_negotiates_against_default_config() {
+        let cfg = InitializeConfig::default();
+        let mut p = ok_init_params();
+        p["protocolVersion"] = json!("2025-06-18");
+        let r = req("initialize", Some(p));
+        let out = handle_initialize(&r, &cfg, &FixedMinter("legacy-session-2"));
+        let result = out.response.result.unwrap();
+        assert_eq!(result["protocolVersion"], json!("2025-06-18"));
+    }
+
+    #[test]
+    fn current_2025_11_25_client_negotiates_against_default_config() {
+        let cfg = InitializeConfig::default();
+        let mut p = ok_init_params();
+        p["protocolVersion"] = json!("2025-11-25");
+        let r = req("initialize", Some(p));
+        let out = handle_initialize(&r, &cfg, &FixedMinter("current-session"));
+        let result = out.response.result.unwrap();
+        assert_eq!(result["protocolVersion"], json!("2025-11-25"));
+        assert_eq!(result["protocolVersion"], json!(MCP_PROTOCOL_VERSION));
     }
 
     #[test]

--- a/inference-router/src/mcp/mod.rs
+++ b/inference-router/src/mcp/mod.rs
@@ -4,8 +4,8 @@
 //! MCP 2026 Streamable HTTP transport — production code path.
 //!
 //! This module is the **router-side** implementation of the Model Context
-//! Protocol's Streamable HTTP transport (spec revision `2025-03-26`,
-//! [transports](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports)).
+//! Protocol's Streamable HTTP transport (spec revision `2025-11-25`,
+//! [transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)).
 //!
 //! ## Status: implemented
 //!

--- a/inference-router/src/mcp/oauth.rs
+++ b/inference-router/src/mcp/oauth.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! OAuth 2.1 access-token verifier for MCP 2025-03-26 / 2026 Streamable HTTP.
+//! OAuth 2.1 access-token verifier for MCP 2025-11-25 Streamable HTTP.
 // ci:loc-ok: The OAuth 2.1 / RFC 9700 / RFC 7517 (JWK) / RFC 7515 (JWS)
 // verifier is one cohesive defence-in-depth pipeline (header parsing,
 // kid lookup, alg allow-list, JWKS-cache, claim validation, replay
@@ -17,7 +17,7 @@
 //! - **RFC 8725** ("JWT Best Current Practices"): explicit `alg`
 //!   allow-list, no `none`, kid-based key selection, iss/aud/exp/nbf
 //!   claim validation, leeway for clock skew.
-//! - **MCP 2025-03-26** transports section: bearer tokens accepted on
+//! - **MCP 2025-11-25** transports section: bearer tokens accepted on
 //!   POST `/mcp` requests; resource-server semantics.
 //!
 //! # Total function
@@ -53,7 +53,7 @@
 //! - <https://www.rfc-editor.org/rfc/rfc8725> (JWT BCP)
 //! - <https://www.rfc-editor.org/rfc/rfc9700> (OAuth 2.0 BCP)
 //! - <https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1>
-//! - MCP transports: <https://modelcontextprotocol.io/specification/2025-03-26>
+//! - MCP transports: <https://modelcontextprotocol.io/specification/2025-11-25>
 
 use jsonwebtoken::jwk::{Jwk, JwkSet, KeyAlgorithm};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};

--- a/inference-router/src/mcp/pipeline.rs
+++ b/inference-router/src/mcp/pipeline.rs
@@ -3,7 +3,7 @@
 
 //! MCP request pipeline — the full body→response transform.
 //!
-//! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
+//! Spec: <https://modelcontextprotocol.io/specification/2025-11-25/basic/transports>
 //!
 //! This module is the entire MCP Streamable HTTP server logic short
 //! of axum binding. It takes raw HTTP body bytes + the `Accept` header

--- a/inference-router/src/mcp/streamable_http.rs
+++ b/inference-router/src/mcp/streamable_http.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //! Streamable HTTP transport envelope per
-//! [MCP spec rev. 2025-03-26 §Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).
+//! [MCP spec rev. 2025-11-25 §Streamable HTTP](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports).
 //!
 //! This module covers transport-level concerns:
 //!
@@ -14,6 +14,10 @@
 //!   by future POST handlers before parsing the body.
 //! - [`MCP_PROTOCOL_VERSION`] — pinned protocol version string we
 //!   negotiate during `initialize`.
+//! - [`SUPPORTED_MCP_PROTOCOL_VERSIONS`] — backward-compat list of
+//!   protocol versions the server will accept during initialize
+//!   negotiation. Newest first; the first entry MUST equal
+//!   [`MCP_PROTOCOL_VERSION`].
 //!
 //! Route handlers (POST `/mcp`, GET `/mcp`, DELETE `/mcp`) are NOT in
 //! this PR — see `phase1/mcp-2026-streamable-http-routes`.
@@ -21,8 +25,19 @@
 use std::str::FromStr;
 
 /// MCP protocol version string we advertise during `initialize`.
-/// Pinned to the 2025-03-26 spec revision (see module docs).
-pub const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
+/// Pinned to the 2025-11-25 spec revision (see module docs).
+pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Backward-compatible set of MCP protocol versions this server will
+/// accept during `initialize` negotiation. Ordered newest-first; the
+/// first entry MUST equal [`MCP_PROTOCOL_VERSION`].
+///
+/// Older clients pinned to the 2025-06-18 or 2025-03-26 revisions
+/// continue to work — negotiation in
+/// [`super::initialize::handle_initialize`] echoes back the client's
+/// requested version when it appears in this list, otherwise falls
+/// back to the newest.
+pub const SUPPORTED_MCP_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-06-18", "2025-03-26"];
 
 /// Default oversize-frame cap (4 MiB).
 ///
@@ -167,7 +182,14 @@ mod tests {
 
     #[test]
     fn protocol_version_pinned() {
-        assert_eq!(MCP_PROTOCOL_VERSION, "2025-03-26");
+        assert_eq!(MCP_PROTOCOL_VERSION, "2025-11-25");
+    }
+
+    #[test]
+    fn supported_versions_newest_first_and_includes_legacy() {
+        assert_eq!(SUPPORTED_MCP_PROTOCOL_VERSIONS[0], MCP_PROTOCOL_VERSION);
+        assert!(SUPPORTED_MCP_PROTOCOL_VERSIONS.contains(&"2025-06-18"));
+        assert!(SUPPORTED_MCP_PROTOCOL_VERSIONS.contains(&"2025-03-26"));
     }
 
     #[test]

--- a/inference-router/src/mcp/tools.rs
+++ b/inference-router/src/mcp/tools.rs
@@ -3,7 +3,7 @@
 
 //! MCP `tools/list` and `tools/call` method handlers — pure dispatch.
 //!
-//! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/server/tools>
+//! Spec: <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>
 //!
 //! Defines:
 //!
@@ -41,7 +41,7 @@ use super::jsonrpc::{Request, Response};
 /// [`ToolCatalog::with_page_size`].
 pub const DEFAULT_PAGE_SIZE: usize = 64;
 
-/// One published tool. Wire format follows MCP 2025-03-26 §tools.
+/// One published tool. Wire format follows MCP 2025-11-25 §tools.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolDefinition {

--- a/inference-router/src/routes/mcp.rs
+++ b/inference-router/src/routes/mcp.rs
@@ -3,7 +3,7 @@
 
 //! POST /mcp axum route — thin wrapper around [`crate::mcp::pipeline::process_request`].
 //!
-//! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
+//! Spec: <https://modelcontextprotocol.io/specification/2025-11-25/basic/transports>
 //!
 //! Per §0.2 principle 8 (no scaffolding) every code path here is real:
 //! body-size 413, Accept-header 406, JSON-RPC parse error, batch

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1257,6 +1257,128 @@ EOF
     kubectl delete namespace "${ns}" --wait=false >/dev/null 2>&1 || true
 }
 
+test_mcp_initialize_version_negotiation() {
+    local ns="azureclaw-e2e-mcp"
+    local pod="mcp-init-probe"
+
+    kubectl create namespace "${ns}" >/dev/null 2>&1 || true
+
+    local apply_err
+    apply_err=$(cat <<EOF | kubectl apply -f - 2>&1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${pod}
+  namespace: ${ns}
+  labels:
+    app: mcp-init-probe
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile: {type: RuntimeDefault}
+  containers:
+    - name: router
+      image: azureclaw-inference-router:e2e
+      imagePullPolicy: Never
+      env:
+        - {name: ROUTER_PORT, value: "8443"}
+        - {name: CONTENT_SAFETY_ENABLED, value: "false"}
+        - {name: PROMPT_SHIELDS_ENABLED, value: "false"}
+      ports:
+        - containerPort: 8443
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities: {drop: ["ALL"]}
+        runAsUser: 1000
+    - name: probe
+      image: curlimages/curl:8.10.1
+      imagePullPolicy: IfNotPresent
+      command: ["sleep", "600"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities: {drop: ["ALL"]}
+        runAsUser: 100
+EOF
+    )
+    if [ -n "$apply_err" ] && ! echo "$apply_err" | grep -q "created\|configured\|unchanged"; then
+        warn "MCP probe pod apply: $apply_err"
+        fail "MCP probe pod apply failed"
+        kubectl delete namespace "${ns}" --wait=false >/dev/null 2>&1 || true
+        return
+    fi
+
+    local deadline=$(($(date +%s) + 90))
+    local ready=""
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        ready=$(kubectl get pod "${pod}" -n "${ns}" \
+            -o jsonpath='{.status.containerStatuses[*].ready}' 2>/dev/null || true)
+        if [ "$ready" = "true true" ]; then
+            break
+        fi
+        sleep 2
+    done
+    if [ "$ready" != "true true" ]; then
+        warn "MCP probe pod containers not ready: '$ready'"
+        kubectl describe pod "${pod}" -n "${ns}" 2>&1 | tail -40 || true
+        kubectl logs "${pod}" -n "${ns}" -c router 2>&1 | tail -30 || true
+        fail "MCP probe: router pod did not become ready"
+        kubectl delete namespace "${ns}" --wait=false >/dev/null 2>&1 || true
+        return
+    fi
+
+    # Current 2025-11-25 client → must echo back 2025-11-25.
+    local body_current='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"e2e","version":"0.0.1"}}}'
+    local resp_current
+    resp_current=$(kubectl exec -n "${ns}" "${pod}" -c probe -- \
+        curl -sS -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            --data "${body_current}" \
+            http://127.0.0.1:8443/mcp 2>&1 || true)
+    if echo "${resp_current}" | grep -q '"protocolVersion":"2025-11-25"'; then
+        pass "MCP initialize: 2025-11-25 client negotiates to 2025-11-25"
+    else
+        warn "MCP 2025-11-25 response: ${resp_current}"
+        fail "MCP initialize: 2025-11-25 client did not negotiate to 2025-11-25"
+    fi
+
+    # Legacy 2025-03-26 client → must echo back 2025-03-26 (backward compat).
+    local body_legacy='{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-legacy","version":"0.0.1"}}}'
+    local resp_legacy
+    resp_legacy=$(kubectl exec -n "${ns}" "${pod}" -c probe -- \
+        curl -sS -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            --data "${body_legacy}" \
+            http://127.0.0.1:8443/mcp 2>&1 || true)
+    if echo "${resp_legacy}" | grep -q '"protocolVersion":"2025-03-26"'; then
+        pass "MCP initialize: 2025-03-26 legacy client negotiates back to 2025-03-26"
+    else
+        warn "MCP 2025-03-26 response: ${resp_legacy}"
+        fail "MCP initialize: 2025-03-26 client did not negotiate to 2025-03-26"
+    fi
+
+    # Intermediate 2025-06-18 client → must echo back 2025-06-18.
+    local body_mid='{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"e2e-mid","version":"0.0.1"}}}'
+    local resp_mid
+    resp_mid=$(kubectl exec -n "${ns}" "${pod}" -c probe -- \
+        curl -sS -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            --data "${body_mid}" \
+            http://127.0.0.1:8443/mcp 2>&1 || true)
+    if echo "${resp_mid}" | grep -q '"protocolVersion":"2025-06-18"'; then
+        pass "MCP initialize: 2025-06-18 client negotiates back to 2025-06-18"
+    else
+        warn "MCP 2025-06-18 response: ${resp_mid}"
+        fail "MCP initialize: 2025-06-18 client did not negotiate to 2025-06-18"
+    fi
+
+    kubectl delete namespace "${ns}" --wait=false >/dev/null 2>&1 || true
+}
+
 test_controller_emits_events() {
     # Reconcilers should emit Kubernetes Events for major lifecycle
     # transitions. A truly silent controller is a debugging nightmare
@@ -1308,6 +1430,7 @@ main() {
     test_sandbox_networkpolicy_denies_ingress || true
     test_controller_emits_events || true
     test_ap2_commerce_required_route_gate || true
+    test_mcp_initialize_version_negotiation || true
     # Phase 2/3 CRD reconciler coverage. These run before
     # cleanup_sandbox so the sandbox is still present (some CRs
     # reference it). The CR objects own no Pod, do no network I/O,


### PR DESCRIPTION
## Phase B — MCP `2025-11-25` bump (closes §14.6 "MCP version")

Bumps `MCP_PROTOCOL_VERSION` from `2025-03-26` to `2025-11-25` (current upstream) and introduces `SUPPORTED_MCP_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26"]` so legacy clients continue to negotiate.

### What changed
- **`inference-router/src/mcp/streamable_http.rs`** — bumped const + new supported-versions slice + 2 new unit tests.
- **`inference-router/src/mcp/initialize.rs`** — `InitializeConfig::default()` now advertises all 3 supported versions; 3 new unit tests covering 2025-03-26, 2025-06-18, 2025-11-25 client negotiation against the default config.
- **`inference-router/src/mcp/{mod.rs,oauth.rs,pipeline.rs,tools.rs}` + `routes/mcp.rs`** — doc-comment URLs bumped to `2025-11-25`.
- **`tests/e2e/run.sh`** — new `test_mcp_initialize_version_negotiation` exercising all three versions against a live router pod.
- **`docs/security-audits/2026-05-02-mcp-2025-11-25.md`** — STRIDE / OWASP / fail-closed analysis.

### Backward-compat reasoning
`initialize.rs:233-239` already echoes back any client-requested version present in the server's allow-list, falling back to the first (newest) entry otherwise. Adding the legacy versions to the const slice = automatic backward compat with zero protocol surface change.

### Tests
- Router unit + integration: **all green** (`cargo test --package azureclaw-inference-router`)
- Clippy: **clean** (`-D warnings`)
- Local E2E (kind, macOS): **40/40** (was 37 pre-Phase-B + 3 new MCP assertions)

### Spec-version research
- Latest upstream MCP revision: `2025-11-25`
- Intermediate revision: `2025-06-18`
- Changes since `2025-03-26` are purely additive (icons, OIDC discovery, URL elicitation, tasks, OAuth Client ID Metadata, sampling tool calling, JSON Schema 2020-12). One transport clarification: 403 on disallowed Origin (already enforced in our axum layer).

### Follow-ups (not in this PR)
- Phase C: A2A v1.0.0 GA spec alignment.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>