### PR TITLE
feat(crd): add 3 CEL rules to ClawSandbox + e2e regression coverage

### DIFF
--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -19,6 +19,31 @@ spec:
             spec:
               type: object
               required: ["runtime", "sandbox", "inferenceRef"]
+              x-kubernetes-validations:
+                # P2 #13: top-level cross-field invariants.
+                #
+                # 1. BYO runtime is mutually exclusive with the
+                #    Foundry-agent path. BYO containers bring their
+                #    own inference + agent loop and don't go through
+                #    the controller-managed Foundry prompt agent
+                #    (see crd.rs ClawSandboxSpec docs and
+                #    reconciler/mod.rs ~line 1017). Without this CEL
+                #    the controller silently no-ops the agent block
+                #    on BYO; the rule turns it into an immediate
+                #    `kubectl apply` error.
+                - rule: "self.runtime.kind != 'BYO' || !has(self.agent)"
+                  message: "spec.agent (Foundry agent) is incompatible with spec.runtime.kind=BYO; BYO runtimes own their own inference + agent loop"
+                  reason: "FieldValueInvalid"
+                # 2. governance.toolPolicyRef is in the same
+                #    namespace as the ClawSandbox (cross-namespace
+                #    refs are forbidden by docs/crd-precedence.md).
+                #    The schema-level pattern already enforces a
+                #    valid DNS label; this rule guards against the
+                #    common authoring mistake of pasting
+                #    "ns/name" or "ns:name".
+                - rule: "!has(self.governance) || !has(self.governance.toolPolicyRef) || !has(self.governance.toolPolicyRef.name) || (!self.governance.toolPolicyRef.name.contains('/') && !self.governance.toolPolicyRef.name.contains(':'))"
+                  message: "spec.governance.toolPolicyRef.name must be a same-namespace name (no '/' or ':' separators); cross-namespace refs are forbidden"
+                  reason: "FieldValueInvalid"
               properties:
                 runtime:
                   type: object
@@ -357,6 +382,13 @@ spec:
                   x-kubernetes-validations:
                     - rule: "!has(self.enabled) || !self.enabled || (has(self.toolPolicyRef) && self.toolPolicyRef.name.size() > 0)"
                       message: "spec.governance.toolPolicyRef.name must be set when governance.enabled=true"
+                    # P2 #13: trust score domain is 0-1000 (see crd.rs
+                    # GovernanceConfig docstring). Values outside this
+                    # range are silently clamped by the inference router
+                    # but the authoring intent is almost always a typo.
+                    - rule: "!has(self.trustThreshold) || (self.trustThreshold >= 0 && self.trustThreshold <= 1000)"
+                      message: "spec.governance.trustThreshold must be in the range [0, 1000]"
+                      reason: "FieldValueInvalid"
                   properties:
                     enabled:
                       type: boolean

--- a/docs/security-audits/2026-05-03-craftsmanship-cel-validations.md
+++ b/docs/security-audits/2026-05-03-craftsmanship-cel-validations.md
@@ -1,0 +1,112 @@
+# Security Audit — Phase G P2 #13: CEL validations on ClawSandbox
+
+**Date:** 2026-05-03
+**Scope:** Spec-level admission CEL on the flagship `ClawSandbox`
+CRD. Adds three new `x-kubernetes-validations` rules covering
+cross-field invariants that were previously enforced only at the
+reconciler layer (or not at all).
+**Closes §14.6 line item:** "CEL validations embedded in CRD
+YAML (P2 #13)".
+
+## Change summary
+
+`deploy/helm/azureclaw/templates/crd.yaml` ClawSandbox `spec`:
+
+1. **BYO ⊕ Foundry-agent mutual exclusion.**
+   ```cel
+   self.runtime.kind != 'BYO' || !has(self.agent)
+   ```
+   BYO containers own their own inference + agent loop and bypass
+   the controller-managed Foundry prompt agent
+   (`reconciler/mod.rs` ~line 1017 silently no-ops the agent block
+   on BYO). The CEL turns the silent no-op into an immediate
+   `kubectl apply` rejection so the operator can't be misled into
+   thinking their `instructions` block is being honoured.
+
+2. **`governance.toolPolicyRef.name` is same-namespace only.**
+   ```cel
+   !has(self.governance) || !has(self.governance.toolPolicyRef) || !has(self.governance.toolPolicyRef.name) || (!self.governance.toolPolicyRef.name.contains('/') && !self.governance.toolPolicyRef.name.contains(':'))
+   ```
+   The schema-level `pattern: "^[a-z0-9](...)"` regex already
+   rejects `ns/name` and `ns:name` — but it rejects them with a
+   generic "does not match pattern" message that doesn't tell the
+   operator *why*. The new CEL gives a precise message naming the
+   security invariant (`docs/crd-precedence.md`: cross-namespace
+   refs forbidden because they would be a privilege-escalation
+   vector).
+
+3. **`governance.trustThreshold` ∈ [0, 1000].**
+   ```cel
+   !has(self.trustThreshold) || (self.trustThreshold >= 0 && self.trustThreshold <= 1000)
+   ```
+   The trust-score domain is documented as 0–1000 (see
+   `crd.rs::GovernanceConfig`). Values outside the range are
+   silently clamped at the inference-router boundary; without the
+   CEL the operator sees no error and the agent silently runs at
+   the clamp value.
+
+## STRIDE delta
+
+| Threat | Pre-PR posture | Post-PR posture |
+|---|---|---|
+| **E**levation via cross-namespace `toolPolicyRef` | Already blocked by schema pattern, but with a generic error | Same block **with operator-actionable error message** — operator can't accidentally retry with a different ns syntax |
+| **T**ampering — operator sets `agent` on a BYO sandbox expecting it to take effect | Silently ignored at reconcile time (no Foundry agent created); operator sees `Running` but no agent | Rejected at apply time with explicit message |
+| **D**oS — operator sets `trustThreshold: 999999` accidentally | Silently clamped; trust-score check effectively disabled (or always-deny depending on clamp direction) | Rejected at apply; explicit range message |
+
+## Fail-closed semantics
+
+* All three rules are written so that a missing nested field is
+  treated as "rule does not apply" (`!has(...) || ...`) — they
+  are guards, not requirements. The ClawSandbox `required` list
+  is unchanged.
+* On CEL compilation failure the API server fails closed
+  (rejects all writes to the CRD) — so a typo in this YAML would
+  surface immediately on `helm upgrade` rather than silently
+  disabling the rule.
+
+## OWASP-LLM mapping
+
+* **LLM01 (Prompt Injection):** Rule #1 prevents a BYO sandbox
+  from carrying a stale `agent.instructions` block that an
+  operator might assume is being delivered. Eliminates a class of
+  "I set the system prompt but the agent isn't following it"
+  incidents that often get debugged as prompt-injection.
+* **LLM06 (Sensitive Information Disclosure):** Rule #2 makes
+  the same-namespace invariant explicit; cross-tenant
+  toolPolicyRef would be the canonical privilege-escalation
+  primitive.
+
+## Test coverage
+
+`tests/e2e/run.sh` (the §14.6 single-most-important gate):
+
+* `test_clawsandbox_cel_rejects_byo_with_agent`
+* `test_clawsandbox_cel_rejects_trust_threshold_out_of_range`
+* `test_clawsandbox_cel_rejects_cross_namespace_toolpolicy_ref`
+
+Each test attempts a `kubectl apply` of a deliberately-bad
+ClawSandbox and asserts that the apply fails. A regression that
+removes the CEL would let the apply succeed and the test would
+fail.
+
+## Scope deferrals
+
+* No changes to the Rust-side controller `crd_validations.rs`
+  module (covers the 6 sub-CRDs via kube-rs derive + injection).
+  ClawSandbox CRD is hand-written in Helm and is **not** part of
+  the `helm_drift` test scope (`controller/src/helm_drift.rs`
+  covers MCP / ToolPolicy / A2AAgent / InferencePolicy /
+  ClawMemory / ClawEval only). The Helm CRD remains the single
+  source of truth for ClawSandbox; this PR is purely additive.
+* No new Rust unit tests — CEL is enforced by the K8s API server,
+  not by the controller. The E2E gate is the correct place to
+  cover regressions.
+
+## Verification commands
+
+```sh
+# Local kind run:
+make test-e2e
+
+# CI: same gate runs in `Kind E2E` job.
+```

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1112,6 +1112,107 @@ EOF
     kubectl delete inferencepolicy "${sandbox}-inference" -n azureclaw-system --ignore-not-found >/dev/null 2>&1
 }
 
+test_clawsandbox_cel_rejects_byo_with_agent() {
+    # P2 #13: spec-level CEL must reject BYO runtime + Foundry agent
+    # combination — they are architecturally incompatible (BYO
+    # containers own their own inference + agent loop).
+    if kubectl apply -f - >/dev/null 2>&1 <<'EOF'
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: e2e-cel-byo-with-agent
+  namespace: azureclaw-system
+spec:
+  inferenceRef:
+    name: e2e-test-inference
+  runtime:
+    kind: BYO
+    byo:
+      image: ghcr.io/example/byo:e2e
+      contractVersion: v1
+  agent:
+    instructions: "this should be rejected"
+  sandbox:
+    isolation: standard
+EOF
+    then
+        kubectl delete clawsandbox e2e-cel-byo-with-agent -n azureclaw-system --wait=false >/dev/null 2>&1 || true
+        fail "CEL did NOT reject ClawSandbox with runtime.kind=BYO + spec.agent set"
+    else
+        pass "CEL rejects ClawSandbox with runtime.kind=BYO + spec.agent set"
+    fi
+}
+
+test_clawsandbox_cel_rejects_trust_threshold_out_of_range() {
+    # P2 #13: governance.trustThreshold must be in [0, 1000]. The
+    # docstring says so; this CEL guards the operator's first-apply
+    # against a typo (e.g. 9999 → silently clamped before this rule).
+    if kubectl apply -f - >/dev/null 2>&1 <<'EOF'
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: e2e-cel-trust-overflow
+  namespace: azureclaw-system
+spec:
+  inferenceRef:
+    name: e2e-test-inference
+  runtime:
+    kind: OpenClaw
+    openclaw: {}
+  governance:
+    enabled: true
+    toolPolicyRef:
+      name: e2e-tool-policy
+    trustThreshold: 9999
+  sandbox:
+    isolation: standard
+EOF
+    then
+        kubectl delete clawsandbox e2e-cel-trust-overflow -n azureclaw-system --wait=false >/dev/null 2>&1 || true
+        fail "CEL did NOT reject ClawSandbox with governance.trustThreshold=9999"
+    else
+        pass "CEL rejects ClawSandbox with governance.trustThreshold out of [0,1000]"
+    fi
+}
+
+test_clawsandbox_cel_rejects_cross_namespace_toolpolicy_ref() {
+    # P2 #13: cross-namespace refs are forbidden by
+    # docs/crd-precedence.md. The CRD-side pattern already guards
+    # the regex but would silently accept "ns/name" (no slash) by
+    # rejecting the whole field. The new CEL rule rejects the
+    # common "ns/name" / "ns:name" authoring mistakes explicitly
+    # so the operator gets a precise error message.
+    if kubectl apply -f - >/dev/null 2>&1 <<'EOF'
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: e2e-cel-xns-ref
+  namespace: azureclaw-system
+spec:
+  inferenceRef:
+    name: e2e-test-inference
+  runtime:
+    kind: OpenClaw
+    openclaw: {}
+  governance:
+    enabled: true
+    toolPolicyRef:
+      name: "other-ns:e2e-tool-policy"
+    trustThreshold: 500
+  sandbox:
+    isolation: standard
+EOF
+    then
+        kubectl delete clawsandbox e2e-cel-xns-ref -n azureclaw-system --wait=false >/dev/null 2>&1 || true
+        fail "CEL did NOT reject cross-namespace toolPolicyRef.name"
+    else
+        pass "CEL rejects cross-namespace toolPolicyRef.name"
+    fi
+}
+
 test_tool_policy_update_flow() {
     # Apply ToolPolicy → record ConfigMap content → update the spec
     # → assert the ConfigMap content changed. This exercises the
@@ -1799,6 +1900,9 @@ main() {
     test_sandbox_networkpolicy_denies_ingress || true
     test_sandbox_suspended_lifecycle || true
     test_secondary_resource_watch || true
+    test_clawsandbox_cel_rejects_byo_with_agent || true
+    test_clawsandbox_cel_rejects_trust_threshold_out_of_range || true
+    test_clawsandbox_cel_rejects_cross_namespace_toolpolicy_ref || true
     test_controller_emits_events || true
     test_ap2_commerce_required_route_gate || true
     test_mcp_initialize_version_negotiation || true


### PR DESCRIPTION
## Phase G P2 #13 — CEL validations on ClawSandbox

Closes the §14.6 'controller craftsmanship — CEL validations' line item.

### Adds (deploy/helm/azureclaw/templates/crd.yaml ClawSandbox spec)
2. **toolPolicyRef.name same-namespace** guard (precise message; pattern was already rejecting but generically)
3. **trustThreshold ∈ [0, 1000]** range guard (was silently clamped before)

### E2E (§14.6 most-important gate)
- `test_clawsandbox_cel_rejects_byo_with_agent`
- `test_clawsandbox_cel_rejects_trust_threshold_out_of_range`
- `test_clawsandbox_cel_rejects_cross_namespace_toolpolicy_ref`

### Tests
- 440/440 controller tests pass (no Rust changes)
- ClawSandbox CRD is hand-written; not in helm_drift scope

### Security
See `docs/security-audits/2026-05-03-craftsmanship-cel-validations.md` for STRIDE delta + fail-closed semantics + OWASP-LLM mapping.

### Auto-pilot context
Targets `dev` only, never `main`.
