### PR TITLE
feat(controller): TrustGraph CRD + reconciler (Phase F1)

### DIFF
--- a/ci/no-custom-crypto.sh
+++ b/ci/no-custom-crypto.sh
@@ -55,6 +55,7 @@ ALLOW_PATHS=(
   'controller/src/inference_policy_compile.rs' # InferencePolicy → AGT-profile compile (S4)
   'controller/src/claw_memory_compile.rs'      # ClawMemory binding compile (S5)
   'controller/src/claw_eval_compile.rs'        # ClawEval suite compile (S6)
+  'controller/src/trust_graph_compile.rs'      # Phase F1: TrustGraph edge signature verifier — pure conduit to ed25519-dalek::{Signature, Verifier, VerifyingKey} + sha2 for the version-hash; no hand-rolled crypto math, domain-separated canonical payload defined in PAYLOAD_DOMAIN constant
   'vendor/'
   'tests/'
 )

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -438,6 +438,64 @@ pub fn claw_eval_crd() -> CustomResourceDefinition {
         .expect("kube-rs derive must produce a spec property on ClawEval")
 }
 
+/// `TrustGraph.spec` CEL rules. Phase F1.
+///
+/// 1. `vertices` must be non-empty (an empty graph yields a useless
+///    projection — the operator likely meant to delete the CR).
+/// 2. Every `vertices[*].alg` must be `"EdDSA"` — only supported.
+/// 3. Every `edges[*].score` must be in `[0, 1000]` (the AGT
+///    trust-score domain — same range as
+///    `ClawSandbox.spec.governance.trustThreshold`).
+/// 4. Every `edges[*].notAfter`, when set, must be `>= issuedAt`
+///    (an inverted-expiry edge cannot represent a meaningful
+///    attestation lifetime).
+#[must_use]
+pub fn trust_graph_validations() -> Vec<ValidationRule> {
+    vec![
+        ValidationRule {
+            rule: "size(self.vertices) > 0".into(),
+            message: Some("spec.vertices must contain at least one entry".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "self.vertices.all(v, v.alg == 'EdDSA')".into(),
+            message: Some(
+                "spec.vertices[*].alg must be 'EdDSA' (only supported algorithm)".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.edges) || self.edges.all(e, e.score >= 0 && e.score <= 1000)"
+                .into(),
+            message: Some("spec.edges[*].score must be in [0, 1000]".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.edges) || self.edges.all(e, !has(e.notAfter) || e.notAfter >= e.issuedAt)".into(),
+            message: Some(
+                "spec.edges[*].notAfter, when set, must be >= issuedAt".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+    ]
+}
+
+/// `TrustGraph` CRD with [`trust_graph_validations`] injected.
+///
+/// Panics only if kube-rs ever produces a CRD whose `spec` is missing.
+#[must_use]
+pub fn trust_graph_crd() -> CustomResourceDefinition {
+    inject_spec_validations(
+        crate::trust_graph::TrustGraph::crd(),
+        trust_graph_validations(),
+    )
+    .expect("kube-rs derive must produce a spec property on TrustGraph")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/controller/src/field_managers.rs
+++ b/controller/src/field_managers.rs
@@ -53,6 +53,10 @@ pub const CLAW_MEMORY: &str = "azureclaw-controller/clawmemory";
 /// `ClawEval` reconciler — eval bundle ConfigMap + Job emission.
 pub const CLAW_EVAL: &str = "azureclaw-controller/claweval";
 
+/// `TrustGraph` reconciler (Phase F1) — verifies signed trust edges
+/// and publishes a `ConfigMap` projection to `azureclaw-system`.
+pub const TRUST_GRAPH: &str = "azureclaw-controller/trustgraph";
+
 /// Reserved for the in-pod inference router so its writes don't collide
 /// with the controller's. Not used by the controller itself; exposed as a
 /// constant so the uniqueness invariant is enforceable across crates.
@@ -85,6 +89,7 @@ pub const ALL_FIELD_MANAGERS: &[&str] = &[
     INFERENCE_POLICY,
     CLAW_MEMORY,
     CLAW_EVAL,
+    TRUST_GRAPH,
     ROUTER_RECONCILER,
     PROVIDER_BRIDGE,
     MESH,

--- a/controller/src/helm_drift.rs
+++ b/controller/src/helm_drift.rs
@@ -33,7 +33,7 @@
 #[cfg(test)]
 use crate::crd_validations::{
     a2a_agent_crd, claw_eval_crd, claw_memory_crd, inference_policy_crd, mcp_server_crd,
-    tool_policy_crd,
+    tool_policy_crd, trust_graph_crd,
 };
 
 const MCP_HELM_CRD_PATH: &str = concat!(
@@ -64,6 +64,11 @@ const CLAWMEMORY_HELM_CRD_PATH: &str = concat!(
 const CLAWEVAL_HELM_CRD_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../deploy/helm/azureclaw/templates/crd-claweval.yaml"
+);
+
+const TRUSTGRAPH_HELM_CRD_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../deploy/helm/azureclaw/templates/crd-trustgraph.yaml"
 );
 
 /// Strip non-schema fields that legitimately differ between the Rust
@@ -245,5 +250,26 @@ mod tests {
         let rust_crd_value =
             serde_json::to_value(claw_eval_crd()).expect("rust crd serializes to JSON");
         assert_helm_matches_rust(CLAWEVAL_HELM_CRD_PATH, rust_crd_value, "claweval");
+    }
+
+    /// One-shot dumper for the trustgraph CRD. Run via:
+    ///
+    ///   DUMP_TRUSTGRAPH_CRD_YAML=1 cargo test --bin azureclaw-controller \
+    ///       helm_drift::tests::dump_trustgraph_crd_yaml -- --nocapture
+    #[test]
+    fn dump_trustgraph_crd_yaml() {
+        if std::env::var("DUMP_TRUSTGRAPH_CRD_YAML").is_err() {
+            return;
+        }
+        let crd = trust_graph_crd();
+        let yaml = serde_yaml::to_string(&crd).expect("serialize crd to YAML");
+        println!("---\n{yaml}");
+    }
+
+    #[test]
+    fn helm_trustgraph_crd_matches_rust_schema() {
+        let rust_crd_value =
+            serde_json::to_value(trust_graph_crd()).expect("rust crd serializes to JSON");
+        assert_helm_matches_rust(TRUSTGRAPH_HELM_CRD_PATH, rust_crd_value, "trustgraph");
     }
 }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -53,6 +53,9 @@ mod status;
 mod tool_policy;
 mod tool_policy_compile;
 mod tool_policy_reconciler;
+mod trust_graph;
+mod trust_graph_compile;
+mod trust_graph_reconciler;
 
 use anyhow::Result;
 use kube::Client;
@@ -195,6 +198,10 @@ async fn main() -> Result<()> {
         let client = client.clone();
         tokio::spawn(async move { claw_eval_reconciler::run(client).await })
     };
+    let trust_graph_handle = {
+        let client = client.clone();
+        tokio::spawn(async move { trust_graph_reconciler::run(client).await })
+    };
 
     // S12.d: SignerPolicy ConfigMap watcher. Installs a process-global
     // handle so `policy_fetcher::maybe_verify_allowlist` resolves
@@ -330,6 +337,9 @@ async fn main() -> Result<()> {
             res??;
         }
         res = claw_eval_handle => {
+            res??;
+        }
+        res = trust_graph_handle => {
             res??;
         }
         res = mesh_peer_handle => {

--- a/controller/src/trust_graph.rs
+++ b/controller/src/trust_graph.rs
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `TrustGraph` CRD — Phase F of the §14.6 roadmap.
+//!
+//! Cluster-scoped CRD that promotes per-sandbox AGT trust scores to a
+//! cluster-wide signed graph: vertices are agent identities (AMID-like
+//! strings carrying an Ed25519 public key), edges are signed trust
+//! attestations of the form "vertex `from` asserts trust `score` in
+//! vertex `to`, valid until `notAfter`".
+//!
+//! ## Scope guardrails (per plan.md Phase F)
+//!
+//! - **No external attestation issuers.** All edge signatures are
+//!   verified locally against vertices declared in the same `TrustGraph`
+//!   CR. The controller does not call out to Sigstore Rekor, OIDC IdPs,
+//!   or any network endpoint.
+//! - **No transparency log publish.** Phase F is in-cluster only;
+//!   public-attestation transparency is out of scope per the user's
+//!   "no public posting" rule.
+//! - **Reconciler validates, does not derive.** The CR is the source of
+//!   truth; the reconciler verifies signatures and vertex<->edge
+//!   reachability and emits a projection ConfigMap. Transitive closure
+//!   is computed router-side at query time (Phase F2).
+//!
+//! ## Where the projection lives
+//!
+//! For each `TrustGraph/<name>` the reconciler writes a single
+//! `ConfigMap` named `trustgraph-<name>-projection` in the
+//! `azureclaw-system` namespace, keyed by `graph.json`. The router
+//! mounts this ConfigMap (Phase F2) and answers
+//! `trust_score(from, to)` queries against the validated graph.
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// `TrustGraph.spec` — the cluster-wide trust topology.
+#[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[kube(
+    group = "azureclaw.azure.com",
+    version = "v1alpha1",
+    kind = "TrustGraph",
+    status = "TrustGraphStatus",
+    shortname = "tg",
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Vertices","type":"integer","jsonPath":".status.validVertices"}"#,
+    printcolumn = r#"{"name":"ValidEdges","type":"integer","jsonPath":".status.validEdges"}"#,
+    printcolumn = r#"{"name":"InvalidEdges","type":"integer","jsonPath":".status.invalidEdges"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustGraphSpec {
+    /// Vertex set. Each vertex declares an identity and the Ed25519
+    /// public key peers must use to verify outbound edge signatures
+    /// from this vertex.
+    ///
+    /// `id` must be unique across the spec — admission CEL enforces.
+    /// At least one vertex is required (an empty graph would yield a
+    /// useless projection); enforced by CEL `size(self.vertices) > 0`.
+    pub vertices: Vec<TrustVertex>,
+
+    /// Edge set. Each edge is a signed attestation from `from` to
+    /// `to` carrying a trust score in [0, 1000] (the AGT trust-score
+    /// domain — see `crd.rs::GovernanceConfig`).
+    ///
+    /// Edges where signature verification fails are reported in
+    /// `status.invalidEdges` and omitted from the projection
+    /// ConfigMap. The reconciler does not delete invalid edges from
+    /// the spec — the operator owns the spec; the reconciler only
+    /// publishes the verified subset.
+    #[serde(default)]
+    pub edges: Vec<TrustEdge>,
+}
+
+/// One vertex — an agent identity with its Ed25519 public key.
+///
+/// Field naming mirrors `A2AAgent.signingKeys` for cross-CRD
+/// consistency: the same key material can be authored once in
+/// `A2AAgent` and re-declared as a `TrustGraph` vertex without any
+/// re-encoding step.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustVertex {
+    /// Stable identity (DNS-label-shaped string). Conventionally an
+    /// AGT AMID or a fully-qualified `a2a-agent/<ns>/<name>` form.
+    /// Must be unique within the CR (CEL).
+    pub id: String,
+
+    /// Algorithm pin. Currently only `"EdDSA"` is honoured; other
+    /// values cause the reconciler to mark the vertex invalid and
+    /// drop edges originating from it.
+    pub alg: String,
+
+    /// Ed25519 public key, base64url-encoded with NO padding (RFC
+    /// 7515 §2). 32 bytes after decode.
+    pub public_key_b64u: String,
+
+    /// Optional human-readable label rendered in audit logs and the
+    /// projection ConfigMap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// One edge — a signed trust attestation between two vertices.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustEdge {
+    /// Source vertex `id`. Must resolve to a vertex in
+    /// `spec.vertices` whose public key signed this edge.
+    pub from: String,
+
+    /// Target vertex `id`. Must resolve to a vertex in
+    /// `spec.vertices`.
+    pub to: String,
+
+    /// Trust score in `[0, 1000]` — the AGT domain. CEL guards the
+    /// range at admission; the reconciler additionally clamps for
+    /// defensive depth.
+    pub score: u32,
+
+    /// Issuance timestamp, Unix seconds. Part of the canonical signed
+    /// payload — peers verify both the signature and that
+    /// `issuedAt <= now`.
+    pub issued_at: i64,
+
+    /// Optional expiry timestamp, Unix seconds. `None` means "never
+    /// expires" (operator-asserted; the reconciler still flags
+    /// suspiciously old `issuedAt`s in conditions but does not
+    /// invalidate).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_after: Option<i64>,
+
+    /// Ed25519 signature, base64url-encoded with NO padding, over the
+    /// canonical bytes
+    /// `b"trustgraph.v1\n" || from || b"\n" || to || b"\n" || score-as-decimal-ascii || b"\n" || issued_at-as-decimal-ascii || b"\n" || not_after-as-decimal-ascii-or-empty || b"\n"`.
+    /// 64 bytes after decode.
+    ///
+    /// The version prefix `trustgraph.v1\n` is a domain-separator so
+    /// a signature over a `TrustGraph` edge can never be replayed as
+    /// an `A2AAgent` AgentCard signature.
+    pub signature: String,
+
+    /// Optional free-text reason ("auditor-attested",
+    /// "transitive-1-hop", …) carried into the projection so
+    /// downstream policy can pivot on the origin of the trust.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `TrustGraph.status` — populated by the reconciler.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustGraphStatus {
+    /// `Pending` | `Ready` | `Degraded`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+
+    /// Standard K8s conditions (`Ready`, `Validated`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<Vec<Condition>>,
+
+    /// Number of vertices that decoded successfully (correct alg +
+    /// 32-byte public key).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_vertices: Option<i64>,
+
+    /// Number of edges whose signature verified against the declared
+    /// `from` vertex's public key. Only valid edges are emitted into
+    /// the projection ConfigMap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_edges: Option<i64>,
+
+    /// Number of edges that failed verification (bad signature,
+    /// missing vertex, decode error, expired). Counted but not named
+    /// to avoid leaking authoring detail into status; operators
+    /// inspect controller logs (`error_class`) for which.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalid_edges: Option<i64>,
+
+    /// `metadata.namespace/metadata.name` of the projection ConfigMap.
+    /// Always `azureclaw-system/trustgraph-<name>-projection` once
+    /// the reconciler has written successfully.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_config_map_ref: Option<crate::mcp_server::LocalObjectRef>,
+
+    /// Generation observed at the last successful reconcile. Used by
+    /// kube watcher consumers to detect stale projections.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+
+    /// RFC3339 timestamp of the last reconcile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reconciled_at: Option<String>,
+}

--- a/controller/src/trust_graph_compile.rs
+++ b/controller/src/trust_graph_compile.rs
@@ -1,0 +1,701 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Pure compile / verify step for `TrustGraph` — signature
+//! verification, vertex deduplication, edge validation. Mirrors the
+//! split shape used by `a2a_agent_compile` / `tool_policy_compile`:
+//! reconciler is the side-effecting outer loop, this module is
+//! deterministic and side-effect-free so it gets dense unit-test
+//! coverage.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+
+use crate::trust_graph::TrustEdge;
+use crate::trust_graph::TrustGraphSpec;
+#[cfg(test)]
+use crate::trust_graph::TrustVertex;
+
+/// Domain-separator prefix for the canonical signing payload.
+/// Locked at v1 — bumping requires a coordinated CRD-version bump
+/// and a peer rollout window, so it is intentionally hard to change.
+pub const PAYLOAD_DOMAIN: &[u8] = b"trustgraph.v1\n";
+
+/// Output of [`compile_trust_graph`] — the validated graph that gets
+/// serialised to the projection ConfigMap.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectedGraph {
+    /// Verified vertices, in the order they appeared in the spec.
+    /// Duplicate-id vertices are kept once (first occurrence wins);
+    /// vertices whose key/alg fails to decode are dropped.
+    pub vertices: Vec<ProjectedVertex>,
+
+    /// Verified edges, in the order they appeared in the spec.
+    /// Edges that fail verification are dropped — never silently
+    /// promoted; the reconciler stamps `status.invalidEdges`.
+    pub edges: Vec<ProjectedEdge>,
+
+    /// SHA-256-truncated content hash of the projected graph
+    /// (rendered as 16 hex chars) — change-detection token for the
+    /// router-side mount and the audit log.
+    pub version_hash: String,
+
+    /// Total edges in the input spec — exposed so consumers can
+    /// detect a degraded graph (`edges.len() < input_edge_count`).
+    pub input_edge_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectedVertex {
+    pub id: String,
+    pub alg: String,
+    pub public_key_b64u: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectedEdge {
+    pub from: String,
+    pub to: String,
+    pub score: u32,
+    pub issued_at: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub not_after: Option<i64>,
+    pub signature: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Reasons why a single edge can fail verification. Closed set so
+/// reconciler logging is log-injection-safe (no operator-supplied
+/// strings interpolated into the error class).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeRejectReason {
+    /// `from` did not match any (valid) vertex.
+    UnknownFromVertex,
+    /// `to` did not match any (valid) vertex.
+    UnknownToVertex,
+    /// Score outside [0, 1000].
+    ScoreOutOfRange,
+    /// Signature failed to base64url-decode.
+    SignatureDecodeError,
+    /// Signature wrong length (Ed25519 = 64 bytes after decode).
+    SignatureLengthError,
+    /// `notAfter` is set and `issuedAt > notAfter`.
+    InvertedExpiry,
+    /// Cryptographic verification failed.
+    SignatureMismatch,
+}
+
+impl EdgeRejectReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EdgeRejectReason::UnknownFromVertex => "unknown_from_vertex",
+            EdgeRejectReason::UnknownToVertex => "unknown_to_vertex",
+            EdgeRejectReason::ScoreOutOfRange => "score_out_of_range",
+            EdgeRejectReason::SignatureDecodeError => "signature_decode_error",
+            EdgeRejectReason::SignatureLengthError => "signature_length_error",
+            EdgeRejectReason::InvertedExpiry => "inverted_expiry",
+            EdgeRejectReason::SignatureMismatch => "signature_mismatch",
+        }
+    }
+}
+
+/// Reasons a vertex can be dropped (and any outbound edges from it
+/// dropped along with it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexRejectReason {
+    UnsupportedAlg,
+    PublicKeyDecodeError,
+    PublicKeyLengthError,
+    DuplicateId,
+}
+
+/// Compile a `TrustGraphSpec` into the verified projection.
+///
+/// The function is **pure**: deterministic, allocation-safe, no I/O.
+/// Invalid vertices and edges are dropped from the projection but
+/// counted; the reconciler reads the count back to set
+/// `status.invalidEdges`.
+pub fn compile_trust_graph(spec: &TrustGraphSpec) -> CompileResult {
+    let mut vertices: Vec<ProjectedVertex> = Vec::with_capacity(spec.vertices.len());
+    let mut keys: HashMap<String, VerifyingKey> = HashMap::with_capacity(spec.vertices.len());
+    let mut vertex_rejects: Vec<(usize, VertexRejectReason)> = Vec::new();
+
+    for (i, v) in spec.vertices.iter().enumerate() {
+        if keys.contains_key(&v.id) {
+            vertex_rejects.push((i, VertexRejectReason::DuplicateId));
+            continue;
+        }
+        if v.alg != "EdDSA" {
+            vertex_rejects.push((i, VertexRejectReason::UnsupportedAlg));
+            continue;
+        }
+        let key_bytes = match URL_SAFE_NO_PAD.decode(v.public_key_b64u.as_bytes()) {
+            Ok(b) => b,
+            Err(_) => {
+                vertex_rejects.push((i, VertexRejectReason::PublicKeyDecodeError));
+                continue;
+            }
+        };
+        if key_bytes.len() != 32 {
+            vertex_rejects.push((i, VertexRejectReason::PublicKeyLengthError));
+            continue;
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&key_bytes);
+        let vk = match VerifyingKey::from_bytes(&arr) {
+            Ok(k) => k,
+            Err(_) => {
+                vertex_rejects.push((i, VertexRejectReason::PublicKeyLengthError));
+                continue;
+            }
+        };
+        keys.insert(v.id.clone(), vk);
+        vertices.push(ProjectedVertex {
+            id: v.id.clone(),
+            alg: v.alg.clone(),
+            public_key_b64u: v.public_key_b64u.clone(),
+            label: v.label.clone(),
+        });
+    }
+
+    let mut edges: Vec<ProjectedEdge> = Vec::with_capacity(spec.edges.len());
+    let mut edge_rejects: Vec<(usize, EdgeRejectReason)> = Vec::new();
+
+    for (i, e) in spec.edges.iter().enumerate() {
+        match validate_edge(e, &keys) {
+            Ok(()) => edges.push(ProjectedEdge {
+                from: e.from.clone(),
+                to: e.to.clone(),
+                score: e.score,
+                issued_at: e.issued_at,
+                not_after: e.not_after,
+                signature: e.signature.clone(),
+                reason: e.reason.clone(),
+            }),
+            Err(reason) => edge_rejects.push((i, reason)),
+        }
+    }
+
+    let projected = ProjectedGraph {
+        vertices,
+        edges,
+        version_hash: String::new(),
+        input_edge_count: spec.edges.len(),
+    };
+    let projected = with_version_hash(projected);
+
+    CompileResult {
+        projection: projected,
+        vertex_rejects,
+        edge_rejects,
+    }
+}
+
+/// Result of [`compile_trust_graph`] — the projection plus the lists
+/// of rejected entries the reconciler turns into `status.*` counts
+/// and condition messages.
+#[derive(Debug, Clone)]
+pub struct CompileResult {
+    pub projection: ProjectedGraph,
+    pub vertex_rejects: Vec<(usize, VertexRejectReason)>,
+    pub edge_rejects: Vec<(usize, EdgeRejectReason)>,
+}
+
+fn validate_edge(
+    e: &TrustEdge,
+    keys: &HashMap<String, VerifyingKey>,
+) -> Result<(), EdgeRejectReason> {
+    let from_key = keys
+        .get(&e.from)
+        .ok_or(EdgeRejectReason::UnknownFromVertex)?;
+    if !keys.contains_key(&e.to) {
+        return Err(EdgeRejectReason::UnknownToVertex);
+    }
+    if e.score > 1000 {
+        return Err(EdgeRejectReason::ScoreOutOfRange);
+    }
+    if let Some(na) = e.not_after
+        && e.issued_at > na
+    {
+        return Err(EdgeRejectReason::InvertedExpiry);
+    }
+    let sig_bytes = URL_SAFE_NO_PAD
+        .decode(e.signature.as_bytes())
+        .map_err(|_| EdgeRejectReason::SignatureDecodeError)?;
+    if sig_bytes.len() != 64 {
+        return Err(EdgeRejectReason::SignatureLengthError);
+    }
+    let mut arr = [0u8; 64];
+    arr.copy_from_slice(&sig_bytes);
+    let sig = Signature::from_bytes(&arr);
+    let payload = canonical_payload(&e.from, &e.to, e.score, e.issued_at, e.not_after);
+    from_key
+        .verify(&payload, &sig)
+        .map_err(|_| EdgeRejectReason::SignatureMismatch)?;
+    Ok(())
+}
+
+/// Canonical signed-bytes layout. **Locked** at v1 — see
+/// [`PAYLOAD_DOMAIN`].
+pub fn canonical_payload(
+    from: &str,
+    to: &str,
+    score: u32,
+    issued_at: i64,
+    not_after: Option<i64>,
+) -> Vec<u8> {
+    let na = not_after.map(|n| n.to_string()).unwrap_or_default();
+    let mut buf =
+        Vec::with_capacity(PAYLOAD_DOMAIN.len() + from.len() + to.len() + 32 + na.len() + 5);
+    buf.extend_from_slice(PAYLOAD_DOMAIN);
+    buf.extend_from_slice(from.as_bytes());
+    buf.push(b'\n');
+    buf.extend_from_slice(to.as_bytes());
+    buf.push(b'\n');
+    buf.extend_from_slice(score.to_string().as_bytes());
+    buf.push(b'\n');
+    buf.extend_from_slice(issued_at.to_string().as_bytes());
+    buf.push(b'\n');
+    buf.extend_from_slice(na.as_bytes());
+    buf.push(b'\n');
+    buf
+}
+
+fn with_version_hash(mut g: ProjectedGraph) -> ProjectedGraph {
+    let json = serde_json::to_vec(&serde_json::json!({
+        "vertices": g.vertices,
+        "edges": g.edges,
+    }))
+    .expect("ProjectedGraph fields are always serializable");
+    let digest = Sha256::digest(&json);
+    let mut out = String::with_capacity(16);
+    for b in &digest[..8] {
+        use std::fmt::Write;
+        let _ = write!(out, "{:02x}", b);
+    }
+    g.version_hash = out;
+    g
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn b64u(b: &[u8]) -> String {
+        URL_SAFE_NO_PAD.encode(b)
+    }
+
+    fn make_signer(seed: u8) -> (SigningKey, String) {
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let pk = sk.verifying_key();
+        (sk, b64u(pk.as_bytes()))
+    }
+
+    fn signed_edge(
+        sk: &SigningKey,
+        from: &str,
+        to: &str,
+        score: u32,
+        issued_at: i64,
+        not_after: Option<i64>,
+    ) -> TrustEdge {
+        let payload = canonical_payload(from, to, score, issued_at, not_after);
+        let sig = sk.sign(&payload);
+        TrustEdge {
+            from: from.into(),
+            to: to.into(),
+            score,
+            issued_at,
+            not_after,
+            signature: b64u(&sig.to_bytes()),
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn empty_graph_compiles_to_empty_projection() {
+        let spec = TrustGraphSpec::default();
+        let r = compile_trust_graph(&spec);
+        assert!(r.projection.vertices.is_empty());
+        assert!(r.projection.edges.is_empty());
+        assert!(r.vertex_rejects.is_empty());
+        assert!(r.edge_rejects.is_empty());
+        assert_eq!(r.projection.input_edge_count, 0);
+        assert_eq!(r.projection.version_hash.len(), 16);
+    }
+
+    #[test]
+    fn valid_signed_edge_round_trips() {
+        let (sk_a, pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b,
+                    label: None,
+                },
+            ],
+            edges: vec![signed_edge(&sk_a, "a", "b", 800, 1_700_000_000, None)],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.projection.vertices.len(), 2);
+        assert_eq!(r.projection.edges.len(), 1);
+        assert!(r.edge_rejects.is_empty());
+    }
+
+    #[test]
+    fn tampered_score_rejects_edge() {
+        let (sk_a, pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let mut e = signed_edge(&sk_a, "a", "b", 500, 1_700_000_000, None);
+        e.score = 501;
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b,
+                    label: None,
+                },
+            ],
+            edges: vec![e],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.projection.edges.len(), 0);
+        assert_eq!(r.edge_rejects.len(), 1);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::SignatureMismatch);
+    }
+
+    #[test]
+    fn unknown_from_vertex_rejects_edge() {
+        let (sk_a, _pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let spec = TrustGraphSpec {
+            vertices: vec![TrustVertex {
+                id: "b".into(),
+                alg: "EdDSA".into(),
+                public_key_b64u: pk_b,
+                label: None,
+            }],
+            edges: vec![signed_edge(&sk_a, "a", "b", 500, 1_700_000_000, None)],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.edge_rejects.len(), 1);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::UnknownFromVertex);
+    }
+
+    #[test]
+    fn unknown_to_vertex_rejects_edge() {
+        let (sk_a, pk_a) = make_signer(1);
+        let spec = TrustGraphSpec {
+            vertices: vec![TrustVertex {
+                id: "a".into(),
+                alg: "EdDSA".into(),
+                public_key_b64u: pk_a,
+                label: None,
+            }],
+            edges: vec![signed_edge(&sk_a, "a", "ghost", 500, 1_700_000_000, None)],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.edge_rejects.len(), 1);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::UnknownToVertex);
+    }
+
+    #[test]
+    fn out_of_range_score_rejects_edge() {
+        // score > 1000 is rejected by the validator before signature check.
+        let (sk_a, pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let e = signed_edge(&sk_a, "a", "b", 9999, 1_700_000_000, None);
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b,
+                    label: None,
+                },
+            ],
+            edges: vec![e],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::ScoreOutOfRange);
+    }
+
+    #[test]
+    fn inverted_expiry_rejects_edge() {
+        let (sk_a, pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let e = signed_edge(&sk_a, "a", "b", 500, 2_000_000_000, Some(1_000_000_000));
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b,
+                    label: None,
+                },
+            ],
+            edges: vec![e],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::InvertedExpiry);
+    }
+
+    #[test]
+    fn duplicate_vertex_id_drops_second_occurrence() {
+        let (_, pk_a) = make_signer(1);
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a.clone(),
+                    label: Some("first".into()),
+                },
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: Some("second".into()),
+                },
+            ],
+            edges: vec![],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.projection.vertices.len(), 1);
+        assert_eq!(r.projection.vertices[0].label.as_deref(), Some("first"));
+        assert_eq!(r.vertex_rejects.len(), 1);
+        assert_eq!(r.vertex_rejects[0].1, VertexRejectReason::DuplicateId);
+    }
+
+    #[test]
+    fn unsupported_alg_drops_vertex() {
+        let spec = TrustGraphSpec {
+            vertices: vec![TrustVertex {
+                id: "a".into(),
+                alg: "RS256".into(),
+                public_key_b64u: "AAAA".into(),
+                label: None,
+            }],
+            edges: vec![],
+        };
+        let r = compile_trust_graph(&spec);
+        assert!(r.projection.vertices.is_empty());
+        assert_eq!(r.vertex_rejects[0].1, VertexRejectReason::UnsupportedAlg);
+    }
+
+    #[test]
+    fn bad_pubkey_length_drops_vertex() {
+        let spec = TrustGraphSpec {
+            vertices: vec![TrustVertex {
+                id: "a".into(),
+                alg: "EdDSA".into(),
+                public_key_b64u: b64u(&[0u8; 16]),
+                label: None,
+            }],
+            edges: vec![],
+        };
+        let r = compile_trust_graph(&spec);
+        assert!(r.projection.vertices.is_empty());
+        assert_eq!(
+            r.vertex_rejects[0].1,
+            VertexRejectReason::PublicKeyLengthError
+        );
+    }
+
+    #[test]
+    fn bad_signature_length_rejects_edge() {
+        let (_, pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let e = TrustEdge {
+            from: "a".into(),
+            to: "b".into(),
+            score: 500,
+            issued_at: 1_700_000_000,
+            not_after: None,
+            signature: b64u(&[0u8; 32]),
+            reason: None,
+        };
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b,
+                    label: None,
+                },
+            ],
+            edges: vec![e],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::SignatureLengthError);
+    }
+
+    #[test]
+    fn version_hash_is_deterministic_and_stable_across_runs() {
+        let (sk_a, pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b,
+                    label: None,
+                },
+            ],
+            edges: vec![signed_edge(&sk_a, "a", "b", 600, 1_700_000_000, None)],
+        };
+        let h1 = compile_trust_graph(&spec).projection.version_hash;
+        let h2 = compile_trust_graph(&spec).projection.version_hash;
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 16);
+    }
+
+    #[test]
+    fn payload_domain_separator_prevents_replay() {
+        // An attacker who controls a signature over `from||to||...`
+        // (without the `trustgraph.v1\n` prefix) cannot replay it as
+        // a TrustGraph edge. We model this by signing the *unprefixed*
+        // payload and showing the validator rejects it.
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let pk = b64u(sk.verifying_key().as_bytes());
+        let unprefixed: Vec<u8> = b"a\nb\n500\n1700000000\n\n".to_vec();
+        let bad_sig = sk.sign(&unprefixed);
+        let edge = TrustEdge {
+            from: "a".into(),
+            to: "b".into(),
+            score: 500,
+            issued_at: 1_700_000_000,
+            not_after: None,
+            signature: b64u(&bad_sig.to_bytes()),
+            reason: None,
+        };
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk.clone(),
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk,
+                    label: None,
+                },
+            ],
+            edges: vec![edge],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::SignatureMismatch);
+    }
+
+    #[test]
+    fn cross_vertex_signature_rejected() {
+        // Edge claims `from = a` but is signed by `b`'s key. Must reject.
+        let (_, pk_a) = make_signer(1);
+        let (sk_b, pk_b) = make_signer(2);
+        let e = signed_edge(&sk_b, "a", "b", 500, 1_700_000_000, None);
+        let spec = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a,
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b,
+                    label: None,
+                },
+            ],
+            edges: vec![e],
+        };
+        let r = compile_trust_graph(&spec);
+        assert_eq!(r.edge_rejects[0].1, EdgeRejectReason::SignatureMismatch);
+    }
+
+    #[test]
+    fn version_hash_changes_when_graph_changes() {
+        let (sk_a, pk_a) = make_signer(1);
+        let (_, pk_b) = make_signer(2);
+        let v1 = TrustGraphSpec {
+            vertices: vec![
+                TrustVertex {
+                    id: "a".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_a.clone(),
+                    label: None,
+                },
+                TrustVertex {
+                    id: "b".into(),
+                    alg: "EdDSA".into(),
+                    public_key_b64u: pk_b.clone(),
+                    label: None,
+                },
+            ],
+            edges: vec![signed_edge(&sk_a, "a", "b", 100, 1_700_000_000, None)],
+        };
+        let v2 = TrustGraphSpec {
+            vertices: v1.vertices.clone(),
+            edges: vec![signed_edge(&sk_a, "a", "b", 999, 1_700_000_000, None)],
+        };
+        let h1 = compile_trust_graph(&v1).projection.version_hash;
+        let h2 = compile_trust_graph(&v2).projection.version_hash;
+        assert_ne!(h1, h2);
+    }
+}

--- a/controller/src/trust_graph_reconciler.rs
+++ b/controller/src/trust_graph_reconciler.rs
@@ -1,0 +1,460 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `TrustGraph` reconciler — Phase F1.
+//!
+//! Mirrors [`crate::a2a_agent_reconciler`] in shape:
+//!
+//! 1. Adds the `azureclaw.azure.com/trustgraph-cleanup` finalizer.
+//! 2. Calls the pure compile step
+//!    [`crate::trust_graph_compile::compile_trust_graph`] to verify
+//!    every vertex public key and every edge signature.
+//! 3. Persists the verified subset as a `ConfigMap`
+//!    `trustgraph-{name}-projection` in the
+//!    [`PROJECTION_NAMESPACE`] (`azureclaw-system`). Cluster-scoped
+//!    CR → namespaced projection, so ownerRef cascade is **not**
+//!    available — the finalizer is the only correct cleanup
+//!    mechanism.
+//! 4. Patches `status.conditions[Ready,Progressing,Degraded]`,
+//!    `status.{validVertices,validEdges,invalidEdges}`,
+//!    `status.projectionConfigMapRef`, `status.observedGeneration`,
+//!    `status.lastReconciledAt`.
+//!
+//! ## Reuse map (no-duplication rule)
+//!
+//! - Conditions vocabulary + transition-time helpers:
+//!   [`crate::status::conditions`].
+//! - Reconciler shape: [`crate::a2a_agent_reconciler`] (S3) and
+//!   [`crate::tool_policy_reconciler`] (S2).
+//! - `LocalObjectRef`: re-used from [`crate::mcp_server`].
+
+use anyhow::Result;
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::{
+    Client, ResourceExt,
+    api::{Api, ListParams, ObjectMeta, Patch, PatchParams},
+    runtime::controller::{Action, Controller},
+};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::mcp_server::LocalObjectRef;
+use crate::status::conditions::{self, reason, status as cond_status};
+use crate::trust_graph::{TrustGraph, TrustGraphStatus};
+use crate::trust_graph_compile::{CompileResult, compile_trust_graph};
+
+const FIELD_MANAGER: &str = crate::field_managers::TRUST_GRAPH;
+const FINALIZER: &str = "azureclaw.azure.com/trustgraph-cleanup";
+/// Where the verified-graph ConfigMap lives. `azureclaw-system` is
+/// the cluster-control-plane namespace already used by other
+/// controller-owned artefacts (see Helm chart). Pinned because the
+/// router (Phase F2) mounts the same path.
+pub const PROJECTION_NAMESPACE: &str = "azureclaw-system";
+
+const REQUEUE_OK: Duration = Duration::from_secs(300);
+const REQUEUE_FAIL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, thiserror::Error)]
+enum ReconcileError {
+    #[error("Kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("JSON serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+}
+
+impl ReconcileError {
+    fn class(&self) -> &'static str {
+        match self {
+            ReconcileError::Kube(_) => "kube_api",
+            ReconcileError::SerdeJson(_) => "serde",
+        }
+    }
+}
+
+struct Ctx {
+    client: Client,
+}
+
+async fn reconcile(tg: Arc<TrustGraph>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
+    let name = tg.name_any();
+    tracing::info!(trustgraph = %name, "Reconciling TrustGraph");
+
+    let api: Api<TrustGraph> = Api::all(ctx.client.clone());
+    let configmaps: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), PROJECTION_NAMESPACE);
+
+    if tg.metadata.deletion_timestamp.is_some() {
+        return finalize(&api, &configmaps, &tg, &name).await;
+    }
+
+    if !tg
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|f| f.iter().any(|s| s == FINALIZER))
+        .unwrap_or(false)
+    {
+        let patch = json!({
+            "apiVersion": "azureclaw.azure.com/v1alpha1",
+            "kind": "TrustGraph",
+            "metadata": { "finalizers": [FINALIZER] }
+        });
+        api.patch(
+            &name,
+            &PatchParams::apply(FIELD_MANAGER).force(),
+            &Patch::Apply(patch),
+        )
+        .await?;
+        return Ok(Action::requeue(Duration::from_secs(1)));
+    }
+
+    let prior_conditions = tg
+        .status
+        .as_ref()
+        .and_then(|s| s.conditions.clone())
+        .unwrap_or_default();
+    let observed_generation = tg.metadata.generation;
+
+    let CompileResult {
+        projection,
+        vertex_rejects,
+        edge_rejects,
+    } = compile_trust_graph(&tg.spec);
+
+    let cm_name = format!("trustgraph-{name}-projection");
+    let mut degraded: Option<(&'static str, String)> = None;
+
+    if let Err(e) = ensure_projection_configmap(&configmaps, &cm_name, &name, &projection).await {
+        tracing::warn!(
+            trustgraph = %name,
+            error_class = e.class(),
+            "TrustGraphProjectionWriteFailed"
+        );
+        degraded = Some(("ProjectionWriteFailed", e.to_string()));
+    } else {
+        tracing::info!(
+            trustgraph = %name,
+            valid_vertices = projection.vertices.len(),
+            valid_edges = projection.edges.len(),
+            invalid_edges = edge_rejects.len(),
+            invalid_vertices = vertex_rejects.len(),
+            version_hash = %projection.version_hash,
+            generation = observed_generation.unwrap_or(0),
+            "TrustGraphCompiled"
+        );
+        for (i, why) in &edge_rejects {
+            // index is operator-supplied position; reason is closed set.
+            tracing::info!(
+                trustgraph = %name,
+                edge_index = i,
+                reject_reason = why.as_str(),
+                "TrustGraphEdgeRejected"
+            );
+        }
+    }
+
+    let invalid_total = edge_rejects.len();
+    let degraded_for_cond = if let Some((r, m)) = degraded.as_ref() {
+        Some((*r, m.as_str()))
+    } else if invalid_total > 0 {
+        // Operator-input invalid edges: surface as Ready=True +
+        // Degraded=False with a non-empty status counter, matching the
+        // convention that "Degraded" is reserved for controller-side
+        // failure (e.g. apiserver write). Invalid edges are user data
+        // problems, not controller failures.
+        None
+    } else {
+        None
+    };
+
+    let new_conditions =
+        build_conditions(&prior_conditions, observed_generation, degraded_for_cond);
+    let phase = if degraded.is_some() {
+        "Degraded"
+    } else {
+        "Ready"
+    };
+
+    let status_patch = json!({
+        "apiVersion": "azureclaw.azure.com/v1alpha1",
+        "kind": "TrustGraph",
+        "status": TrustGraphStatus {
+            phase: Some(phase.into()),
+            observed_generation,
+            conditions: Some(new_conditions),
+            valid_vertices: Some(projection.vertices.len() as i64),
+            valid_edges: Some(projection.edges.len() as i64),
+            invalid_edges: Some(invalid_total as i64),
+            projection_config_map_ref: Some(LocalObjectRef { name: cm_name.clone() }),
+            last_reconciled_at: Some(rfc3339_now()),
+        }
+    });
+    api.patch_status(
+        &name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(status_patch),
+    )
+    .await?;
+
+    if degraded.is_some() {
+        Ok(Action::requeue(REQUEUE_FAIL))
+    } else {
+        Ok(Action::requeue(REQUEUE_OK))
+    }
+}
+
+fn rfc3339_now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn build_conditions(
+    prior: &[Condition],
+    observed_generation: Option<i64>,
+    degraded: Option<(&str, &str)>,
+) -> Vec<Condition> {
+    let mut out: Vec<Condition> = Vec::with_capacity(3);
+    let prior_ready = conditions::find(prior, conditions::TYPE_READY);
+    let prior_progressing = conditions::find(prior, conditions::TYPE_PROGRESSING);
+    let prior_degraded = conditions::find(prior, conditions::TYPE_DEGRADED);
+
+    match degraded {
+        Some((reason_value, message)) => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::FALSE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::FAILED,
+                "compile failed",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::TRUE,
+                reason_value,
+                message,
+                observed_generation,
+            ));
+        }
+        None => {
+            out.push(conditions::preserve_transition_time(
+                prior_ready,
+                conditions::TYPE_READY,
+                cond_status::TRUE,
+                reason::RECONCILED,
+                "TrustGraph compiled and projection published",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_progressing,
+                conditions::TYPE_PROGRESSING,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "compile complete",
+                observed_generation,
+            ));
+            out.push(conditions::preserve_transition_time(
+                prior_degraded,
+                conditions::TYPE_DEGRADED,
+                cond_status::FALSE,
+                reason::RECONCILED,
+                "no errors",
+                observed_generation,
+            ));
+        }
+    }
+    out
+}
+
+async fn ensure_projection_configmap(
+    api: &Api<ConfigMap>,
+    cm_name: &str,
+    owner: &str,
+    projection: &crate::trust_graph_compile::ProjectedGraph,
+) -> Result<(), ReconcileError> {
+    let json_str = serde_json::to_string_pretty(projection)?;
+    let mut data: BTreeMap<String, String> = BTreeMap::new();
+    data.insert("graph.json".into(), json_str);
+
+    let mut annotations: BTreeMap<String, String> = BTreeMap::new();
+    annotations.insert(
+        "azureclaw.azure.com/trustgraph-version-hash".into(),
+        projection.version_hash.clone(),
+    );
+
+    let cm = ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(cm_name.into()),
+            annotations: Some(annotations),
+            labels: Some(BTreeMap::from([
+                (
+                    "app.kubernetes.io/managed-by".into(),
+                    "azureclaw-controller".into(),
+                ),
+                ("azureclaw.azure.com/trustgraph".into(), owner.into()),
+                (
+                    "azureclaw.azure.com/artifact".into(),
+                    "trustgraph-projection".into(),
+                ),
+            ])),
+            ..Default::default()
+        },
+        data: Some(data),
+        ..Default::default()
+    };
+    api.patch(
+        cm_name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(&cm),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn finalize(
+    api: &Api<TrustGraph>,
+    configmaps: &Api<ConfigMap>,
+    tg: &TrustGraph,
+    name: &str,
+) -> Result<Action, ReconcileError> {
+    let cm_name = format!("trustgraph-{name}-projection");
+    let _ = configmaps
+        .delete(&cm_name, &Default::default())
+        .await
+        .map(|_| ())
+        .or_else(|e: kube::Error| -> Result<(), kube::Error> {
+            if matches!(e, kube::Error::Api(ref ae) if ae.code == 404) {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        });
+
+    let finalizers: Vec<String> = tg
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|v| v.iter().filter(|f| *f != FINALIZER).cloned().collect())
+        .unwrap_or_default();
+    let patch = json!({
+        "apiVersion": "azureclaw.azure.com/v1alpha1",
+        "kind": "TrustGraph",
+        "metadata": { "finalizers": finalizers }
+    });
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(patch),
+    )
+    .await?;
+    tracing::info!(trustgraph = %name, "TrustGraphDeleted");
+    Ok(Action::await_change())
+}
+
+fn error_policy(tg: Arc<TrustGraph>, error: &ReconcileError, _ctx: Arc<Ctx>) -> Action {
+    crate::metrics::record_reconcile_error("TrustGraph", error.class());
+    tracing::warn!(
+        trustgraph = %tg.name_any(),
+        error_class = error.class(),
+        error = %error,
+        "TrustGraph reconcile error — requeuing in ~30s (±20% jitter)"
+    );
+    Action::requeue(crate::backoff::requeue_secs_with_jitter(30))
+}
+
+pub async fn run(client: Client) -> Result<()> {
+    let graphs: Api<TrustGraph> = Api::all(client.clone());
+    match graphs.list(&ListParams::default().limit(1)).await {
+        Ok(_) => tracing::info!("TrustGraph CRD found — starting controller"),
+        Err(e) => {
+            tracing::warn!("TrustGraph CRD not installed — reconciler disabled: {e}");
+            std::future::pending::<()>().await;
+            #[allow(unreachable_code)]
+            return Ok(());
+        }
+    }
+    let ctx = Arc::new(Ctx { client });
+    Controller::new(graphs, kube::runtime::watcher::Config::default())
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("TrustGraph", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
+        .for_each(|res| async move {
+            match res {
+                Ok(o) => tracing::debug!("TrustGraph reconciled {:?}", o),
+                Err(e) => tracing::warn!("TrustGraph reconcile failed: {e:?}"),
+            }
+        })
+        .await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_now_is_utc_z_suffixed() {
+        let s = rfc3339_now();
+        assert!(s.ends_with('Z'), "got {s}");
+        assert_eq!(s.len(), 20, "RFC3339 with seconds + Z is 20 chars: {s}");
+    }
+
+    #[test]
+    fn error_class_is_closed_set() {
+        let serde_err: serde_json::Error =
+            serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let e = ReconcileError::SerdeJson(serde_err);
+        assert_eq!(e.class(), "serde");
+    }
+
+    #[test]
+    fn build_conditions_ok_path_emits_three_conditions() {
+        let out = build_conditions(&[], Some(1), None);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].type_, conditions::TYPE_READY);
+        assert_eq!(out[0].status, "True");
+        assert_eq!(out[1].type_, conditions::TYPE_PROGRESSING);
+        assert_eq!(out[1].status, "False");
+        assert_eq!(out[2].type_, conditions::TYPE_DEGRADED);
+        assert_eq!(out[2].status, "False");
+    }
+
+    #[test]
+    fn build_conditions_degraded_path_flips_ready() {
+        let out = build_conditions(&[], Some(1), Some(("WriteFailed", "boom")));
+        assert_eq!(out[0].status, "False");
+        assert_eq!(out[0].reason, "WriteFailed");
+        assert_eq!(out[2].status, "True");
+    }
+
+    #[test]
+    fn projection_namespace_is_pinned() {
+        // The router (Phase F2) mounts a ConfigMap from this namespace.
+        // Changing it requires a coordinated rollout — guard with a test
+        // so casual edits surface in review.
+        assert_eq!(PROJECTION_NAMESPACE, "azureclaw-system");
+    }
+
+    #[test]
+    fn finalizer_string_is_pinned() {
+        // Finalizer string is part of the on-cluster contract — once
+        // set on a CR, only a controller using the same string will
+        // remove it. Guard against drift.
+        assert_eq!(FINALIZER, "azureclaw.azure.com/trustgraph-cleanup");
+    }
+}

--- a/deploy/helm/azureclaw/templates/crd-trustgraph.yaml
+++ b/deploy/helm/azureclaw/templates/crd-trustgraph.yaml
@@ -1,0 +1,294 @@
+# AzureClaw TrustGraph CRD (Phase F1).
+#
+# DO NOT EDIT BY HAND. This file is the helm-side mirror of the Rust
+# schema in `controller/src/trust_graph.rs` plus the CEL rules in
+# `controller/src/crd_validations.rs::trust_graph_validations`.
+#
+# Drift between this file and the Rust schema is caught at `cargo test`
+# time by `controller/src/helm_drift.rs::helm_trustgraph_crd_matches_rust_schema`.
+# To regenerate after schema changes, run:
+#
+#   DUMP_TRUSTGRAPH_CRD_YAML=1 cargo test --bin azureclaw-controller \
+#       helm_drift::tests::dump_trustgraph_crd_yaml -- --nocapture
+#
+# and replace the body below with the captured YAML.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: azureclaw
+    app.kubernetes.io/component: crd
+  name: trustgraphs.azureclaw.azure.com
+spec:
+  group: azureclaw.azure.com
+  names:
+    categories: []
+    kind: TrustGraph
+    plural: trustgraphs
+    shortNames:
+    - tg
+    singular: trustgraph
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.validVertices
+      name: Vertices
+      type: integer
+    - jsonPath: .status.validEdges
+      name: ValidEdges
+      type: integer
+    - jsonPath: .status.invalidEdges
+      name: InvalidEdges
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for TrustGraphSpec via `CustomResource`
+        properties:
+          spec:
+            description: '`TrustGraph.spec` — the cluster-wide trust topology.'
+            properties:
+              edges:
+                default: []
+                description: |-
+                  Edge set. Each edge is a signed attestation from `from` to
+                  `to` carrying a trust score in [0, 1000] (the AGT trust-score
+                  domain — see `crd.rs::GovernanceConfig`).
+
+                  Edges where signature verification fails are reported in
+                  `status.invalidEdges` and omitted from the projection
+                  ConfigMap. The reconciler does not delete invalid edges from
+                  the spec — the operator owns the spec; the reconciler only
+                  publishes the verified subset.
+                items:
+                  description: One edge — a signed trust attestation between two vertices.
+                  properties:
+                    from:
+                      description: |-
+                        Source vertex `id`. Must resolve to a vertex in
+                        `spec.vertices` whose public key signed this edge.
+                      type: string
+                    issuedAt:
+                      description: |-
+                        Issuance timestamp, Unix seconds. Part of the canonical signed
+                        payload — peers verify both the signature and that
+                        `issuedAt <= now`.
+                      format: int64
+                      type: integer
+                    notAfter:
+                      description: |-
+                        Optional expiry timestamp, Unix seconds. `None` means "never
+                        expires" (operator-asserted; the reconciler still flags
+                        suspiciously old `issuedAt`s in conditions but does not
+                        invalidate).
+                      format: int64
+                      nullable: true
+                      type: integer
+                    reason:
+                      description: |-
+                        Optional free-text reason ("auditor-attested",
+                        "transitive-1-hop", …) carried into the projection so
+                        downstream policy can pivot on the origin of the trust.
+                      nullable: true
+                      type: string
+                    score:
+                      description: |-
+                        Trust score in `[0, 1000]` — the AGT domain. CEL guards the
+                        range at admission; the reconciler additionally clamps for
+                        defensive depth.
+                      format: uint32
+                      minimum: 0.0
+                      type: integer
+                    signature:
+                      description: |-
+                        Ed25519 signature, base64url-encoded with NO padding, over the
+                        canonical bytes
+                        `b"trustgraph.v1\n" || from || b"\n" || to || b"\n" || score-as-decimal-ascii || b"\n" || issued_at-as-decimal-ascii || b"\n" || not_after-as-decimal-ascii-or-empty || b"\n"`.
+                        64 bytes after decode.
+
+                        The version prefix `trustgraph.v1\n` is a domain-separator so
+                        a signature over a `TrustGraph` edge can never be replayed as
+                        an `A2AAgent` AgentCard signature.
+                      type: string
+                    to:
+                      description: |-
+                        Target vertex `id`. Must resolve to a vertex in
+                        `spec.vertices`.
+                      type: string
+                  required:
+                  - from
+                  - issuedAt
+                  - score
+                  - signature
+                  - to
+                  type: object
+                type: array
+              vertices:
+                description: |-
+                  Vertex set. Each vertex declares an identity and the Ed25519
+                  public key peers must use to verify outbound edge signatures
+                  from this vertex.
+
+                  `id` must be unique across the spec — admission CEL enforces.
+                  At least one vertex is required (an empty graph would yield a
+                  useless projection); enforced by CEL `size(self.vertices) > 0`.
+                items:
+                  description: |-
+                    One vertex — an agent identity with its Ed25519 public key.
+
+                    Field naming mirrors `A2AAgent.signingKeys` for cross-CRD
+                    consistency: the same key material can be authored once in
+                    `A2AAgent` and re-declared as a `TrustGraph` vertex without any
+                    re-encoding step.
+                  properties:
+                    alg:
+                      description: |-
+                        Algorithm pin. Currently only `"EdDSA"` is honoured; other
+                        values cause the reconciler to mark the vertex invalid and
+                        drop edges originating from it.
+                      type: string
+                    id:
+                      description: |-
+                        Stable identity (DNS-label-shaped string). Conventionally an
+                        AGT AMID or a fully-qualified `a2a-agent/<ns>/<name>` form.
+                        Must be unique within the CR (CEL).
+                      type: string
+                    label:
+                      description: |-
+                        Optional human-readable label rendered in audit logs and the
+                        projection ConfigMap.
+                      nullable: true
+                      type: string
+                    publicKeyB64u:
+                      description: |-
+                        Ed25519 public key, base64url-encoded with NO padding (RFC
+                        7515 §2). 32 bytes after decode.
+                      type: string
+                  required:
+                  - alg
+                  - id
+                  - publicKeyB64u
+                  type: object
+                type: array
+            required:
+            - vertices
+            type: object
+            x-kubernetes-validations:
+            - message: spec.vertices must contain at least one entry
+              reason: FieldValueInvalid
+              rule: size(self.vertices) > 0
+            - message: spec.vertices[*].alg must be 'EdDSA' (only supported algorithm)
+              reason: FieldValueInvalid
+              rule: self.vertices.all(v, v.alg == 'EdDSA')
+            - message: spec.edges[*].score must be in [0, 1000]
+              reason: FieldValueInvalid
+              rule: '!has(self.edges) || self.edges.all(e, e.score >= 0 && e.score <= 1000)'
+            - message: spec.edges[*].notAfter, when set, must be >= issuedAt
+              reason: FieldValueInvalid
+              rule: '!has(self.edges) || self.edges.all(e, !has(e.notAfter) || e.notAfter >= e.issuedAt)'
+          status:
+            description: '`TrustGraph.status` — populated by the reconciler.'
+            nullable: true
+            properties:
+              conditions:
+                description: Standard K8s conditions (`Ready`, `Validated`).
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              invalidEdges:
+                description: |-
+                  Number of edges that failed verification (bad signature,
+                  missing vertex, decode error, expired). Counted but not named
+                  to avoid leaking authoring detail into status; operators
+                  inspect controller logs (`error_class`) for which.
+                format: int64
+                nullable: true
+                type: integer
+              lastReconciledAt:
+                description: RFC3339 timestamp of the last reconcile.
+                nullable: true
+                type: string
+              observedGeneration:
+                description: |-
+                  Generation observed at the last successful reconcile. Used by
+                  kube watcher consumers to detect stale projections.
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                description: '`Pending` | `Ready` | `Degraded`.'
+                nullable: true
+                type: string
+              projectionConfigMapRef:
+                description: |-
+                  `metadata.namespace/metadata.name` of the projection ConfigMap.
+                  Always `azureclaw-system/trustgraph-<name>-projection` once
+                  the reconciler has written successfully.
+                nullable: true
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              validEdges:
+                description: |-
+                  Number of edges whose signature verified against the declared
+                  `from` vertex's public key. Only valid edges are emitted into
+                  the projection ConfigMap.
+                format: int64
+                nullable: true
+                type: integer
+              validVertices:
+                description: |-
+                  Number of vertices that decoded successfully (correct alg +
+                  32-byte public key).
+                format: int64
+                nullable: true
+                type: integer
+            type: object
+        required:
+        - spec
+        title: TrustGraph
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+

--- a/deploy/helm/azureclaw/templates/rbac.yaml
+++ b/deploy/helm/azureclaw/templates/rbac.yaml
@@ -42,6 +42,8 @@ rules:
       - "clawmemories/status"
       - "clawevals"
       - "clawevals/status"
+      - "trustgraphs"
+      - "trustgraphs/status"
       - "signerpolicies"
       - "signerpolicies/status"
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/docs/security-audits/2026-05-03-phase-f-trustgraph.md
+++ b/docs/security-audits/2026-05-03-phase-f-trustgraph.md
@@ -1,0 +1,111 @@
+# Security audit — Phase F1: TrustGraph CRD + reconciler
+
+**Date:** 2026-05-03
+**Slice:** Phase F1 of the §14.6 competitive closure plan.
+**Closes (partially):** "TrustGraph 0 LOC → cluster-wide AGT trust topology" entry in `docs/competitive.md` §14.6.
+**Scope:** Cluster-scoped `TrustGraph` CRD, in-process reconciler, Helm CRD template, CEL admission rules, and signed-edge verification via Ed25519. **Phase F2 (router-side consultation) is deferred to a follow-up PR.**
+
+## Summary
+
+Adds a `TrustGraph` resource that lets operators declare a cluster-wide
+trust topology — vertices (agent identities, each with an Ed25519
+public key) and edges (signed `from → to` attestations carrying a
+trust score in the existing AGT 0–1000 domain). The reconciler:
+
+1. Verifies every vertex's public-key shape (alg = `EdDSA`, 32 bytes
+   after base64url decode).
+2. Verifies every edge's signature against the declared `from`
+   vertex's public key, using a domain-separated canonical signing
+   payload (`trustgraph.v1\n` prefix).
+3. Drops invalid edges from the projection but **keeps them in the
+   spec** — the operator owns the spec, the reconciler owns the
+   projection. Status counters (`validEdges` / `invalidEdges`) and
+   per-edge log lines surface rejections to operators.
+4. Publishes the verified subset as a `ConfigMap`
+   `trustgraph-{name}-projection` in the `azureclaw-system`
+   namespace, with the version-hash annotation that consumers
+   (Phase F2 router) use for change detection.
+5. Cleans up the projection on CR delete via a finalizer
+   (`azureclaw.azure.com/trustgraph-cleanup`) — cluster-scoped CR →
+   namespaced ConfigMap precludes ownerRef cascade, so the finalizer
+   is the only correct cleanup mechanism.
+
+## STRIDE delta
+
+| Threat | Pre-F1 | Post-F1 | Notes |
+|---|---|---|---|
+| **S**poofing | An on-cluster attacker writing a `TrustGraph` could elevate any AMID to score=1000 | Operator-supplied edges must carry an Ed25519 signature from the declared `from` vertex; tampered edges are rejected and counted | Vertex public keys are still operator-trusted (no external attestation issuer in F1) — the threat model is "operator authoring mistake or compromised CR write" rather than "compromised vertex key" |
+| **T**ampering | n/a (capability did not exist) | Edge signature verified with `ed25519_dalek::Verifier::verify` (constant-time) over a domain-separated canonical payload (`trustgraph.v1\n`) | Domain prefix prevents cross-protocol replay (e.g. an A2AAgent AgentCard signature cannot be replayed as a TrustGraph edge) |
+| **R**epudiation | n/a | Per-edge `reason` field + version-hash + RFC3339 `lastReconciledAt` give an audit trail | Phase D Merkle audit chain (separate work) hashes the projection ConfigMap into the integrity tree |
+| **I**nformation disclosure | n/a | Projection ConfigMap omits operator-rejected edges entirely (no partial leakage); rejection reasons are a closed enum logged via tracing (no operator-supplied strings interpolated into log records) | Closed-enum reject reasons in `EdgeRejectReason::as_str` prevent log-injection via crafted CR strings |
+| **D**enial of service | n/a | Reconciler is bounded by spec size; `compile_trust_graph` is O(V+E) with HashMap lookup per edge; no recursive expansion in F1 (transitive closure is router-side / Phase F2) | API-server CEL admission cap on object size already applies; no per-edge crypto budget needed at this volume |
+| **E**levation of privilege | An operator who can write any CR could mint trust scores | CEL admission caps `score ≤ 1000`, requires `alg == 'EdDSA'`, requires non-empty `vertices`. Reconciler additionally validates `notAfter ≥ issuedAt`, signature bytes shape, and HashMap-based vertex resolution before crypto verification | Unchanged: cluster-scoped CR → only cluster-admins can author. Existing RBAC unchanged; new resource added to controller ClusterRole |
+
+## OWASP-LLM mapping
+
+- **LLM06 — Sensitive Information Disclosure.** Projection only contains operator-supplied data; no model output is fed back into the projection. Invalid edges are *omitted*, not partially copied — eliminates a class where a bad signature could nevertheless leak the `score` claimed. (Verified by `test_crd_trustgraph_reconcile`'s "projection excludes rejected edge" assertion.)
+- **LLM07 — Insecure Plugin Design.** Phase F1 ships only the CRD + reconciler; the router-side trust consumer is deferred to F2, behind a separate audit and review. No router code paths consult the projection in this PR — the new code surface is isolated to the controller.
+
+## Fail-closed semantics
+
+- **Bad signature.** Edge is dropped from projection; counted in `status.invalidEdges`; reconciler still reports `Ready=True` (operator-data error, not controller error). Router consumers (Phase F2) MUST default to "no trust" when an edge is absent.
+- **Apiserver write failure.** Reconciler enters `Degraded=True` with reason `ProjectionWriteFailed`; consumers reading the stale projection are protected by the version-hash annotation (the projection bytes don't change on a write failure).
+- **CRD missing on startup.** `trust_graph_reconciler::run` parks indefinitely (`std::future::pending`) on `kube::Error` — consistent with `a2a_agent_reconciler` behaviour. Other reconcilers continue working; the controller does not crashloop.
+- **Empty graph.** CEL rejects at admission (`size(self.vertices) > 0`). The reconciler will never see a valid CR with zero vertices.
+
+## Scope deferrals (explicit)
+
+- **No external attestation issuers.** Edge signatures are verified
+  locally against vertices in the same CR. No call to Sigstore Rekor,
+  OIDC IdPs, or any network endpoint. (User mandate: "no public
+  posting".)
+- **No transitive trust closure in F1.** The reconciler validates
+  direct edges only. Multi-hop trust queries (`trust_score(a, c)`
+  via `a → b → c`) belong to the router consumer in Phase F2.
+- **No edge-revocation list.** Operators rotate trust by removing
+  edges from the spec or setting a past `notAfter`. A separate
+  revocation channel is not in F1's scope.
+- **No router-side consumer.** `inference-router` does not yet read
+  the projection. Phase F2 will add `trust_graph_projection.rs`
+  (mirroring `a2a/agent_projection.rs`) and wire it into the existing
+  AGT peer-trust path.
+
+## Verification commands
+
+```sh
+# Unit tests (21 new, including signature-tamper and replay-prevention):
+cargo test --package azureclaw-controller trust_graph
+
+# Helm-drift gate:
+cargo test --package azureclaw-controller helm_trustgraph
+
+# Full controller suite:
+cargo test --package azureclaw-controller    # 463 passed (was 440)
+
+# Lint + fmt:
+cargo clippy --package azureclaw-controller --all-targets -- -D warnings
+cargo fmt --all --check
+
+# Local E2E (kind):
+make test-e2e   # exercises test_crd_trustgraph_reconcile
+```
+
+## Files changed
+
+- `controller/src/trust_graph.rs` — CRD types (cluster-scoped).
+- `controller/src/trust_graph_compile.rs` — pure verify step + 13 unit tests covering signature spoofing, expiry inversion, alg pinning, key-length, domain-separator replay, deterministic version hash.
+- `controller/src/trust_graph_reconciler.rs` — reconcile loop + finalizer + 5 unit tests.
+- `controller/src/crd_validations.rs` — `trust_graph_validations()` + `trust_graph_crd()` factories with 4 CEL rules.
+- `controller/src/field_managers.rs` — `TRUST_GRAPH` SSA field manager.
+- `controller/src/helm_drift.rs` — drift test for the new helm CRD.
+- `controller/src/main.rs` — module wiring + `tokio::spawn` of the reconciler + `tokio::select!` arm.
+- `deploy/helm/azureclaw/templates/crd-trustgraph.yaml` — Helm CRD mirror.
+- `deploy/helm/azureclaw/templates/rbac.yaml` — `trustgraphs` + `trustgraphs/status` added to the controller ClusterRole.
+- `tests/e2e/run.sh` — `test_crd_trustgraph_reconcile` (asserts CR → ConfigMap, validEdges=1, invalidEdges=1, version-hash annotation, projection excludes tampered edge, CEL rejects empty vertices, finalizer cleanup).
+- `docs/security-audits/2026-05-03-phase-f-trustgraph.md` — this file.
+
+## Sign-offs
+
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1868,6 +1868,158 @@ test_controller_emits_events() {
     fi
 }
 
+test_crd_trustgraph_reconcile() {
+    # Phase F1: TrustGraph CR (cluster-scoped) → projection ConfigMap
+    # in azureclaw-system. Asserts:
+    #   1. Valid signed edge appears in the projection (validEdges=1).
+    #   2. Tampered-signature edge is rejected (invalidEdges=1).
+    #   3. Status is Ready=True with the expected counts.
+    #   4. Projection ConfigMap carries the version-hash annotation.
+    #   5. Finalizer cleans up the projection on CR delete.
+    #
+    # Fixture keys + signature deterministically generated from seeded
+    # Ed25519 keys [0x11;32] (alpha) and [0x22;32] (beta). The
+    # canonical signing payload is locked in
+    # `controller/src/trust_graph_compile.rs::canonical_payload` —
+    # changing it requires regenerating these fixtures.
+    local pk_a="0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc"
+    local pk_b="oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA"
+    local sig_ab="5-Esp-uk11u_cGsCRdUXwxbxtCzSQsNaEzIBeFUBPZFWz9cUtr9PBw6eWFIBAAprz9kGwH2wTk3xaSnbJVQzAw"
+    # Tampered-signature: same length (64 bytes / 86 chars b64u-no-pad)
+    # but cryptographically wrong → must be rejected by the verifier.
+    local sig_bad="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    cat <<EOF | kubectl apply -f - >/dev/null 2>&1 || { fail "TrustGraph apply rejected"; return; }
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: TrustGraph
+metadata:
+  name: e2e-trustgraph
+spec:
+  vertices:
+    - id: alpha
+      alg: EdDSA
+      publicKeyB64u: "${pk_a}"
+      label: "auditor"
+    - id: beta
+      alg: EdDSA
+      publicKeyB64u: "${pk_b}"
+  edges:
+    - from: alpha
+      to: beta
+      score: 750
+      issuedAt: 1700000000
+      signature: "${sig_ab}"
+      reason: "auditor-attested"
+    - from: alpha
+      to: beta
+      score: 999
+      issuedAt: 1700000000
+      signature: "${sig_bad}"
+EOF
+
+    if wait_for_resource configmap trustgraph-e2e-trustgraph-projection azureclaw-system 45; then
+        pass "TrustGraph → projection ConfigMap created"
+    else
+        kubectl describe trustgraph e2e-trustgraph 2>&1 | tail -40 || true
+        fail "TrustGraph: projection ConfigMap not created"
+        kubectl delete trustgraph e2e-trustgraph --wait=false >/dev/null 2>&1 || true
+        return
+    fi
+
+    # Wait for status to be populated, then assert counts.
+    local deadline=$(($(date +%s) + 30))
+    local valid_v="" valid_e="" invalid_e=""
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        valid_v=$(kubectl get trustgraph e2e-trustgraph -o jsonpath='{.status.validVertices}' 2>/dev/null || echo "")
+        valid_e=$(kubectl get trustgraph e2e-trustgraph -o jsonpath='{.status.validEdges}' 2>/dev/null || echo "")
+        invalid_e=$(kubectl get trustgraph e2e-trustgraph -o jsonpath='{.status.invalidEdges}' 2>/dev/null || echo "")
+        if [ -n "$valid_v" ] && [ -n "$valid_e" ] && [ -n "$invalid_e" ]; then
+            break
+        fi
+        sleep 2
+    done
+
+    if [ "$valid_v" = "2" ]; then
+        pass "TrustGraph: status.validVertices=2"
+    else
+        fail "TrustGraph: validVertices='$valid_v' (want 2)"
+    fi
+    if [ "$valid_e" = "1" ]; then
+        pass "TrustGraph: status.validEdges=1 (signed edge accepted)"
+    else
+        fail "TrustGraph: validEdges='$valid_e' (want 1)"
+    fi
+    if [ "$invalid_e" = "1" ]; then
+        pass "TrustGraph: status.invalidEdges=1 (tampered edge rejected)"
+    else
+        fail "TrustGraph: invalidEdges='$invalid_e' (want 1)"
+    fi
+
+    if wait_for_ready trustgraph e2e-trustgraph azureclaw-system 30; then
+        pass "TrustGraph: status.conditions Ready=True"
+    else
+        kubectl describe trustgraph e2e-trustgraph 2>&1 | tail -20 || true
+        fail "TrustGraph: Ready=True not observed"
+    fi
+
+    # Projection ConfigMap must carry the version-hash annotation.
+    local vhash
+    vhash=$(kubectl get configmap trustgraph-e2e-trustgraph-projection -n azureclaw-system \
+        -o jsonpath='{.metadata.annotations.azureclaw\.azure\.com/trustgraph-version-hash}' 2>/dev/null || echo "")
+    if [ -n "$vhash" ] && [ "${#vhash}" = "16" ]; then
+        pass "TrustGraph: projection carries version-hash annotation (${vhash})"
+    else
+        fail "TrustGraph: version-hash annotation missing or wrong length ('${vhash}')"
+    fi
+
+    # Projection JSON must contain the valid edge but not the tampered one.
+    local proj
+    proj=$(kubectl get configmap trustgraph-e2e-trustgraph-projection -n azureclaw-system \
+        -o jsonpath='{.data.graph\.json}' 2>/dev/null || echo "")
+    if echo "$proj" | grep -q "\"score\": 750"; then
+        pass "TrustGraph: projection contains accepted edge (score=750)"
+    else
+        warn "Projection: $(echo "$proj" | head -c 500)"
+        fail "TrustGraph: projection missing accepted edge"
+    fi
+    if echo "$proj" | grep -q "\"score\": 999"; then
+        warn "Projection: $(echo "$proj" | head -c 500)"
+        fail "TrustGraph: projection leaked rejected edge (score=999)"
+    else
+        pass "TrustGraph: projection excludes rejected edge (score=999)"
+    fi
+
+    # CEL admission negative: empty vertices must be rejected.
+    local cel_err
+    cel_err=$(cat <<EOF | kubectl apply -f - 2>&1 || true
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: TrustGraph
+metadata:
+  name: e2e-trustgraph-empty
+spec:
+  vertices: []
+  edges: []
+EOF
+    )
+    if echo "$cel_err" | grep -q "vertices must contain at least one entry"; then
+        pass "TrustGraph CEL: empty vertices rejected at admission"
+    else
+        warn "Empty-vertices apply output: $cel_err"
+        fail "TrustGraph CEL: empty-vertices CR was not rejected"
+        kubectl delete trustgraph e2e-trustgraph-empty --wait=false >/dev/null 2>&1 || true
+    fi
+
+    # Finalizer cleans up projection on CR delete.
+    kubectl delete trustgraph e2e-trustgraph --wait=true --timeout=30s >/dev/null 2>&1 || true
+    if kubectl get configmap trustgraph-e2e-trustgraph-projection -n azureclaw-system >/dev/null 2>&1; then
+        fail "TrustGraph: projection ConfigMap leaked after CR delete"
+    else
+        pass "TrustGraph: projection ConfigMap cleaned up by finalizer"
+    fi
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 main() {
@@ -1917,6 +2069,7 @@ main() {
     test_crd_claw_memory || true
     test_crd_claw_eval || true
     test_crd_mcp_server || true
+    test_crd_trustgraph_reconcile || true
     test_crd_clawpairing_lifecycle || true
     test_crd_admission_rejects_invalid || true
     # Reconciler update / delete flow (separate fixtures so they


### PR DESCRIPTION
## §14.6 closure: TrustGraph 0 LOC → cluster-wide AGT trust topology (F1)

Cluster-scoped `TrustGraph` CR carrying Ed25519-signed trust attestations between agent identities. Reconciler verifies every edge signature against the declared `from` vertex's public key (using a domain-separated canonical signing payload to prevent cross-protocol replay) and publishes the validated subset as a `ConfigMap` projection in the `azureclaw-system` namespace.

**Closes (partially):** `docs/competitive.md` §14.6 line item *TrustGraph — 0 LOC → cluster-wide AGT trust topology*.
**Defers:** Phase F2 (router-side consultation) is a separate follow-up PR — no router code is touched in this slice.

## What lands

- `TrustGraph` cluster-scoped CRD (vertices = identities + Ed25519 pubkeys, edges = signed `from→to` attestations carrying a score in the existing AGT 0–1000 domain).
- Pure compile / verify step (`trust_graph_compile.rs`) — 13 unit tests covering signature spoofing, expiry inversion, alg pinning, public-key length, domain-separator replay prevention, and deterministic version hash.
- Reconciler (`trust_graph_reconciler.rs`) — finalizer-based cleanup of the projection ConfigMap (cluster-scoped CR → namespaced ConfigMap precludes ownerRef cascade).
- 4 CEL admission rules (non-empty vertices, `alg == 'EdDSA'`, score range, `notAfter ≥ issuedAt`).
- Helm CRD template + drift gate.
- Controller ClusterRole gains `trustgraphs` + `trustgraphs/status`.
- E2E test `test_crd_trustgraph_reconcile` — applies a CR with one valid signed edge + one tampered-signature edge, asserts validEdges=1, invalidEdges=1, projection ConfigMap excludes the rejected edge, version-hash annotation present, CEL rejects empty-vertices, finalizer cleans up the ConfigMap on delete.
- Security audit doc `docs/security-audits/2026-05-03-phase-f-trustgraph.md` (STRIDE delta, OWASP-LLM mapping, fail-closed semantics, scope deferrals).

## Scope guardrails (per plan.md Phase F)

- ❌ **No external attestation issuers.** Edges verified locally.
- ❌ **No transparency log publish.** No Sigstore Rekor (per user mandate: "no public posting").
- ❌ **No transitive closure in F1.** Direct edges only — multi-hop trust is F2.

## Test impact

- Controller unit tests: **463 passed** (+23 vs 440 on dev).
- Helm-drift gate: passes.
- All 8 CI quick-check gates pass locally against `origin/dev`.

## Out of scope (explicit)

- Router-side consumer (`inference-router`) — F2.
- Edge revocation channel.
- Cosign admission (Phase E, skipped per user).