### PR TITLE
feat(controller): derive + expose controller_config_info hash

### DIFF
--- a/controller/src/config_hash.rs
+++ b/controller/src/config_hash.rs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Controller configuration hash.
+//!
+//! P2 #12: Computes a deterministic 16-hex-char SHA-256 digest over
+//! the controller's runtime configuration (image refs, Foundry
+//! endpoints, leader-election toggles, …). The hash is logged at
+//! startup and surfaced as a Prometheus info-metric so operators
+//! can:
+//!
+//! - See whether two controller pods are running the same config
+//!   (lease handover sanity check).
+//! - Correlate a config rollout with a behaviour change (the hash
+//!   changes iff one of the inputs changes).
+//! - Use it as one input to a future per-CR
+//!   `status.observedHash` skip-cache (P0 item 3 in §14.6's
+//!   roadmap), so bumping the controller invalidates every CR's
+//!   skip-cache exactly once on next reconcile.
+//!
+//! Determinism guarantees:
+//! - The list of input env vars is hard-coded in this module
+//!   (`CONFIG_HASH_INPUTS`), so the hash domain is stable across
+//!   restarts.
+//! - Inputs are joined with a NUL byte separator + key-sorted, so
+//!   the hash is independent of process env-var iteration order.
+//! - Missing env vars are recorded as the empty string so
+//!   "unset" and "set to empty" are equivalent (operationally
+//!   identical for this controller).
+
+use prometheus::{IntGaugeVec, opts, register_int_gauge_vec};
+use sha2::{Digest, Sha256};
+use std::sync::LazyLock;
+
+/// Env var names that contribute to the controller config hash.
+///
+/// Adding/removing entries from this list is itself a config-hash
+/// change and should be called out in the audit trail.
+pub const CONFIG_HASH_INPUTS: &[&str] = &[
+    "AZURECLAW_DISABLE_ENTRA_AUTH",
+    "AZURE_AUTHORITY_HOST",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_SUBSCRIPTION_ID",
+    "AZURE_TENANT_ID",
+    "BYO_STRICT_MODE",
+    "CLUSTER_NAME",
+    "CONTENT_SAFETY_ENDPOINT",
+    "CONTROLLER_METRICS_ADDR",
+    "FEDCRED_REAPER_INTERVAL_SECS",
+    "FOUNDRY_DEPLOYMENTS",
+    "FOUNDRY_ENDPOINT",
+    "FOUNDRY_PROJECT_ENDPOINT",
+    "IDENTITY_NAME",
+    "IDENTITY_RESOURCE_GROUP",
+    "IMDS_CLIENT_ID",
+    "INFERENCE_ROUTER_IMAGE",
+    "LEADER_ELECTION_ENABLED",
+    "LEADER_ELECTION_LEASE_NAME",
+    "MAF_RUNTIME_IMAGE",
+    "MESH_PEER_ENABLED",
+    "MESH_REGISTRY_URL",
+    "MESH_RELAY_URL",
+    "OIDC_ISSUER_URL",
+    "OPENAI_AGENTS_RUNTIME_IMAGE",
+    "SANDBOX_IMAGE",
+];
+
+/// Compute the controller config hash from the supplied lookup
+/// function. Pure for testability — production code calls
+/// [`compute_from_env`].
+pub fn compute_with<F>(inputs: &[&str], lookup: F) -> String
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut keys: Vec<&str> = inputs.to_vec();
+    keys.sort_unstable();
+    keys.dedup();
+
+    let mut hasher = Sha256::new();
+    for k in keys {
+        let v = lookup(k).unwrap_or_default();
+        hasher.update(k.as_bytes());
+        hasher.update(b"=");
+        hasher.update(v.as_bytes());
+        hasher.update([0u8]);
+    }
+    let digest = hasher.finalize();
+    // 16 hex chars (8 bytes) is plenty for change-detection while
+    // staying small enough to log/label cheaply.
+    let mut out = String::with_capacity(16);
+    for b in &digest[..8] {
+        use std::fmt::Write;
+        let _ = write!(out, "{:02x}", b);
+    }
+    out
+}
+
+/// Compute the controller config hash from `std::env`.
+pub fn compute_from_env() -> String {
+    compute_with(CONFIG_HASH_INPUTS, |k| std::env::var(k).ok())
+}
+
+/// Prometheus info-metric exposing the current controller config
+/// hash. Always set to `1`; the hash is a label so PromQL queries
+/// can join on it.
+///
+/// Cardinality: exactly one series per controller pod. On a config
+/// rollover the *new* hash gets a new series; the old one stops
+/// being touched and falls out after the scrape-staleness window.
+pub static CONTROLLER_CONFIG_INFO: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        opts!(
+            "azureclaw_controller_config_info",
+            "Controller config hash info-metric (always 1; hash is a label)"
+        ),
+        &["config_hash"]
+    )
+    .expect("failed to register azureclaw_controller_config_info")
+});
+
+/// Stamp the gauge with the current config hash. Idempotent.
+pub fn record_config_hash(config_hash: &str) {
+    CONTROLLER_CONFIG_INFO
+        .with_label_values(&[config_hash])
+        .set(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn lookup_fn(map: HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
+        move |k: &str| map.get(k).map(|s| s.to_string())
+    }
+
+    #[test]
+    fn hash_is_deterministic() {
+        let inputs = &["A", "B", "C"];
+        let l = lookup_fn(HashMap::from([("A", "1"), ("B", "2"), ("C", "3")]));
+        let h1 = compute_with(inputs, &l);
+        let h2 = compute_with(inputs, &l);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 16);
+    }
+
+    #[test]
+    fn hash_is_input_order_independent() {
+        let l = lookup_fn(HashMap::from([("A", "1"), ("B", "2"), ("C", "3")]));
+        let h_sorted = compute_with(&["A", "B", "C"], &l);
+        let h_shuffled = compute_with(&["C", "A", "B"], &l);
+        assert_eq!(h_sorted, h_shuffled);
+    }
+
+    #[test]
+    fn hash_changes_when_value_changes() {
+        let inputs = &["A"];
+        let l1 = lookup_fn(HashMap::from([("A", "v1")]));
+        let l2 = lookup_fn(HashMap::from([("A", "v2")]));
+        assert_ne!(compute_with(inputs, &l1), compute_with(inputs, &l2));
+    }
+
+    #[test]
+    fn hash_treats_unset_and_empty_as_equivalent() {
+        let inputs = &["A", "B"];
+        let l_unset = lookup_fn(HashMap::from([("A", "v")]));
+        let l_empty = lookup_fn(HashMap::from([("A", "v"), ("B", "")]));
+        assert_eq!(
+            compute_with(inputs, &l_unset),
+            compute_with(inputs, &l_empty)
+        );
+    }
+
+    #[test]
+    fn hash_changes_when_key_added_to_input_set() {
+        let l = lookup_fn(HashMap::from([("A", "1"), ("B", "2")]));
+        // "B" missing from inputs vs included with value "2" must
+        // differ — guards against accidental input-set drift.
+        let h_a_only = compute_with(&["A"], &l);
+        let h_a_b = compute_with(&["A", "B"], &l);
+        assert_ne!(h_a_only, h_a_b);
+    }
+
+    #[test]
+    fn duplicate_inputs_do_not_affect_hash() {
+        let l = lookup_fn(HashMap::from([("A", "1"), ("B", "2")]));
+        let h1 = compute_with(&["A", "B"], &l);
+        let h2 = compute_with(&["A", "B", "A"], &l);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn record_config_hash_renders_info_metric() {
+        record_config_hash("deadbeefcafebabe");
+        let mut buf = Vec::new();
+        let encoder = prometheus::TextEncoder::new();
+        let families = prometheus::gather();
+        prometheus::Encoder::encode(&encoder, &families, &mut buf).unwrap();
+        let rendered = String::from_utf8(buf).unwrap();
+        assert!(rendered.contains("azureclaw_controller_config_info"));
+        assert!(rendered.contains("deadbeefcafebabe"));
+    }
+
+    #[test]
+    fn production_input_list_is_non_empty_and_unique() {
+        assert!(!CONFIG_HASH_INPUTS.is_empty());
+        let mut seen = std::collections::HashSet::new();
+        for k in CONFIG_HASH_INPUTS {
+            assert!(
+                seen.insert(*k),
+                "duplicate input key in CONFIG_HASH_INPUTS: {k}"
+            );
+        }
+    }
+}

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -24,6 +24,7 @@ mod claw_eval_reconciler;
 mod claw_memory;
 mod claw_memory_compile;
 mod claw_memory_reconciler;
+mod config_hash;
 mod crd;
 #[allow(dead_code)]
 // CRD-installation pipeline (Phase 1 close-out + future kubectl-claw-attest) consumes these helpers.
@@ -81,6 +82,16 @@ async fn main() -> Result<()> {
         .init();
 
     tracing::info!("AzureClaw Controller starting");
+
+    // P2 #12: stamp the controller config hash early so it appears
+    // in the very first log line operators look at and is exposed
+    // on /metrics before any reconciler fires.
+    let config_hash = config_hash::compute_from_env();
+    config_hash::record_config_hash(&config_hash);
+    tracing::info!(
+        controller_config_hash = %config_hash,
+        "controller config hash computed; surfaced as azureclaw_controller_config_info"
+    );
 
     let client = Client::try_default().await?;
 

--- a/docs/security-audits/2026-05-03-craftsmanship-controller-config-hash.md
+++ b/docs/security-audits/2026-05-03-craftsmanship-controller-config-hash.md
@@ -1,0 +1,104 @@
+# Security Audit — Phase G P2 #12: Controller-config hash derivation
+
+**Date:** 2026-05-03
+**Scope:** Compute a deterministic 16-hex-char SHA-256 digest of
+the controller's runtime configuration; log on startup and
+surface as a Prometheus info-metric.
+**Closes §14.6 line item:** "Controller-config hash derivation
+(env vars → hash field) (P2 #12)".
+
+## Change summary
+
+A new module `controller/src/config_hash.rs` introduces:
+
+* `CONFIG_HASH_INPUTS` — a hard-coded list of 26 env var names
+  that contribute to the hash. Adding/removing a name is itself a
+  hash change and is called out in this audit.
+* `compute_with(inputs, lookup) -> String` — pure, testable hash
+  computation. Inputs are sorted, deduped, joined with `=` + NUL.
+* `compute_from_env()` — production wrapper reading
+  `std::env::var`.
+* `azureclaw_controller_config_info{config_hash}` — Prometheus
+  `IntGaugeVec`, always set to `1`. Operators query in PromQL via
+  `count by (config_hash) (azureclaw_controller_config_info)`.
+
+Wired in `main.rs` immediately after the tracing subscriber init
+so the hash appears in the first log line and on `/metrics`
+before any reconciler fires.
+
+## Determinism guarantees
+
+* **Stable input domain:** the list is in source, not derived from
+  process env iteration.
+* **Order independence:** `compute_with` sorts its `inputs` slice
+  with `sort_unstable` + `dedup` before hashing.
+* **Unset == empty:** missing env vars and env vars set to the
+  empty string produce the same hash. This matches the controller's
+  operational behaviour — both are treated as "unconfigured".
+* **Truncation:** SHA-256 is truncated to its first 8 bytes (16
+  hex chars). Sufficient for change detection (collision space
+  2^32 for the birthday bound; we expect ≪ 10⁵ distinct configs
+  in any cluster's lifetime).
+
+## STRIDE delta
+
+| Threat | Posture |
+|---|---|
+| **I**nformation disclosure via the hash | The hash is a **one-way** digest; reversing requires brute-forcing 26 env-var values, each potentially long. Operators with `/metrics` access can already read most of these env vars via `kubectl describe pod`. Net: no new disclosure surface. |
+| **I**nformation disclosure via the metric label cardinality | Each controller pod emits exactly one series per its current config. On rollover the new hash gets a new series; the old one ages out at scrape-staleness. Worst case: ~5 series per controller restart cycle. |
+| **T**ampering — attacker mutates an env var to change behaviour | Out of scope: env vars come from the K8s Pod spec / Deployment, which is RBAC-gated. The hash *exposes* tampering by changing visibly. |
+| **D**oS — hash computation cost | Single SHA-256 over <2 KB of input at startup; sub-millisecond. |
+
+## Fail-closed semantics
+
+* `compute_from_env()` is infallible — `std::env::var` errors
+  (`NotPresent`, `NotUnicode`) are mapped to empty strings via
+  `.ok().unwrap_or_default()`. A non-UTF-8 env var value is
+  therefore silently treated as absent. This is the safest
+  operational choice: we never crash the controller because of a
+  weird env var, and we never spuriously change the hash if a
+  non-ASCII byte slips in via a tooling roundtrip.
+
+## OWASP-LLM mapping
+
+Indirect: gives operators a fast supply-chain integrity signal
+(**LLM05 Supply Chain**) — if two controller pods report
+different `config_hash`, one of them is running the wrong config,
+which is an immediate red flag for a partial rollout or
+misconfigured CI.
+
+## Test coverage
+
+`controller/src/config_hash.rs::tests`:
+
+* `hash_is_deterministic`
+* `hash_is_input_order_independent`
+* `hash_changes_when_value_changes`
+* `hash_treats_unset_and_empty_as_equivalent`
+* `hash_changes_when_key_added_to_input_set`
+* `duplicate_inputs_do_not_affect_hash`
+* `record_config_hash_renders_info_metric`
+* `production_input_list_is_non_empty_and_unique`
+
+440/440 controller tests pass (was 432, +8 new); clippy clean;
+rustfmt clean.
+
+## Scope deferrals
+
+* **Per-CR `status.observedHash`** — wiring this hash into a
+  per-ClawSandbox skip-cache (§14.6 P0 item 3) is a follow-up; it
+  needs a referenced-Secret resourceVersion + canonical-JSON spec
+  digest combined with this controller hash. Tracked separately.
+* **`CONTROLLER_GIT_SHA` build-time input** — not yet plumbed
+  through the build pipeline; the env-var-only digest is
+  sufficient for the operational signal §14.6 calls out, and the
+  image digest already surfaces independently via
+  `kubectl describe pod`.
+
+## Verification commands
+
+```sh
+cargo test --package azureclaw-controller             # 440/440
+cargo clippy --package azureclaw-controller --all-targets -- -D warnings
+cargo fmt --all -- --check
+```


### PR DESCRIPTION
## Phase G P2 #12 — Controller-config hash derivation

Closes the §14.6 'controller craftsmanship — controller-config hash' line item.

### Adds
- New `controller/src/config_hash.rs` module with 26 hard-coded env-var inputs
- `azureclaw_controller_config_info{config_hash}` Prometheus info-metric
- Logs hash at startup before any reconciler fires

Operators can `count by (config_hash)` to detect partial rollouts.

### Tests
- 440/440 controller tests pass (was 432, +8 new)
- clippy clean; rustfmt clean

### Security
See `docs/security-audits/2026-05-03-craftsmanship-controller-config-hash.md` for determinism + fail-closed semantics + cardinality bound.

### Auto-pilot context
Targets `dev` only, never `main`.
