### PR TITLE
feat(runtime): ship LangGraph TypeScript adapter; trim .NET MAF [GAP-V1]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -477,3 +477,6 @@ nohup.out
 docs/implementation-plan.md
 *.code-workspace
 docs/internal/
+
+# LangGraph TS adapter — built in Docker stage, not committed
+runtimes/langgraph-ts/dist/

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -531,13 +531,16 @@ pub struct MicrosoftAgentFrameworkConfig {
     pub extra_env: Option<std::collections::BTreeMap<String, String>>,
 }
 
+/// Microsoft Agent Framework adapter language flavour.
+///
+/// Only `python` ships in v1.0 — the .NET flavour is a roadmap item
+/// (see `docs/roadmap.md`). The single-variant enum stays in the
+/// schema so adding new flavours later is a non-breaking change.
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema, PartialEq, Eq)]
 pub enum MafLanguage {
     #[default]
     #[serde(rename = "python")]
     Python,
-    #[serde(rename = "dotnet")]
-    Dotnet,
 }
 
 /// Semantic Kernel runtime variant (Tier-2 placeholder).  // ci:stub-ok: Tier-2 roadmap stake — declared CRD variant per Phase 2 plan §S10
@@ -581,6 +584,11 @@ pub struct LangGraphConfig {
     pub extra_env: Option<std::collections::BTreeMap<String, String>>,
 }
 
+/// LangGraph adapter language flavour.
+///
+/// Both `python` and `typescript` ship as first-class v1.0 runtimes
+/// (LangGraph.js for the TypeScript flavour). The image dispatched
+/// is selected by `plan_langgraph` based on this field.
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema, PartialEq, Eq)]
 pub enum LangGraphLanguage {
     #[default]
@@ -1237,11 +1245,11 @@ mod tests {
     }
 
     #[test]
-    fn runtime_microsoft_agent_framework_dotnet_round_trip() {
+    fn runtime_microsoft_agent_framework_python_round_trip() {
         let rt: RuntimeSpec = serde_json::from_value(serde_json::json!({
             "kind": "MicrosoftAgentFramework",
             "microsoftAgentFramework": {
-                "language": "dotnet",
+                "language": "python",
                 "agentCode": {
                     "git": { "url": "https://github.com/contoso/agent.git", "ref": "main" }
                 }
@@ -1250,7 +1258,7 @@ mod tests {
         .unwrap();
         assert_eq!(rt.kind, RuntimeKind::MicrosoftAgentFramework);
         let cfg = rt.microsoft_agent_framework.as_ref().unwrap();
-        assert_eq!(cfg.language, Some(MafLanguage::Dotnet));
+        assert_eq!(cfg.language, Some(MafLanguage::Python));
         let code = cfg.agent_code.as_ref().unwrap();
         assert!(code.git.is_some());
         assert_eq!(

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -535,10 +535,7 @@ fn plan_microsoft_agent_framework(
     };
 
     let mut runtime_extra_env: BTreeMap<String, String> = BTreeMap::new();
-    runtime_extra_env.insert(
-        "RUNTIME_MAF_LANGUAGE".to_string(),
-        lang_str.to_string(),
-    );
+    runtime_extra_env.insert("RUNTIME_MAF_LANGUAGE".to_string(), lang_str.to_string());
     if let Some(user_env) = cfg.extra_env.as_ref() {
         for (k, v) in user_env {
             runtime_extra_env.insert(k.clone(), v.clone());

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -112,11 +112,15 @@ pub fn anthropic_default_image() -> String {
 /// Why a dedicated adapter (vs BYO): LangGraph relies on LangChain
 /// model factories that read `OPENAI_BASE_URL` (and provider-specific
 /// equivalents) at construction time. The adapter pins those to the
-/// router sidecar and wires AGT/OTel/AAD broker on bootstrap. The
-/// TypeScript flavour is **deferred** — see `plan_langgraph` for the
-/// gating error.
+/// router sidecar and wires AGT/OTel/AAD broker on bootstrap.
 pub const DEFAULT_LANGGRAPH_PYTHON_IMAGE: &str =
     "azureclawacr.azurecr.io/azureclaw-runtime-langgraph:latest";
+
+/// Default container image for the LangGraph **TypeScript** runtime
+/// (LangGraph.js). Mirrors the Python adapter via a Node 22 sandbox
+/// image. Operators pin via `LANGGRAPH_TS_RUNTIME_IMAGE`.
+pub const DEFAULT_LANGGRAPH_TS_IMAGE: &str =
+    "azureclawacr.azurecr.io/azureclaw-runtime-langgraph-ts:latest";
 
 /// Resolve the LangGraph Python adapter image, honouring an operator
 /// override via `LANGGRAPH_RUNTIME_IMAGE`. Falls back to
@@ -126,6 +130,16 @@ pub fn langgraph_default_image() -> String {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_LANGGRAPH_PYTHON_IMAGE.to_string())
+}
+
+/// Resolve the LangGraph TypeScript adapter image, honouring
+/// `LANGGRAPH_TS_RUNTIME_IMAGE`. Falls back to
+/// [`DEFAULT_LANGGRAPH_TS_IMAGE`].
+pub fn langgraph_ts_default_image() -> String {
+    std::env::var("LANGGRAPH_TS_RUNTIME_IMAGE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_LANGGRAPH_TS_IMAGE.to_string())
 }
 
 /// Default container image for the Pydantic-AI Python runtime
@@ -505,36 +519,26 @@ fn plan_openai_agents(cfg: &OpenAIAgentsConfig) -> RuntimeDeploymentPlan {
 
 /// Producer for [`RuntimeKind::MicrosoftAgentFramework`] (S10.A4).
 ///
-/// MAF Python is wired in this build; MAF .NET is deferred to Phase 3
-/// (AgentMesh.Sdk .NET upstream gap). When `language: dotnet` is
-/// requested we surface a [`RuntimePlanError::ShapeInvalid`] so the
-/// reconciler stamps `Degraded / SpecInvalid` rather than silently
-/// running a Python image against a .NET agent.
+/// MAF Python is wired in this build. .NET MAF is `[GAP-V1]`: blocked
+/// upstream on the absence of an `AgentMesh` client class in the
+/// `Microsoft.AgentGovernance` .NET package (it ships trust /
+/// identity / policy / audit only). The CRD enum has been narrowed
+/// to `["python"]` for v1.0; .NET will be re-introduced in v1.1 once
+/// either the upstream package adds a relay client or we ship our
+/// own .NET HTTP/WS bridge. See `docs/internal/agt-upstream-asks.md`.
 fn plan_microsoft_agent_framework(
     cfg: &MicrosoftAgentFrameworkConfig,
 ) -> Result<RuntimeDeploymentPlan, RuntimePlanError> {
-    // Language gate: only Python is wired this slice.
     let lang = cfg.language.clone().unwrap_or_default();
-    if !matches!(lang, MafLanguage::Python) {
-        return Err(RuntimePlanError::ShapeInvalid(
-            "spec.runtime.microsoftAgentFramework.language=dotnet is not yet wired \
-             (blocked on AgentMesh.Sdk .NET upstream availability — see \
-             docs/internal/agt-upstream-asks.md §3); use `language: python` \
-             or wait for Phase 3"
-                .to_string(),
-        ));
-    }
+    let (image, lang_str) = match lang {
+        MafLanguage::Python => (maf_python_default_image(), "python"),
+    };
 
-    let image = maf_python_default_image();
-
-    // Same merge contract as `plan_openai_agents`: producer-supplied
-    // defaults first, user `extra_env` on top. Reserved-prefix
-    // filtering (which would strip `AZURECLAW_*`) happens in the
-    // deployment builder; the producer must use non-reserved keys for
-    // its defaults. None for MAF today (no python_version pin in the
-    // CRD); reserved here as a hook.
     let mut runtime_extra_env: BTreeMap<String, String> = BTreeMap::new();
-    runtime_extra_env.insert("RUNTIME_MAF_LANGUAGE".to_string(), "python".to_string());
+    runtime_extra_env.insert(
+        "RUNTIME_MAF_LANGUAGE".to_string(),
+        lang_str.to_string(),
+    );
     if let Some(user_env) = cfg.extra_env.as_ref() {
         for (k, v) in user_env {
             runtime_extra_env.insert(k.clone(), v.clone());
@@ -610,22 +614,15 @@ fn plan_anthropic(cfg: &AnthropicConfig) -> RuntimeDeploymentPlan {
 /// egress.
 fn plan_langgraph(cfg: &LangGraphConfig) -> Result<RuntimeDeploymentPlan, RuntimePlanError> {
     let lang = cfg.language.clone().unwrap_or_default();
-    if !matches!(lang, LangGraphLanguage::Python) {
-        return Err(RuntimePlanError::ShapeInvalid(
-            "spec.runtime.langGraph.language=typescript is not yet wired \
-             (Python adapter ships first; TS adapter is deferred to a \
-             follow-up phase). Use `language: python` or wait for the \
-             TypeScript adapter image."
-                .to_string(),
-        ));
-    }
-
-    let image = langgraph_default_image();
+    let (image, lang_str) = match lang {
+        LangGraphLanguage::Python => (langgraph_default_image(), "python"),
+        LangGraphLanguage::Typescript => (langgraph_ts_default_image(), "typescript"),
+    };
 
     let mut runtime_extra_env: BTreeMap<String, String> = BTreeMap::new();
     runtime_extra_env.insert(
         "RUNTIME_LANGGRAPH_LANGUAGE".to_string(),
-        "python".to_string(),
+        lang_str.to_string(),
     );
     if let Some(user_env) = cfg.extra_env.as_ref() {
         for (k, v) in user_env {
@@ -1043,7 +1040,10 @@ mod tests {
     }
 
     #[test]
-    fn plan_langgraph_typescript_is_shape_invalid() {
+    fn plan_langgraph_typescript_dispatches_to_ts_image() {
+        unsafe {
+            std::env::remove_var("LANGGRAPH_TS_RUNTIME_IMAGE");
+        }
         let rt = RuntimeSpec {
             kind: RuntimeKind::LangGraph,
             openclaw: None,
@@ -1053,10 +1053,15 @@ mod tests {
             }),
             ..Default::default()
         };
-        let err = build_runtime_plan(&rt, "ignored").expect_err("typescript must be gated");
-        assert!(
-            matches!(err, RuntimePlanError::ShapeInvalid(ref m) if m.contains("typescript")),
-            "expected ShapeInvalid mentioning typescript, got: {err}"
+        let plan =
+            build_runtime_plan(&rt, "ignored").expect("typescript must dispatch to ts image");
+        assert_eq!(plan.kind_str, "LangGraph");
+        assert_eq!(plan.image, DEFAULT_LANGGRAPH_TS_IMAGE);
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_LANGGRAPH_LANGUAGE")
+                .map(|s| s.as_str()),
+            Some("typescript")
         );
     }
 
@@ -1491,25 +1496,19 @@ mod tests {
     }
 
     #[test]
-    fn plan_maf_dotnet_returns_shape_invalid_pending_phase3() {
-        let cfg = MicrosoftAgentFrameworkConfig {
-            language: Some(MafLanguage::Dotnet),
-            ..Default::default()
-        };
-        let err = plan_microsoft_agent_framework(&cfg).expect_err("dotnet must short-circuit");
-        match err {
-            RuntimePlanError::ShapeInvalid(msg) => {
-                assert!(
-                    msg.contains("dotnet"),
-                    "ShapeInvalid msg should name the offending language: {msg}"
-                );
-                assert!(
-                    msg.contains("Phase 3") || msg.contains("AgentMesh.Sdk .NET"),
-                    "ShapeInvalid msg should cite the upstream blocker / phase: {msg}"
-                );
-            }
-            other => panic!("expected ShapeInvalid for dotnet, got {other:?}"),
+    fn plan_maf_default_language_is_python() {
+        unsafe {
+            std::env::remove_var("MAF_RUNTIME_IMAGE");
         }
+        let cfg = MicrosoftAgentFrameworkConfig::default();
+        let plan = plan_microsoft_agent_framework(&cfg).expect("default must succeed");
+        assert_eq!(plan.image, DEFAULT_MAF_PYTHON_IMAGE);
+        assert_eq!(
+            plan.runtime_extra_env
+                .get("RUNTIME_MAF_LANGUAGE")
+                .map(|s| s.as_str()),
+            Some("python")
+        );
     }
 
     #[test]
@@ -1618,20 +1617,5 @@ mod tests {
             .expect("MAF Python must produce a plan");
         assert_eq!(plan.kind_str, "MicrosoftAgentFramework");
         assert_eq!(plan.image, DEFAULT_MAF_PYTHON_IMAGE);
-    }
-
-    #[test]
-    fn build_runtime_plan_surfaces_shape_invalid_for_maf_dotnet() {
-        let rt = RuntimeSpec {
-            kind: RuntimeKind::MicrosoftAgentFramework,
-            openclaw: None,
-            microsoft_agent_framework: Some(MicrosoftAgentFrameworkConfig {
-                language: Some(MafLanguage::Dotnet),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let err = build_runtime_plan(&rt, "x").expect_err("dotnet must short-circuit");
-        assert!(matches!(err, RuntimePlanError::ShapeInvalid(_)));
     }
 }

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -144,12 +144,12 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                     microsoftAgentFramework:
                       type: object
-                      description: "Microsoft Agent Framework runtime variant. Phase 2 parses but does not deploy until S10.A4 lands the adapter image."
+                      description: "Microsoft Agent Framework runtime variant. Python is wired (S10.A4). .NET is `[GAP-V1]`: blocked upstream on a `Microsoft.AgentGovernance` .NET package that exposes an `AgentMesh` relay client (the package today ships trust/identity/policy/audit only). Re-introduced in v1.1 once upstream lands."
                       properties:
                         language:
                           type: string
-                          enum: ["python", "dotnet"]
-                          description: "Adapter image flavour."
+                          enum: ["python"]
+                          description: "Adapter image flavour. v1.0 ships Python only; .NET tracked for v1.1."
                         agentCode:
                           type: object
                           x-kubernetes-validations:
@@ -218,12 +218,12 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                     langGraph:
                       type: object
-                      description: "LangGraph runtime variant (Tier-2 placeholder). Schema is locked but the controller stamps `RuntimeReady=False / AdapterMissing` until the LangGraph adapter image ships."
+                      description: "LangGraph (LangChain) runtime variant. Both Python (`runtimes/langgraph/`) and TypeScript / Node.js 22 (`runtimes/langgraph-ts/`) ship as first-class adapters in v1.0."
                       properties:
                         language:
                           type: string
                           enum: ["python", "typescript"]
-                          description: "Adapter image flavour. Defaults to `python`."
+                          description: "Adapter image flavour. Defaults to `python`. `typescript` selects the Node.js 22 (LangChain.js) image."
                         agentCode:
                           type: object
                           x-kubernetes-validations:
@@ -255,7 +255,7 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                     anthropic:
                       type: object
-                      description: "Anthropic Claude Agents SDK runtime variant (Tier-2 placeholder). Schema is locked but the controller stamps `RuntimeReady=False / AdapterMissing` until the Anthropic adapter image ships."
+                      description: "Anthropic Claude Agents SDK runtime variant. Ships in v1.0 (Phase H#1)."
                       properties:
                         pythonVersion:
                           type: string

--- a/runtimes/langgraph-ts/README.md
+++ b/runtimes/langgraph-ts/README.md
@@ -1,0 +1,44 @@
+# `@azureclaw/runtime-langgraph-ts`
+
+In-pod adapter for **LangGraph (TypeScript / Node.js 22)** running on
+AzureClaw. Mirrors the Python adapter at
+[`runtimes/langgraph/`](../langgraph) with the same v1 contract:
+
+- pins each LLM provider base URL (`OPENAI_BASE_URL`,
+  `AZURE_OPENAI_ENDPOINT`, `ANTHROPIC_BASE_URL`) to the router sidecar
+  at `http://127.0.0.1:8443/...`;
+- stamps each provider API-key env with the `router-managed` sentinel
+  so LangChain factories construct without erroring — the router
+  substitutes the real credential on egress;
+- initializes OpenTelemetry (traces + metrics) against the router's
+  OTLP/HTTP collector;
+- exposes a thin `MeshClient` over the router's reverse-proxied
+  `/agt/relay` and `/agt/registry` endpoints for AgentMesh
+  inter-agent comms;
+- brokers AAD tokens via `WorkloadIdentityCredential` with a 5-minute
+  skew cache.
+
+Foundry's 9 platform MCP tools are reachable at
+`http://127.0.0.1:8443/platform/mcp` via any MCP client — LangGraph
+nodes can invoke them directly.
+
+## Usage
+
+The sandbox image's `entrypoint.sh` calls `bootstrap()` automatically;
+user agent code does not normally import this package.
+
+```ts
+import { bootstrap } from '@azureclaw/runtime-langgraph-ts';
+await bootstrap();
+// ... user graph code ...
+```
+
+## Build
+
+```bash
+npm ci
+npm run build
+```
+
+The sandbox image (`sandbox-images/langgraph-ts/`) installs the
+already-built `dist/` output.

--- a/runtimes/langgraph-ts/package.json
+++ b/runtimes/langgraph-ts/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@azureclaw/runtime-langgraph-ts",
+  "version": "0.1.0",
+  "description": "AzureClaw in-pod adapter for LangGraph (TypeScript / Node.js) — AAD shim, OTel auto-init, AgentMesh bridge, and router-managed LLM credentials out of the box.",
+  "license": "MIT",
+  "author": "Microsoft Corporation <azureclaw@microsoft.com>",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p .",
+    "typecheck": "tsc -p . --noEmit",
+    "test": "vitest run --reporter=basic",
+    "lint": "tsc -p . --noEmit"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@azure/identity": "^4.4.0",
+    "@langchain/langgraph": "^0.2.0",
+    "@langchain/core": "^0.3.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.54.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-undici": "^0.7.0",
+    "@opentelemetry/resources": "^1.27.0",
+    "@opentelemetry/sdk-metrics": "^1.27.0",
+    "@opentelemetry/sdk-trace-base": "^1.27.0",
+    "@opentelemetry/sdk-trace-node": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.27.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Azure/azureclaw.git",
+    "directory": "runtimes/langgraph-ts"
+  }
+}

--- a/runtimes/langgraph-ts/src/aad.ts
+++ b/runtimes/langgraph-ts/src/aad.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * AAD token broker for the in-pod adapter.
+ *
+ * Acquires bearer tokens via Azure Workload Identity (AKS) using
+ * `@azure/identity`'s `WorkloadIdentityCredential`. Tokens are cached
+ * by scope and refreshed when within `SKEW_SECONDS` of expiry so no
+ * caller pays the IMDS round-trip on the hot path.
+ *
+ * The router sidecar handles the LLM-side credential exchange — this
+ * broker is for *in-process* needs (e.g. signed mesh envelopes,
+ * attestation of a sub-agent spawn). The two paths must remain
+ * independent.
+ */
+
+export const DEFAULT_SCOPE = 'https://cognitiveservices.azure.com/.default';
+const SKEW_SECONDS = 300; // refresh 5 minutes before token expiry
+
+export interface AccessTokenLike {
+  token: string;
+  /** Unix seconds. */
+  expiresOnTimestamp: number;
+}
+
+export interface CredentialLike {
+  getToken(scopes: string | string[]): Promise<AccessTokenLike | null>;
+}
+
+interface CachedToken {
+  token: string;
+  expiresOn: number;
+}
+
+export class TokenBroker {
+  private credential: CredentialLike | undefined;
+  private readonly skew: number;
+  private readonly cache = new Map<string, CachedToken>();
+  private readonly inflight = new Map<string, Promise<string>>();
+
+  constructor(credential?: CredentialLike, skewSeconds: number = SKEW_SECONDS) {
+    this.credential = credential;
+    this.skew = skewSeconds;
+  }
+
+  private async ensureCredential(): Promise<CredentialLike> {
+    if (this.credential) {
+      return this.credential;
+    }
+    // Lazy import keeps unit tests cheap when an injected fake is used.
+    const mod = await import('@azure/identity');
+    this.credential = new mod.WorkloadIdentityCredential();
+    return this.credential;
+  }
+
+  async getToken(scope: string = DEFAULT_SCOPE): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    const cached = this.cache.get(scope);
+    if (cached && cached.expiresOn - this.skew > now) {
+      return cached.token;
+    }
+    const inflight = this.inflight.get(scope);
+    if (inflight) {
+      return inflight;
+    }
+    const promise = this.fetchToken(scope).finally(() => {
+      this.inflight.delete(scope);
+    });
+    this.inflight.set(scope, promise);
+    return promise;
+  }
+
+  private async fetchToken(scope: string): Promise<string> {
+    const cred = await this.ensureCredential();
+    const access = await cred.getToken(scope);
+    if (!access) {
+      throw new Error(`AAD token acquisition returned null for scope ${scope}`);
+    }
+    this.cache.set(scope, {
+      token: access.token,
+      expiresOn: Math.floor(access.expiresOnTimestamp / 1000),
+    });
+    return access.token;
+  }
+
+  invalidate(scope?: string): void {
+    if (scope === undefined) {
+      this.cache.clear();
+    } else {
+      this.cache.delete(scope);
+    }
+  }
+}
+
+let defaultBroker: TokenBroker | undefined;
+
+function broker(): TokenBroker {
+  if (!defaultBroker) {
+    defaultBroker = new TokenBroker();
+  }
+  return defaultBroker;
+}
+
+export async function getToken(scope: string = DEFAULT_SCOPE): Promise<string> {
+  return broker().getToken(scope);
+}
+
+/** Test hook — drop the process-wide singleton. */
+export function resetDefaultBroker(): void {
+  defaultBroker = undefined;
+}

--- a/runtimes/langgraph-ts/src/index.ts
+++ b/runtimes/langgraph-ts/src/index.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const VERSION = '0.1.0';
+
+export {
+  bootstrap,
+  PROVIDER_BASE_URLS,
+  ROUTER_MANAGED_KEY_SENTINEL,
+  SERVICE_NAME,
+  ENV_INITIALIZED,
+} from './runtime';
+export type { BootstrapOptions } from './runtime';
+
+export { TokenBroker, getToken, resetDefaultBroker, DEFAULT_SCOPE } from './aad';
+export type { CredentialLike, AccessTokenLike } from './aad';
+
+export {
+  MeshClient,
+  sendMessage,
+  receiveMessages,
+  resetDefaultClient,
+  DEFAULT_RELAY_URL,
+  DEFAULT_REGISTRY_URL,
+  ENV_AGENT_DID,
+  ENV_AGENT_NAME,
+} from './mesh';
+export type { MeshClientOptions, TaskEnvelope } from './mesh';
+
+export { initTelemetry } from './otel';
+export type { InitTelemetryOptions } from './otel';

--- a/runtimes/langgraph-ts/src/mesh.ts
+++ b/runtimes/langgraph-ts/src/mesh.ts
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * AgentMesh bridge for the in-pod adapter.
+ *
+ * The router sidecar reverse-proxies the AgentMesh relay/registry at
+ * `/agt/relay` and `/agt/registry` so we have one endpoint for
+ * governance/auth. This module is a thin transport over those
+ * endpoints. It serializes a TaskEnvelope-shaped object for outbound
+ * messages and returns inbox payloads as plain dicts (we keep
+ * envelopes opaque to the user — they only see the content).
+ *
+ * Wire format mirrors the upstream `a2a_agentmesh` schema (camelCase
+ * keys converted to snake_case where the relay expects it).
+ */
+
+export const DEFAULT_RELAY_URL = 'http://127.0.0.1:8443/agt/relay/';
+export const DEFAULT_REGISTRY_URL = 'http://127.0.0.1:8443/agt/registry/';
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+export const ENV_AGENT_DID = 'AZURECLAW_AGENT_DID';
+export const ENV_AGENT_NAME = 'AZURECLAW_AGENT_NAME';
+
+function envDid(): string {
+  return process.env[ENV_AGENT_DID] ?? 'did:mesh:unknown';
+}
+
+export interface TaskEnvelope {
+  task_id: string;
+  state: string;
+  skill_id: string;
+  source_did: string;
+  target_did: string;
+  messages: Array<{
+    role: string;
+    parts: Array<{ type: string; text: string }>;
+  }>;
+  created_at: number;
+}
+
+function buildEnvelope(
+  targetDid: string,
+  content: string,
+  skillId: string,
+): TaskEnvelope {
+  return {
+    task_id: `task-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    state: 'submitted',
+    skill_id: skillId,
+    source_did: envDid(),
+    target_did: targetDid,
+    messages: [
+      { role: 'user', parts: [{ type: 'text/plain', text: content }] },
+    ],
+    created_at: Date.now() / 1000,
+  };
+}
+
+function joinUrl(base: string, path: string): string {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = path.startsWith('/') ? path.slice(1) : path;
+  return `${b}${p}`;
+}
+
+export interface MeshClientOptions {
+  relayUrl?: string;
+  registryUrl?: string;
+  timeoutMs?: number;
+  /** Test hook — override fetch implementation. */
+  fetchImpl?: typeof fetch;
+}
+
+export class MeshClient {
+  readonly relayUrl: string;
+  readonly registryUrl: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: MeshClientOptions = {}) {
+    const relay =
+      opts.relayUrl ?? process.env.AZURECLAW_AGT_RELAY_URL ?? DEFAULT_RELAY_URL;
+    const registry =
+      opts.registryUrl ??
+      process.env.AZURECLAW_AGT_REGISTRY_URL ??
+      DEFAULT_REGISTRY_URL;
+    this.relayUrl = relay.endsWith('/') ? relay : `${relay}/`;
+    this.registryUrl = registry.endsWith('/') ? registry : `${registry}/`;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  private async request(
+    url: string,
+    init: RequestInit,
+  ): Promise<unknown> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(url, { ...init, signal: ctrl.signal });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(
+          `mesh request failed: ${res.status} ${res.statusText} ${body}`,
+        );
+      }
+      // 404 from /lookup is handled by caller.
+      const text = await res.text();
+      return text ? JSON.parse(text) : null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async send(
+    targetAgent: string,
+    content: string,
+    opts: { skillId?: string } = {},
+  ): Promise<Record<string, unknown>> {
+    const envelope = buildEnvelope(
+      targetAgent,
+      content,
+      opts.skillId ?? 'chat',
+    );
+    const url = joinUrl(this.relayUrl, 'send');
+    const body = (await this.request(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(envelope),
+    })) as Record<string, unknown> | null;
+    return body ?? {};
+  }
+
+  async receive(): Promise<Array<Record<string, unknown>>> {
+    const url = `${joinUrl(this.relayUrl, 'inbox')}?agent_did=${encodeURIComponent(envDid())}`;
+    const body = (await this.request(url, { method: 'GET' })) as
+      | { messages?: Array<Record<string, unknown>> }
+      | Array<Record<string, unknown>>
+      | null;
+    if (Array.isArray(body)) {
+      return body;
+    }
+    if (body && Array.isArray(body.messages)) {
+      return body.messages;
+    }
+    return [];
+  }
+
+  async lookup(
+    agentName: string,
+  ): Promise<Record<string, unknown> | null> {
+    const url = `${joinUrl(this.registryUrl, 'lookup')}?name=${encodeURIComponent(agentName)}`;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(url, {
+        method: 'GET',
+        signal: ctrl.signal,
+      });
+      if (res.status === 404) {
+        return null;
+      }
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(
+          `registry lookup failed: ${res.status} ${res.statusText} ${body}`,
+        );
+      }
+      return (await res.json()) as Record<string, unknown>;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+let defaultClient: MeshClient | undefined;
+
+function client(): MeshClient {
+  if (!defaultClient) {
+    defaultClient = new MeshClient();
+  }
+  return defaultClient;
+}
+
+export async function sendMessage(
+  targetAgent: string,
+  content: string,
+  opts: { skillId?: string } = {},
+): Promise<Record<string, unknown>> {
+  return client().send(targetAgent, content, opts);
+}
+
+export async function receiveMessages(): Promise<
+  Array<Record<string, unknown>>
+> {
+  return client().receive();
+}
+
+/** Test hook — drop the cached MeshClient. */
+export function resetDefaultClient(): void {
+  defaultClient = undefined;
+}

--- a/runtimes/langgraph-ts/src/otel.ts
+++ b/runtimes/langgraph-ts/src/otel.ts
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * OpenTelemetry auto-init for the LangGraph (TypeScript) adapter.
+ *
+ * The router sidecar exposes an OTLP/HTTP collector at
+ * `/v1/traces` and `/v1/metrics`. We default to the loopback address
+ * so egress-guard can keep the pod sealed; an operator may override
+ * via `OTEL_EXPORTER_OTLP_ENDPOINT` if they front the collector
+ * elsewhere.
+ *
+ * `initTelemetry()` is idempotent: a second call is a no-op once a
+ * tracer/meter provider is set globally.
+ */
+
+const DEFAULT_OTLP_TRACES_ENDPOINT = 'http://127.0.0.1:8443/v1/traces';
+const DEFAULT_OTLP_METRICS_ENDPOINT = 'http://127.0.0.1:8443/v1/metrics';
+
+let initialized = false;
+
+function otlpEndpoint(envVar: string, fallback: string): string {
+  const raw = process.env[envVar];
+  return raw && raw.length > 0 ? raw : fallback;
+}
+
+export interface InitTelemetryOptions {
+  serviceName: string;
+  serviceVersion?: string;
+  tracesEndpoint?: string;
+  metricsEndpoint?: string;
+}
+
+export async function initTelemetry(
+  opts: InitTelemetryOptions,
+): Promise<void> {
+  if (initialized) {
+    return;
+  }
+
+  // Lazy imports so the module imports cheaply when tests just probe
+  // constants, and so a missing OTel dep doesn't crash bootstrap.
+  let api:
+    | typeof import('@opentelemetry/api')
+    | undefined;
+  try {
+    api = await import('@opentelemetry/api');
+    const { Resource } = await import('@opentelemetry/resources');
+    const {
+      ATTR_SERVICE_NAME,
+      ATTR_SERVICE_VERSION,
+    } = await import('@opentelemetry/semantic-conventions');
+    const { NodeTracerProvider } = await import(
+      '@opentelemetry/sdk-trace-node'
+    );
+    const { BatchSpanProcessor } = await import(
+      '@opentelemetry/sdk-trace-base'
+    );
+    const { OTLPTraceExporter } = await import(
+      '@opentelemetry/exporter-trace-otlp-http'
+    );
+    const {
+      MeterProvider,
+      PeriodicExportingMetricReader,
+    } = await import('@opentelemetry/sdk-metrics');
+    const { OTLPMetricExporter } = await import(
+      '@opentelemetry/exporter-metrics-otlp-http'
+    );
+
+    const tracesUrl =
+      opts.tracesEndpoint ??
+      otlpEndpoint(
+        'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+        otlpEndpoint(
+          'OTEL_EXPORTER_OTLP_ENDPOINT',
+          DEFAULT_OTLP_TRACES_ENDPOINT,
+        ),
+      );
+    const metricsUrl =
+      opts.metricsEndpoint ??
+      otlpEndpoint(
+        'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
+        DEFAULT_OTLP_METRICS_ENDPOINT,
+      );
+
+    const resource = new Resource({
+      [ATTR_SERVICE_NAME]: opts.serviceName,
+      [ATTR_SERVICE_VERSION]: opts.serviceVersion ?? '0.1.0',
+      'service.namespace': 'azureclaw',
+      'azureclaw.runtime.kind': 'LangGraph',
+      'azureclaw.runtime.language': 'typescript',
+    });
+
+    const tracerProvider = new NodeTracerProvider({ resource });
+    tracerProvider.addSpanProcessor(
+      new BatchSpanProcessor(new OTLPTraceExporter({ url: tracesUrl })),
+    );
+    tracerProvider.register();
+
+    const meterProvider = new MeterProvider({
+      resource,
+      readers: [
+        new PeriodicExportingMetricReader({
+          exporter: new OTLPMetricExporter({ url: metricsUrl }),
+        }),
+      ],
+    });
+    api.metrics.setGlobalMeterProvider(meterProvider);
+
+    await instrumentHttp();
+
+    initialized = true;
+    // eslint-disable-next-line no-console
+    console.error(
+      `[azureclaw-runtime-langgraph-ts] OTel initialized: traces=${tracesUrl} metrics=${metricsUrl}`,
+    );
+  } catch (err) {
+    // Telemetry must never crash the agent.
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[azureclaw-runtime-langgraph-ts] initTelemetry failed:',
+      err,
+    );
+  }
+}
+
+async function instrumentHttp(): Promise<void> {
+  try {
+    const { registerInstrumentations } = await import(
+      '@opentelemetry/instrumentation'
+    );
+    const { HttpInstrumentation } = await import(
+      '@opentelemetry/instrumentation-http'
+    );
+    // Node.js 22 / undici fetch coverage is best-effort. The
+    // dedicated undici instrumentation, when available, captures the
+    // built-in fetch.
+    const instrumentations: Array<unknown> = [new HttpInstrumentation()];
+    try {
+      const undici = await import('@opentelemetry/instrumentation-undici');
+      // The export name varies across versions; probe defensively.
+      const Cls =
+        (undici as { UndiciInstrumentation?: new () => unknown })
+          .UndiciInstrumentation ??
+        undefined;
+      if (Cls) {
+        instrumentations.push(new Cls());
+      }
+    } catch {
+      // Optional dep missing — fall back to http instrumentation only.
+    }
+    registerInstrumentations({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      instrumentations: instrumentations as any,
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[azureclaw-runtime-langgraph-ts] HTTP instrumentation failed:',
+      err,
+    );
+  }
+}
+
+/** Test-only hook to reset the module-level init flag. */
+export function _resetForTests(): void {
+  initialized = false;
+}

--- a/runtimes/langgraph-ts/src/runtime.ts
+++ b/runtimes/langgraph-ts/src/runtime.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Bootstrap entrypoint for the LangGraph (TypeScript) adapter.
+ *
+ * Called from `sandbox-images/langgraph-ts/entrypoint.sh` immediately
+ * before the user's graph code runs. Idempotent — guarded by
+ * `__AZURECLAW_RUNTIME_INITIALIZED__` so re-imports during user code
+ * or tests are no-ops.
+ *
+ * LangGraph TS is provider-agnostic, but every realistic graph
+ * invokes one or more LangChain.js model factories (`ChatOpenAI`,
+ * `AzureChatOpenAI`, `ChatAnthropic`, ...). Those factories read
+ * provider base URLs and API keys from the process env at
+ * construction time. The adapter pins each known provider base URL
+ * to the router sidecar's matching proxy endpoint so model calls
+ * cannot egress directly. The router enforces governance, content
+ * safety, and AAD attestation (no API keys in the pod).
+ *
+ * For each provider we set the API-key env to a sentinel value
+ * (`router-managed`); the router strips and substitutes its own
+ * AAD-attested credential on egress. The egress-guard iptables init
+ * container drops UID-1000 packets to non-loopback / non-DNS
+ * targets, so even a leaked base-url cannot reach the public
+ * provider endpoint.
+ */
+
+import { initTelemetry } from './otel';
+
+export const ENV_INITIALIZED = '__AZURECLAW_RUNTIME_INITIALIZED__';
+export const ROUTER_MANAGED_KEY_SENTINEL = 'router-managed';
+export const SERVICE_NAME = 'azureclaw-runtime-langgraph-ts';
+
+interface ProviderPin {
+  baseUrlEnv: string;
+  defaultUrl: string;
+  apiKeyEnv: string | null;
+}
+
+export const PROVIDER_BASE_URLS: ProviderPin[] = [
+  {
+    baseUrlEnv: 'OPENAI_BASE_URL',
+    defaultUrl: 'http://127.0.0.1:8443/openai/v1',
+    apiKeyEnv: 'OPENAI_API_KEY',
+  },
+  {
+    baseUrlEnv: 'AZURE_OPENAI_ENDPOINT',
+    defaultUrl: 'http://127.0.0.1:8443/azure-openai',
+    apiKeyEnv: 'AZURE_OPENAI_API_KEY',
+  },
+  {
+    baseUrlEnv: 'ANTHROPIC_BASE_URL',
+    defaultUrl: 'http://127.0.0.1:8443/anthropic/v1',
+    apiKeyEnv: 'ANTHROPIC_API_KEY',
+  },
+];
+
+function setIfUnset(env: string, value: string): void {
+  if (process.env[env] === undefined || process.env[env] === '') {
+    process.env[env] = value;
+  }
+}
+
+function installSignalHandlers(): void {
+  const handler = (signal: NodeJS.Signals) => {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[azureclaw-runtime-langgraph-ts] received ${signal} — exiting`,
+    );
+    // Allow batched span exporters a brief drain window.
+    setTimeout(() => process.exit(0), 50).unref();
+  };
+  for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+    try {
+      process.on(sig, handler);
+    } catch {
+      // Some environments (workers) refuse signal hooks — non-fatal.
+    }
+  }
+}
+
+export interface BootstrapOptions {
+  serviceName?: string;
+  serviceVersion?: string;
+}
+
+/**
+ * Idempotently initialize the in-pod adapter.
+ *
+ * 1. Skip if `__AZURECLAW_RUNTIME_INITIALIZED__` is already set.
+ * 2. Pin each known provider base URL to the router sidecar so
+ *    LangChain factories cannot reach the public model endpoints
+ *    directly (egress-guard would drop the packet anyway).
+ * 3. Set each provider API-key env to a sentinel; the router
+ *    substitutes the real credential on egress.
+ * 4. Initialize OTel.
+ * 5. Install signal handlers for graceful shutdown.
+ * 6. Mark the env so subsequent imports are no-ops.
+ */
+export async function bootstrap(
+  opts: BootstrapOptions = {},
+): Promise<void> {
+  if (process.env[ENV_INITIALIZED] === '1') {
+    return;
+  }
+
+  for (const pin of PROVIDER_BASE_URLS) {
+    setIfUnset(pin.baseUrlEnv, pin.defaultUrl);
+    if (pin.apiKeyEnv) {
+      setIfUnset(pin.apiKeyEnv, ROUTER_MANAGED_KEY_SENTINEL);
+    }
+  }
+
+  await initTelemetry({
+    serviceName: opts.serviceName ?? SERVICE_NAME,
+    serviceVersion: opts.serviceVersion,
+  });
+
+  installSignalHandlers();
+
+  process.env[ENV_INITIALIZED] = '1';
+  // eslint-disable-next-line no-console
+  console.error(
+    '[azureclaw-runtime-langgraph-ts] bootstrapped: providers pinned to router',
+  );
+}

--- a/runtimes/langgraph-ts/tsconfig.json
+++ b/runtimes/langgraph-ts/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/sandbox-images/langgraph-ts/Dockerfile
+++ b/sandbox-images/langgraph-ts/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1.7
+#
+# AzureClaw runtime image: LangGraph (LangChain.js) for TypeScript /
+# Node.js 22.
+#
+# Ships the in-pod adapter package `@azureclaw/runtime-langgraph-ts`,
+# which is invoked from `entrypoint.sh` before the user agent code
+# runs. The adapter:
+#   - pins each LLM provider base URL (OPENAI_BASE_URL,
+#     AZURE_OPENAI_ENDPOINT, ANTHROPIC_BASE_URL) to the router sidecar;
+#   - sets each provider API-key env to a sentinel — router
+#     substitutes the real cred on egress;
+#   - initializes OpenTelemetry against the router's OTLP collector;
+#   - brokers AAD tokens via Workload Identity (5-min skew cache);
+#   - bridges AgentMesh A2A messages over `/agt/relay`.
+#
+# Foundry tools (9 platform MCP tools) are reachable at
+# `http://127.0.0.1:8443/platform/mcp` via any MCP client — LangGraph
+# nodes can invoke them directly. No SDK-specific tool wrapper module
+# is shipped.
+#
+# Contract this image must honor:
+#   - Process runs as UID 1000 (egress-guard pin in `reconciler/mod.rs`).
+#   - LLM traffic goes via `http://127.0.0.1:8443` (router sidecar).
+#   - Reads MCP gateway from `AZURECLAW_PLATFORM_MCP_URL`.
+#   - Honors `AZURECLAW_*` env wiring (router URL, AGT relay URL, identity SAN).
+#   - Does not bind privileged ports; default `securityContext` only.
+#
+# Build context MUST be the repo root (the COPY paths are anchored at
+# `runtimes/langgraph-ts/` and `sandbox-images/langgraph-ts/`).
+
+FROM mcr.microsoft.com/cbl-mariner/base/nodejs:22 AS builder
+
+WORKDIR /build/runtime
+
+COPY runtimes/langgraph-ts/package.json runtimes/langgraph-ts/tsconfig.json ./
+RUN npm install --no-audit --no-fund --no-package-lock
+
+COPY runtimes/langgraph-ts/src ./src
+RUN ./node_modules/.bin/tsc -p .
+
+# ---- Production stage ----------------------------------------------------
+FROM mcr.microsoft.com/cbl-mariner/base/nodejs:22
+
+LABEL org.azureclaw.runtime.contract="v1"
+LABEL org.azureclaw.runtime.kind="LangGraph"
+LABEL org.azureclaw.runtime.language="typescript"
+
+WORKDIR /opt/azureclaw-runtime-langgraph-ts
+
+COPY runtimes/langgraph-ts/package.json ./
+RUN npm install --omit=dev --no-audit --no-fund --no-package-lock
+
+COPY --from=builder /build/runtime/dist ./dist
+
+# ---- Adapter entrypoint --------------------------------------------------
+COPY sandbox-images/langgraph-ts/entrypoint.sh /usr/local/bin/azureclaw-langgraph-ts-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/azureclaw-langgraph-ts-entrypoint.sh
+
+# Workspace where the controller mounts user-supplied agent code via
+# `agentCode: { oci | git }` (see `LangGraphConfig` in crd.rs).
+RUN mkdir -p /sandbox/agent && chown -R 1000:1000 /sandbox
+
+USER 1000
+WORKDIR /sandbox/agent
+
+ENTRYPOINT ["/usr/local/bin/azureclaw-langgraph-ts-entrypoint.sh"]
+CMD ["node", "/sandbox/agent/index.js"]

--- a/sandbox-images/langgraph-ts/entrypoint.sh
+++ b/sandbox-images/langgraph-ts/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# AzureClaw LangGraph (LangChain.js, TypeScript / Node.js 22) runtime entrypoint.
+#
+# Pins each known LLM provider base URL to the router sidecar, points
+# MCP-aware tools at the platform MCP server, then invokes the in-pod
+# adapter's `bootstrap()` (AAD broker, OTel auto-init, signal
+# handlers, provider base-URL pins, API-key sentinels) before
+# `exec`-ing the user agent code.
+#
+# Hard rules:
+#   - Process must already be running as UID 1000 (Dockerfile USER 1000).
+#   - No direct LLM endpoint variables: only `127.0.0.1:8443` is allowed.
+#     The egress-guard iptables init container blocks every other path.
+#   - No real provider API key ever reaches this pod. Each provider
+#     API-key env (OPENAI_API_KEY, AZURE_OPENAI_API_KEY,
+#     ANTHROPIC_API_KEY) is set to a sentinel so LangChain factories
+#     construct without erroring; the router sidecar substitutes the
+#     real credential on egress.
+
+set -eu
+
+# Provider base URLs — all routed through the inference-router
+# sidecar. LangChain.js factories read these at construction time
+# (ChatOpenAI, AzureChatOpenAI, ChatAnthropic, ...).
+export OPENAI_BASE_URL="${OPENAI_BASE_URL:-http://127.0.0.1:8443/openai/v1}"
+export AZURE_OPENAI_ENDPOINT="${AZURE_OPENAI_ENDPOINT:-http://127.0.0.1:8443/azure-openai}"
+export ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-http://127.0.0.1:8443/anthropic/v1}"
+
+# Sentinel API keys — router strips on egress. NEVER real keys.
+export OPENAI_API_KEY="${OPENAI_API_KEY:-router-managed}"
+export AZURE_OPENAI_API_KEY="${AZURE_OPENAI_API_KEY:-router-managed}"
+export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-router-managed}"
+
+# Platform MCP server: 9 Foundry-shim tools every runtime gets for
+# free. LangGraph nodes can call this via any MCP client.
+export AZURECLAW_PLATFORM_MCP_URL="${AZURECLAW_PLATFORM_MCP_URL:-http://127.0.0.1:8443/platform/mcp}"
+
+# AGT relay/registry — reverse-proxied by the router so AgentMesh
+# traffic shares the same governance gate as LLM traffic.
+export AZURECLAW_AGT_RELAY_URL="${AZURECLAW_AGT_RELAY_URL:-http://127.0.0.1:8443/agt/relay/}"
+export AZURECLAW_AGT_REGISTRY_URL="${AZURECLAW_AGT_REGISTRY_URL:-http://127.0.0.1:8443/agt/registry/}"
+
+# OTel collector — the router exposes `/v1/traces` and `/v1/metrics`.
+export OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:8443/v1/traces}"
+
+# Surface the controller-supplied language flag (typescript here).
+if [ -n "${RUNTIME_LANGGRAPH_LANGUAGE:-}" ]; then
+    echo "[azureclaw-langgraph-ts] language: ${RUNTIME_LANGGRAPH_LANGUAGE}" >&2
+fi
+
+# In-pod adapter bootstrap. Idempotent (guarded by
+# `__AZURECLAW_RUNTIME_INITIALIZED__`). Non-fatal if telemetry init
+# fails — the adapter logs and continues.
+node -e "require('/opt/azureclaw-runtime-langgraph-ts/dist/index.js').bootstrap().catch((e)=>{console.warn('[azureclaw-langgraph-ts] bootstrap failed:', e); process.exit(0);}).then(()=>{})" || true
+
+# Make the adapter resolvable from the user agent code via either the
+# package name (`require('@azureclaw/runtime-langgraph-ts')`) or
+# absolute path. The package is already installed in
+# /opt/azureclaw-runtime-langgraph-ts/node_modules; expose its parent.
+export NODE_PATH="${NODE_PATH:-}:/opt/azureclaw-runtime-langgraph-ts/node_modules:/opt/azureclaw-runtime-langgraph-ts"
+
+exec "$@"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -709,11 +709,12 @@ EOF
     kubectl delete clawsandbox e2e-langgraph -n azureclaw-system 2>/dev/null || true
 }
 
-# Phase H#2: LangGraph TypeScript flavour is gated as ShapeInvalid in
-# `plan_langgraph` until the TS adapter image ships. The CRD admission
-# accepts the value (it's a valid enum variant); the controller stamps
-# RuntimeReady=False / ShapeInvalid in Conditions instead.
-test_runtime_langgraph_typescript_gated() {
+# LangGraph TypeScript flavour ships as a first-class adapter in
+# v1.0 (runtimes/langgraph-ts/, sandbox-images/langgraph-ts/). The
+# controller dispatches `language: typescript` to the Node.js 22
+# image; the deployment should reach a Running status without being
+# stamped ShapeInvalid.
+test_runtime_langgraph_typescript() {
     cat <<EOF | kubectl apply -f - 2>&1 | head -3
 ---
 apiVersion: azureclaw.azure.com/v1alpha1
@@ -735,18 +736,17 @@ spec:
     isolation: standard
 EOF
     sleep 5
-    # The controller should refuse to plan, surfacing ShapeInvalid in
-    # the Conditions chain. Namespace may or may not exist depending
-    # on reconciler ordering — the diagnostic signal is the Conditions.
+    # The controller should plan a Deployment using the langgraph-ts
+    # image (no ShapeInvalid). We don't pin the exact image string here
+    # because operators may override via LANGGRAPH_TS_RUNTIME_IMAGE; we
+    # only assert that ShapeInvalid is NOT in the Conditions chain.
     local conds
     conds=$(kubectl get clawsandbox e2e-langgraph-ts -n azureclaw-system -o jsonpath='{.status.conditions[*].reason}' 2>/dev/null || true)
     if echo "$conds" | grep -qi "ShapeInvalid\|SpecInvalid"; then
-        pass "LangGraph typescript correctly gated (reason in conditions)"
-    else
         echo "  [diag] conditions: $conds"
-        # Don't fail the lane — controller may not have reconciled yet
-        # in this fast E2E run. Surface as diagnostic only.
-        echo "  [diag] LangGraph TS gate: condition not yet observed"
+        fail "LangGraph typescript should NOT be ShapeInvalid in v1.0"
+    else
+        pass "LangGraph typescript dispatched (no ShapeInvalid)"
     fi
     kubectl delete clawsandbox e2e-langgraph-ts -n azureclaw-system 2>/dev/null || true
 }
@@ -2381,7 +2381,7 @@ main() {
         oai-agents)      test_runtime_oai_agents ;;
         maf-python)      test_runtime_maf_python ;;
         anthropic)       test_runtime_anthropic ;;
-        langgraph)       test_runtime_langgraph ; test_runtime_langgraph_typescript_gated ;;
+        langgraph)       test_runtime_langgraph ; test_runtime_langgraph_typescript ;;
         pydantic-ai)     test_runtime_pydantic_ai ;;
         byo)             test_runtime_byo ;;
         all)
@@ -2390,7 +2390,7 @@ main() {
             test_runtime_maf_python || true
             test_runtime_anthropic || true
             test_runtime_langgraph || true
-            test_runtime_langgraph_typescript_gated || true
+            test_runtime_langgraph_typescript || true
             test_runtime_pydantic_ai || true
             test_runtime_byo || true
             ;;


### PR DESCRIPTION
## Summary

R1 batch 1 of the v1.0 release readiness plan. Narrows runtime variants
to what we actually deliver in v1.0, and ships a real **LangGraph
TypeScript** adapter instead of the previous `ShapeInvalid` gate.

## LangGraph TypeScript — first-class v1.0 runtime

Validated upstream availability before building: TypeScript AGT
(`@microsoft/agent-governance-sdk` 3.3.0) ships a full `AgentMeshClient`
with x3dh / ratchet / channel modules, so cross-language inter-agent
comms works on the wire.

New code:

* `runtimes/langgraph-ts/` — Node 22 / TS 5 adapter package
  (`@azureclaw/runtime-langgraph-ts`) mirroring `runtimes/langgraph/`
  (Python).
  * `src/aad.ts` — `WorkloadIdentityCredential`-backed token broker
    with 5-min skew cache.
  * `src/mesh.ts` — HTTP transport over the router-proxied
    `/agt/relay` and `/agt/registry` endpoints.
  * `src/otel.ts` — lazy-imported OTel SDK init (NodeTracerProvider,
    OTLP/HTTP exporters, HTTP + undici instrumentation).
  * `src/runtime.ts` — idempotent `bootstrap()` (provider URL
    pinning, sentinel API keys, signal handlers, init guard).
* `sandbox-images/langgraph-ts/` — multi-stage Mariner Node 22
  `Dockerfile` (`USER 1000`, contract v1) + `entrypoint.sh`.
* Controller dispatch: `plan_langgraph` matches on `language` and
  selects `langgraph-python` or `langgraph-ts` image accordingly.
  New helper `langgraph_ts_default_image()` honours
  `LANGGRAPH_TS_RUNTIME_IMAGE` env override.
* CRD yaml: `langGraph` no longer a "Tier-2 placeholder"; same fix
  for `anthropic` (already shipped in H#1).
* `tests/e2e/run.sh`: replaced the negative gate test with a positive
  test that asserts `ShapeInvalid` is **not** in Conditions.

## Microsoft Agent Framework — .NET trimmed to `[GAP-V1]`

The `Microsoft.AgentGovernance` .NET package ships trust / identity /
policy / audit but **no AgentMesh relay client class**. Without it
the .NET adapter would have no inter-agent comms — that's not
release-quality. Trimmed for v1.0; re-introduced in v1.1 once
upstream lands a .NET `AgentMesh` client (or we ship our own bridge).

* CRD enum narrowed: `microsoftAgentFramework.language` now
  `["python"]`.
* `MafLanguage::Dotnet` variant removed.
* `plan_microsoft_agent_framework` simplified to a single-arm match.
* Round-trip test renamed `_dotnet_round_trip` → `_python_round_trip`;
  ShapeInvalid-for-dotnet tests removed.

## Verification

* `cargo build --package azureclaw-controller` — clean
* `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` — clean
* `cargo test --package azureclaw-controller -- --test-threads=1` —
  **483 passed, 0 failed**
* `npm install && npx tsc -p .` in `runtimes/langgraph-ts/` — clean

## Gap markers

* `[GAP-V1]` — .NET MAF deferred until either upstream ships a .NET
  AgentMesh client or we implement a .NET HTTP/WS bridge.