### PR TITLE
feat(controller): add skip_cache_hits + conditions_transitions metrics

### DIFF
--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -103,6 +103,60 @@ pub static RECONCILE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("failed to register azureclaw_controller_reconcile_total")
 });
 
+/// Total status-patch skips (idempotency cache hits) by CRD kind.
+///
+/// P2 #10: each reconcile pass diffs the desired status against the
+/// observed `.status` and skips the API patch when they match
+/// (`running_status_matches_with_extras` etc.). This counter
+/// surfaces how often that fast path fires; a sudden drop indicates
+/// a regression where every pass re-patches and the controller
+/// burns API quota.
+pub static STATUS_PATCH_SKIPS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        opts!(
+            "azureclaw_controller_skip_cache_hits_total",
+            "Total status-patch skips (idempotency cache hits) by CRD kind"
+        ),
+        &["crd_kind"]
+    )
+    .expect("failed to register azureclaw_controller_skip_cache_hits_total")
+});
+
+/// Increment the skip-cache counter for a CRD kind.
+pub fn record_status_patch_skip(crd_kind: &str) {
+    STATUS_PATCH_SKIPS.with_label_values(&[crd_kind]).inc();
+}
+
+/// Total condition status-flips by condition type and the new
+/// status value.
+///
+/// P2 #10: incremented inside [`crate::status::conditions::preserve_transition_time`]
+/// whenever a condition transitions (i.e. a fresh
+/// `last_transition_time` is stamped). Lets operators alert on
+/// e.g. a `Ready -> False` flap rate without parsing CR yaml.
+///
+/// Labels:
+/// - `condition_type`: e.g. `Ready` / `Progressing` / `Suspended` /
+///   `RuntimeReady` / `AuditIntegrity`.
+/// - `new_status`: `True` / `False` / `Unknown`.
+pub static CONDITION_TRANSITIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        opts!(
+            "azureclaw_controller_conditions_transitions_total",
+            "Total condition status-flips by condition type and new status value"
+        ),
+        &["condition_type", "new_status"]
+    )
+    .expect("failed to register azureclaw_controller_conditions_transitions_total")
+});
+
+/// Increment the condition-transition counter.
+pub fn record_condition_transition(condition_type: &str, new_status: &str) {
+    CONDITION_TRANSITIONS
+        .with_label_values(&[condition_type, new_status])
+        .inc();
+}
+
 /// Wraps a reconcile future, recording its duration + outcome on
 /// completion. Generic over the `Result` so each reconciler keeps
 /// its own `ReconcileError` type; we only need `is_ok()`.
@@ -256,5 +310,56 @@ mod tests {
         assert!(rendered.contains("azureclaw_controller_reconcile_duration_seconds"));
         assert!(rendered.contains("azureclaw_controller_reconcile_total"));
         assert!(rendered.contains("RenderDurKind"));
+    }
+
+    #[test]
+    fn record_status_patch_skip_increments_counter() {
+        let before = STATUS_PATCH_SKIPS.with_label_values(&["SkipKind"]).get();
+        record_status_patch_skip("SkipKind");
+        record_status_patch_skip("SkipKind");
+        assert_eq!(
+            STATUS_PATCH_SKIPS.with_label_values(&["SkipKind"]).get(),
+            before + 2
+        );
+    }
+
+    #[test]
+    fn record_condition_transition_uses_independent_label_pairs() {
+        let before_true = CONDITION_TRANSITIONS
+            .with_label_values(&["FlapKind", "True"])
+            .get();
+        let before_false = CONDITION_TRANSITIONS
+            .with_label_values(&["FlapKind", "False"])
+            .get();
+        record_condition_transition("FlapKind", "True");
+        record_condition_transition("FlapKind", "False");
+        record_condition_transition("FlapKind", "False");
+        assert_eq!(
+            CONDITION_TRANSITIONS
+                .with_label_values(&["FlapKind", "True"])
+                .get(),
+            before_true + 1
+        );
+        assert_eq!(
+            CONDITION_TRANSITIONS
+                .with_label_values(&["FlapKind", "False"])
+                .get(),
+            before_false + 2
+        );
+    }
+
+    #[test]
+    fn skip_and_transition_metrics_render_in_text_format() {
+        record_status_patch_skip("RenderSkipKind");
+        record_condition_transition("RenderTransKind", "True");
+        let mut buf = Vec::new();
+        let encoder = prometheus::TextEncoder::new();
+        let families = prometheus::gather();
+        prometheus::Encoder::encode(&encoder, &families, &mut buf).unwrap();
+        let rendered = String::from_utf8(buf).unwrap();
+        assert!(rendered.contains("azureclaw_controller_skip_cache_hits_total"));
+        assert!(rendered.contains("azureclaw_controller_conditions_transitions_total"));
+        assert!(rendered.contains("RenderSkipKind"));
+        assert!(rendered.contains("RenderTransKind"));
     }
 }

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -2117,6 +2117,8 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             let _ = sandbox_api
                 .patch_status(&name, &PatchParams::default(), &Patch::Merge(status_obj))
                 .await;
+        } else {
+            crate::metrics::record_status_patch_skip("ClawSandbox");
         }
     }
 

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -238,13 +238,18 @@ pub fn preserve_transition_time(
             last_transition_time: p.last_transition_time.clone(),
             observed_generation,
         },
-        _ => new_condition(
-            type_,
-            status_value,
-            reason_value,
-            message,
-            observed_generation,
-        ),
+        _ => {
+            // Status flipped (or no prior) — record the transition so
+            // operators can alert on flap rate without parsing CR yaml.
+            crate::metrics::record_condition_transition(type_, status_value);
+            new_condition(
+                type_,
+                status_value,
+                reason_value,
+                message,
+                observed_generation,
+            )
+        }
     }
 }
 

--- a/docs/security-audits/2026-05-03-craftsmanship-prometheus-metrics.md
+++ b/docs/security-audits/2026-05-03-craftsmanship-prometheus-metrics.md
@@ -1,0 +1,91 @@
+# Security Audit — Phase G P2 #10: Prometheus Metrics Expansion
+
+**Date:** 2026-05-03
+**Scope:** Controller observability surface — adds skip-cache-hit
+counter and condition-transition counter to the existing
+`/metrics` endpoint.
+**Closes §14.6 line item:** "Prometheus metrics
+(`reconcile_total`, `reconcile_duration_seconds`,
+`skip_cache_hits`, `conditions_transitions_total`) on
+`:9091/metrics` from the controller (P2 #10)".
+
+## Change summary
+
+Pre-PR the controller exposed:
+
+* `azureclaw_controller_reconcile_errors_total{crd_kind, error_class}`
+* `azureclaw_controller_reconcile_retries_total{crd_kind}`
+* `azureclaw_controller_reconcile_duration_seconds{crd_kind, outcome}`
+* `azureclaw_controller_reconcile_total{crd_kind, outcome}`
+
+This PR adds the two metrics §14.6 P2 #10 calls out and that
+`controller-runtime` operators ship by default:
+
+* `azureclaw_controller_skip_cache_hits_total{crd_kind}` —
+  incremented at every reconcile pass that observes a
+  fully-converged `.status` and skips the API patch via
+  `running_status_matches_with_extras`. Lets operators alert when
+  the steady-state fast path stops firing (a regression that
+  burns API quota).
+* `azureclaw_controller_conditions_transitions_total{condition_type, new_status}` —
+  incremented inside `preserve_transition_time` whenever the
+  helper stamps a fresh `last_transition_time` (i.e. status
+  flipped). Lets operators alert on flap rate without parsing
+  CR yaml.
+
+## STRIDE delta
+
+| Threat | Pre / Post |
+|---|---|
+| **I**nformation disclosure via metric label cardinality blow-up | Both new counters use small bounded label sets: `crd_kind` ∈ 8 values; `condition_type` ∈ {`Ready`, `Progressing`, `RuntimeReady`, `Suspended`, `AuditIntegrity`, …} ≈ 8 values; `new_status` ∈ {`True`, `False`, `Unknown`}. Worst-case time-series count for both metrics combined: ~32 — well below any sensible cardinality budget. No PII / namespace / sandbox-name labels exposed. |
+| **D**oS via unbounded series via attacker-controlled labels | None of the labels accept user input. `crd_kind` is hard-coded at the call site; `condition_type` is hard-coded in the conditions module; `new_status` is one of three K8s-defined strings. |
+| **T**ampering — counter increments are not authenticated | Same posture as the existing 4 counters. The `:9091/metrics` endpoint is only exposed inside the controller pod and behind the cluster-internal Service; not accessible from sandbox pods or externally. |
+
+## Fail-closed semantics
+
+* Both new counters use `LazyLock` registration via the global
+  Prometheus registry — same panic-on-collision contract as the
+  existing four metrics.
+* If recording panicked we would crash the controller pod, but
+  `IntCounterVec::with_label_values(...).inc()` is infallible
+  given non-empty static label sets, so this is structurally
+  unreachable.
+* The skip-cache hit path is the steady-state hot path; the
+  counter increment is a single atomic add (sub-microsecond) so
+  no measurable controller throughput impact.
+
+## OWASP-LLM mapping
+
+Indirect: improved observability of the controller's reconcile
+behaviour gives operators a faster signal on **LLM10 (Model
+Theft)** posture (rate of `Suspended -> True` transitions) and
+**LLM06 (Sensitive Information Disclosure)** posture (rate of
+`AuditIntegrity -> False` transitions, once Phase D lands).
+
+## Test coverage
+
+`controller/src/metrics.rs` mod `tests`:
+
+* `record_status_patch_skip_increments_counter`
+* `record_condition_transition_uses_independent_label_pairs`
+* `skip_and_transition_metrics_render_in_text_format`
+
+432/432 controller tests pass; clippy clean; rustfmt clean.
+
+## Scope deferrals
+
+* **Workqueue depth gauge** (controller-runtime's
+  `workqueue_depth`) is not yet wired — kube-rs's `Controller`
+  does not expose its scheduler internals publicly, so capturing
+  this would require a fork. Tracked under a follow-up.
+* **OTel GenAI SemConv traces** for reconcile spans (§14.6 line
+  item beyond P2 #10) are out of scope here; tracked under a
+  separate Phase G follow-up.
+
+## Verification commands
+
+```sh
+cargo test --package azureclaw-controller             # 432/432
+cargo clippy --package azureclaw-controller --all-targets -- -D warnings
+cargo fmt --all -- --check
+```


### PR DESCRIPTION
## Phase G P2 #10 — Prometheus metrics expansion

Closes the §14.6 'controller craftsmanship — Prometheus metrics' line item (`skip_cache_hits`, `conditions_transitions_total`).

### Adds
- `azureclaw_controller_skip_cache_hits_total{crd_kind}` — incremented when reconcile observes converged `.status` and skips the API patch
- `azureclaw_controller_conditions_transitions_total{condition_type, new_status}` — incremented inside `preserve_transition_time` whenever status flips

Both label sets bounded; worst-case ~32 time-series. No user-supplied labels.

### Tests
- 432/432 controller tests pass (was 429, +3 new)
- clippy clean; rustfmt clean

### Security
See `docs/security-audits/2026-05-03-craftsmanship-prometheus-metrics.md` for cardinality + STRIDE delta + fail-closed semantics.

### Auto-pilot context
Targets `dev` only, never `main`.
