### PR TITLE
feat(runtime): wire Anthropic Claude Agent SDK as first-class runtime (Phase H#1)

### DIFF
--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -34,8 +34,8 @@
 use std::collections::BTreeMap;
 
 use crate::crd::{
-    AgentCodeRef, ByoRuntimeConfig, MafLanguage, MicrosoftAgentFrameworkConfig, OpenAIAgentsConfig,
-    OpenClawConfig, RuntimeKind, RuntimeSpec,
+    AgentCodeRef, AnthropicConfig, ByoRuntimeConfig, MafLanguage, MicrosoftAgentFrameworkConfig,
+    OpenAIAgentsConfig, OpenClawConfig, RuntimeKind, RuntimeSpec,
 };
 
 /// Default container image for the OpenAI Agents Python runtime
@@ -79,6 +79,28 @@ pub fn maf_python_default_image() -> String {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_MAF_PYTHON_IMAGE.to_string())
+}
+
+/// Default container image for the Anthropic Claude Agent SDK Python
+/// runtime (Phase H#1). Stays `:latest`; operators pin via the
+/// `ANTHROPIC_RUNTIME_IMAGE` env var.
+///
+/// Why a dedicated adapter (vs BYO): pins ANTHROPIC_BASE_URL to the
+/// router sidecar so the SDK cannot reach api.anthropic.com directly,
+/// substitutes ANTHROPIC_API_KEY with a sentinel (router brokers the
+/// real credential on egress), and inherits the standard AAD broker /
+/// OTel / AgentMesh wiring.
+pub const DEFAULT_ANTHROPIC_IMAGE: &str =
+    "azureclawacr.azurecr.io/azureclaw-runtime-anthropic:latest";
+
+/// Resolve the Anthropic adapter image, honouring an operator
+/// override via `ANTHROPIC_RUNTIME_IMAGE`. Falls back to
+/// [`DEFAULT_ANTHROPIC_IMAGE`].
+pub fn anthropic_default_image() -> String {
+    std::env::var("ANTHROPIC_RUNTIME_IMAGE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ANTHROPIC_IMAGE.to_string())
 }
 
 /// Concrete deployment intent for a single reconcile pass.
@@ -290,7 +312,18 @@ pub fn build_runtime_plan(
         }
         RuntimeKind::SemanticKernel => Err(RuntimePlanError::AdapterMissing("SemanticKernel")),
         RuntimeKind::LangGraph => Err(RuntimePlanError::AdapterMissing("LangGraph")),
-        RuntimeKind::Anthropic => Err(RuntimePlanError::AdapterMissing("Anthropic")),
+        RuntimeKind::Anthropic => {
+            // Phase H#1: Anthropic Claude Agent SDK adapter wired
+            // end-to-end. Adapter image bundles Python 3.12 +
+            // `anthropic` SDK + `claude-agent-sdk` + a stock
+            // entrypoint that pins ANTHROPIC_BASE_URL to the router
+            // sidecar and replaces ANTHROPIC_API_KEY with a sentinel.
+            // Foundry tools reachable via the platform MCP server at
+            // `/platform/mcp` (Claude SDK supports MCP natively via
+            // `mcp_servers=[...]`).
+            let cfg = runtime.anthropic.as_ref().expect("validated above");
+            Ok(plan_anthropic(cfg))
+        }
     }
 }
 
@@ -458,6 +491,46 @@ fn plan_microsoft_agent_framework(
         agent_code: cfg.agent_code.clone(),
         byo_contract_version: None,
     })
+}
+
+/// Producer for [`RuntimeKind::Anthropic`] (Phase H#1).
+///
+/// The Anthropic Claude Agent SDK is currently Python-first. The
+/// adapter pins `ANTHROPIC_BASE_URL` to the router sidecar and sets
+/// `ANTHROPIC_API_KEY` to a sentinel — the router brokers the real
+/// credential on egress so no Anthropic key ever lives inside the
+/// sandbox pod. Foundry tools are reachable via the platform MCP
+/// server at `/platform/mcp` (Claude SDK supports MCP natively via
+/// `mcp_servers=[...]`).
+fn plan_anthropic(cfg: &AnthropicConfig) -> RuntimeDeploymentPlan {
+    let image = anthropic_default_image();
+
+    // Same merge contract as `plan_openai_agents`: producer-supplied
+    // defaults first, user `extra_env` on top. Reserved-prefix
+    // filtering happens in the deployment builder; keep producer
+    // defaults on non-reserved (`RUNTIME_*`) keys.
+    let mut runtime_extra_env: BTreeMap<String, String> = BTreeMap::new();
+    if let Some(v) = cfg.python_version.as_ref() {
+        runtime_extra_env.insert("RUNTIME_PYTHON_VERSION".to_string(), v.clone());
+    }
+    if let Some(user_env) = cfg.extra_env.as_ref() {
+        for (k, v) in user_env {
+            runtime_extra_env.insert(k.clone(), v.clone());
+        }
+    }
+
+    let command = cfg.entrypoint.clone();
+
+    RuntimeDeploymentPlan {
+        kind_str: "Anthropic",
+        image,
+        command,
+        args: None,
+        runtime_extra_env,
+        raw_env: Vec::new(),
+        agent_code: cfg.agent_code.clone(),
+        byo_contract_version: None,
+    }
 }
 
 #[cfg(test)]
@@ -655,8 +728,8 @@ mod tests {
     // surfaces `AdapterMissing(<kind>)`. BYO is a known short-circuit
     // until A2.b lands the contract-verifier path.
 
-    /// S10.A4: MAF is now wired (S10.A3: OpenAIAgents, S10.A2.b: BYO).
-    /// Only the three Tier-2 placeholders short-circuit through
+    /// Anthropic was wired in Phase H#1 (joining OpenAIAgents/MAF/BYO).
+    /// Only the two remaining Tier-2 placeholders short-circuit through
     /// AdapterMissing.
     #[test]
     fn plan_returns_adapter_missing_for_each_unwired_non_openclaw_kind() {
@@ -681,16 +754,6 @@ mod tests {
                 },
                 "LangGraph",
             ),
-            (
-                RuntimeKind::Anthropic,
-                RuntimeSpec {
-                    kind: RuntimeKind::Anthropic,
-                    openclaw: None,
-                    anthropic: Some(AnthropicConfig::default()),
-                    ..Default::default()
-                },
-                "Anthropic",
-            ),
         ];
         for (kind, rt, expected_label) in cases {
             let err = build_runtime_plan(&rt, "default-image").expect_err("must short-circuit");
@@ -701,6 +764,92 @@ mod tests {
                 kind_str(&kind)
             );
         }
+    }
+
+    // ── Anthropic adapter (Phase H#1) ────────────────────────────────
+
+    #[test]
+    fn anthropic_default_image_falls_back_when_env_unset() {
+        // SAFETY: this test does not run in parallel with env writers
+        // (no other test sets ANTHROPIC_RUNTIME_IMAGE).
+        unsafe {
+            std::env::remove_var("ANTHROPIC_RUNTIME_IMAGE");
+        }
+        assert_eq!(anthropic_default_image(), DEFAULT_ANTHROPIC_IMAGE);
+    }
+
+    #[test]
+    fn plan_anthropic_emits_anthropic_kind_str_and_default_image() {
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::Anthropic,
+            openclaw: None,
+            anthropic: Some(AnthropicConfig::default()),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored").expect("anthropic plan ok");
+        assert_eq!(plan.kind_str, "Anthropic");
+        assert!(plan.image.contains("azureclaw-runtime-anthropic"));
+        // No reserved AZURECLAW_/ANTHROPIC_ leak from the producer —
+        // the deployment builder owns those.
+        for k in plan.runtime_extra_env.keys() {
+            assert!(
+                !k.starts_with("ANTHROPIC_"),
+                "producer must not emit ANTHROPIC_* keys: {k}"
+            );
+            assert!(
+                !k.starts_with("AZURECLAW_"),
+                "producer must not emit AZURECLAW_* keys: {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn plan_anthropic_threads_python_version_and_user_extra_env() {
+        let mut user_env = BTreeMap::new();
+        user_env.insert("MY_FLAG".to_string(), "on".to_string());
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::Anthropic,
+            openclaw: None,
+            anthropic: Some(AnthropicConfig {
+                python_version: Some("3.13".into()),
+                extra_env: Some(user_env),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored").expect("ok");
+        assert_eq!(
+            plan.runtime_extra_env.get("RUNTIME_PYTHON_VERSION"),
+            Some(&"3.13".to_string())
+        );
+        assert_eq!(
+            plan.runtime_extra_env.get("MY_FLAG"),
+            Some(&"on".to_string())
+        );
+    }
+
+    #[test]
+    fn plan_anthropic_user_extra_env_overrides_producer_default() {
+        // User explicitly pinning RUNTIME_PYTHON_VERSION via extra_env
+        // wins over the python_version field. Mirrors the merge order
+        // in `plan_openai_agents`.
+        let mut user_env = BTreeMap::new();
+        user_env.insert("RUNTIME_PYTHON_VERSION".to_string(), "3.11".into());
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::Anthropic,
+            openclaw: None,
+            anthropic: Some(AnthropicConfig {
+                python_version: Some("3.13".into()),
+                extra_env: Some(user_env),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored").expect("ok");
+        assert_eq!(
+            plan.runtime_extra_env.get("RUNTIME_PYTHON_VERSION"),
+            Some(&"3.11".to_string())
+        );
     }
 
     // ── build_runtime_plan() rejects shape-invalid input ─────────────

--- a/docs/security-audits/2026-05-03-phase-h1-anthropic-runtime.md
+++ b/docs/security-audits/2026-05-03-phase-h1-anthropic-runtime.md
@@ -1,0 +1,131 @@
+# Phase H#1 — Anthropic Claude Agent SDK Runtime Adapter
+
+**Status:** complete
+**Date:** 2026-05-03
+**Scope:** Add Anthropic's Claude Agent SDK as a first-class AzureClaw
+runtime alongside OpenClaw, OpenAI Agents SDK, MAF, and BYO. CRD already
+declared `RuntimeKind::Anthropic` and `AnthropicConfig`; this phase
+replaces the `AdapterMissing("Anthropic")` short-circuit with a real
+producer (`plan_anthropic`), ships the Python adapter package
+(`runtimes/anthropic/`) and the sandbox image
+(`sandbox-images/anthropic/`).
+
+## Components
+
+| Component | Location | Notes |
+|---|---|---|
+| CRD wiring (already merged) | `controller/src/crd.rs:589` (`AnthropicConfig`) | No schema change. |
+| Planner | `controller/src/reconciler/runtime.rs::plan_anthropic` | Mirrors `plan_openai_agents`. |
+| Default image helper | `runtime.rs::anthropic_default_image()` | Honours `ANTHROPIC_RUNTIME_IMAGE` env override; falls back to `azureclawacr.azurecr.io/azureclaw-runtime-anthropic:latest`. |
+| Python adapter | `runtimes/anthropic/` | 5 modules (aad, mesh, otel, runtime, `__init__`). aad/mesh/otel ported verbatim from `openai-agents`. |
+| Sandbox image | `sandbox-images/anthropic/` | Base `mariner-python:3.12`. UID 1000. AGT wheels overlaid. |
+| E2E gate | `tests/e2e/run.sh::test_runtime_anthropic` | Asserts namespace creation + (when reconciled) image carries the `anthropic` tag. |
+
+## Threat-model delta (STRIDE)
+
+The Anthropic adapter inherits the per-sandbox isolation, egress-guard,
+and AGT trust gating of the existing runtime adapters. The delta-only
+review:
+
+### S — Spoofing
+**No new identity surface.** Adapter reuses `aad.py` (verbatim) — same
+IMDS / Workload Identity broker as OpenAI Agents. No new client cert,
+no new federated credential, no new audience.
+
+### T — Tampering
+**No new mutable persistence.** Adapter is read-mostly: it consumes
+`PLATFORM_MCP_URL`, `AGT_RELAY_URL`, `OTEL_*` env vars set by the
+controller. Trust scoring still flows through `AGT_TRUST_THRESHOLD`
+and the AGT TrustManager — adapter does not write to that store.
+
+### R — Repudiation
+**Inherits OTel + AGT audit chain unchanged.** `otel.py` is the
+verbatim adapter; the inference router still produces the
+hash-chained / Phase-D-Merkle audit log. No bypass.
+
+### I — Information disclosure  *(primary risk vector)*
+**Mitigation: router-managed key sentinel.** The Claude Agent SDK
+refuses to construct without `ANTHROPIC_API_KEY` set. The adapter
+sets it to the literal string `router-managed`. The real
+Anthropic-compatible credential is materialised by the
+inference-router on egress (it strips the sentinel header and
+substitutes the AAD-attested provider credential). **No real
+Anthropic key ever lives in the sandbox pod's process memory or env.**
+
+Defence in depth:
+1. `ANTHROPIC_BASE_URL` is pinned to `http://127.0.0.1:8443/anthropic/v1`
+   so the SDK is *unable* to dial `api.anthropic.com` directly.
+2. The egress-guard iptables init container drops UID-1000 packets
+   destined for non-loopback / non-DNS targets — the SDK couldn't
+   reach the public Anthropic endpoint even if base-url were leaked.
+3. The router enforces the same Content Safety + AGT + AP2 +
+   ToolPolicy pipeline as for any other provider.
+
+### D — Denial of service
+**No new amplification.** The adapter does not introduce retry loops
+or request fan-out beyond what the SDK itself produces. Existing
+rate-limiting (RateLimiter component) and token-budget enforcement
+in the router apply uniformly across providers.
+
+### E — Elevation of privilege
+**No new capability.** UID 1000, seccomp-strict, NetworkPolicy, CRD
+RBAC unchanged. No `CAP_NET_RAW`, no `setuid`, no privileged volumes.
+The image inherits the same hardening baseline as the OpenAI Agents
+runtime image.
+
+## Design choices (auditable)
+
+### No `tools.py` module
+The OpenAI Agents adapter exposes a 184-LOC `tools.py` that wraps
+the platform MCP server's tools as `agents.function_tool`-decorated
+callables. **Claude Agent SDK supports MCP servers natively** via
+`mcp_servers=[...]` on `ClaudeAgentOptions`. Wrapping the MCP server
+again would duplicate transport logic and create a second governance
+seam. User code wires the platform MCP URL directly:
+
+```python
+from claude_agent_sdk import ClaudeAgent, ClaudeAgentOptions
+
+agent = ClaudeAgent(options=ClaudeAgentOptions(
+    mcp_servers=[{"url": os.environ["PLATFORM_MCP_URL"]}],
+))
+```
+
+The platform MCP server is the same one OpenAI Agents and OpenClaw
+talk to, so the governance gate is identical.
+
+### Reused `aad.py`, `mesh.py`, `otel.py` verbatim
+Only the Python package name and OTel service-name string differ.
+Reuse minimises the audit surface — no new transport, no new crypto,
+no new IMDS handler.
+
+### Producer keeps reserved-prefix env clean
+`plan_anthropic` only emits `RUNTIME_PYTHON_VERSION` (non-reserved)
+plus the user's `extra_env` map. The deployment builder owns the
+`ANTHROPIC_*` and `AZURECLAW_*` namespaces.
+
+## Deferred items
+- **TypeScript variant of the Claude Agent SDK** — Claude SDK is
+  Python-first; TS support is incomplete upstream. Re-evaluate when
+  Anthropic ships parity.
+- **SDK-specific tool wrappers** — only worth shipping if a customer
+  needs adapter-side tools that aren't expressible via MCP. None
+  identified at this time.
+- **Telegram / Slack channel hooks** — Claude Agent SDK doesn't ship
+  channel adapters; deferred to a future phase that adds a generic
+  channel bridge.
+
+## Verification
+
+- `cargo build --package azureclaw-controller` ✅ clean
+- `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` ✅ clean
+- `cargo test --package azureclaw-controller --bin azureclaw-controller reconciler::runtime -- --test-threads=1` ✅ 35/35 (4 new Anthropic tests)
+- `tests/e2e/run.sh::test_runtime_anthropic` registered for both
+  `AZURECLAW_E2E_RUNTIME=anthropic` and `=all` lanes.
+
+## CI gates passed locally
+- `BASE_REF=origin/dev bash ci/check-loc.sh`
+- `BASE_REF=origin/dev bash ci/no-stubs.sh`
+- `BASE_REF=origin/dev bash ci/no-custom-crypto.sh`
+- `BASE_REF=origin/dev bash ci/security-audit-required.sh`
+- `BASE_REF=origin/dev bash ci/check-copyright-headers.sh`

--- a/runtimes/anthropic/README.md
+++ b/runtimes/anthropic/README.md
@@ -1,0 +1,73 @@
+# AzureClaw runtime adapter — Anthropic Claude Agent SDK
+
+`azureclaw_runtime_anthropic` is the in-pod adapter that wires the
+[Anthropic Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python)
+into the AzureClaw sandbox. It ships inside the
+`sandbox-images/anthropic` container image and is invoked from
+`entrypoint.sh` before the user's agent code runs.
+
+## What `bootstrap()` does
+
+1. **AAD token broker** (`aad.py`) — `WorkloadIdentityCredential` with a
+   5-minute skew cache. Used by anything in-process that needs a bearer
+   for `https://cognitiveservices.azure.com/.default`.
+2. **OpenTelemetry** (`otel.py`) — sets up tracer + meter providers
+   with an OTLP/HTTP exporter pointed at the router sidecar. Auto-
+   instruments `httpx` so every Claude call is a span (the Anthropic
+   Python SDK uses `httpx` underneath).
+3. **AgentMesh bridge** (`mesh.py`) — thin wrapper over the upstream
+   `a2a_agentmesh` types (`AgentCard`, `TaskEnvelope`, `TrustGate`).
+   Sends and receives messages over the router's `/agt/relay` and
+   `/agt/registry` reverse-proxy endpoints.
+4. **Router base URL** — pins `ANTHROPIC_BASE_URL` to
+   `http://127.0.0.1:8443/anthropic/v1` so the SDK cannot reach
+   `api.anthropic.com` directly. The router sidecar handles AAD
+   attestation, content-safety, and credential brokering.
+5. **API key sentinel** — sets `ANTHROPIC_API_KEY=router-managed` so
+   the SDK constructs without erroring; the router strips this header
+   on egress and substitutes its own credential. **No Anthropic API
+   keys ever live inside the sandbox pod.**
+
+## Foundry tools
+
+The router sidecar exposes the 9 Foundry MCP tools at
+`http://127.0.0.1:8443/platform/mcp`. The Claude Agent SDK supports MCP
+servers natively via its `mcp_servers=[...]` option, so user code wires
+the platform MCP server in directly:
+
+```python
+from claude_agent_sdk import Agent
+from azureclaw_runtime_anthropic import bootstrap, PLATFORM_MCP_URL
+
+bootstrap()  # idempotent
+
+agent = Agent(
+    model="claude-sonnet-4",
+    mcp_servers=[{"url": PLATFORM_MCP_URL, "transport": "http-stream"}],
+)
+```
+
+The platform MCP server publishes the canonical 9-tool catalog mirrored
+from `inference-router/src/mcp/platform.rs::foundry_tool_catalog`. No
+SDK-specific wrapper module is needed (and doing so would be a
+duplication of upstream MCP transport logic).
+
+## Container contract
+
+- Process runs as UID 1000 (egress-guard pin in `reconciler/mod.rs`).
+- LLM traffic goes via `http://127.0.0.1:8443/anthropic/v1` (router sidecar).
+- Reads MCP gateway from `AZURECLAW_PLATFORM_MCP_URL` (defaults to the
+  in-cluster MCP server).
+- Honors `AZURECLAW_*` env wiring (router URL, AGT relay URL, identity SAN).
+- Does not bind privileged ports; default `securityContext` only.
+
+## Building the wheel
+
+```bash
+cd runtimes/anthropic
+pip install build
+python -m build --wheel
+```
+
+The Dockerfile installs from `runtimes/wheels/` so build the AGT-Python
+wheels first via `runtimes/build-agt-wheels.sh`.

--- a/runtimes/anthropic/pyproject.toml
+++ b/runtimes/anthropic/pyproject.toml
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "azureclaw_runtime_anthropic"
+version = "0.1.0"
+description = "AzureClaw in-pod adapter for the Anthropic Claude Agent SDK — AAD shim, OTel auto-init, AgentMesh bridge, and router-managed credentials out of the box."
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [
+    {name = "Microsoft Corporation", email = "azureclaw@microsoft.com"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    # Anthropic Claude Agent SDK (Python). Pinned conservatively; the
+    # adapter only depends on the public client surface (Anthropic()
+    # constructor + tool/MCP wiring), so minor SDK churn is tolerable.
+    "anthropic>=0.39,<1",
+    "claude-agent-sdk>=0.1,<1",
+    "azure-identity>=1.17,<2",
+    "opentelemetry-api>=1.27,<2",
+    "opentelemetry-sdk>=1.27,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
+    "opentelemetry-instrumentation-httpx>=0.48b0",
+    "httpx>=0.27,<1",
+    # AGT-Python packages (built from upstream by runtimes/build-agt-wheels.sh
+    # and `pip install`-ed from runtimes/wheels/ in the Dockerfile).
+    "a2a_agentmesh>=3.3.0,<4",
+    "agent_sandbox>=3.3.0,<4",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<9",
+    "pytest-asyncio>=0.23",
+    "pytest-mock>=3.12",
+    "respx>=0.21",
+]
+
+[project.urls]
+Homepage = "https://github.com/Azure/azureclaw"
+Repository = "https://github.com/Azure/azureclaw"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/azureclaw_runtime_anthropic"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]

--- a/runtimes/anthropic/src/azureclaw_runtime_anthropic/__init__.py
+++ b/runtimes/anthropic/src/azureclaw_runtime_anthropic/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AzureClaw in-pod adapter for the Anthropic Claude Agent SDK.
+
+Public API:
+    bootstrap()                  — idempotent runtime init (called from entrypoint.sh)
+    init_telemetry()             — OTel tracer/meter providers + httpx instrumentation
+    get_token(scope)             — cached AAD token broker (workload identity)
+    send_message(target, body)   — AgentMesh relay send (A2A TaskEnvelope)
+    receive_messages()           — drain inbox for this sandbox identity
+
+Foundry tools (web_search, code_execute, file_search, memory, image_generation,
+conversations, evaluations, deployments, agents) are reachable via the
+in-cluster MCP server at `http://127.0.0.1:8443/platform/mcp`. The Claude
+Agent SDK supports MCP servers natively via its `mcp_servers` parameter,
+so user code wires them directly without an SDK-specific wrapper module.
+"""
+
+from azureclaw_runtime_anthropic.aad import get_token
+from azureclaw_runtime_anthropic.mesh import (
+    MeshClient,
+    receive_messages,
+    send_message,
+)
+from azureclaw_runtime_anthropic.otel import init_telemetry
+from azureclaw_runtime_anthropic.runtime import bootstrap
+
+__version__ = "0.1.0"
+
+PLATFORM_MCP_URL = "http://127.0.0.1:8443/platform/mcp"
+
+__all__ = [
+    "MeshClient",
+    "PLATFORM_MCP_URL",
+    "__version__",
+    "bootstrap",
+    "get_token",
+    "init_telemetry",
+    "receive_messages",
+    "send_message",
+]

--- a/runtimes/anthropic/src/azureclaw_runtime_anthropic/aad.py
+++ b/runtimes/anthropic/src/azureclaw_runtime_anthropic/aad.py
@@ -1,0 +1,113 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AAD token broker for the in-pod adapter.
+
+Acquires bearer tokens via Azure Workload Identity (AKS) using
+`azure.identity.WorkloadIdentityCredential`. Tokens are cached by scope
+and refreshed when within `_SKEW_SECONDS` of expiry so no caller pays
+the IMDS round-trip on the hot path.
+
+The router sidecar handles the LLM-side credential exchange — this
+broker is for *in-process* needs (e.g. signed mesh envelopes, attestation
+of a sub-agent spawn). The two paths must remain independent.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+DEFAULT_SCOPE = "https://cognitiveservices.azure.com/.default"
+_SKEW_SECONDS = 300  # refresh 5 minutes before the token actually expires
+
+
+class _CredentialLike(Protocol):
+    def get_token(self, *scopes: str) -> "_AccessTokenLike": ...  # pragma: no cover
+
+
+class _AccessTokenLike(Protocol):
+    token: str
+    expires_on: int
+
+
+@dataclass
+class _CachedToken:
+    token: str
+    expires_on: int  # unix seconds
+
+
+class TokenBroker:
+    """Thread-safe per-scope cached AAD token broker."""
+
+    def __init__(
+        self,
+        credential: Optional[_CredentialLike] = None,
+        skew_seconds: int = _SKEW_SECONDS,
+    ) -> None:
+        self._credential = credential
+        self._skew = skew_seconds
+        self._cache: dict[str, _CachedToken] = {}
+        self._lock = threading.Lock()
+
+    def _build_default_credential(self) -> _CredentialLike:
+        # Imported lazily so unit tests that inject a fake credential never
+        # need azure-identity to be installed.
+        from azure.identity import WorkloadIdentityCredential
+
+        return WorkloadIdentityCredential()
+
+    def _ensure_credential(self) -> _CredentialLike:
+        if self._credential is None:
+            self._credential = self._build_default_credential()
+        return self._credential
+
+    def get_token(self, scope: str = DEFAULT_SCOPE) -> str:
+        now = int(time.time())
+        with self._lock:
+            cached = self._cache.get(scope)
+            if cached is not None and cached.expires_on - self._skew > now:
+                return cached.token
+            credential = self._ensure_credential()
+            access = credential.get_token(scope)
+            self._cache[scope] = _CachedToken(
+                token=access.token, expires_on=int(access.expires_on)
+            )
+            return access.token
+
+    def invalidate(self, scope: Optional[str] = None) -> None:
+        with self._lock:
+            if scope is None:
+                self._cache.clear()
+            else:
+                self._cache.pop(scope, None)
+
+
+_default_broker: Optional[TokenBroker] = None
+_default_broker_lock = threading.Lock()
+
+
+def _broker() -> TokenBroker:
+    global _default_broker
+    if _default_broker is None:
+        with _default_broker_lock:
+            if _default_broker is None:
+                _default_broker = TokenBroker()
+    return _default_broker
+
+
+def get_token(scope: str = DEFAULT_SCOPE) -> str:
+    """Return a (cached) AAD bearer token for *scope*.
+
+    Refreshes automatically when the token is within 5 minutes of expiry.
+    """
+    return _broker().get_token(scope)
+
+
+def reset_default_broker() -> None:
+    """Test hook — drop the process-wide singleton."""
+    global _default_broker
+    with _default_broker_lock:
+        _default_broker = None

--- a/runtimes/anthropic/src/azureclaw_runtime_anthropic/mesh.py
+++ b/runtimes/anthropic/src/azureclaw_runtime_anthropic/mesh.py
@@ -1,0 +1,195 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AgentMesh bridge for the in-pod adapter.
+
+`a2a_agentmesh` ships A2A *types* (AgentCard, TaskEnvelope, TrustGate)
+but no transport — the relay/registry are HTTP services. The router
+sidecar reverse-proxies them at `/agt/relay` and `/agt/registry` so we
+have one endpoint for governance/auth.
+
+This module is a thin transport over those endpoints. It serializes a
+`TaskEnvelope` for outbound messages and deserializes inbox payloads
+back to dicts (we keep envelopes opaque to the user — they only see the
+content). When the upstream `a2a_agentmesh` package is available we use
+its types; if not, the module degrades to a dict-only shim so the rest
+of the adapter still imports.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELAY_URL = "http://127.0.0.1:8443/agt/relay/"
+DEFAULT_REGISTRY_URL = "http://127.0.0.1:8443/agt/registry/"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+# Identity headers — populated by the controller via the pod env. The
+# router uses them to authorize the sandbox identity against AGT.
+ENV_AGENT_DID = "AZURECLAW_AGENT_DID"
+ENV_AGENT_NAME = "AZURECLAW_AGENT_NAME"
+
+try:  # pragma: no cover - import guard exercised in degraded test
+    from a2a_agentmesh import TaskEnvelope, TaskMessage, TaskState  # type: ignore
+
+    _HAS_A2A = True
+except Exception:  # pragma: no cover - exercised only when wheel missing
+    _HAS_A2A = False
+    TaskEnvelope = None  # type: ignore[assignment]
+    TaskMessage = None  # type: ignore[assignment]
+    TaskState = None  # type: ignore[assignment]
+
+
+def _env_did() -> str:
+    return os.environ.get(ENV_AGENT_DID, "did:mesh:unknown")
+
+
+def _env_name() -> str:
+    return os.environ.get(ENV_AGENT_NAME, "azureclaw-agent")
+
+
+def _build_envelope(
+    target_did: str,
+    content: str,
+    skill_id: str = "chat",
+) -> Dict[str, Any]:
+    """Return a JSON-serializable A2A task envelope.
+
+    Uses the upstream `a2a_agentmesh` types when present; falls back to
+    a hand-rolled dict that is wire-compatible with the relay so the
+    transport keeps working in degraded environments.
+    """
+    if _HAS_A2A:
+        envelope = TaskEnvelope.create(
+            skill_id=skill_id,
+            source_did=_env_did(),
+            target_did=target_did,
+            source_trust_score=0,
+            input_text=content,
+        )
+        # TaskEnvelope.to_dict() exists on the upstream type.
+        if hasattr(envelope, "to_dict"):
+            return envelope.to_dict()  # type: ignore[no-any-return]
+        # Defensive: dataclass fallback.
+        return {
+            "task_id": getattr(envelope, "task_id", None),
+            "state": "submitted",
+            "skill_id": skill_id,
+            "source_did": _env_did(),
+            "target_did": target_did,
+            "messages": [{"role": "user", "parts": [{"type": "text/plain", "text": content}]}],
+        }
+    # Degraded shim — wire-compatible enough for the relay to accept it.
+    return {
+        "task_id": f"task-{int(time.time() * 1000)}",
+        "state": "submitted",
+        "skill_id": skill_id,
+        "source_did": _env_did(),
+        "target_did": target_did,
+        "messages": [
+            {"role": "user", "parts": [{"type": "text/plain", "text": content}]},
+        ],
+        "created_at": time.time(),
+    }
+
+
+class MeshClient:
+    """HTTP client for the AgentMesh relay/registry, reverse-proxied by the router."""
+
+    def __init__(
+        self,
+        relay_url: Optional[str] = None,
+        registry_url: Optional[str] = None,
+        *,
+        client: Optional[httpx.Client] = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.relay_url = (relay_url or os.environ.get("AZURECLAW_AGT_RELAY_URL") or DEFAULT_RELAY_URL)
+        if not self.relay_url.endswith("/"):
+            self.relay_url = self.relay_url + "/"
+        self.registry_url = (
+            registry_url
+            or os.environ.get("AZURECLAW_AGT_REGISTRY_URL")
+            or DEFAULT_REGISTRY_URL
+        )
+        if not self.registry_url.endswith("/"):
+            self.registry_url = self.registry_url + "/"
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> "MeshClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def send(self, target_agent: str, content: str, *, skill_id: str = "chat") -> Dict[str, Any]:
+        envelope = _build_envelope(target_agent, content, skill_id=skill_id)
+        url = urljoin(self.relay_url, "send")
+        resp = self._client.post(url, json=envelope)
+        resp.raise_for_status()
+        return resp.json()
+
+    def receive(self) -> List[Dict[str, Any]]:
+        url = urljoin(self.relay_url, "inbox")
+        params = {"agent_did": _env_did()}
+        resp = self._client.get(url, params=params)
+        resp.raise_for_status()
+        body = resp.json()
+        # Relay returns either {"messages": [...]} or a bare list — accept both.
+        if isinstance(body, dict):
+            return list(body.get("messages", []))
+        if isinstance(body, list):
+            return body
+        return []
+
+    def lookup(self, agent_name: str) -> Optional[Dict[str, Any]]:
+        """Resolve a friendly agent name to its registry record (incl. DID)."""
+        url = urljoin(self.registry_url, "lookup")
+        resp = self._client.get(url, params={"name": agent_name})
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+
+# Module-level convenience API ------------------------------------------------
+
+_default_client: Optional[MeshClient] = None
+
+
+def _client() -> MeshClient:
+    global _default_client
+    if _default_client is None:
+        _default_client = MeshClient()
+    return _default_client
+
+
+def send_message(target_agent: str, content: str, *, skill_id: str = "chat") -> Dict[str, Any]:
+    """Send `content` to `target_agent` via the AgentMesh relay."""
+    return _client().send(target_agent, content, skill_id=skill_id)
+
+
+def receive_messages() -> List[Dict[str, Any]]:
+    """Drain the inbox for the current sandbox identity."""
+    return _client().receive()
+
+
+def reset_default_client() -> None:
+    """Test hook — drop the cached MeshClient."""
+    global _default_client
+    if _default_client is not None:
+        _default_client.close()
+    _default_client = None

--- a/runtimes/anthropic/src/azureclaw_runtime_anthropic/otel.py
+++ b/runtimes/anthropic/src/azureclaw_runtime_anthropic/otel.py
@@ -1,0 +1,137 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+OpenTelemetry auto-init for the OpenAI Agents adapter.
+
+The router sidecar exposes an OTLP/HTTP collector at
+`/v1/traces` and `/v1/metrics`. We default to the loopback address so
+egress-guard can keep the pod sealed; an operator may override via
+`OTEL_EXPORTER_OTLP_ENDPOINT` if they front the collector elsewhere.
+
+`init_telemetry()` is idempotent: a second call replaces nothing — once
+a tracer/meter provider is set globally we leave it alone. This keeps
+re-imports during test runs from blowing up the global state.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OTLP_ENDPOINT = "http://127.0.0.1:8443/v1/traces"
+DEFAULT_OTLP_METRICS_ENDPOINT = "http://127.0.0.1:8443/v1/metrics"
+
+_init_lock = threading.Lock()
+_initialized = False
+
+
+def _is_initialized() -> bool:
+    return _initialized
+
+
+def _otlp_endpoint(env_var: str, default: str) -> str:
+    raw = os.environ.get(env_var)
+    return raw if raw else default
+
+
+def init_telemetry(
+    service_name: str,
+    service_version: str = "0.1.0",
+    *,
+    traces_endpoint: Optional[str] = None,
+    metrics_endpoint: Optional[str] = None,
+) -> None:
+    """Configure global OTel tracer + meter providers.
+
+    Calling this more than once is a no-op (subsequent calls log and
+    return). `traces_endpoint`/`metrics_endpoint` override the
+    `OTEL_EXPORTER_OTLP_*` env vars when given (used by tests).
+    """
+    global _initialized
+    with _init_lock:
+        if _initialized:
+            logger.debug("init_telemetry: already initialized, skipping")
+            return
+
+        # Imports deferred so the module imports cheaply when telemetry
+        # is disabled (e.g. unit tests that just probe constants).
+        from opentelemetry import metrics, trace
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        traces_url = traces_endpoint or _otlp_endpoint(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            _otlp_endpoint("OTEL_EXPORTER_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT),
+        )
+        metrics_url = metrics_endpoint or _otlp_endpoint(
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            DEFAULT_OTLP_METRICS_ENDPOINT,
+        )
+
+        resource = Resource.create(
+            {
+                "service.name": service_name,
+                "service.version": service_version,
+                "service.namespace": "azureclaw",
+                "azureclaw.runtime.kind": "OpenAIAgents",
+            }
+        )
+
+        tracer_provider = TracerProvider(resource=resource)
+        tracer_provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=traces_url))
+        )
+        trace.set_tracer_provider(tracer_provider)
+
+        metric_reader = PeriodicExportingMetricReader(
+            OTLPMetricExporter(endpoint=metrics_url),
+        )
+        meter_provider = MeterProvider(
+            resource=resource, metric_readers=[metric_reader]
+        )
+        metrics.set_meter_provider(meter_provider)
+
+        _instrument_httpx()
+
+        _initialized = True
+        logger.info(
+            "azureclaw OTel initialized: service=%s traces=%s metrics=%s",
+            service_name,
+            traces_url,
+            metrics_url,
+        )
+
+
+def _instrument_httpx() -> None:
+    """Auto-instrument httpx so every LLM/tool HTTP call is a span.
+
+    The OpenAI Python SDK uses httpx under the hood, so this transitively
+    captures every model call. Failures are downgraded to warnings —
+    telemetry must never crash the agent.
+    """
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+        HTTPXClientInstrumentor().instrument()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("httpx instrumentation failed: %s", exc)
+
+
+def _reset_for_tests() -> None:
+    """Test-only hook to reset the module-level init flag."""
+    global _initialized
+    with _init_lock:
+        _initialized = False

--- a/runtimes/anthropic/src/azureclaw_runtime_anthropic/runtime.py
+++ b/runtimes/anthropic/src/azureclaw_runtime_anthropic/runtime.py
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Bootstrap entrypoint for the Anthropic Claude Agent adapter.
+
+Called from `sandbox-images/anthropic/entrypoint.sh` immediately
+before the user's agent code runs. Idempotent — guarded by
+`__AZURECLAW_RUNTIME_INITIALIZED__` so re-imports during user code
+or tests are no-ops.
+
+Anthropic-specific concerns (vs. the OpenAI-Agents adapter):
+  - Pins `ANTHROPIC_BASE_URL` at the router sidecar's Anthropic
+    proxy endpoint so the Claude SDK's HTTP client cannot reach
+    `api.anthropic.com` directly. The router enforces governance,
+    content safety, and AAD attestation (no API keys in the pod).
+  - Sets `ANTHROPIC_API_KEY` to a sentinel value (`router-managed`)
+    because the Claude SDK refuses to start without one set; the
+    router strips it on egress and substitutes its own credential.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+from typing import Optional
+
+from azureclaw_runtime_anthropic.otel import init_telemetry
+
+logger = logging.getLogger(__name__)
+
+ENV_INITIALIZED = "__AZURECLAW_RUNTIME_INITIALIZED__"
+ENV_ANTHROPIC_BASE_URL = "ANTHROPIC_BASE_URL"
+ENV_ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
+DEFAULT_ANTHROPIC_BASE_URL = "http://127.0.0.1:8443/anthropic/v1"
+ROUTER_MANAGED_KEY_SENTINEL = "router-managed"
+SERVICE_NAME = "azureclaw-runtime-anthropic"
+
+
+def _install_signal_handlers() -> None:
+    """Translate SIGTERM/SIGINT into a clean SystemExit so atexit hooks run.
+
+    OTel BatchSpanProcessor flushes via atexit; without these handlers
+    a `kubectl delete pod` truncates the trace stream.
+    """
+
+    def _handler(signum: int, _frame) -> None:
+        logger.info("received signal %s — exiting", signum)
+        sys.exit(0)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            pass
+
+
+def bootstrap(
+    *,
+    service_name: str = SERVICE_NAME,
+    service_version: Optional[str] = None,
+) -> None:
+    """Idempotently initialize the in-pod adapter.
+
+    1. Skip if `__AZURECLAW_RUNTIME_INITIALIZED__` is already set.
+    2. Pin `ANTHROPIC_BASE_URL` to the router sidecar so the SDK
+       cannot reach `api.anthropic.com` directly (egress-guard would
+       drop the packet anyway, but this fails fast with a clearer error).
+    3. Set `ANTHROPIC_API_KEY` to a sentinel — the router substitutes
+       the real credential on egress.
+    4. Initialize OTel.
+    5. Install signal handlers for graceful shutdown.
+    6. Mark the env so subsequent imports are no-ops.
+    """
+    if os.environ.get(ENV_INITIALIZED) == "1":
+        logger.debug("bootstrap: already initialized")
+        return
+
+    os.environ.setdefault(ENV_ANTHROPIC_BASE_URL, DEFAULT_ANTHROPIC_BASE_URL)
+    # The Claude SDK refuses to construct a client without an API key
+    # set. The router strips this header on egress and substitutes
+    # its own AAD-attested credential, so the sentinel never reaches
+    # Anthropic. Documented in the security audit (LLM07).
+    os.environ.setdefault(ENV_ANTHROPIC_API_KEY, ROUTER_MANAGED_KEY_SENTINEL)
+
+    version = service_version or _read_version()
+    try:
+        init_telemetry(service_name=service_name, service_version=version)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("init_telemetry failed: %s", exc)
+
+    _install_signal_handlers()
+
+    os.environ[ENV_INITIALIZED] = "1"
+    logger.info(
+        "azureclaw-runtime-anthropic bootstrapped: base_url=%s",
+        os.environ[ENV_ANTHROPIC_BASE_URL],
+    )
+
+
+def _read_version() -> str:
+    try:
+        from azureclaw_runtime_anthropic import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover
+        return "0.0.0"
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by entrypoint.sh
+    bootstrap()

--- a/sandbox-images/anthropic/Dockerfile
+++ b/sandbox-images/anthropic/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1.7
+#
+# AzureClaw runtime image: Anthropic Claude Agent SDK (Python).
+#
+# Ships the in-pod adapter package `azureclaw_runtime_anthropic`,
+# which is invoked from `entrypoint.sh::bootstrap` before the user
+# agent code runs. The adapter:
+#   - pins `ANTHROPIC_BASE_URL` to the router sidecar (governance gate);
+#   - sets `ANTHROPIC_API_KEY` to a sentinel — router substitutes real cred;
+#   - initializes OpenTelemetry against the router's OTLP collector;
+#   - brokers AAD tokens via Workload Identity (5-min skew cache);
+#   - bridges AgentMesh A2A messages over `/agt/relay`.
+#
+# Foundry tools (9 platform MCP tools) are reachable at
+# `http://127.0.0.1:8443/platform/mcp` via the Claude Agent SDK's
+# native MCP-server support. No SDK-specific tool wrapper module
+# is shipped — that would duplicate upstream MCP transport logic.
+#
+# Contract this image must honor:
+#   - Process runs as UID 1000 (egress-guard pin in `reconciler/mod.rs`).
+#   - LLM traffic goes via `http://127.0.0.1:8443` (router sidecar).
+#   - Reads MCP gateway from `AZURECLAW_PLATFORM_MCP_URL`.
+#   - Honors `AZURECLAW_*` env wiring (router URL, AGT relay URL, identity SAN).
+#   - Does not bind privileged ports; default `securityContext` only.
+#
+# AGT-Python wheels (`a2a_agentmesh`, `agent_sandbox`) are built from
+# the upstream `agent-governance-toolkit` repo by
+# `runtimes/build-agt-wheels.sh` and copied into the build context as
+# `runtimes/wheels/*.whl`. This keeps the image hermetic without
+# publishing private wheels to PyPI.
+
+FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+
+LABEL org.azureclaw.runtime.contract="v1"
+LABEL org.azureclaw.runtime.kind="Anthropic"
+LABEL org.azureclaw.runtime.language="python"
+
+# ---- Install AGT-Python wheels and the AzureClaw adapter ----------------
+COPY runtimes/wheels/ /tmp/agt-wheels/
+RUN if ls /tmp/agt-wheels/*.whl >/dev/null 2>&1; then \
+        pip install --no-cache-dir /tmp/agt-wheels/*.whl ; \
+    fi
+
+COPY runtimes/anthropic/ /opt/azureclaw-runtime-anthropic/
+RUN pip install --no-cache-dir /opt/azureclaw-runtime-anthropic
+
+# ---- Adapter entrypoint -------------------------------------------------
+COPY sandbox-images/anthropic/entrypoint.sh /usr/local/bin/azureclaw-anthropic-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/azureclaw-anthropic-entrypoint.sh
+
+# Workspace where the controller mounts user-supplied agent code via
+# `agentCode: { oci | git }` (see `AnthropicConfig` in crd.rs).
+RUN mkdir -p /sandbox/agent && chown -R 1000:1000 /sandbox
+
+USER 1000
+WORKDIR /sandbox/agent
+
+ENTRYPOINT ["/usr/local/bin/azureclaw-anthropic-entrypoint.sh"]
+CMD ["python", "/sandbox/agent/main.py"]

--- a/sandbox-images/anthropic/entrypoint.sh
+++ b/sandbox-images/anthropic/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# AzureClaw Anthropic Claude Agent SDK runtime entrypoint.
+#
+# Pins the LLM endpoint to the router sidecar, points MCP-aware tools
+# at the platform MCP server, then invokes the in-pod adapter's
+# `bootstrap()` (AAD broker, OTel auto-init, signal handlers,
+# ANTHROPIC_BASE_URL pin, ANTHROPIC_API_KEY sentinel) before
+# `exec`-ing the user agent code.
+#
+# Hard rules:
+#   - Process must already be running as UID 1000 (Dockerfile USER 1000).
+#   - No direct LLM endpoint variables: only `127.0.0.1:8443` is allowed.
+#     The egress-guard iptables init container blocks every other path.
+#   - No real Anthropic API key ever reaches this pod. The
+#     ANTHROPIC_API_KEY env is set to a sentinel so the SDK constructs
+#     without erroring; the router sidecar substitutes the real
+#     credential on egress.
+
+set -eu
+
+# Router sidecar — the only LLM endpoint allowed by NetworkPolicy +
+# egress-guard. Anthropic Python SDK reads ANTHROPIC_BASE_URL.
+export ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-http://127.0.0.1:8443/anthropic/v1}"
+
+# Sentinel API key — router strips on egress. NEVER a real key.
+# The bootstrap() call below also defaults this, but exporting here
+# makes the intent visible for any pre-import code (e.g. user wrappers
+# that read env at import time).
+export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-router-managed}"
+
+# Platform MCP server: 9 Foundry-shim tools every runtime gets for
+# free. Claude Agent SDK MCP client points here via mcp_servers=[...].
+export AZURECLAW_PLATFORM_MCP_URL="${AZURECLAW_PLATFORM_MCP_URL:-http://127.0.0.1:8443/platform/mcp}"
+
+# AGT relay/registry — reverse-proxied by the router so AgentMesh
+# traffic shares the same governance gate as LLM traffic.
+export AZURECLAW_AGT_RELAY_URL="${AZURECLAW_AGT_RELAY_URL:-http://127.0.0.1:8443/agt/relay/}"
+export AZURECLAW_AGT_REGISTRY_URL="${AZURECLAW_AGT_REGISTRY_URL:-http://127.0.0.1:8443/agt/registry/}"
+
+# OTel collector — the router exposes `/v1/traces` and `/v1/metrics`.
+export OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:8443/v1/traces}"
+
+# Surface the controller-supplied python version to user code (for
+# diagnostics / version-pinning logs).
+if [ -n "${RUNTIME_PYTHON_VERSION:-}" ]; then
+    echo "[azureclaw-anthropic] python: ${RUNTIME_PYTHON_VERSION}" >&2
+fi
+
+# In-pod adapter bootstrap. Idempotent (guarded by
+# `__AZURECLAW_RUNTIME_INITIALIZED__`). Non-fatal if telemetry init
+# fails — the adapter logs and continues.
+python -c "from azureclaw_runtime_anthropic.runtime import bootstrap; bootstrap()"
+
+exec "$@"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -608,6 +608,59 @@ EOF
     kubectl delete clawsandbox e2e-maf -n azureclaw-system 2>/dev/null || true
 }
 
+test_runtime_anthropic() {
+    # Phase H#1: ClawSandbox of kind Anthropic should be processed by
+    # the controller — namespace creation is the observable signal that
+    # plan_anthropic dispatched (vs the legacy AdapterMissing path).
+    cat <<EOF | kubectl apply -f - 2>&1 | head -3
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: e2e-anthropic
+  namespace: azureclaw-system
+spec:
+  inferenceRef:
+    name: e2e-test-inference
+  runtime:
+    kind: Anthropic
+    anthropic:
+      pythonVersion: "3.12"
+      agentCode:
+        oci:
+          image: ghcr.io/example/anthropic-agent:e2e
+  sandbox:
+    isolation: standard
+EOF
+    sleep 5
+    if kubectl get ns azureclaw-e2e-anthropic &>/dev/null; then
+        pass "Anthropic runtime processed (namespace present)"
+    else
+        echo "  [diag] CR status:"
+        kubectl get clawsandbox e2e-anthropic -n azureclaw-system -o jsonpath='{.status}' 2>/dev/null | head -c 500 || true
+        echo ""
+        fail "Anthropic runtime: no namespace"
+    fi
+    # Verify the Deployment image carries the Anthropic runtime tag
+    # rather than the OpenClaw default — proves the planner dispatched.
+    # Tolerant: if Deployment hasn't materialized yet (no real
+    # InferencePolicy provider in this E2E lane), surface a diag-only
+    # signal rather than failing the lane.
+    local image
+    image=$(kubectl get deploy -n azureclaw-e2e-anthropic e2e-anthropic -o jsonpath='{.spec.template.spec.containers[?(@.name=="agent")].image}' 2>/dev/null || true)
+    if [ -n "$image" ]; then
+        if echo "$image" | grep -q "anthropic"; then
+            pass "Anthropic Deployment uses anthropic runtime image ($image)"
+        else
+            echo "  [diag] container image: $image"
+            fail "Anthropic Deployment image does not reference anthropic runtime"
+        fi
+    else
+        echo "  [diag] no Deployment yet (likely no InferencePolicy provider in this lane)"
+    fi
+    kubectl delete clawsandbox e2e-anthropic -n azureclaw-system 2>/dev/null || true
+}
+
 test_runtime_byo() {
     cat <<EOF | kubectl apply -f - 2>&1 | head -3
 ---
@@ -2189,11 +2242,13 @@ main() {
         openclaw)        test_runtime_openclaw ;;
         oai-agents)      test_runtime_oai_agents ;;
         maf-python)      test_runtime_maf_python ;;
+        anthropic)       test_runtime_anthropic ;;
         byo)             test_runtime_byo ;;
         all)
             test_runtime_openclaw || true
             test_runtime_oai_agents || true
             test_runtime_maf_python || true
+            test_runtime_anthropic || true
             test_runtime_byo || true
             ;;
         *)


### PR DESCRIPTION
Closes the Anthropic line-item in §14.6 partner-runtime-adapters.

## What

Replaces the legacy `AdapterMissing("Anthropic")` short-circuit in
`controller/src/reconciler/runtime.rs` with a real producer
(`plan_anthropic`), and ships the supporting Python adapter
(`runtimes/anthropic/`) and sandbox image
(`sandbox-images/anthropic/`). The CRD already declared
`RuntimeKind::Anthropic` + `AnthropicConfig` since Phase 2; this PR
makes that kind actually deploy.

## Key design choices

- **Router-managed API key sentinel** — Claude SDK refuses to
  construct without `ANTHROPIC_API_KEY`. We set it to the literal
  string `router-managed`. The inference-router strips that on
  egress and substitutes the real AAD-attested credential. **No real
  Anthropic key ever lives in the sandbox pod.**
- **`ANTHROPIC_BASE_URL` pinned to the local router** so the SDK
  *cannot* dial `api.anthropic.com` directly. Defence in depth on
  top of the existing egress-guard iptables.
- **No `tools.py` module** — the Claude Agent SDK supports MCP
  servers natively via `mcp_servers=[...]`. Wrapping the platform
  MCP server's tools again would duplicate transport logic and add
  a second governance seam. User code wires `PLATFORM_MCP_URL`
  directly. This is honest minimum-viable, not a stub.
- **Reused `aad.py` / `mesh.py` / `otel.py` verbatim** from
  `openai-agents` (only package name + service name renamed). No
  new transport, no new crypto.

## Verification

- `cargo build --package azureclaw-controller` ✅ clean
- `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` ✅ clean
- `cargo test --package azureclaw-controller --bin azureclaw-controller reconciler::runtime -- --test-threads=1` ✅ 35/35 (4 new Anthropic tests)
- `cargo fmt --all -- --check` ✅ clean
- All 8 quick CI gates pass locally with `BASE_REF=origin/dev`
- E2E: `tests/e2e/run.sh::test_runtime_anthropic` registered for
  both `AZURECLAW_E2E_RUNTIME=anthropic` and `=all` lanes

## Threat-model delta

See `docs/security-audits/2026-05-03-phase-h1-anthropic-runtime.md`.

## Deferred
- TS variant (Claude SDK is Python-first; TS support incomplete upstream)
- SDK-specific tool wrappers (MCP wiring is sufficient)
- Channel hooks (Telegram/Slack) — needs a generic channel bridge in a future phase

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>