### PR TITLE
feat(controller): add spec.suspended graceful pause (Phase G P1 #4)

### DIFF
--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -109,6 +109,26 @@ pub struct ClawSandboxSpec {
     /// **Default OFF.** Schema lands now so future reconciler branches are
     /// pure wiring. No code path consumes this field yet.
     pub upstream_compatibility: Option<UpstreamCompatibilityConfig>,
+
+    /// Operator-driven graceful pause (Phase G P1 #4).
+    ///
+    /// When `Some(true)`, the controller scales the sandbox Deployment
+    /// to `replicas: 0` and stamps the K8s `Suspended=True` Condition
+    /// with reason `SuspendedBySpec`. The namespace, NetworkPolicy,
+    /// ServiceAccount, governance ConfigMaps, and any Azure
+    /// federated-identity binding are preserved byte-identical, so
+    /// flipping back to `Some(false)` (or unsetting) restores the
+    /// agent in-place without losing state.
+    ///
+    /// Distinct from `Suspended=True / Reason=OverlayMode` (induced by
+    /// `spec.upstreamCompatibility.sigsAgentSandbox=overlay`), which
+    /// signals that an upstream CR owns the Pod entirely. Spec-level
+    /// suspension is the operator-driven graceful pause; OverlayMode
+    /// is the architectural reason the controller never owns the Pod
+    /// at all. When both apply, OverlayMode wins (its reason is
+    /// stamped, no Deployment is created either way).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suspended: Option<bool>,
 }
 
 /// Upstream-protocol compatibility (Phase 1 scaffold extended in Phase 2 S8).

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -907,6 +907,14 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         if overlay_mode {
             break 'deployment_block;
         }
+        // Phase G P1 #4: spec.suspended scales the Deployment to 0
+        // replicas without removing it, preserving cluster state for
+        // a graceful resume. We still walk the rest of this block so
+        // image / env / volume drift is reflected on the suspended
+        // Deployment (so resume picks up the latest spec).
+        let suspended_by_spec = spec.suspended.unwrap_or(false);
+        let desired_replicas: i64 = if suspended_by_spec { 0 } else { 1 };
+
         // S10.A2: image now comes from the runtime plan (already
         // resolved against the controller default fallback). The
         // deployment builder must not re-derive the image from
@@ -1660,7 +1668,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
                 }
             },
             "spec": {
-                "replicas": 1,
+                "replicas": desired_replicas,
                 "selector": {
                     "matchLabels": {"azureclaw.azure.com/sandbox": name}
                 },
@@ -2009,7 +2017,45 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         // single AllowlistAuthoritative=False/Inline condition (or an
         // empty list when `networkPolicy` itself is unset). The
         // fetcher itself short-circuits before any network IO.
-        let extras: Vec<_> = allowlist_resolution.conditions.clone();
+        let mut extras: Vec<_> = allowlist_resolution.conditions.clone();
+
+        // Phase G P1 #4: stamp Suspended condition when spec.suspended
+        // is true, or clear a prior SuspendedBySpec when it is false.
+        // We deliberately do NOT stamp Suspended=False on CRs that
+        // were never suspended — that would add a new condition
+        // retroactively to every existing sandbox.
+        let suspended_by_spec = spec.suspended.unwrap_or(false);
+        let prior_conditions_for_susp = sandbox
+            .status
+            .as_ref()
+            .map(|s| s.conditions.as_slice())
+            .unwrap_or(&[]);
+        let prior_suspended = crate::status::conditions::find(
+            prior_conditions_for_susp,
+            crate::status::conditions::TYPE_SUSPENDED,
+        );
+        let prior_was_spec_suspended = prior_suspended
+            .is_some_and(|c| c.reason == crate::status::conditions::reason::SUSPENDED_BY_SPEC);
+        if suspended_by_spec {
+            extras.push(crate::status::conditions::preserve_transition_time(
+                prior_suspended,
+                crate::status::conditions::TYPE_SUSPENDED,
+                crate::status::conditions::status::TRUE,
+                crate::status::conditions::reason::SUSPENDED_BY_SPEC,
+                "spec.suspended=true; Deployment scaled to replicas=0",
+                sandbox.metadata.generation,
+            ));
+        } else if prior_was_spec_suspended {
+            extras.push(crate::status::conditions::preserve_transition_time(
+                prior_suspended,
+                crate::status::conditions::TYPE_SUSPENDED,
+                crate::status::conditions::status::FALSE,
+                crate::status::conditions::reason::ACTIVE,
+                "spec.suspended cleared; Deployment scaled back to replicas=1",
+                sandbox.metadata.generation,
+            ));
+        }
+
         if !crate::status::running_status_matches_with_extras(
             &sandbox,
             &sandbox_ns,

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -148,6 +148,15 @@ pub mod reason {
     /// to create a Deployment rather than silently fall through to the
     /// OpenClaw image.
     pub const ADAPTER_MISSING: &str = "AdapterMissing";
+    /// Phase G P1 #4 — `SuspendedBySpec`: the operator set
+    /// `spec.suspended: true`. Reconciler scales the Deployment to
+    /// `replicas: 0` while preserving namespace + governance overlay.
+    pub const SUSPENDED_BY_SPEC: &str = "SuspendedBySpec";
+    /// Phase G P1 #4 — `Active`: paired with `Suspended=False`. Used
+    /// only to clear a prior `Suspended=True/SuspendedBySpec` so
+    /// operators see the un-suspend transition; never stamped on CRs
+    /// that have not previously been suspended.
+    pub const ACTIVE: &str = "Active";
     /// Phase 2 S12.b — `Verified`: signed allowlist artifact fetched,
     /// cosign signature passed, signer identity matched cluster
     /// SignerPolicy, canonical form re-validated.

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -498,6 +498,26 @@ spec:
                     limits:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                suspended:
+                  type: boolean
+                  description: |
+                    When `true`, the controller scales the sandbox
+                    Deployment to `replicas: 0` and stamps
+                    `Suspended=True / Reason=SuspendedBySpec`. The
+                    namespace, NetworkPolicy, ServiceAccount, and all
+                    governance overlay objects are preserved
+                    byte-identical, so flipping this field back to
+                    `false` (or removing it) restores the agent
+                    in-place. Default `false`.
+
+                    Distinct from the `Suspended=True / Reason=OverlayMode`
+                    transition, which is induced by
+                    `spec.upstreamCompatibility.sigsAgentSandbox=overlay`
+                    (operator delegates Pod ownership to an upstream
+                    `Sandbox` CR). Spec-level suspension is the
+                    operator-driven graceful pause; OverlayMode is the
+                    architectural reason the controller doesn't own
+                    the Pod at all.
             status:
               type: object
               properties:

--- a/docs/security-audits/2026-05-03-craftsmanship-suspended-phase.md
+++ b/docs/security-audits/2026-05-03-craftsmanship-suspended-phase.md
@@ -1,0 +1,107 @@
+# Security Audit — `craftsmanship-suspended-phase`
+
+**Date:** 2026-05-03
+**PR:** #170 (target `dev`)
+**Author:** @copilot-cli
+**Independent reviewer:** TBD (controller-data-plane)
+**Capability scope:**
+Adds operator-driven graceful pause to `ClawSandbox` via a new
+`spec.suspended: bool` field. When `true`, the controller scales the
+sandbox Deployment to `replicas: 0` while preserving every other
+overlay object (namespace, NetworkPolicy, ServiceAccount, governance
+ConfigMaps, federated-identity binding) byte-identical, and stamps
+the K8s-canonical `Suspended=True / Reason=SuspendedBySpec` condition
+on `.status.conditions`. Touches `controller/src/crd.rs` (one new
+field), `controller/src/reconciler/mod.rs` (replicas gate + status
+extras), `controller/src/status/conditions.rs` (two new reason
+constants), the Helm CRD YAML (one new field declaration), and the
+E2E gate (`tests/e2e/run.sh` — `test_sandbox_suspended_lifecycle`,
+4 assertions). Closes Phase G P1 #4 of the §14.6 craftsmanship list.
+
+---
+
+## 1. Summary
+
+Operators previously had two ways to pause a sandbox: delete the
+`ClawSandbox` (destroys all state including AGT trust + governance
+ConfigMaps) or scale the underlying `Deployment` directly (silently
+fights the controller's reconcile loop, since the controller
+re-applies `replicas: 1` on every pass via Server-Side Apply).
+Neither is correct. Phase G #4 closes that gap with a first-class
+`spec.suspended` field that the reconciler honours: `True` means
+"freeze the Pod, preserve everything else"; absent or `False` means
+"normal operation". The Suspended Condition is stamped to expose the
+state to dashboards and `kubectl wait --for=condition=Suspended`.
+
+## 2. Threat model delta (STRIDE)
+
+| Threat | Before | After |
+|---|---|---|
+| **Tampering** with overlay state during pause | Operator's only choices were `delete` (destructive) or hand-scaling Deployment (fights controller). | First-class `spec.suspended` preserves all overlay state. No new tamper surface introduced — the field is part of `spec`, subject to the same RBAC + admission policies as every other field. |
+| **Repudiation** of pause/resume | Operator-driven scale-down was invisible in the CR. | `Suspended=True/SuspendedBySpec` Condition with `lastTransitionTime` provides an audit trail in the CR itself. Un-suspend stamps `Suspended=False/Active` so the resume transition is also visible. |
+| **Spoofing** | N/A — same as any other spec mutation. | N/A. |
+| **Information disclosure** | N/A. | N/A — no new data exposed. |
+| **Denial of service** | An attacker with `update` on `clawsandboxes` can already corrupt spec. | Same threat surface; suspended just gives them one more knob (set-and-leave to silently halt agents). Mitigated by existing RBAC + audit-log of `kubectl edit`/`kubectl patch`. Not a new vector. |
+| **Elevation of privilege** | N/A. | N/A. |
+
+## 3. OWASP LLM-Top-10 mapping
+
+- **LLM08 — Excessive Agency**: explicit pause/resume gives operators
+  a graceful kill-switch that doesn't lose forensic state, which
+  improves response capability when an agent misbehaves.
+
+Other items unaffected.
+
+## 4. Fail-closed semantics
+
+- **Default off**: `spec.suspended` is `Option<bool>` with `serde
+  default` and `skip_serializing_if = "Option::is_none"`. Existing
+  CRs do not get a `Suspended` Condition retroactively unless they
+  opt in.
+- **Overlay-mode dominance**: if both `suspended=true` *and*
+  `upstreamCompatibility.sigsAgentSandbox=overlay` are set, OverlayMode
+  wins (no Deployment is created either way; `Suspended=True/OverlayMode`
+  is stamped, not `SuspendedBySpec`). This avoids stamping a
+  contradictory pair of reasons.
+- **Drift handling**: even when `suspended=true`, the reconciler
+  walks the rest of the deployment block — image, env, volume changes
+  are still applied to the (zero-replica) Deployment so resume picks
+  up the latest spec without a forced re-roll.
+- **Condition cleanup**: when an operator un-suspends, the controller
+  stamps `Suspended=False/Active` *only* if the prior reason was
+  `SuspendedBySpec` (i.e. the pause was operator-driven). Sandboxes
+  that have never had a Suspended condition do not grow one
+  retroactively.
+
+## 5. Test coverage
+
+- **424 / 424** controller unit tests pass after the change
+  (`cargo test --package azureclaw-controller`).
+- **E2E `test_sandbox_suspended_lifecycle`** (4 assertions):
+  1. Sandbox created with `suspended: true` → Deployment `replicas: 0`
+  2. `Suspended=True / Reason=SuspendedBySpec` Condition stamped
+  3. Patch `suspended: false` → Deployment `replicas: 1` restored
+  4. `Suspended=False / Reason=Active` Condition stamped after resume
+
+## 6. Backward compatibility
+
+- Field is `Option<bool>` with `skip_serializing_if`. CRs that omit
+  it serialize byte-identical to pre-change CRs.
+- The CRD YAML adds the field but does not require it (`type: boolean`
+  with no `required`).
+- No change to RuntimeReady, Ready, Progressing semantics.
+- No change to overlay-mode behaviour.
+- No new K8s API objects, no new Conditions types (Suspended already
+  existed for OverlayMode); only two new `reason` constants.
+
+## 7. Out-of-scope (explicitly deferred)
+
+- Pod-eviction-on-suspend (we scale to 0 and let the existing Pod
+  terminate via the Deployment's own grace period; no
+  `evictPolicy: Delete` semantics).
+- Pause of governance reconcile (governance ConfigMaps still update
+  on suspended sandboxes — by design, so resume is correct).
+- CronJob-driven auto-suspend (e.g. "suspend at 6pm") — operator
+  tooling, not controller responsibility.
+- Suspended-state metrics — covered by Phase G P2 #10
+  (Prometheus expansion) in a follow-up PR.

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -887,6 +887,109 @@ test_sandbox_networkpolicy_denies_ingress() {
     fi
 }
 
+test_sandbox_suspended_lifecycle() {
+    # Phase G P1 #4: spec.suspended scales the Deployment to
+    # replicas=0 without removing it, and stamps
+    # Suspended=True/SuspendedBySpec on .status.conditions.
+    # Un-setting (or flipping to false) restores replicas=1 and
+    # stamps Suspended=False/Active.
+    local sandbox=suspend-test
+    cat <<EOF | kubectl apply -f - >/dev/null
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: ${sandbox}-inference
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: ${sandbox}
+spec:
+  appliesTo:
+    sandboxName: ${sandbox}
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: ${sandbox}
+  namespace: azureclaw-system
+spec:
+  runtime:
+    kind: OpenClaw
+    openclaw:
+      version: "2026.3.13"
+  sandbox:
+    isolation: standard
+  inferenceRef:
+    name: ${sandbox}-inference
+  suspended: true
+EOF
+    # Wait up to 60s for the controller to reconcile + scale down.
+    local replicas=""
+    local i
+    for i in $(seq 1 30); do
+        replicas=$(kubectl get deploy -n "azureclaw-${sandbox}" "${sandbox}" \
+            -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+        if [[ "$replicas" == "0" ]]; then
+            break
+        fi
+        sleep 2
+    done
+    if [[ "$replicas" == "0" ]]; then
+        pass "Suspended sandbox Deployment scaled to replicas=0"
+    else
+        fail "Suspended Deployment replicas=$replicas (expected 0)"
+        kubectl delete clawsandbox "${sandbox}" -n azureclaw-system --ignore-not-found >/dev/null 2>&1
+        kubectl delete inferencepolicy "${sandbox}-inference" -n azureclaw-system --ignore-not-found >/dev/null 2>&1
+        return
+    fi
+
+    # Suspended=True/SuspendedBySpec must be stamped.
+    local cond_status cond_reason
+    cond_status=$(kubectl get clawsandbox "${sandbox}" -n azureclaw-system \
+        -o jsonpath='{.status.conditions[?(@.type=="Suspended")].status}' 2>/dev/null)
+    cond_reason=$(kubectl get clawsandbox "${sandbox}" -n azureclaw-system \
+        -o jsonpath='{.status.conditions[?(@.type=="Suspended")].reason}' 2>/dev/null)
+    if [[ "$cond_status" == "True" && "$cond_reason" == "SuspendedBySpec" ]]; then
+        pass "Suspended=True/SuspendedBySpec condition stamped"
+    else
+        fail "Suspended condition wrong (status=$cond_status reason=$cond_reason)"
+    fi
+
+    # Un-suspend → replicas=1, Suspended=False/Active.
+    kubectl patch clawsandbox "${sandbox}" -n azureclaw-system --type merge \
+        -p '{"spec":{"suspended":false}}' >/dev/null
+    for i in $(seq 1 30); do
+        replicas=$(kubectl get deploy -n "azureclaw-${sandbox}" "${sandbox}" \
+            -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+        if [[ "$replicas" == "1" ]]; then
+            break
+        fi
+        sleep 2
+    done
+    if [[ "$replicas" == "1" ]]; then
+        pass "Un-suspended sandbox Deployment restored to replicas=1"
+    else
+        fail "Un-suspended Deployment replicas=$replicas (expected 1)"
+    fi
+
+    cond_status=$(kubectl get clawsandbox "${sandbox}" -n azureclaw-system \
+        -o jsonpath='{.status.conditions[?(@.type=="Suspended")].status}' 2>/dev/null)
+    cond_reason=$(kubectl get clawsandbox "${sandbox}" -n azureclaw-system \
+        -o jsonpath='{.status.conditions[?(@.type=="Suspended")].reason}' 2>/dev/null)
+    if [[ "$cond_status" == "False" && "$cond_reason" == "Active" ]]; then
+        pass "Suspended=False/Active condition stamped after un-suspend"
+    else
+        fail "Suspended condition after un-suspend wrong (status=$cond_status reason=$cond_reason)"
+    fi
+
+    kubectl delete clawsandbox "${sandbox}" -n azureclaw-system --ignore-not-found >/dev/null 2>&1
+    kubectl delete inferencepolicy "${sandbox}-inference" -n azureclaw-system --ignore-not-found >/dev/null 2>&1
+}
+
 # ─── Reconciler update / delete flow ────────────────────────────────────────
 
 test_tool_policy_update_flow() {
@@ -1574,6 +1677,7 @@ main() {
     test_sandbox_namespace_labels || true
     test_sandbox_deployment_exists || true
     test_sandbox_networkpolicy_denies_ingress || true
+    test_sandbox_suspended_lifecycle || true
     test_controller_emits_events || true
     test_ap2_commerce_required_route_gate || true
     test_mcp_initialize_version_negotiation || true


### PR DESCRIPTION
## Summary

Adds operator-driven graceful pause to `ClawSandbox` via a new `spec.suspended: bool` field. Closes **Phase G P1 #4** of the §14.6 craftsmanship list.

When `true`, the controller scales the sandbox Deployment to `replicas: 0` while preserving every other overlay object (namespace, NetworkPolicy, ServiceAccount, governance ConfigMaps, federated-identity binding) byte-identical, and stamps the K8s-canonical `Suspended=True / Reason=SuspendedBySpec` Condition.

## Why

Operators previously had to choose between deleting the CR (destroys all state including AGT trust + governance ConfigMaps) or hand-scaling the Deployment (silently fights the controller's reconcile loop). Both were wrong. Phase G #4 closes that gap.

## Behaviour

- `spec.suspended: true` → `replicas: 0` + `Suspended=True/SuspendedBySpec`
- `spec.suspended: false` (after prior True) → `replicas: 1` + `Suspended=False/Active`
- `spec.suspended` absent (default) → no `Suspended` condition stamped (no retroactive churn for existing CRs)
- OverlayMode dominates: when both apply, `Suspended=True/OverlayMode` wins (no Deployment in either path)
- Drift handling: even when suspended, image/env/volume changes still apply to the zero-replica Deployment so resume picks up the latest spec

## Tests

- **Controller unit:** 424/424 pass
- **E2E** (new `test_sandbox_suspended_lifecycle`, 4 assertions):
  1. `suspended: true` → Deployment `replicas: 0`
  2. `Suspended=True/SuspendedBySpec` Condition stamped
  3. Patch `suspended: false` → `replicas: 1` restored
  4. `Suspended=False/Active` Condition stamped

`cargo clippy --package azureclaw-controller --all-targets -- -D warnings` clean. `cargo fmt --all` clean.

## Backward compatibility

- Field is `Option<bool>` with `skip_serializing_if = "Option::is_none"`. Existing CRs serialize byte-identical.
- CRD YAML adds field but does not require it.
- No change to RuntimeReady, Ready, Progressing, OverlayMode semantics.

## Security audit

`docs/security-audits/2026-05-03-craftsmanship-suspended-phase.md` — STRIDE delta, OWASP-LLM mapping, fail-closed semantics.

## Closes

Phase G P1 #4 (Suspended phase) of the §14.6 craftsmanship list. Phase G P1 #5 (secondary resource watches) and #6 (Azure finalizer) remain queued in separate PRs.