### PR TITLE
feat(runtime): Phase H#3 — Pydantic-AI first-class runtime

### DIFF
--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -417,6 +417,7 @@ pub enum RuntimeKind {
     SemanticKernel,
     LangGraph,
     Anthropic,
+    PydanticAi,
     BYO,
 }
 
@@ -462,6 +463,11 @@ pub struct RuntimeSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anthropic: Option<AnthropicConfig>,
 
+    /// Pydantic-AI runtime configuration. Required iff
+    /// `kind == PydanticAi`. Adapter ships in Phase H#3.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pydantic_ai: Option<PydanticAiConfig>,
+
     /// Bring-your-own runtime. Required iff `kind == BYO`. Image must
     /// honor the BYO contract (UID 1000, inference via `127.0.0.1:8443`,
     /// `AZURECLAW_*` env, no privileged caps). Phase 2 enforcement is
@@ -481,6 +487,7 @@ impl Default for RuntimeSpec {
             semantic_kernel: None,
             lang_graph: None,
             anthropic: None,
+            pydantic_ai: None,
             byo: None,
         }
     }
@@ -589,6 +596,25 @@ pub enum LangGraphLanguage {
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AnthropicConfig {
+    /// Python interpreter version (e.g. `"3.12"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub python_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_code: Option<AgentCodeRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_env: Option<std::collections::BTreeMap<String, String>>,
+}
+
+/// Pydantic-AI runtime variant (Phase H#3).
+///
+/// [Pydantic-AI](https://ai.pydantic.dev/) is the type-safe Python
+/// agent framework from the Pydantic team. Python-only by design.
+/// Wire field shape mirrors `AnthropicConfig` / `OpenAIAgentsConfig`.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PydanticAiConfig {
     /// Python interpreter version (e.g. `"3.12"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub python_version: Option<String>,

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -35,8 +35,8 @@ use std::collections::BTreeMap;
 
 use crate::crd::{
     AgentCodeRef, AnthropicConfig, ByoRuntimeConfig, LangGraphConfig, LangGraphLanguage,
-    MafLanguage, MicrosoftAgentFrameworkConfig, OpenAIAgentsConfig, OpenClawConfig, RuntimeKind,
-    RuntimeSpec,
+    MafLanguage, MicrosoftAgentFrameworkConfig, OpenAIAgentsConfig, OpenClawConfig,
+    PydanticAiConfig, RuntimeKind, RuntimeSpec,
 };
 
 /// Default container image for the OpenAI Agents Python runtime
@@ -126,6 +126,28 @@ pub fn langgraph_default_image() -> String {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_LANGGRAPH_PYTHON_IMAGE.to_string())
+}
+
+/// Default container image for the Pydantic-AI Python runtime
+/// (Phase H#3). Stays `:latest`; operators pin via the
+/// `PYDANTIC_AI_RUNTIME_IMAGE` env var.
+///
+/// Why a dedicated adapter (vs BYO): Pydantic-AI is provider-agnostic
+/// (the same agent can call OpenAI, Anthropic, Gemini, ...). The
+/// adapter pins each known provider base URL to the router sidecar
+/// at bootstrap and substitutes API keys with router-managed
+/// sentinels — same defence pattern as LangGraph.
+pub const DEFAULT_PYDANTIC_AI_IMAGE: &str =
+    "azureclawacr.azurecr.io/azureclaw-runtime-pydantic-ai:latest";
+
+/// Resolve the Pydantic-AI adapter image, honouring an operator
+/// override via `PYDANTIC_AI_RUNTIME_IMAGE`. Falls back to
+/// [`DEFAULT_PYDANTIC_AI_IMAGE`].
+pub fn pydantic_ai_default_image() -> String {
+    std::env::var("PYDANTIC_AI_RUNTIME_IMAGE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_PYDANTIC_AI_IMAGE.to_string())
 }
 
 /// Concrete deployment intent for a single reconcile pass.
@@ -218,6 +240,7 @@ pub fn kind_str(kind: &RuntimeKind) -> &'static str {
         RuntimeKind::SemanticKernel => "SemanticKernel",
         RuntimeKind::LangGraph => "LangGraph",
         RuntimeKind::Anthropic => "Anthropic",
+        RuntimeKind::PydanticAi => "PydanticAi",
         RuntimeKind::BYO => "BYO",
     }
 }
@@ -253,6 +276,7 @@ pub fn validate_runtime_shape(runtime: &RuntimeSpec) -> Result<(), RuntimePlanEr
         ),
         ("LangGraph", "langGraph", runtime.lang_graph.is_some()),
         ("Anthropic", "anthropic", runtime.anthropic.is_some()),
+        ("PydanticAi", "pydanticAi", runtime.pydantic_ai.is_some()),
         ("BYO", "byo", runtime.byo.is_some()),
     ];
     for (cel_kind, field, present) in pairs {
@@ -354,6 +378,13 @@ pub fn build_runtime_plan(
             // `mcp_servers=[...]`).
             let cfg = runtime.anthropic.as_ref().expect("validated above");
             Ok(plan_anthropic(cfg))
+        }
+        RuntimeKind::PydanticAi => {
+            // Phase H#3: Pydantic-AI adapter wired end-to-end.
+            // Provider-agnostic — adapter pins multiple LLM provider
+            // base URLs to the router sidecar at bootstrap.
+            let cfg = runtime.pydantic_ai.as_ref().expect("validated above");
+            Ok(plan_pydantic_ai(cfg))
         }
     }
 }
@@ -616,13 +647,48 @@ fn plan_langgraph(cfg: &LangGraphConfig) -> Result<RuntimeDeploymentPlan, Runtim
     })
 }
 
+/// Producer for [`RuntimeKind::PydanticAi`] (Phase H#3).
+///
+/// [Pydantic-AI](https://ai.pydantic.dev/) is the type-safe Python
+/// agent framework from the Pydantic team. Provider-agnostic: a
+/// single `Agent` definition can target OpenAI, Anthropic, Gemini,
+/// or Azure OpenAI. The adapter pins each known provider base URL
+/// to the router sidecar at bootstrap and substitutes API keys with
+/// router-managed sentinels — same defence pattern as LangGraph.
+fn plan_pydantic_ai(cfg: &PydanticAiConfig) -> RuntimeDeploymentPlan {
+    let image = pydantic_ai_default_image();
+
+    let mut runtime_extra_env: BTreeMap<String, String> = BTreeMap::new();
+    if let Some(v) = cfg.python_version.as_ref() {
+        runtime_extra_env.insert("RUNTIME_PYTHON_VERSION".to_string(), v.clone());
+    }
+    if let Some(user_env) = cfg.extra_env.as_ref() {
+        for (k, v) in user_env {
+            runtime_extra_env.insert(k.clone(), v.clone());
+        }
+    }
+
+    let command = cfg.entrypoint.clone();
+
+    RuntimeDeploymentPlan {
+        kind_str: "PydanticAi",
+        image,
+        command,
+        args: None,
+        runtime_extra_env,
+        raw_env: Vec::new(),
+        agent_code: cfg.agent_code.clone(),
+        byo_contract_version: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::crd::{
         AgentCodeRef, AnthropicConfig, ByoRuntimeConfig, LangGraphConfig, LangGraphLanguage,
         MafLanguage, MicrosoftAgentFrameworkConfig, OciAgentCode, OpenAIAgentsConfig,
-        OpenClawConfig, SemanticKernelConfig,
+        OpenClawConfig, PydanticAiConfig, SemanticKernelConfig,
     };
 
     fn rt_openclaw(image: Option<&str>) -> RuntimeSpec {
@@ -645,6 +711,7 @@ mod tests {
             semantic_kernel: None,
             lang_graph: None,
             anthropic: None,
+            pydantic_ai: None,
             byo: None,
         }
     }
@@ -662,6 +729,7 @@ mod tests {
         assert_eq!(kind_str(&RuntimeKind::SemanticKernel), "SemanticKernel");
         assert_eq!(kind_str(&RuntimeKind::LangGraph), "LangGraph");
         assert_eq!(kind_str(&RuntimeKind::Anthropic), "Anthropic");
+        assert_eq!(kind_str(&RuntimeKind::PydanticAi), "PydanticAi");
         assert_eq!(kind_str(&RuntimeKind::BYO), "BYO");
     }
 
@@ -716,6 +784,7 @@ mod tests {
             (RuntimeKind::SemanticKernel, "semanticKernel"),
             (RuntimeKind::LangGraph, "langGraph"),
             (RuntimeKind::Anthropic, "anthropic"),
+            (RuntimeKind::PydanticAi, "pydanticAi"),
         ] {
             let rt = rt_only_kind(kind);
             let err = validate_runtime_shape(&rt).expect_err("must reject");
@@ -753,6 +822,15 @@ mod tests {
                     kind: RuntimeKind::Anthropic,
                     openclaw: None,
                     anthropic: Some(AnthropicConfig::default()),
+                    ..Default::default()
+                },
+            ),
+            (
+                RuntimeKind::PydanticAi,
+                RuntimeSpec {
+                    kind: RuntimeKind::PydanticAi,
+                    openclaw: None,
+                    pydantic_ai: Some(PydanticAiConfig::default()),
                     ..Default::default()
                 },
             ),
@@ -1007,6 +1085,81 @@ mod tests {
         assert_eq!(
             plan.runtime_extra_env.get("RUNTIME_LANGGRAPH_LANGUAGE"),
             Some(&"python".to_string())
+        );
+    }
+
+    // ── Pydantic-AI adapter (Phase H#3) ──────────────────────────────
+
+    #[test]
+    fn pydantic_ai_default_image_falls_back_when_env_unset() {
+        unsafe {
+            std::env::remove_var("PYDANTIC_AI_RUNTIME_IMAGE");
+        }
+        assert_eq!(pydantic_ai_default_image(), DEFAULT_PYDANTIC_AI_IMAGE);
+    }
+
+    #[test]
+    fn plan_pydantic_ai_emits_pydanticai_kind_str_and_default_image() {
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::PydanticAi,
+            openclaw: None,
+            pydantic_ai: Some(PydanticAiConfig::default()),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored").expect("pydantic_ai plan ok");
+        assert_eq!(plan.kind_str, "PydanticAi");
+        assert!(plan.image.contains("azureclaw-runtime-pydantic-ai"));
+        for k in plan.runtime_extra_env.keys() {
+            assert!(
+                !k.starts_with("AZURECLAW_"),
+                "producer must not emit AZURECLAW_* keys: {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn plan_pydantic_ai_threads_python_version_and_user_extra_env() {
+        let mut user_env = BTreeMap::new();
+        user_env.insert("MY_FLAG".to_string(), "on".to_string());
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::PydanticAi,
+            openclaw: None,
+            pydantic_ai: Some(PydanticAiConfig {
+                python_version: Some("3.13".into()),
+                extra_env: Some(user_env),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored").expect("ok");
+        assert_eq!(
+            plan.runtime_extra_env.get("RUNTIME_PYTHON_VERSION"),
+            Some(&"3.13".to_string())
+        );
+        assert_eq!(
+            plan.runtime_extra_env.get("MY_FLAG"),
+            Some(&"on".to_string())
+        );
+    }
+
+    #[test]
+    fn plan_pydantic_ai_user_extra_env_overrides_producer_default() {
+        let mut user_env = BTreeMap::new();
+        user_env.insert("RUNTIME_PYTHON_VERSION".to_string(), "3.11".into());
+        let rt = RuntimeSpec {
+            kind: RuntimeKind::PydanticAi,
+            openclaw: None,
+            pydantic_ai: Some(PydanticAiConfig {
+                python_version: Some("3.13".into()),
+                extra_env: Some(user_env),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let plan = build_runtime_plan(&rt, "ignored").expect("ok");
+        assert_eq!(
+            plan.runtime_extra_env.get("RUNTIME_PYTHON_VERSION"),
+            Some(&"3.11".to_string())
         );
     }
 

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -52,13 +52,14 @@ spec:
                     Agent runtime selector (S10.A1 multi-runtime hosting).
                     The `kind` discriminator selects which sibling struct
                     (`openclaw` / `openaiAgents` / `microsoftAgentFramework`
-                    / `semanticKernel` / `langGraph` / `anthropic` / `byo`)
+                    / `semanticKernel` / `langGraph` / `anthropic`
+                    / `pydanticAi` / `byo`)
                     is required; the others must be absent.
                     Replaces the legacy `spec.openclaw` field — the
                     AzureClaw v1alpha1 schema is in-place edited (no
                     conversion webhook; pre-release simplification).
-                    Tier-2 placeholders (`semanticKernel`, `langGraph`,
-                    `anthropic`) parse but the controller stamps
+                    Tier-2 placeholders (`semanticKernel`) parse but the
+                    controller stamps
                     `RuntimeReady=False / AdapterMissing` until the
                     respective adapter image ships.
                   x-kubernetes-validations:
@@ -74,12 +75,14 @@ spec:
                       message: "spec.runtime.langGraph must be set iff kind is LangGraph"
                     - rule: "(self.kind == 'Anthropic') == has(self.anthropic)"
                       message: "spec.runtime.anthropic must be set iff kind is Anthropic"
+                    - rule: "(self.kind == 'PydanticAi') == has(self.pydanticAi)"
+                      message: "spec.runtime.pydanticAi must be set iff kind is PydanticAi"
                     - rule: "(self.kind == 'BYO') == has(self.byo)"
                       message: "spec.runtime.byo must be set iff kind is BYO"
                   properties:
                     kind:
                       type: string
-                      enum: ["OpenClaw", "OpenAIAgents", "MicrosoftAgentFramework", "SemanticKernel", "LangGraph", "Anthropic", "BYO"]
+                      enum: ["OpenClaw", "OpenAIAgents", "MicrosoftAgentFramework", "SemanticKernel", "LangGraph", "Anthropic", "PydanticAi", "BYO"]
                       description: "Variant discriminator. PascalCase wire values."
                     openclaw:
                       type: object
@@ -262,6 +265,42 @@ spec:
                           x-kubernetes-validations:
                             - rule: "has(self.oci) != has(self.git)"
                               message: "spec.runtime.anthropic.agentCode must set exactly one of `oci` or `git`"
+                          properties:
+                            oci:
+                              type: object
+                              required: ["image"]
+                              properties:
+                                image:
+                                  type: string
+                            git:
+                              type: object
+                              required: ["url"]
+                              properties:
+                                url:
+                                  type: string
+                                ref:
+                                  type: string
+                                path:
+                                  type: string
+                        entrypoint:
+                          type: array
+                          items:
+                            type: string
+                        extraEnv:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                    pydanticAi:
+                      type: object
+                      description: "Pydantic-AI runtime variant (Phase H#3). Type-safe Python agent framework with native multi-provider support."
+                      properties:
+                        pythonVersion:
+                          type: string
+                          description: "Python interpreter version, e.g. '3.12'."
+                        agentCode:
+                          type: object
+                          x-kubernetes-validations:
+                            - rule: "has(self.oci) != has(self.git)"
+                              message: "spec.runtime.pydanticAi.agentCode must set exactly one of `oci` or `git`"
                           properties:
                             oci:
                               type: object
@@ -594,7 +633,7 @@ spec:
                   description: "Foundry Agent Service agent ID (created by controller)"
                 runtimeKind:
                   type: string
-                  enum: ["OpenClaw", "OpenAIAgents", "MicrosoftAgentFramework", "SemanticKernel", "LangGraph", "Anthropic", "BYO"]
+                  enum: ["OpenClaw", "OpenAIAgents", "MicrosoftAgentFramework", "SemanticKernel", "LangGraph", "Anthropic", "PydanticAi", "BYO"]
                   description: "Runtime kind the controller observed for the current observedGeneration (S10.A1)."
       subresources:
         status: {}

--- a/docs/security-audits/2026-05-03-phase-h3-pydantic-ai-runtime.md
+++ b/docs/security-audits/2026-05-03-phase-h3-pydantic-ai-runtime.md
@@ -1,0 +1,123 @@
+# Phase H#3 — Pydantic-AI runtime adapter (security audit)
+
+**Date:** 2026-05-03
+**PR:** #181 (target branch: `dev`)
+**Scope:** First-class runtime support for the [Pydantic-AI](https://ai.pydantic.dev/)
+agent framework. Adds `RuntimeKind::PydanticAi` to the controller, a
+producer in `reconciler/runtime.rs`, the `runtimes/pydantic-ai`
+in-pod adapter package, and the `sandbox-images/pydantic-ai`
+container image. Wires the new variant into the CRD and the E2E gate.
+
+## Why a dedicated adapter (vs. BYO)
+
+Pydantic-AI is provider-agnostic — a single `Agent` definition can
+target OpenAI, Azure OpenAI, Anthropic, Gemini, etc. Each provider
+SDK reads its base URL + API key from process env at construction
+time. BYO would require every Pydantic-AI user to re-implement the
+same env-pinning + sentinel logic the LangGraph adapter already
+solved. Shipping it as a first-class runtime lets users supply only
+their agent code.
+
+## Threat model
+
+| Threat | Mitigation |
+|---|---|
+| Direct egress to public LLM endpoints | Adapter pins `OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, `ANTHROPIC_BASE_URL` to `127.0.0.1:8443`; egress-guard iptables init container drops UID-1000 packets to non-loopback / non-DNS targets. |
+| Real provider API keys land in pod env | Each `*_API_KEY` env is set to the sentinel `router-managed`. The router substitutes the AAD-attested credential on egress. No real key ever reaches the pod. |
+| Adapter bypassing AGT governance | All LLM traffic flows through the inference-router sidecar which gates on AGT trust score, runs Foundry Content Safety, emits OTel GenAI spans, and applies token budgets. |
+| Container running as root | `Dockerfile USER 1000`. Workspace `/sandbox/agent` chowned to UID 1000. Reconciler-enforced runAsUser/runAsNonRoot pin in `reconciler/mod.rs`. |
+| Producer leaking reserved env keys | `plan_pydantic_ai` only emits `RUNTIME_PYTHON_VERSION` plus the user's `extra_env`; the deployment builder strips `AGT_*` / `AZURE_*` / `AZURECLAW_*` reserved prefixes from any user-supplied env. Unit tests assert the producer emits no `AZURECLAW_*` keys. |
+| Wrong variant struct accepted at admission | CEL rule `(self.kind == 'PydanticAi') == has(self.pydanticAi)` plus the in-process `validate_runtime_shape` mirror catch all combinations. |
+
+## What was added
+
+### Controller / CRD
+
+* `RuntimeKind::PydanticAi` enum variant (PascalCase wire format).
+* `RuntimeSpec.pydantic_ai: Option<PydanticAiConfig>` field.
+* `PydanticAiConfig` struct: `python_version`, `agent_code`,
+  `entrypoint`, `extra_env` — same shape as `AnthropicConfig` /
+  `LangGraphConfig`.
+* `DEFAULT_PYDANTIC_AI_IMAGE` const + `pydantic_ai_default_image()`
+  helper honouring the `PYDANTIC_AI_RUNTIME_IMAGE` env override.
+* `plan_pydantic_ai` producer threading `python_version` into
+  `RUNTIME_PYTHON_VERSION` and merging user `extra_env` last.
+* CRD `kind` enum + `runtimeKind` printer-column enum extended.
+* CRD CEL rule + `pydanticAi` property block (mirrors `anthropic`).
+
+### Runtime adapter
+
+`runtimes/pydantic-ai/`:
+
+* `pyproject.toml` declares `pydantic-ai>=0.0.13,<1` plus the same
+  `azure-identity`, `opentelemetry-*`, `httpx`, `a2a_agentmesh`,
+  `agent_sandbox` deps as the LangGraph adapter.
+* `runtime.py::bootstrap()` is idempotent
+  (`__AZURECLAW_RUNTIME_INITIALIZED__=1` guard), pins three provider
+  base URLs to the router proxy, sets sentinel API keys, initializes
+  OTel, installs SIGTERM/SIGINT handlers.
+* `aad.py`, `mesh.py`, `otel.py` ported verbatim from the LangGraph
+  adapter (same router proxy contract).
+
+### Sandbox image
+
+`sandbox-images/pydantic-ai/Dockerfile`:
+
+* `FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base`.
+* Installs AGT-Python wheels then the `azureclaw_runtime_pydantic_ai`
+  package.
+* Labels `org.azureclaw.runtime.kind="PydanticAi"`,
+  `org.azureclaw.runtime.contract="v1"`,
+  `org.azureclaw.runtime.language="python"`.
+* `USER 1000`, workdir `/sandbox/agent`, entrypoint
+  `azureclaw-pydantic-ai-entrypoint.sh`.
+
+`entrypoint.sh` pins all three provider URLs + sentinel API keys,
+exports `AZURECLAW_PLATFORM_MCP_URL`, `AZURECLAW_AGT_RELAY_URL`,
+`AZURECLAW_AGT_REGISTRY_URL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, then
+calls `bootstrap()` and `exec`s the user agent.
+
+### Tests
+
+Controller (44 tests in `reconciler::runtime`, +4 new):
+
+* `pydantic_ai_default_image_falls_back_when_env_unset`
+* `plan_pydantic_ai_emits_pydanticai_kind_str_and_default_image`
+* `plan_pydantic_ai_threads_python_version_and_user_extra_env`
+* `plan_pydantic_ai_user_extra_env_overrides_producer_default`
+
+Plus the existing parametrized validate tests are extended to cover
+the new variant (`validate_rejects_each_tier2_kind_without_struct`,
+`validate_accepts_each_tier2_kind_with_correct_struct`,
+`kind_str_returns_pinned_wire_strings`).
+
+E2E (`tests/e2e/run.sh`):
+
+* `test_runtime_pydantic_ai` — applies a `ClawSandbox` of kind
+  `PydanticAi` and asserts the namespace materializes and (when a
+  Deployment is produced) the agent container image references the
+  pydantic-ai runtime tag.
+* Registered in the `case "$RUNTIME"` dispatcher under
+  `pydantic-ai` and in the `all` lane.
+
+## AGT boundary respect
+
+The adapter does **not** reimplement trust scoring, policy
+enforcement, or audit. All of those happen in the inference-router
+which calls into the upstream `agentmesh` crate (Microsoft AGT).
+The adapter is purely a bootstrapper: it pins env vars and exits.
+
+## Verification
+
+* `cargo build --package azureclaw-controller` — clean
+* `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` — clean
+* `cargo test --package azureclaw-controller -- --test-threads=1` — 484 passed
+* `cargo fmt --all` — no diff
+
+## Out of scope (follow-up)
+
+* Building and pushing the `azureclaw-runtime-pydantic-ai` image to
+  the production ACR — that's an ops PR, not a code PR.
+* Pydantic-AI Logfire integration — Pydantic-AI emits OTel natively,
+  so the existing OTel pipeline already captures it. No special
+  Logfire bridge needed for now.

--- a/runtimes/pydantic-ai/README.md
+++ b/runtimes/pydantic-ai/README.md
@@ -1,0 +1,49 @@
+# azureclaw-runtime-pydantic-ai
+
+In-pod adapter for the [Pydantic-AI](https://ai.pydantic.dev/) agent
+framework. Phase H#3 of the multi-runtime hosting initiative
+(controller `RuntimeKind::PydanticAi`).
+
+## Why a dedicated adapter (vs. BYO)
+
+Pydantic-AI is provider-agnostic: a single `Agent` definition can
+target OpenAI, Azure OpenAI, Anthropic, Gemini, etc. Each provider
+SDK reads its base URL + API key from the process env at construction
+time. The adapter pins each known provider base URL to the router
+sidecar's matching proxy endpoint so that:
+
+  * model calls cannot egress directly (the egress-guard init
+    container drops UID-1000 packets to non-loopback / non-DNS
+    targets anyway, but we belt-and-braces the pinning at the SDK
+    level too);
+  * API keys never live in the pod — the router substitutes the real
+    AAD-attested credential on egress;
+  * AGT governance, content safety, and audit run on every model
+    call regardless of which provider the user picked.
+
+## Bootstrap
+
+```python
+from azureclaw_runtime_pydantic_ai.runtime import bootstrap
+bootstrap()  # idempotent — safe to call from user code or tests
+```
+
+`sandbox-images/pydantic-ai/entrypoint.sh` runs this for you before
+the user agent module is imported.
+
+## What `bootstrap()` does
+
+1. Pins every known provider base URL to the router proxy:
+   - `OPENAI_BASE_URL=http://127.0.0.1:8443/openai/v1`
+   - `AZURE_OPENAI_ENDPOINT=http://127.0.0.1:8443/azure-openai`
+   - `ANTHROPIC_BASE_URL=http://127.0.0.1:8443/anthropic/v1`
+2. Sets each provider API-key env to the sentinel `router-managed`.
+3. Initializes OpenTelemetry (GenAI semantic conventions).
+4. Installs SIGTERM/SIGINT handlers for graceful shutdown.
+5. Marks `__AZURECLAW_RUNTIME_INITIALIZED__=1` so re-imports no-op.
+
+## Provenance
+
+This package is mirrored from `runtimes/langgraph` (Phase H#2). The
+multi-provider env strategy is identical because Pydantic-AI is in
+the same architectural position (provider-agnostic).

--- a/runtimes/pydantic-ai/pyproject.toml
+++ b/runtimes/pydantic-ai/pyproject.toml
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "azureclaw_runtime_pydantic_ai"
+version = "0.1.0"
+description = "AzureClaw in-pod adapter for Pydantic-AI (Python) — AAD shim, OTel auto-init, AgentMesh bridge, and router-managed LLM credentials out of the box."
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [
+    {name = "Microsoft Corporation", email = "azureclaw@microsoft.com"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    # Pydantic-AI: type-safe agent framework. Pinned conservatively;
+    # the adapter only depends on the public env-var surface
+    # (OPENAI_BASE_URL, AZURE_OPENAI_ENDPOINT, ANTHROPIC_BASE_URL,
+    # etc.), so minor Pydantic-AI churn is tolerable.
+    "pydantic-ai>=0.0.13,<1",
+    "azure-identity>=1.17,<2",
+    "opentelemetry-api>=1.27,<2",
+    "opentelemetry-sdk>=1.27,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
+    "opentelemetry-instrumentation-httpx>=0.48b0",
+    "httpx>=0.27,<1",
+    # AGT-Python packages (built from upstream by runtimes/build-agt-wheels.sh
+    # and `pip install`-ed from runtimes/wheels/ in the Dockerfile).
+    "a2a_agentmesh>=3.3.0,<4",
+    "agent_sandbox>=3.3.0,<4",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<9",
+    "pytest-asyncio>=0.23",
+    "pytest-mock>=3.12",
+    "respx>=0.21",
+]
+
+[project.urls]
+Homepage = "https://github.com/Azure/azureclaw"
+Repository = "https://github.com/Azure/azureclaw"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/azureclaw_runtime_pydantic_ai"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]

--- a/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/__init__.py
+++ b/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/__init__.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AzureClaw in-pod adapter for Pydantic-AI.
+
+Public API:
+    bootstrap()                  — idempotent runtime init (called from entrypoint.sh)
+    init_telemetry()             — OTel tracer/meter providers + httpx instrumentation
+    get_token(scope)             — cached AAD token broker (workload identity)
+    send_message(target, body)   — AgentMesh relay send (A2A TaskEnvelope)
+    receive_messages()           — drain inbox for this sandbox identity
+
+Foundry tools (web_search, code_execute, file_search, memory, image_generation,
+conversations, evaluations, deployments, agents) are reachable via the
+in-cluster MCP server at `http://127.0.0.1:8443/platform/mcp`. Pydantic-AI
+agents can call this via any standard MCP client.
+"""
+
+from azureclaw_runtime_pydantic_ai.aad import get_token
+from azureclaw_runtime_pydantic_ai.mesh import (
+    MeshClient,
+    receive_messages,
+    send_message,
+)
+from azureclaw_runtime_pydantic_ai.otel import init_telemetry
+from azureclaw_runtime_pydantic_ai.runtime import bootstrap
+
+__version__ = "0.1.0"
+
+PLATFORM_MCP_URL = "http://127.0.0.1:8443/platform/mcp"
+
+__all__ = [
+    "MeshClient",
+    "PLATFORM_MCP_URL",
+    "__version__",
+    "bootstrap",
+    "get_token",
+    "init_telemetry",
+    "receive_messages",
+    "send_message",
+]

--- a/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/aad.py
+++ b/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/aad.py
@@ -1,0 +1,113 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AAD token broker for the in-pod adapter.
+
+Acquires bearer tokens via Azure Workload Identity (AKS) using
+`azure.identity.WorkloadIdentityCredential`. Tokens are cached by scope
+and refreshed when within `_SKEW_SECONDS` of expiry so no caller pays
+the IMDS round-trip on the hot path.
+
+The router sidecar handles the LLM-side credential exchange — this
+broker is for *in-process* needs (e.g. signed mesh envelopes, attestation
+of a sub-agent spawn). The two paths must remain independent.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+DEFAULT_SCOPE = "https://cognitiveservices.azure.com/.default"
+_SKEW_SECONDS = 300  # refresh 5 minutes before the token actually expires
+
+
+class _CredentialLike(Protocol):
+    def get_token(self, *scopes: str) -> "_AccessTokenLike": ...  # pragma: no cover
+
+
+class _AccessTokenLike(Protocol):
+    token: str
+    expires_on: int
+
+
+@dataclass
+class _CachedToken:
+    token: str
+    expires_on: int  # unix seconds
+
+
+class TokenBroker:
+    """Thread-safe per-scope cached AAD token broker."""
+
+    def __init__(
+        self,
+        credential: Optional[_CredentialLike] = None,
+        skew_seconds: int = _SKEW_SECONDS,
+    ) -> None:
+        self._credential = credential
+        self._skew = skew_seconds
+        self._cache: dict[str, _CachedToken] = {}
+        self._lock = threading.Lock()
+
+    def _build_default_credential(self) -> _CredentialLike:
+        # Imported lazily so unit tests that inject a fake credential never
+        # need azure-identity to be installed.
+        from azure.identity import WorkloadIdentityCredential
+
+        return WorkloadIdentityCredential()
+
+    def _ensure_credential(self) -> _CredentialLike:
+        if self._credential is None:
+            self._credential = self._build_default_credential()
+        return self._credential
+
+    def get_token(self, scope: str = DEFAULT_SCOPE) -> str:
+        now = int(time.time())
+        with self._lock:
+            cached = self._cache.get(scope)
+            if cached is not None and cached.expires_on - self._skew > now:
+                return cached.token
+            credential = self._ensure_credential()
+            access = credential.get_token(scope)
+            self._cache[scope] = _CachedToken(
+                token=access.token, expires_on=int(access.expires_on)
+            )
+            return access.token
+
+    def invalidate(self, scope: Optional[str] = None) -> None:
+        with self._lock:
+            if scope is None:
+                self._cache.clear()
+            else:
+                self._cache.pop(scope, None)
+
+
+_default_broker: Optional[TokenBroker] = None
+_default_broker_lock = threading.Lock()
+
+
+def _broker() -> TokenBroker:
+    global _default_broker
+    if _default_broker is None:
+        with _default_broker_lock:
+            if _default_broker is None:
+                _default_broker = TokenBroker()
+    return _default_broker
+
+
+def get_token(scope: str = DEFAULT_SCOPE) -> str:
+    """Return a (cached) AAD bearer token for *scope*.
+
+    Refreshes automatically when the token is within 5 minutes of expiry.
+    """
+    return _broker().get_token(scope)
+
+
+def reset_default_broker() -> None:
+    """Test hook — drop the process-wide singleton."""
+    global _default_broker
+    with _default_broker_lock:
+        _default_broker = None

--- a/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/mesh.py
+++ b/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/mesh.py
@@ -1,0 +1,195 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AgentMesh bridge for the in-pod adapter.
+
+`a2a_agentmesh` ships A2A *types* (AgentCard, TaskEnvelope, TrustGate)
+but no transport — the relay/registry are HTTP services. The router
+sidecar reverse-proxies them at `/agt/relay` and `/agt/registry` so we
+have one endpoint for governance/auth.
+
+This module is a thin transport over those endpoints. It serializes a
+`TaskEnvelope` for outbound messages and deserializes inbox payloads
+back to dicts (we keep envelopes opaque to the user — they only see the
+content). When the upstream `a2a_agentmesh` package is available we use
+its types; if not, the module degrades to a dict-only shim so the rest
+of the adapter still imports.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELAY_URL = "http://127.0.0.1:8443/agt/relay/"
+DEFAULT_REGISTRY_URL = "http://127.0.0.1:8443/agt/registry/"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+# Identity headers — populated by the controller via the pod env. The
+# router uses them to authorize the sandbox identity against AGT.
+ENV_AGENT_DID = "AZURECLAW_AGENT_DID"
+ENV_AGENT_NAME = "AZURECLAW_AGENT_NAME"
+
+try:  # pragma: no cover - import guard exercised in degraded test
+    from a2a_agentmesh import TaskEnvelope, TaskMessage, TaskState  # type: ignore
+
+    _HAS_A2A = True
+except Exception:  # pragma: no cover - exercised only when wheel missing
+    _HAS_A2A = False
+    TaskEnvelope = None  # type: ignore[assignment]
+    TaskMessage = None  # type: ignore[assignment]
+    TaskState = None  # type: ignore[assignment]
+
+
+def _env_did() -> str:
+    return os.environ.get(ENV_AGENT_DID, "did:mesh:unknown")
+
+
+def _env_name() -> str:
+    return os.environ.get(ENV_AGENT_NAME, "azureclaw-agent")
+
+
+def _build_envelope(
+    target_did: str,
+    content: str,
+    skill_id: str = "chat",
+) -> Dict[str, Any]:
+    """Return a JSON-serializable A2A task envelope.
+
+    Uses the upstream `a2a_agentmesh` types when present; falls back to
+    a hand-rolled dict that is wire-compatible with the relay so the
+    transport keeps working in degraded environments.
+    """
+    if _HAS_A2A:
+        envelope = TaskEnvelope.create(
+            skill_id=skill_id,
+            source_did=_env_did(),
+            target_did=target_did,
+            source_trust_score=0,
+            input_text=content,
+        )
+        # TaskEnvelope.to_dict() exists on the upstream type.
+        if hasattr(envelope, "to_dict"):
+            return envelope.to_dict()  # type: ignore[no-any-return]
+        # Defensive: dataclass fallback.
+        return {
+            "task_id": getattr(envelope, "task_id", None),
+            "state": "submitted",
+            "skill_id": skill_id,
+            "source_did": _env_did(),
+            "target_did": target_did,
+            "messages": [{"role": "user", "parts": [{"type": "text/plain", "text": content}]}],
+        }
+    # Degraded shim — wire-compatible enough for the relay to accept it.
+    return {
+        "task_id": f"task-{int(time.time() * 1000)}",
+        "state": "submitted",
+        "skill_id": skill_id,
+        "source_did": _env_did(),
+        "target_did": target_did,
+        "messages": [
+            {"role": "user", "parts": [{"type": "text/plain", "text": content}]},
+        ],
+        "created_at": time.time(),
+    }
+
+
+class MeshClient:
+    """HTTP client for the AgentMesh relay/registry, reverse-proxied by the router."""
+
+    def __init__(
+        self,
+        relay_url: Optional[str] = None,
+        registry_url: Optional[str] = None,
+        *,
+        client: Optional[httpx.Client] = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.relay_url = (relay_url or os.environ.get("AZURECLAW_AGT_RELAY_URL") or DEFAULT_RELAY_URL)
+        if not self.relay_url.endswith("/"):
+            self.relay_url = self.relay_url + "/"
+        self.registry_url = (
+            registry_url
+            or os.environ.get("AZURECLAW_AGT_REGISTRY_URL")
+            or DEFAULT_REGISTRY_URL
+        )
+        if not self.registry_url.endswith("/"):
+            self.registry_url = self.registry_url + "/"
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> "MeshClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def send(self, target_agent: str, content: str, *, skill_id: str = "chat") -> Dict[str, Any]:
+        envelope = _build_envelope(target_agent, content, skill_id=skill_id)
+        url = urljoin(self.relay_url, "send")
+        resp = self._client.post(url, json=envelope)
+        resp.raise_for_status()
+        return resp.json()
+
+    def receive(self) -> List[Dict[str, Any]]:
+        url = urljoin(self.relay_url, "inbox")
+        params = {"agent_did": _env_did()}
+        resp = self._client.get(url, params=params)
+        resp.raise_for_status()
+        body = resp.json()
+        # Relay returns either {"messages": [...]} or a bare list — accept both.
+        if isinstance(body, dict):
+            return list(body.get("messages", []))
+        if isinstance(body, list):
+            return body
+        return []
+
+    def lookup(self, agent_name: str) -> Optional[Dict[str, Any]]:
+        """Resolve a friendly agent name to its registry record (incl. DID)."""
+        url = urljoin(self.registry_url, "lookup")
+        resp = self._client.get(url, params={"name": agent_name})
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+
+# Module-level convenience API ------------------------------------------------
+
+_default_client: Optional[MeshClient] = None
+
+
+def _client() -> MeshClient:
+    global _default_client
+    if _default_client is None:
+        _default_client = MeshClient()
+    return _default_client
+
+
+def send_message(target_agent: str, content: str, *, skill_id: str = "chat") -> Dict[str, Any]:
+    """Send `content` to `target_agent` via the AgentMesh relay."""
+    return _client().send(target_agent, content, skill_id=skill_id)
+
+
+def receive_messages() -> List[Dict[str, Any]]:
+    """Drain the inbox for the current sandbox identity."""
+    return _client().receive()
+
+
+def reset_default_client() -> None:
+    """Test hook — drop the cached MeshClient."""
+    global _default_client
+    if _default_client is not None:
+        _default_client.close()
+    _default_client = None

--- a/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/otel.py
+++ b/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/otel.py
@@ -1,0 +1,137 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+OpenTelemetry auto-init for the OpenAI Agents adapter.
+
+The router sidecar exposes an OTLP/HTTP collector at
+`/v1/traces` and `/v1/metrics`. We default to the loopback address so
+egress-guard can keep the pod sealed; an operator may override via
+`OTEL_EXPORTER_OTLP_ENDPOINT` if they front the collector elsewhere.
+
+`init_telemetry()` is idempotent: a second call replaces nothing — once
+a tracer/meter provider is set globally we leave it alone. This keeps
+re-imports during test runs from blowing up the global state.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OTLP_ENDPOINT = "http://127.0.0.1:8443/v1/traces"
+DEFAULT_OTLP_METRICS_ENDPOINT = "http://127.0.0.1:8443/v1/metrics"
+
+_init_lock = threading.Lock()
+_initialized = False
+
+
+def _is_initialized() -> bool:
+    return _initialized
+
+
+def _otlp_endpoint(env_var: str, default: str) -> str:
+    raw = os.environ.get(env_var)
+    return raw if raw else default
+
+
+def init_telemetry(
+    service_name: str,
+    service_version: str = "0.1.0",
+    *,
+    traces_endpoint: Optional[str] = None,
+    metrics_endpoint: Optional[str] = None,
+) -> None:
+    """Configure global OTel tracer + meter providers.
+
+    Calling this more than once is a no-op (subsequent calls log and
+    return). `traces_endpoint`/`metrics_endpoint` override the
+    `OTEL_EXPORTER_OTLP_*` env vars when given (used by tests).
+    """
+    global _initialized
+    with _init_lock:
+        if _initialized:
+            logger.debug("init_telemetry: already initialized, skipping")
+            return
+
+        # Imports deferred so the module imports cheaply when telemetry
+        # is disabled (e.g. unit tests that just probe constants).
+        from opentelemetry import metrics, trace
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        traces_url = traces_endpoint or _otlp_endpoint(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            _otlp_endpoint("OTEL_EXPORTER_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT),
+        )
+        metrics_url = metrics_endpoint or _otlp_endpoint(
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            DEFAULT_OTLP_METRICS_ENDPOINT,
+        )
+
+        resource = Resource.create(
+            {
+                "service.name": service_name,
+                "service.version": service_version,
+                "service.namespace": "azureclaw",
+                "azureclaw.runtime.kind": "OpenAIAgents",
+            }
+        )
+
+        tracer_provider = TracerProvider(resource=resource)
+        tracer_provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=traces_url))
+        )
+        trace.set_tracer_provider(tracer_provider)
+
+        metric_reader = PeriodicExportingMetricReader(
+            OTLPMetricExporter(endpoint=metrics_url),
+        )
+        meter_provider = MeterProvider(
+            resource=resource, metric_readers=[metric_reader]
+        )
+        metrics.set_meter_provider(meter_provider)
+
+        _instrument_httpx()
+
+        _initialized = True
+        logger.info(
+            "azureclaw OTel initialized: service=%s traces=%s metrics=%s",
+            service_name,
+            traces_url,
+            metrics_url,
+        )
+
+
+def _instrument_httpx() -> None:
+    """Auto-instrument httpx so every LLM/tool HTTP call is a span.
+
+    The OpenAI Python SDK uses httpx under the hood, so this transitively
+    captures every model call. Failures are downgraded to warnings —
+    telemetry must never crash the agent.
+    """
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+        HTTPXClientInstrumentor().instrument()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("httpx instrumentation failed: %s", exc)
+
+
+def _reset_for_tests() -> None:
+    """Test-only hook to reset the module-level init flag."""
+    global _initialized
+    with _init_lock:
+        _initialized = False

--- a/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/runtime.py
+++ b/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/runtime.py
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Bootstrap entrypoint for the Pydantic-AI adapter.
+
+Called from `sandbox-images/pydantic-ai/entrypoint.sh` immediately
+before the user's agent code runs. Idempotent — guarded by
+`__AZURECLAW_RUNTIME_INITIALIZED__` so re-imports during user code
+or tests are no-ops.
+
+Pydantic-AI-specific concerns (vs. the OpenAI-Agents adapter):
+  - Pydantic-AI is provider-agnostic — a single `Agent` definition
+    can target OpenAI, Azure OpenAI, Anthropic, Gemini, etc. Each
+    provider's SDK reads its base URL + API key from the process env
+    at construction time. The adapter pins each known provider base
+    URL to the router sidecar's matching proxy endpoint so model
+    calls cannot egress directly. The router enforces governance,
+    content safety, and AAD attestation (no API keys in the pod).
+  - For each provider we set the API-key env to a sentinel value
+    (`router-managed`); the router strips and substitutes its own
+    AAD-attested credential on egress. The egress-guard iptables init
+    container drops UID-1000 packets to non-loopback / non-DNS
+    targets, so even a leaked base-url cannot reach the public
+    provider endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+from typing import Optional
+
+from azureclaw_runtime_pydantic_ai.otel import init_telemetry
+
+logger = logging.getLogger(__name__)
+
+ENV_INITIALIZED = "__AZURECLAW_RUNTIME_INITIALIZED__"
+ROUTER_MANAGED_KEY_SENTINEL = "router-managed"
+SERVICE_NAME = "azureclaw-runtime-pydantic-ai"
+
+# (env_var_for_base_url, default_router_path, env_var_for_api_key)
+PROVIDER_BASE_URLS: list[tuple[str, str, Optional[str]]] = [
+    ("OPENAI_BASE_URL", "http://127.0.0.1:8443/openai/v1", "OPENAI_API_KEY"),
+    (
+        "AZURE_OPENAI_ENDPOINT",
+        "http://127.0.0.1:8443/azure-openai",
+        "AZURE_OPENAI_API_KEY",
+    ),
+    ("ANTHROPIC_BASE_URL", "http://127.0.0.1:8443/anthropic/v1", "ANTHROPIC_API_KEY"),
+]
+
+
+def _install_signal_handlers() -> None:
+    """Translate SIGTERM/SIGINT into a clean SystemExit so atexit hooks run."""
+
+    def _handler(signum: int, _frame) -> None:
+        logger.info("received signal %s — exiting", signum)
+        sys.exit(0)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            pass
+
+
+def bootstrap(
+    *,
+    service_name: str = SERVICE_NAME,
+    service_version: Optional[str] = None,
+) -> None:
+    """Idempotently initialize the in-pod adapter.
+
+    1. Skip if `__AZURECLAW_RUNTIME_INITIALIZED__` is already set.
+    2. Pin each known provider base URL to the router sidecar so
+       LangChain factories cannot reach the public model endpoints
+       directly (egress-guard would drop the packet anyway).
+    3. Set each provider API-key env to a sentinel; the router
+       substitutes the real credential on egress.
+    4. Initialize OTel.
+    5. Install signal handlers for graceful shutdown.
+    6. Mark the env so subsequent imports are no-ops.
+    """
+    if os.environ.get(ENV_INITIALIZED) == "1":
+        logger.debug("bootstrap: already initialized")
+        return
+
+    for base_url_env, default, api_key_env in PROVIDER_BASE_URLS:
+        os.environ.setdefault(base_url_env, default)
+        if api_key_env is not None:
+            os.environ.setdefault(api_key_env, ROUTER_MANAGED_KEY_SENTINEL)
+
+    version = service_version or _read_version()
+    try:
+        init_telemetry(service_name=service_name, service_version=version)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("init_telemetry failed: %s", exc)
+
+    _install_signal_handlers()
+
+    os.environ[ENV_INITIALIZED] = "1"
+    logger.info(
+        "azureclaw-runtime-pydantic-ai bootstrapped: providers pinned to router",
+    )
+
+
+def _read_version() -> str:
+    try:
+        from azureclaw_runtime_pydantic_ai import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover
+        return "0.0.0"
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by entrypoint.sh
+    bootstrap()

--- a/sandbox-images/pydantic-ai/Dockerfile
+++ b/sandbox-images/pydantic-ai/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1.7
+#
+# AzureClaw runtime image: Pydantic-AI for Python.
+#
+# Ships the in-pod adapter package `azureclaw_runtime_pydantic_ai`,
+# which is invoked from `entrypoint.sh::bootstrap` before the user
+# agent code runs. The adapter:
+#   - pins each LLM provider base URL (OPENAI_BASE_URL,
+#     AZURE_OPENAI_ENDPOINT, ANTHROPIC_BASE_URL) to the router sidecar;
+#   - sets each provider API-key env to a sentinel — router
+#     substitutes the real cred on egress;
+#   - initializes OpenTelemetry against the router's OTLP collector;
+#   - brokers AAD tokens via Workload Identity (5-min skew cache);
+#   - bridges AgentMesh A2A messages over `/agt/relay`.
+#
+# Foundry tools (9 platform MCP tools) are reachable at
+# `http://127.0.0.1:8443/platform/mcp` via any MCP client — Pydantic-AI
+# nodes can invoke them directly. No SDK-specific tool wrapper module
+# is shipped.
+#
+# Contract this image must honor:
+#   - Process runs as UID 1000 (egress-guard pin in `reconciler/mod.rs`).
+#   - LLM traffic goes via `http://127.0.0.1:8443` (router sidecar).
+#   - Reads MCP gateway from `AZURECLAW_PLATFORM_MCP_URL`.
+#   - Honors `AZURECLAW_*` env wiring (router URL, AGT relay URL, identity SAN).
+#   - Does not bind privileged ports; default `securityContext` only.
+#
+# AGT-Python wheels (`a2a_agentmesh`, `agent_sandbox`) are built from
+# the upstream `agent-governance-toolkit` repo by
+# `runtimes/build-agt-wheels.sh` and copied into the build context as
+# `runtimes/wheels/*.whl`. This keeps the image hermetic without
+# publishing private wheels to PyPI.
+
+FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+
+LABEL org.azureclaw.runtime.contract="v1"
+LABEL org.azureclaw.runtime.kind="PydanticAi"
+LABEL org.azureclaw.runtime.language="python"
+
+# ---- Install AGT-Python wheels and the AzureClaw adapter ----------------
+COPY runtimes/wheels/ /tmp/agt-wheels/
+RUN if ls /tmp/agt-wheels/*.whl >/dev/null 2>&1; then \
+        pip install --no-cache-dir /tmp/agt-wheels/*.whl ; \
+    fi
+
+COPY runtimes/pydantic-ai/ /opt/azureclaw-runtime-pydantic-ai/
+RUN pip install --no-cache-dir /opt/azureclaw-runtime-pydantic-ai
+
+# ---- Adapter entrypoint -------------------------------------------------
+COPY sandbox-images/pydantic-ai/entrypoint.sh /usr/local/bin/azureclaw-pydantic-ai-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/azureclaw-pydantic-ai-entrypoint.sh
+
+# Workspace where the controller mounts user-supplied agent code via
+# `agentCode: { oci | git }` (see `PydanticAiConfig` in crd.rs).
+RUN mkdir -p /sandbox/agent && chown -R 1000:1000 /sandbox
+
+USER 1000
+WORKDIR /sandbox/agent
+
+ENTRYPOINT ["/usr/local/bin/azureclaw-pydantic-ai-entrypoint.sh"]
+CMD ["python", "/sandbox/agent/main.py"]

--- a/sandbox-images/pydantic-ai/entrypoint.sh
+++ b/sandbox-images/pydantic-ai/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# AzureClaw Pydantic-AI runtime entrypoint.
+#
+# Pins each known LLM provider base URL to the router sidecar, points
+# MCP-aware tools at the platform MCP server, then invokes the in-pod
+# adapter's `bootstrap()` (AAD broker, OTel auto-init, signal
+# handlers, provider base-URL pins, API-key sentinels) before
+# `exec`-ing the user agent code.
+#
+# Hard rules:
+#   - Process must already be running as UID 1000 (Dockerfile USER 1000).
+#   - No direct LLM endpoint variables: only `127.0.0.1:8443` is allowed.
+#     The egress-guard iptables init container blocks every other path.
+#   - No real provider API key ever reaches this pod. Each provider
+#     API-key env (OPENAI_API_KEY, AZURE_OPENAI_API_KEY,
+#     ANTHROPIC_API_KEY) is set to a sentinel so Pydantic-AI model
+#     constructors complete without erroring; the router sidecar
+#     substitutes the real credential on egress.
+
+set -eu
+
+# Provider base URLs — all routed through the inference-router
+# sidecar. Pydantic-AI's per-provider model classes read these at
+# construction time.
+export OPENAI_BASE_URL="${OPENAI_BASE_URL:-http://127.0.0.1:8443/openai/v1}"
+export AZURE_OPENAI_ENDPOINT="${AZURE_OPENAI_ENDPOINT:-http://127.0.0.1:8443/azure-openai}"
+export ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-http://127.0.0.1:8443/anthropic/v1}"
+
+# Sentinel API keys — router strips on egress. NEVER real keys.
+export OPENAI_API_KEY="${OPENAI_API_KEY:-router-managed}"
+export AZURE_OPENAI_API_KEY="${AZURE_OPENAI_API_KEY:-router-managed}"
+export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-router-managed}"
+
+# Platform MCP server: 9 Foundry-shim tools every runtime gets for
+# free. Pydantic-AI agents can call this via any MCP client.
+export AZURECLAW_PLATFORM_MCP_URL="${AZURECLAW_PLATFORM_MCP_URL:-http://127.0.0.1:8443/platform/mcp}"
+
+# AGT relay/registry — reverse-proxied by the router so AgentMesh
+# traffic shares the same governance gate as LLM traffic.
+export AZURECLAW_AGT_RELAY_URL="${AZURECLAW_AGT_RELAY_URL:-http://127.0.0.1:8443/agt/relay/}"
+export AZURECLAW_AGT_REGISTRY_URL="${AZURECLAW_AGT_REGISTRY_URL:-http://127.0.0.1:8443/agt/registry/}"
+
+# OTel collector — the router exposes `/v1/traces` and `/v1/metrics`.
+export OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:8443/v1/traces}"
+
+# In-pod adapter bootstrap. Idempotent (guarded by
+# `__AZURECLAW_RUNTIME_INITIALIZED__`). Non-fatal if telemetry init
+# fails — the adapter logs and continues.
+python -c "from azureclaw_runtime_pydantic_ai.runtime import bootstrap; bootstrap()"
+
+exec "$@"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -751,6 +751,54 @@ EOF
     kubectl delete clawsandbox e2e-langgraph-ts -n azureclaw-system 2>/dev/null || true
 }
 
+test_runtime_pydantic_ai() {
+    # Phase H#3: ClawSandbox of kind PydanticAi should be processed by
+    # the controller. Like other runtime tests, namespace creation is
+    # the primary observable; the Deployment image check is best-effort.
+    cat <<EOF | kubectl apply -f - 2>&1 | head -3
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: e2e-pydantic-ai
+  namespace: azureclaw-system
+spec:
+  inferenceRef:
+    name: e2e-test-inference
+  runtime:
+    kind: PydanticAi
+    pydanticAi:
+      pythonVersion: "3.12"
+      agentCode:
+        oci:
+          image: ghcr.io/example/pydantic-ai-agent:e2e
+  sandbox:
+    isolation: standard
+EOF
+    sleep 5
+    if kubectl get ns azureclaw-e2e-pydantic-ai &>/dev/null; then
+        pass "PydanticAi runtime processed (namespace present)"
+    else
+        echo "  [diag] CR status:"
+        kubectl get clawsandbox e2e-pydantic-ai -n azureclaw-system -o jsonpath='{.status}' 2>/dev/null | head -c 500 || true
+        echo ""
+        fail "PydanticAi runtime: no namespace"
+    fi
+    local image
+    image=$(kubectl get deploy -n azureclaw-e2e-pydantic-ai e2e-pydantic-ai -o jsonpath='{.spec.template.spec.containers[?(@.name=="agent")].image}' 2>/dev/null || true)
+    if [ -n "$image" ]; then
+        if echo "$image" | grep -q "pydantic-ai"; then
+            pass "PydanticAi Deployment uses pydantic-ai runtime image ($image)"
+        else
+            echo "  [diag] container image: $image"
+            fail "PydanticAi Deployment image does not reference pydantic-ai runtime"
+        fi
+    else
+        echo "  [diag] no Deployment yet (likely no InferencePolicy provider in this lane)"
+    fi
+    kubectl delete clawsandbox e2e-pydantic-ai -n azureclaw-system 2>/dev/null || true
+}
+
 test_runtime_byo() {
     cat <<EOF | kubectl apply -f - 2>&1 | head -3
 ---
@@ -2334,6 +2382,7 @@ main() {
         maf-python)      test_runtime_maf_python ;;
         anthropic)       test_runtime_anthropic ;;
         langgraph)       test_runtime_langgraph ; test_runtime_langgraph_typescript_gated ;;
+        pydantic-ai)     test_runtime_pydantic_ai ;;
         byo)             test_runtime_byo ;;
         all)
             test_runtime_openclaw || true
@@ -2342,6 +2391,7 @@ main() {
             test_runtime_anthropic || true
             test_runtime_langgraph || true
             test_runtime_langgraph_typescript_gated || true
+            test_runtime_pydantic_ai || true
             test_runtime_byo || true
             ;;
         *)


### PR DESCRIPTION
## Summary

Adds `RuntimeKind::PydanticAi` as a first-class runtime joining OpenAIAgents, MAF (Python), Anthropic (Phase H#1, #179), and LangGraph (Phase H#2, #180).

[Pydantic-AI](https://ai.pydantic.dev/) is the type-safe Python agent framework from the Pydantic team. Provider-agnostic by design — a single `Agent` definition can target OpenAI, Azure OpenAI, Anthropic, Gemini, etc.

Closes Phase H#3 of [competitive §14.6](docs/competitive.md).

## Why a dedicated adapter (vs BYO)

Pydantic-AI users would otherwise re-implement the same provider env-pinning + sentinel logic the LangGraph adapter already solved. Shipping it as a first-class runtime lets users supply only their agent code.

## Changes

* **Controller / CRD:** `PydanticAi` enum + `PydanticAiConfig` struct + image helper + `plan_pydantic_ai` producer + CRD enum/CEL/property block
* **Runtime adapter:** `runtimes/pydantic-ai/` — mirrors LangGraph's multi-provider env-pinning strategy (3 provider base URLs, 3 sentinel API keys)
* **Sandbox image:** `sandbox-images/pydantic-ai/` — Mariner Python 3.12, USER 1000, runtime contract v1
* **Tests:** +4 controller unit tests (484 total pass with --test-threads=1); `test_runtime_pydantic_ai` E2E added to dispatcher and `all` lane
* **Audit:** docs/security-audits/2026-05-03-phase-h3-pydantic-ai-runtime.md

## AGT boundary respect

Adapter is a pure bootstrapper (env-pinning + OTel + signal handlers). All trust scoring, policy enforcement, and audit happen in the inference-router which calls into the upstream Microsoft AGT `agentmesh` crate. No governance logic reimplemented.

## Local verification

* `cargo build --package azureclaw-controller` — clean
* `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` — clean
* `cargo test --package azureclaw-controller -- --test-threads=1` — 484 passed
* `cargo fmt --all` — no diff
* All 8 quick CI gates pass with `BASE_REF=origin/dev`