### PR TITLE
feat(router): TrustGraph projection reader + AGT bootstrap (Phase F2a)

### DIFF
--- a/docs/security-audits/2026-05-03-phase-f2a-trustgraph-router.md
+++ b/docs/security-audits/2026-05-03-phase-f2a-trustgraph-router.md
@@ -1,0 +1,168 @@
+# Phase F2a — TrustGraph router consultation (bootstrap-only)
+
+| Field | Value |
+|-------|-------|
+| Audit date | 2026-05-03 |
+| Phase | F2a — router-side TrustGraph reader + AGT bootstrap hook |
+| Author | Copilot (drafting) + Pal Lakatos-Toth (sign-off) |
+| Branch | `feat/trustgraph-router-consultation` |
+| Depends on | F1 — `TrustGraph` CRD + reconciler (PR #176, merged) |
+| Blocks | F2b — controller-side per-sandbox projection mount |
+
+## 1. Scope
+
+This phase wires the `inference-router` to consume the `ProjectedGraph`
+JSON document the controller-side `TrustGraph` reconciler publishes to
+`ConfigMap[ns=azureclaw-system, name=trustgraph-<n>-projection]
+.data["graph.json"]` (Phase F1).
+
+A new module — `inference-router/src/a2a/trust_graph_projection.rs` —
+parses the document into an in-memory lookup table. A loader sibling
+— `inference-router/src/a2a/trust_graph_loader.rs` — reads it from the
+filesystem path named by the `TRUSTGRAPH_PROJECTION_PATH` env var. A
+single hook in `governance::trust_ops::update_trust` consults the
+projection on the **bootstrap path only** (peers with zero AGT
+interactions): if a controller-verified edge `<sandbox> → <peer>`
+exists and is not expired, its score is used to seed the AGT trust
+score, capped at the existing 500 maximum.
+
+**Explicitly out of scope (defer to F2b):**
+
+- Per-sandbox projection ConfigMap mounting (the controller change).
+- Cross-namespace ConfigMap watch / refresh.
+- Edge revocation channel (currently only `notAfter` time-based expiry).
+- Transitive closure (multi-hop inference).
+- Operator-facing endpoint to inspect the loaded projection.
+- Re-verification of edge signatures inside the router (the controller
+  is the trust root for verification — see §4.1).
+
+## 2. Threat model delta vs. pre-F2
+
+### 2.1 STRIDE delta
+
+| Threat                       | Pre-F2 posture                      | Post-F2a posture                                   |
+|------------------------------|--------------------------------------|----------------------------------------------------|
+| **S**poofing                 | AGT KNOCK + Ed25519 peer identity    | Unchanged. Bootstrap does not bypass identity verification. |
+| **T**ampering                | AGT trust file written under `/tmp/agt` | New input vector: projection JSON file. Default off. See §4.1. |
+| **R**epudiation              | AuditLogger row per trust update     | Additional `trustgraph_bootstrap:<score>` audit row per bootstrap. |
+| **I**nformation disclosure   | None                                 | An attacker with read access to the projection file learns the operator's trust topology. F2b narrows by per-sandbox slice. |
+| **D**enial of service        | Foundry rate-limits + AGT rate-limiter | Loader is fail-closed (empty projection on parse error). 1 MiB cap. |
+| **E**levation of privilege   | AGT cap of 500 on `requested_score`  | Cap unchanged. Bootstrap cannot exceed `min(500)`. |
+
+### 2.2 OWASP-LLM mapping
+
+- **LLM01 Prompt Injection** — n/a, this path is below the prompt layer.
+- **LLM03 Supply Chain** — projection file is a new supply-chain link.
+  Mitigated by RBAC on the source ConfigMap (controller field-manager
+  guard) and by F2b's per-sandbox slicing. Default-off until F2b lands.
+- **LLM06 Sensitive Information Disclosure** — the projection contains
+  agent identities and (in F1's full form) the entire trust topology.
+  F2b mitigates by mounting per-sandbox slices only.
+- **LLM10 Model Theft** — n/a.
+
+## 3. Fail-closed semantics
+
+Every failure path in F2a yields `TrustGraphProjection::empty()`:
+
+| Condition                                  | Behaviour                                  |
+|--------------------------------------------|--------------------------------------------|
+| `TRUSTGRAPH_PROJECTION_PATH` unset         | Empty projection. `tracing::info!`.        |
+| File missing at the path                   | Empty projection. `tracing::info!`.        |
+| File present but oversize (> 1 MiB)        | Empty projection. `tracing::warn!`.        |
+| File present but malformed JSON            | Empty projection. `tracing::warn!`.        |
+| Edge expired (`notAfter < now`)            | Edge silently dropped at lookup time.      |
+| Edge `from == to` (self-attestation)       | Edge silently dropped (defence in depth).  |
+| Peer has prior AGT interactions            | Bootstrap path skipped; AGT owns the score.|
+| Edge score > 500                           | Capped to 500 by the existing AGT rule.    |
+
+An empty projection is **functionally indistinguishable** from
+pre-F2 behaviour: `update_trust` falls through to the original
+`requested_score.min(500)` path.
+
+## 4. Production readiness gates
+
+### 4.1 Why the router does not re-verify edge signatures
+
+The controller's `compile_trust_graph` Ed25519-verifies every edge
+against the declared `from` vertex's public key, with a domain-prefixed
+canonical payload (`b"trustgraph.v1\n…"`) that is locked at v1. Edges
+that fail verification are dropped before publication; only verified
+edges reach the projection ConfigMap. Re-verifying inside the router
+would:
+
+1. Require shipping all vertex public keys into every sandbox — an
+   information-disclosure regression (LLM06).
+2. Duplicate the canonical-payload code on the trust boundary, exactly
+   what `ci/no-custom-crypto.sh` is designed to prevent.
+3. Double the per-refresh cost.
+
+**Required compensating control (production):** the source ConfigMap
+in `azureclaw-system` MUST be writeable only by the controller
+ServiceAccount. The existing SSA field-manager (`azureclaw-controller/trustgraph`)
+provides last-write-wins protection; production deployments MUST
+additionally apply a Gatekeeper / Kyverno admission policy that
+restricts `update`/`patch` on
+`configmaps` labeled `azureclaw.azure.com/artifact=trustgraph-projection`
+to that ServiceAccount. **F2b will ship the policy template.**
+
+### 4.2 Why the bootstrap fires only on `interactions == 0`
+
+After even one observed interaction, AGT's TrustManager is the
+authoritative source. Re-bootstrapping a peer whose live score has
+fallen due to `record_failure` would erase the operational signal —
+i.e. an attacker who triggers a content-flag penalty could regain
+trust by causing the projection to be reloaded. The `is_new` branch
+gate prevents that.
+
+### 4.3 Default-off in production until F2b
+
+The Helm chart MUST NOT set `TRUSTGRAPH_PROJECTION_PATH` until F2b
+ships the per-sandbox projection mount. Tests rely on the env var
+explicitly; production deployments rely on its absence. F2b will:
+
+1. Add the per-sandbox projection ConfigMap to the sandbox reconciler.
+2. Mount it at `/etc/azureclaw/trustgraph/graph.json`.
+3. Set the env var in the router container.
+4. Add the admission policy described in §4.1.
+
+## 5. Observability
+
+| Metric / signal                                     | Where                                            | Use                                                     |
+|-----------------------------------------------------|--------------------------------------------------|---------------------------------------------------------|
+| `azureclaw_agt_trustgraph_bootstraps_total`         | `inference-router/src/metrics.rs`                | Alert: rate exceeds expected provisioning cadence.      |
+| `azureclaw_agt_trustgraph_projection_version{hash}` | `inference-router/src/metrics.rs`                | Confirm all sandboxes observe the same projection.      |
+| Audit row: `trustgraph_bootstrap:<score>`           | AGT AuditLogger                                  | Forensic trail per bootstrap.                           |
+| `tracing::info!` "TrustGraph projection loaded"     | `trust_graph_loader.rs`                          | Boot-time confirmation; one line per pod start.         |
+
+**Recommended alert (operator-tunable):** `rate(azureclaw_agt_trustgraph_bootstraps_total[1h]) > 10`
+on a single sandbox is a red flag — either an attacker has caused
+mass peer enrollment, or a configuration drift pushed an updated
+projection that the sandbox is treating as new peers.
+
+## 6. Test coverage
+
+- 14 unit tests in `a2a::trust_graph_projection::tests` —
+  parse fixture, lookup hit/miss, self-edge filter, expiry, empty
+  object, malformed JSON, oversize, unknown top-level field, duplicate
+  edge dedup, optional-field round-trip, no-`notAfter` no-expiry.
+- 4 integration tests in `governance::tests` —
+  bootstrap from edge, no-override existing peer, no-op without
+  projection, self-edge rejection.
+
+Total: 18 new tests. Router suite: 632 passed (was 614).
+
+## 7. Sign-off
+
+| Role     | Name                  | Status                  |
+|----------|-----------------------|-------------------------|
+| Author   | Copilot               | ✅ Drafted               |
+| Reviewer | Pal Lakatos-Toth      | _pending PR review_     |
+| Security | Pal Lakatos-Toth      | _pending PR review_     |
+
+## 8. References
+
+- F1 audit doc: `docs/security-audits/2026-05-03-phase-f-trustgraph.md`
+- AGT TrustManager: `agentmesh` crate (workspace dep)
+- A2A module isolation: `ci/a2a-module-isolation.sh`
+- No-custom-crypto gate: `ci/no-custom-crypto.sh`
+- Plan §14.6 line item: TrustGraph 0 LOC → cluster-wide AGT trust topology

--- a/inference-router/src/a2a/mod.rs
+++ b/inference-router/src/a2a/mod.rs
@@ -82,6 +82,8 @@ pub mod mandate_trust_loader;
 pub mod mandate_trust_store;
 pub mod message_send_ap2;
 pub mod snapshot_rebuild;
+pub mod trust_graph_loader;
+pub mod trust_graph_projection;
 pub mod trust_store;
 
 pub use agent_card::{

--- a/inference-router/src/a2a/trust_graph_loader.rs
+++ b/inference-router/src/a2a/trust_graph_loader.rs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TrustGraph projection loader — file-mounted source of the
+//! controller-published projection.
+//!
+//! ## Why a file mount, not a Kube watch
+//!
+//! The router runs *inside* the sandbox pod (UID 1001) under a
+//! restrictive seccomp profile + iptables egress-guard (only loopback +
+//! DNS for UID 1000, plus apiserver for IMDS). Watching a ConfigMap in
+//! the cluster-wide `azureclaw-system` namespace would require either
+//! cross-namespace RBAC or a per-sandbox mirror — both controller
+//! changes that belong to **Phase F2b** (per the security-audit doc).
+//!
+//! For Phase F2a we keep the router side strictly read-only and pure:
+//! the operator (or, in F2b, the controller) is responsible for
+//! materialising the projection JSON at the path named in
+//! `TRUSTGRAPH_PROJECTION_PATH`. A missing file = "no projection
+//! available" = identical behavior to today (no bootstrap, AGT
+//! TrustManager owns the score outright).
+//!
+//! ## Failure semantics
+//!
+//! Every failure mode is fail-closed: the loader returns
+//! [`TrustGraphProjection::empty()`] and emits a `tracing::warn!` with
+//! the error reason. The router never crashes on a malformed projection,
+//! and an empty projection cannot influence trust scoring.
+
+use std::path::{Path, PathBuf};
+
+use super::trust_graph_projection::{ProjectionParseError, TrustGraphProjection};
+
+/// Environment variable that selects the projection file path. Absent
+/// or empty value → no projection loaded → no bootstrap behaviour.
+pub const PROJECTION_PATH_ENV: &str = "TRUSTGRAPH_PROJECTION_PATH";
+
+/// Errors surfaced by the loader. All variants are downgraded to
+/// `info!` (no-mount case) or `warn!` (parse / I/O case) and result in
+/// an empty projection — see [`load_or_empty`].
+#[derive(Debug, thiserror::Error)]
+pub enum LoaderError {
+    #[error("projection path env var {0} not set")]
+    NotConfigured(&'static str),
+
+    #[error("projection file {path:?} could not be read: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("projection file {path:?} parse error: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: ProjectionParseError,
+    },
+}
+
+/// Read a projection JSON document from `path` and parse it.
+pub fn load_from_path(path: &Path) -> Result<TrustGraphProjection, LoaderError> {
+    let raw = std::fs::read_to_string(path).map_err(|e| LoaderError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    TrustGraphProjection::from_json(&raw).map_err(|e| LoaderError::Parse {
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
+/// Resolve the projection path from `TRUSTGRAPH_PROJECTION_PATH` and
+/// load it. Any failure (env var unset, file missing, parse error) is
+/// logged and an empty projection is returned. **This is the
+/// production entry point** — it never propagates an error to the
+/// caller because the trust-graph signal is strictly opportunistic.
+pub fn load_or_empty() -> TrustGraphProjection {
+    let path = match std::env::var(PROJECTION_PATH_ENV) {
+        Ok(s) if !s.is_empty() => PathBuf::from(s),
+        _ => {
+            tracing::info!(
+                env = PROJECTION_PATH_ENV,
+                "TrustGraph projection not configured — proceeding without bootstrap"
+            );
+            return TrustGraphProjection::empty();
+        }
+    };
+
+    match load_from_path(&path) {
+        Ok(p) => {
+            tracing::info!(
+                path = %path.display(),
+                vertices = p.vertex_count(),
+                edges = p.edge_count(),
+                input_edges = p.input_edge_count(),
+                version_hash = %p.version_hash(),
+                "TrustGraph projection loaded"
+            );
+            p
+        }
+        Err(LoaderError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            tracing::info!(
+                path = %path.display(),
+                "TrustGraph projection file absent — proceeding without bootstrap"
+            );
+            TrustGraphProjection::empty()
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "TrustGraph projection load failed — using empty projection");
+            TrustGraphProjection::empty()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn unique_tmp(suffix: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "tg-projection-{}-{}-{suffix}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+
+    #[test]
+    fn load_from_path_parses_valid_file() {
+        let path = unique_tmp("valid");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"vertices":[],"edges":[],"versionHash":"deadbeef","inputEdgeCount":0}}"#
+        )
+        .unwrap();
+        drop(f);
+
+        let p = load_from_path(&path).expect("loads");
+        assert_eq!(p.version_hash(), "deadbeef");
+        assert!(p.is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_from_path_missing_file_returns_io_error() {
+        let path = unique_tmp("missing");
+        match load_from_path(&path).unwrap_err() {
+            LoaderError::Io { source, .. } => {
+                assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+            }
+            other => panic!("expected Io variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_from_path_malformed_returns_parse_error() {
+        let path = unique_tmp("malformed");
+        std::fs::write(&path, b"{ this is not json }").unwrap();
+        match load_from_path(&path).unwrap_err() {
+            LoaderError::Parse { .. } => {}
+            other => panic!("expected Parse variant, got {other:?}"),
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/inference-router/src/a2a/trust_graph_projection.rs
+++ b/inference-router/src/a2a/trust_graph_projection.rs
@@ -1,0 +1,426 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TrustGraph projection — read-only consumer of the controller-side
+//! `TrustGraph` CRD's compiled projection (Phase F1).
+//!
+//! ## What this module is
+//!
+//! A pure parser + lookup table for the JSON document the controller
+//! writes to `ConfigMap[name=trustgraph-<n>-projection,
+//! ns=azureclaw-system].data["graph.json"]`. The wire shape is the
+//! camelCase serialisation of `controller::trust_graph_compile::ProjectedGraph`:
+//!
+//! ```jsonc
+//! {
+//!   "vertices": [{"id": "...", "alg": "EdDSA", "publicKeyB64u": "..."}],
+//!   "edges":    [{"from": "...", "to": "...", "score": 750,
+//!                 "issuedAt": 1700000000, "signature": "..."}],
+//!   "versionHash":     "....",
+//!   "inputEdgeCount":  2
+//! }
+//! ```
+//!
+//! ## What this module is NOT
+//!
+//! - **Not a trust-score store.** The authoritative store is AGT's
+//!   [`agentmesh::TrustManager`] — see `governance::trust_ops`. This
+//!   module is a *signal source* the governance layer can opportunistically
+//!   consult to bootstrap brand-new peers.
+//! - **Not a verifier.** The controller has already cryptographically
+//!   verified every edge before publishing the projection. The router
+//!   trusts the controller's verdict (the projection ConfigMap is signed
+//!   by SSA field-management; tampering is detectable by version-hash
+//!   re-fetch). Only edges that survived `compile_trust_graph` reach this
+//!   reader.
+//! - **Not a writer.** Every method on the public type is `&self`. The
+//!   only mutation path is "swap the whole projection atomically" via
+//!   the loader.
+//!
+//! ## Module isolation
+//!
+//! Lives under `a2a::` to inherit the providers-only / no-credentials /
+//! `forbid(unsafe_code)` posture. No `auth::*` import, no I/O —
+//! the loader half (kube-client / file fetch) lives in
+//! `trust_graph_loader.rs`.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// Maximum projection size accepted by the parser (1 MiB). The controller
+/// caps a TrustGraph CR via apiserver's 1 MiB object limit; we mirror that
+/// here as a defence against a tampered ConfigMap pointing at a bloated
+/// payload.
+pub const MAX_PROJECTION_BYTES: usize = 1_048_576;
+
+/// One vertex in the projected graph — i.e. an agent identity that has
+/// passed `compile_trust_graph`'s alg/key validations.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectedVertex {
+    pub id: String,
+    pub alg: String,
+    #[serde(rename = "publicKeyB64u")]
+    pub public_key_b64u: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// One edge in the projected graph — a controller-verified Ed25519
+/// attestation `from → to` carrying an AGT-domain score [0, 1000].
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectedEdge {
+    pub from: String,
+    pub to: String,
+    pub score: u32,
+    pub issued_at: i64,
+    #[serde(default)]
+    pub not_after: Option<i64>,
+    pub signature: String,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Wire-format root of `graph.json`. Deserialisation is fail-closed —
+/// any unknown top-level field is ignored, but malformed JSON or a
+/// missing required field surfaces as `ProjectionParseError::Json`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireProjection {
+    #[serde(default)]
+    vertices: Vec<ProjectedVertex>,
+    #[serde(default)]
+    edges: Vec<ProjectedEdge>,
+    #[serde(default)]
+    version_hash: String,
+    #[serde(default)]
+    input_edge_count: usize,
+}
+
+/// In-memory, lookup-optimised trust-graph projection.
+///
+/// Indexed by `(from, to)` for O(1) edge lookup on the bootstrap path.
+/// Vertices are stored alongside but not directly indexed — they exist
+/// only so an operator-facing endpoint can enumerate the topology, not
+/// for verification (verification happened in the controller).
+#[derive(Debug, Clone, Default)]
+pub struct TrustGraphProjection {
+    vertices: HashMap<String, ProjectedVertex>,
+    edges_by_pair: HashMap<(String, String), ProjectedEdge>,
+    version_hash: String,
+    input_edge_count: usize,
+    edge_count: usize,
+}
+
+impl TrustGraphProjection {
+    /// Parse a projection JSON document. Returns
+    /// [`ProjectionParseError`] on malformed JSON or oversize payloads.
+    /// An empty `{}` parses to an empty projection (zero vertices, zero
+    /// edges) — semantically identical to "no graph".
+    pub fn from_json(raw: &str) -> Result<Self, ProjectionParseError> {
+        if raw.len() > MAX_PROJECTION_BYTES {
+            return Err(ProjectionParseError::Oversize {
+                actual: raw.len(),
+                max: MAX_PROJECTION_BYTES,
+            });
+        }
+        let wire: WireProjection =
+            serde_json::from_str(raw).map_err(|e| ProjectionParseError::Json(e.to_string()))?;
+
+        let mut vertices = HashMap::with_capacity(wire.vertices.len());
+        for v in wire.vertices {
+            // Last-write-wins on duplicate vertex id — the controller's
+            // compile step already de-duplicates, so this is just a
+            // belt-and-braces guard against a tampered ConfigMap.
+            vertices.insert(v.id.clone(), v);
+        }
+
+        let edge_count = wire.edges.len();
+        let mut edges_by_pair = HashMap::with_capacity(edge_count);
+        for e in wire.edges {
+            edges_by_pair.insert((e.from.clone(), e.to.clone()), e);
+        }
+        // After de-duplication by (from, to), the lookup table may have
+        // fewer entries than the input — record the post-dedup count so
+        // operators can detect a tampered ConfigMap that smuggled
+        // duplicate pairs.
+        let edge_count = edges_by_pair.len();
+
+        Ok(Self {
+            vertices,
+            edges_by_pair,
+            version_hash: wire.version_hash,
+            input_edge_count: wire.input_edge_count,
+            edge_count,
+        })
+    }
+
+    /// Empty projection — semantically identical to "no signed
+    /// attestations available". Used as the default when no projection
+    /// file is mounted.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Look up a single direct edge `from → to`. Returns `None` if
+    /// either endpoint is unknown, no such edge exists, or the edge has
+    /// expired relative to the supplied `now_unix_secs`.
+    ///
+    /// The expiry check is performed here — not at parse time — because
+    /// the projection is loaded once and queried many times; reloading
+    /// solely for expiry would be wasteful, and a freshly-expired edge
+    /// silently dropping is the desired semantics.
+    pub fn direct_edge(&self, from: &str, to: &str, now_unix_secs: i64) -> Option<&ProjectedEdge> {
+        // Reject self-attestations defensively. The controller already
+        // rejects these at admission time, but a hand-edited ConfigMap
+        // could slip one in. A self-attested score MUST NOT bootstrap
+        // anything — it would be a trivial forgery vector.
+        if from == to {
+            return None;
+        }
+        let edge = self
+            .edges_by_pair
+            .get(&(from.to_string(), to.to_string()))?;
+        if let Some(not_after) = edge.not_after
+            && now_unix_secs > not_after
+        {
+            return None;
+        }
+        Some(edge)
+    }
+
+    /// Enumerate the vertices for read-only operator endpoints.
+    pub fn vertices(&self) -> impl Iterator<Item = &ProjectedVertex> {
+        self.vertices.values()
+    }
+
+    /// Total vertex count.
+    pub fn vertex_count(&self) -> usize {
+        self.vertices.len()
+    }
+
+    /// Total verified-edge count (the controller-published number, not
+    /// the input edge count).
+    pub fn edge_count(&self) -> usize {
+        self.edge_count
+    }
+
+    /// Number of edges in the original spec — exposed so operators can
+    /// detect a degraded projection (`edge_count() < input_edge_count()`
+    /// means the controller dropped some edges as invalid).
+    pub fn input_edge_count(&self) -> usize {
+        self.input_edge_count
+    }
+
+    /// Content-hash of the projection — used by
+    /// [`metrics::TRUSTGRAPH_PROJECTION_VERSION`] to label the in-memory
+    /// state and to emit a single audit event on swap.
+    pub fn version_hash(&self) -> &str {
+        &self.version_hash
+    }
+
+    /// Whether the projection contains any data. `true` for both
+    /// `Self::default()` and `Self::from_json("{}")`.
+    pub fn is_empty(&self) -> bool {
+        self.vertices.is_empty() && self.edges_by_pair.is_empty()
+    }
+}
+
+/// Parse-time errors — fail-closed. The router treats every variant as
+/// "no projection available" rather than crashing the trust path.
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionParseError {
+    #[error("trust-graph projection JSON malformed: {0}")]
+    Json(String),
+
+    #[error("trust-graph projection oversize: {actual} bytes exceeds limit {max}")]
+    Oversize { actual: usize, max: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Produced by the F1 fixture generator
+    /// (`/tmp/fix` standalone Rust binary, seeds `[0x11; 32]` /
+    /// `[0x22; 32]`).
+    const PK_A: &str = "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc";
+    const PK_B: &str = "oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA";
+    const SIG_AB: &str =
+        "5-Esp-uk11u_cGsCRdUXwxbxtCzSQsNaEzIBeFUBPZFWz9cUtr9PBw6eWFIBAAprz9kGwH2wTk3xaSnbJVQzAw";
+
+    fn fixture_json() -> String {
+        format!(
+            r#"{{
+              "vertices": [
+                {{"id": "alpha", "alg": "EdDSA", "publicKeyB64u": "{pka}"}},
+                {{"id": "beta",  "alg": "EdDSA", "publicKeyB64u": "{pkb}", "label": "ops"}}
+              ],
+              "edges": [
+                {{"from": "alpha", "to": "beta", "score": 750,
+                  "issuedAt": 1700000000, "signature": "{sig}"}}
+              ],
+              "versionHash": "abc123def4567890",
+              "inputEdgeCount": 1
+            }}"#,
+            pka = PK_A,
+            pkb = PK_B,
+            sig = SIG_AB,
+        )
+    }
+
+    #[test]
+    fn parses_fixture() {
+        let p = TrustGraphProjection::from_json(&fixture_json()).expect("parses");
+        assert_eq!(p.vertex_count(), 2);
+        assert_eq!(p.edge_count(), 1);
+        assert_eq!(p.input_edge_count(), 1);
+        assert_eq!(p.version_hash(), "abc123def4567890");
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn direct_edge_lookup_hits_and_misses() {
+        let p = TrustGraphProjection::from_json(&fixture_json()).unwrap();
+
+        let hit = p.direct_edge("alpha", "beta", 1_700_000_500).unwrap();
+        assert_eq!(hit.score, 750);
+        assert_eq!(hit.from, "alpha");
+        assert_eq!(hit.to, "beta");
+
+        // Reverse direction is *not* automatically derived — trust is
+        // directional.
+        assert!(p.direct_edge("beta", "alpha", 1_700_000_500).is_none());
+
+        // Unknown vertex.
+        assert!(p.direct_edge("alpha", "gamma", 1_700_000_500).is_none());
+    }
+
+    #[test]
+    fn self_attestation_is_dropped() {
+        // Even if a tampered ConfigMap declares an edge alpha→alpha,
+        // direct_edge returns None to prevent self-bootstrap.
+        let raw = format!(
+            r#"{{
+              "vertices": [{{"id": "alpha", "alg": "EdDSA", "publicKeyB64u": "{}"}}],
+              "edges": [{{"from": "alpha", "to": "alpha", "score": 1000,
+                          "issuedAt": 1700000000, "signature": "{}"}}],
+              "versionHash": "0000000000000000",
+              "inputEdgeCount": 1
+            }}"#,
+            PK_A, SIG_AB
+        );
+        let p = TrustGraphProjection::from_json(&raw).unwrap();
+        assert!(p.direct_edge("alpha", "alpha", 1_700_000_500).is_none());
+    }
+
+    #[test]
+    fn expired_edge_is_dropped() {
+        let raw = format!(
+            r#"{{
+              "vertices": [
+                {{"id": "alpha", "alg": "EdDSA", "publicKeyB64u": "{}"}},
+                {{"id": "beta",  "alg": "EdDSA", "publicKeyB64u": "{}"}}
+              ],
+              "edges": [
+                {{"from": "alpha", "to": "beta", "score": 750,
+                  "issuedAt": 1700000000, "notAfter": 1700000100,
+                  "signature": "{}"}}
+              ],
+              "versionHash": "deadbeefcafef00d",
+              "inputEdgeCount": 1
+            }}"#,
+            PK_A, PK_B, SIG_AB
+        );
+        let p = TrustGraphProjection::from_json(&raw).unwrap();
+        // 50s after issuedAt — within window.
+        assert!(p.direct_edge("alpha", "beta", 1_700_000_050).is_some());
+        // 100s after issuedAt — exactly at notAfter, still valid.
+        assert!(p.direct_edge("alpha", "beta", 1_700_000_100).is_some());
+        // 101s after issuedAt — past notAfter, dropped.
+        assert!(p.direct_edge("alpha", "beta", 1_700_000_101).is_none());
+    }
+
+    #[test]
+    fn empty_object_is_empty_projection() {
+        let p = TrustGraphProjection::from_json("{}").unwrap();
+        assert!(p.is_empty());
+        assert_eq!(p.vertex_count(), 0);
+        assert_eq!(p.edge_count(), 0);
+        assert_eq!(p.version_hash(), "");
+    }
+
+    #[test]
+    fn malformed_json_returns_err() {
+        let err = TrustGraphProjection::from_json("not json").unwrap_err();
+        match err {
+            ProjectionParseError::Json(_) => {}
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversize_payload_rejected_before_serde() {
+        let huge = "x".repeat(MAX_PROJECTION_BYTES + 1);
+        match TrustGraphProjection::from_json(&huge).unwrap_err() {
+            ProjectionParseError::Oversize { actual, max } => {
+                assert_eq!(actual, MAX_PROJECTION_BYTES + 1);
+                assert_eq!(max, MAX_PROJECTION_BYTES);
+            }
+            other => panic!("expected Oversize, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_top_level_field_is_ignored() {
+        let raw = r#"{"vertices": [], "edges": [], "futureField": "ignored"}"#;
+        let p = TrustGraphProjection::from_json(raw).unwrap();
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn duplicate_edge_pair_last_write_wins() {
+        let raw = format!(
+            r#"{{
+              "vertices": [
+                {{"id": "alpha", "alg": "EdDSA", "publicKeyB64u": "{}"}},
+                {{"id": "beta",  "alg": "EdDSA", "publicKeyB64u": "{}"}}
+              ],
+              "edges": [
+                {{"from": "alpha", "to": "beta", "score": 100,
+                  "issuedAt": 1700000000, "signature": "{}"}},
+                {{"from": "alpha", "to": "beta", "score": 900,
+                  "issuedAt": 1700000050, "signature": "{}"}}
+              ],
+              "versionHash": "1111111111111111",
+              "inputEdgeCount": 2
+            }}"#,
+            PK_A, PK_B, SIG_AB, SIG_AB
+        );
+        let p = TrustGraphProjection::from_json(&raw).unwrap();
+        // edge_count counts unique (from,to) pairs after de-dup.
+        assert_eq!(p.edge_count(), 1);
+        let e = p.direct_edge("alpha", "beta", 1_700_000_500).unwrap();
+        // Last entry wins.
+        assert_eq!(e.score, 900);
+    }
+
+    #[test]
+    fn vertex_label_optional_field_round_trips() {
+        let p = TrustGraphProjection::from_json(&fixture_json()).unwrap();
+        let beta = p.vertices().find(|v| v.id == "beta").unwrap();
+        assert_eq!(beta.label.as_deref(), Some("ops"));
+        let alpha = p.vertices().find(|v| v.id == "alpha").unwrap();
+        assert!(alpha.label.is_none());
+    }
+
+    #[test]
+    fn missing_optional_not_after_means_no_expiry() {
+        let p = TrustGraphProjection::from_json(&fixture_json()).unwrap();
+        // Far-future timestamp — fixture has no notAfter, so the edge
+        // is still resolvable.
+        assert!(p.direct_edge("alpha", "beta", i64::MAX).is_some());
+    }
+}

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -105,6 +105,11 @@ pub struct Governance {
     /// recency of mesh peers — without it, peers whose name doesn't match
     /// a known sandbox CR (e.g. cloud-offload parents identified only by AMID) are filtered out of the peer panel.
     peer_last_seen: std::sync::Mutex<std::collections::HashMap<String, std::time::SystemTime>>,
+    /// Read-only TrustGraph projection consulted by the bootstrap path
+    /// in `update_trust` to seed AGT scores for brand-new peers.
+    /// Always present; an absent / unconfigured projection is
+    /// represented by [`crate::a2a::trust_graph_projection::TrustGraphProjection::empty`].
+    pub(crate) trust_graph: crate::a2a::trust_graph_projection::TrustGraphProjection,
     start_time: Instant,
     policy_rule_count: AtomicU64,
 }
@@ -219,8 +224,29 @@ impl Governance {
             trust_threshold,
             policy_rule_count,
             peer_last_seen: std::sync::Mutex::new(std::collections::HashMap::new()),
+            trust_graph: {
+                let p = crate::a2a::trust_graph_loader::load_or_empty();
+                if !p.version_hash().is_empty() {
+                    metrics::AGT_TRUSTGRAPH_PROJECTION_VERSION
+                        .with_label_values(&[p.version_hash()])
+                        .set(1);
+                }
+                p
+            },
             start_time: Instant::now(),
         }
+    }
+
+    /// Test-only: replace the trust-graph projection. Lives behind
+    /// `#[cfg(test)]` so the field stays effectively private in
+    /// production — bootstrap data flows through the file-mount
+    /// loader only.
+    #[cfg(test)]
+    pub(crate) fn set_trust_graph_for_test(
+        &mut self,
+        projection: crate::a2a::trust_graph_projection::TrustGraphProjection,
+    ) {
+        self.trust_graph = projection;
     }
 
     /// Load all YAML policy files from a directory.  Returns rule count.
@@ -869,5 +895,130 @@ mod tests {
         );
         let after = gov.trust.get_trust_score("bad-agent").score;
         assert!(after < before, "Content flag should apply trust penalty");
+    }
+
+    #[test]
+    fn trustgraph_bootstrap_overrides_requested_for_new_peer() {
+        const PK_A: &str = "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc";
+        const PK_B: &str = "oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA";
+        const SIG_AB: &str = "5-Esp-uk11u_cGsCRdUXwxbxtCzSQsNaEzIBeFUBPZFWz9cUtr9PBw6eWFIBAAprz9kGwH2wTk3xaSnbJVQzAw";
+
+        let alpha = format!("alpha-tg-bs-{}", std::process::id());
+        let beta = format!("beta-tg-bs-{}", std::process::id());
+        let gamma = format!("gamma-tg-bs-{}", std::process::id());
+
+        let raw = format!(
+            r#"{{
+              "vertices": [
+                {{"id": "{alpha}", "alg": "EdDSA", "publicKeyB64u": "{PK_A}"}},
+                {{"id": "{beta}",  "alg": "EdDSA", "publicKeyB64u": "{PK_B}"}}
+              ],
+              "edges": [
+                {{"from": "{alpha}", "to": "{beta}", "score": 750,
+                  "issuedAt": 1700000000, "signature": "{SIG_AB}"}}
+              ],
+              "versionHash": "abc123def4567890",
+              "inputEdgeCount": 1
+            }}"#
+        );
+        let projection =
+            crate::a2a::trust_graph_projection::TrustGraphProjection::from_json(&raw).unwrap();
+
+        let mut gov = Governance::new(&alpha);
+        gov.set_trust_graph_for_test(projection);
+
+        let res = gov.update_trust(&beta, 0, 0);
+        assert!(res.is_ok());
+        let score = gov.trust.get_trust_score(&beta).score;
+        assert!(
+            score >= 500,
+            "expected bootstrap-from-edge >= 500, got {score}"
+        );
+
+        let _ = gov.update_trust(&gamma, 0, 0);
+        let no_edge_score = gov.trust.get_trust_score(&gamma).score;
+        assert!(
+            no_edge_score < score,
+            "no-edge peer ({no_edge_score}) must not exceed edge-bootstrapped peer ({score})"
+        );
+    }
+
+    #[test]
+    fn trustgraph_does_not_override_existing_peer_score() {
+        const PK_A: &str = "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc";
+        const PK_B: &str = "oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA";
+        const SIG_AB: &str = "5-Esp-uk11u_cGsCRdUXwxbxtCzSQsNaEzIBeFUBPZFWz9cUtr9PBw6eWFIBAAprz9kGwH2wTk3xaSnbJVQzAw";
+
+        let alpha = format!("alpha-tg-stable-{}", std::process::id());
+        let beta = format!("beta-tg-stable-{}", std::process::id());
+
+        let raw = format!(
+            r#"{{
+              "vertices": [
+                {{"id": "{alpha}", "alg": "EdDSA", "publicKeyB64u": "{PK_A}"}},
+                {{"id": "{beta}",  "alg": "EdDSA", "publicKeyB64u": "{PK_B}"}}
+              ],
+              "edges": [
+                {{"from": "{alpha}", "to": "{beta}", "score": 750,
+                  "issuedAt": 1700000000, "signature": "{SIG_AB}"}}
+              ],
+              "versionHash": "abc123def4567890",
+              "inputEdgeCount": 1
+            }}"#
+        );
+        let projection =
+            crate::a2a::trust_graph_projection::TrustGraphProjection::from_json(&raw).unwrap();
+
+        let mut gov = Governance::new(&alpha);
+        gov.set_trust_graph_for_test(projection);
+
+        let _ = gov.update_trust(&beta, 0, 0);
+        let after_bootstrap = gov.trust.get_trust_score(&beta).score;
+
+        let _ = gov.update_trust(&beta, 0, 0);
+        let after_negative = gov.trust.get_trust_score(&beta).score;
+        assert!(
+            after_negative <= after_bootstrap,
+            "negative interaction must not be re-bootstrapped (was {after_bootstrap}, now {after_negative})"
+        );
+    }
+
+    #[test]
+    fn trustgraph_no_projection_is_no_op() {
+        let sandbox = format!("standalone-tg-{}", std::process::id());
+        let peer = format!("peer-tg-noop-{}", std::process::id());
+        let gov = Governance::new(&sandbox);
+        assert!(gov.trust_graph.is_empty());
+
+        let _ = gov.update_trust(&peer, 200, 0);
+        let s = gov.trust.get_trust_score(&peer).score;
+        assert!(
+            (200..=220).contains(&s),
+            "expected bootstrap near 200 with no projection, got {s}"
+        );
+    }
+
+    #[test]
+    fn trustgraph_self_edge_does_not_bootstrap() {
+        const PK_A: &str = "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc";
+        const SIG_AB: &str = "5-Esp-uk11u_cGsCRdUXwxbxtCzSQsNaEzIBeFUBPZFWz9cUtr9PBw6eWFIBAAprz9kGwH2wTk3xaSnbJVQzAw";
+
+        let alpha = format!("alpha-tg-self-{}", std::process::id());
+        let raw = format!(
+            r#"{{
+              "vertices": [{{"id": "{alpha}", "alg": "EdDSA", "publicKeyB64u": "{PK_A}"}}],
+              "edges": [{{"from": "{alpha}", "to": "{alpha}", "score": 1000,
+                          "issuedAt": 1700000000, "signature": "{SIG_AB}"}}],
+              "versionHash": "0000000000000000",
+              "inputEdgeCount": 1
+            }}"#
+        );
+        let projection =
+            crate::a2a::trust_graph_projection::TrustGraphProjection::from_json(&raw).unwrap();
+        let mut gov = Governance::new(&alpha);
+        gov.set_trust_graph_for_test(projection);
+
+        let res = gov.update_trust(&alpha, 0, 0);
+        assert!(res.is_err());
     }
 }

--- a/inference-router/src/governance/trust_ops.rs
+++ b/inference-router/src/governance/trust_ops.rs
@@ -43,10 +43,52 @@ impl Governance {
         let is_new = existing.interactions == 0;
 
         if is_new {
-            // Bootstrap: set initial score (capped at 500) then record first interaction.
-            let initial = requested_score.min(500);
+            // Phase F2 — TrustGraph bootstrap.
+            //
+            // For brand-new peers (zero AGT interactions), opportunistically
+            // consult the controller-published TrustGraph projection for a
+            // signed edge `sandbox_name → agent_id`. If one exists and is
+            // not expired, use its score (still subject to the AGT 500 cap
+            // applied below) instead of the caller-supplied requested_score.
+            //
+            // Hard invariants:
+            //   • Never overrides an existing AGT score (interactions > 0).
+            //   • Never exceeds the AGT bootstrap cap of 500 (matches the
+            //     existing `requested_score.min(500)` semantics).
+            //   • Self-edges are pre-filtered by the projection lookup —
+            //     defence in depth against a tampered ConfigMap.
+            //   • An empty / absent projection is a no-op (identical to
+            //     pre-F2 behaviour).
+            let now_unix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            let bootstrap_score = self
+                .trust_graph
+                .direct_edge(&self.sandbox_name, agent_id, now_unix)
+                .map(|e| e.score);
+
+            let initial = bootstrap_score.unwrap_or(requested_score).min(500);
+
             self.trust.set_trust(agent_id, initial);
             self.trust.record_success(agent_id);
+
+            if let Some(score) = bootstrap_score {
+                metrics::AGT_TRUSTGRAPH_BOOTSTRAPS.inc();
+                tracing::info!(
+                    peer = agent_id,
+                    bootstrap_score = score,
+                    capped_initial = initial,
+                    sandbox = %self.sandbox_name,
+                    projection_version = %self.trust_graph.version_hash(),
+                    "AGT trust bootstrapped from TrustGraph projection edge"
+                );
+                self.audit.log(
+                    agent_id,
+                    &format!("trustgraph_bootstrap:{}", score),
+                    "success",
+                );
+            }
         } else if requested_score >= old_score {
             // Positive interaction — use SDK's built-in reward + decay + interaction bump.
             self.trust.record_success(agent_id);

--- a/inference-router/src/metrics.rs
+++ b/inference-router/src/metrics.rs
@@ -95,6 +95,34 @@ pub static AGT_CONTENT_FLAGS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// Total TrustGraph-projection-driven trust bootstraps. Incremented
+/// once per peer whose initial AGT trust score was seeded from a
+/// controller-verified TrustGraph edge (Phase F2). Never incremented
+/// on subsequent updates — bootstrap is a one-time event per peer.
+pub static AGT_TRUSTGRAPH_BOOTSTRAPS: LazyLock<prometheus::IntCounter> = LazyLock::new(|| {
+    prometheus::register_int_counter!(opts!(
+        "azureclaw_agt_trustgraph_bootstraps_total",
+        "Brand-new peers seeded with an AGT trust score derived from a TrustGraph projection edge"
+    ))
+    .unwrap()
+});
+
+/// Last loaded TrustGraph projection version-hash (gauge with the
+/// hash as a label). One series per (sandbox, version_hash) pair.
+/// Used to confirm in operator dashboards that all sandboxes are
+/// observing the same controller-published projection.
+pub static AGT_TRUSTGRAPH_PROJECTION_VERSION: LazyLock<prometheus::IntGaugeVec> =
+    LazyLock::new(|| {
+        prometheus::register_int_gauge_vec!(
+            opts!(
+                "azureclaw_agt_trustgraph_projection_version",
+                "Constant 1 — labeled with the loaded TrustGraph projection version-hash"
+            ),
+            &["version_hash"]
+        )
+        .unwrap()
+    });
+
 /// Total behavior anomaly alerts.
 pub static AGT_BEHAVIOR_ALERTS: LazyLock<IntGauge> = LazyLock::new(|| {
     register_int_gauge!(opts!(


### PR DESCRIPTION
## §14.6 closure (cont.): TrustGraph router consultation — bootstrap-only

Companion to PR #176 (F1). Wires the inference-router to consume the projection ConfigMap that the F1 reconciler publishes. The new code path runs only on the **bootstrap branch** of `Governance::update_trust` — i.e. peers with zero AGT interactions. AGT's TrustManager remains the authoritative live-score store; this PR feeds it a one-shot, controller-verified initial score capped by the existing 500 maximum.

**Closes (partially):** `docs/competitive.md` §14.6 line item *TrustGraph — 0 LOC → cluster-wide AGT trust topology*.
**Defers to F2b:** controller-side per-sandbox projection mount + admission policy (see audit doc §4.3).

## What lands

- `inference-router/src/a2a/trust_graph_projection.rs` — pure projection parser + (from, to) edge index. 14 unit tests including self-edge filter, `notAfter` expiry, 1 MiB oversize cap, malformed JSON, edge-pair dedup.
- `inference-router/src/a2a/trust_graph_loader.rs` — reads from `TRUSTGRAPH_PROJECTION_PATH`. Fail-closed: every failure mode → empty projection + tracing log.
- `Governance.trust_graph` field, populated once at construction from `load_or_empty()`.
- Bootstrap hook in `governance::trust_ops::update_trust` — fires only when `is_new`. Never overrides live AGT scores. Defence-in-depth self-edge guard.
- Prometheus: `azureclaw_agt_trustgraph_bootstraps_total`, `azureclaw_agt_trustgraph_projection_version{hash}`.
- Audit row `trustgraph_bootstrap:<score>` per bootstrap.
- Security-audit doc `docs/security-audits/2026-05-03-phase-f2a-trustgraph-router.md` with STRIDE delta, OWASP-LLM mapping, fail-closed table, production-gating prerequisites for F2b.

## AGT boundary respected

The router does **not** re-implement trust scoring and does **not** re-verify edge signatures — see audit §4.1 for the rationale (information disclosure, code duplication on the trust boundary, performance). The controller is the verification root; the router is a read-only consumer of its verdict.

## Production posture

`TRUSTGRAPH_PROJECTION_PATH` is unset by default in Helm. With the env var unset, behaviour is byte-identical to dev's HEAD. The variable is set only by F2b (per-sandbox mount) and by the new unit tests.

## Test impact

- Router suite: **632 passed** (+18 vs dev baseline of 614).
- All 8 CI quick-check gates pass locally against `origin/dev`.

## Out of scope (explicit)

- Controller-side projection mount → **F2b**.
- Edge revocation channel.
- Transitive closure / multi-hop trust.
- Operator-facing endpoint to inspect the loaded projection.
- Cosign admission policy on the source ConfigMap (Phase E, skipped per user).