### PR TITLE
release(r1): mesh_inbox nudge + BYO strict-mode demo + stale comment fix

### DIFF
--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -375,9 +375,10 @@ pub fn build_runtime_plan(
         }
         RuntimeKind::SemanticKernel => Err(RuntimePlanError::AdapterMissing("SemanticKernel")),
         RuntimeKind::LangGraph => {
-            // Phase H#2: LangGraph Python adapter wired end-to-end.
-            // TypeScript flavour is gated as ShapeInvalid until the
-            // TS adapter image ships (mirrors the MAF .NET strategy).
+            // LangGraph adapters wired end-to-end for both Python
+            // (`runtimes/langgraph/`) and TypeScript / Node 22
+            // (`runtimes/langgraph-ts/`). `plan_langgraph` matches on
+            // `language` and selects the matching image.
             let cfg = runtime.lang_graph.as_ref().expect("validated above");
             plan_langgraph(cfg)
         }

--- a/examples/byo-quickstart/README.md
+++ b/examples/byo-quickstart/README.md
@@ -76,3 +76,36 @@ Tear down with:
 ```bash
 kubectl delete clawsandbox byo-quickstart
 ```
+
+## 5. Verify strict-mode admission (recommended for production)
+
+The example above runs cleanly under either `byoStrict=false` (default
+— Phase 2 behaviour, advisory warnings only) or `byoStrict=true`
+(Phase 3 — rejection at admission time). For production we recommend
+the latter. To see strict mode actually reject a malformed CR, use the
+intentionally-invalid demo manifest:
+
+```bash
+# Roll the controller with strict mode on:
+helm upgrade azureclaw deploy/helm/azureclaw \
+  --reuse-values --set controller.byoStrict=true
+kubectl rollout status deploy/azureclaw-controller -n azureclaw-system
+
+# Apply a CR with a bogus contractVersion:
+kubectl apply -f k8s/clawsandbox-strict-demo.yaml
+
+# Confirm the controller refused:
+kubectl get clawsandbox byo-strict-demo -n azureclaw-system \
+  -o jsonpath='{.status.conditions}' | jq
+# Expect: type=Degraded, status=True, reason=BYOContractInvalid
+
+# No Deployment / Service / NetworkPolicy should exist:
+kubectl get all -n azureclaw-byo-strict-demo 2>/dev/null || echo "namespace empty (as expected)"
+
+# Tear down:
+kubectl delete -f k8s/clawsandbox-strict-demo.yaml
+```
+
+See [`docs/operations/byo-strict.md`](../../docs/operations/byo-strict.md)
+for the full list of CR-level checks and the Phase 4 roadmap for
+registry-side label introspection.

--- a/examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml
+++ b/examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml
@@ -1,0 +1,51 @@
+# Strict-mode demo: this CR is INTENTIONALLY invalid.
+#
+# When the controller is rolled out with `controller.byoStrict=true`,
+# applying this manifest must NOT produce a half-rendered Deployment.
+# Instead the ClawSandbox is stamped:
+#
+#   status.conditions:
+#     - type: Degraded
+#       status: "True"
+#       reason: BYOContractInvalid
+#       message: "byo.contractVersion=`v999` is not in the supported set ..."
+#
+# Use this to verify strict-mode admission end-to-end before deploying
+# real workloads. With `byoStrict=false` (default) the same manifest is
+# accepted with a `WARN` advisory in controller logs — strict mode is
+# what gives the rejection teeth.
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: byo-strict-demo
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: byo-strict-demo
+spec:
+  appliesTo:
+    sandboxName: byo-strict-demo
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  tokenBudget:
+    perRequestMax: 4000
+    perDayMax: 200000
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: byo-strict-demo
+  namespace: azureclaw-system
+spec:
+  runtime:
+    kind: BYO
+    byo:
+      # Intentionally bogus contract version. Strict mode rejects.
+      image: ghcr.io/example/byo-quickstart:v1
+      contractVersion: v999
+  sandbox:
+    isolation: standard
+  inferenceRef:
+    name: byo-strict-demo

--- a/mesh-plugin/src/index.ts
+++ b/mesh-plugin/src/index.ts
@@ -420,15 +420,19 @@ export function definePluginEntry() {
         name: "mesh_inbox",
         description:
           "Read messages received via the E2E encrypted AGT mesh. ALWAYS call " +
-          "this tool when the user asks about inbox, replies, or peer messages — " +
-          "do NOT rely on what you remember from earlier turns, because new " +
-          "messages may have arrived since then. Default behaviour is *peek-only* " +
-          "and shows only entries you haven't read yet; messages stay in the " +
-          "inbox so you can re-read them. Pass mark_read=true once you have " +
-          "acted on the contents to flag them as seen, or unread_only=false to " +
-          "also see entries from previous turns. The response includes a " +
-          "`diagnostics` block with lifecycle counters so you can tell apart " +
-          "'never received' from 'already consumed by an offload waiter'.",
+          "this tool FIRST whenever your task description says a peer agent " +
+          "has sent you data, output, or a reply — peer messages always " +
+          "arrive before you process them, so checking the inbox is your " +
+          "default opening move whenever you're told to consume something " +
+          "from another agent. Do NOT rely on what you remember from earlier " +
+          "turns, because new messages may have arrived since then. Default " +
+          "behaviour is *peek-only* and shows only entries you haven't read " +
+          "yet; messages stay in the inbox so you can re-read them. Pass " +
+          "mark_read=true once you have acted on the contents to flag them " +
+          "as seen, or unread_only=false to also see entries from previous " +
+          "turns. The response includes a `diagnostics` block with lifecycle " +
+          "counters so you can tell apart 'never received' from 'already " +
+          "consumed by an offload waiter'.",
         parameters: {
           type: "object",
           properties: {

--- a/runtimes/openclaw/src/core/agt-tools/agt.ts
+++ b/runtimes/openclaw/src/core/agt-tools/agt.ts
@@ -680,16 +680,21 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
     name: "azureclaw_mesh_inbox",
     label: "Check Mesh Inbox",
     description:
-      "Read messages received via the E2E encrypted AGT mesh inbox. ALWAYS call " +
-      "this tool whenever you need to know whether a peer has sent you anything — " +
-      "do NOT rely on what you remember from previous turns, because new messages " +
-      "may have arrived since then. By default the tool is *peek-only* and shows " +
-      "only unread entries; messages stay in the inbox so you can read them again. " +
-      "Pass mark_read=true once you have acted on the contents to flag them as " +
-      "seen, or unread_only=false to also show entries you have already read on " +
-      "earlier turns. The response includes a `diagnostics` block with the " +
-      "gateway instance id and counters so you can tell apart 'no message has " +
-      "ever arrived' from 'I already consumed the message earlier'.",
+      "Read messages received via the E2E encrypted AGT mesh inbox. ALWAYS " +
+      "call this tool FIRST whenever your task description says a peer agent " +
+      "has sent you data, output, or a reply — peer messages always arrive " +
+      "before you process them, so checking the inbox is your default opening " +
+      "move whenever you're told to consume something from another agent. " +
+      "Also call it whenever you need to know whether a peer has sent you " +
+      "anything at all — do NOT rely on what you remember from previous " +
+      "turns, because new messages may have arrived since then. By default " +
+      "the tool is *peek-only* and shows only unread entries; messages stay " +
+      "in the inbox so you can read them again. Pass mark_read=true once you " +
+      "have acted on the contents to flag them as seen, or unread_only=false " +
+      "to also show entries you have already read on earlier turns. The " +
+      "response includes a `diagnostics` block with the gateway instance id " +
+      "and counters so you can tell apart 'no message has ever arrived' from " +
+      "'I already consumed the message earlier'.",
     parameters: {
       type: "object",
       properties: {


### PR DESCRIPTION
## R1 Batch 2 — release readiness fixes

Three small, independent items from the v1.0 release-readiness plan.
All on \`dev\`. Stacked on top of #182 (R1 batch 1).

### 1. \`mesh_inbox\` tool description nudge

Both \`mesh-plugin\` and the OpenClaw \`agt-tools\` plugin now have an
explicit \"ALWAYS call this tool FIRST whenever your task description
says a peer agent has sent you data\" line at the top of \`mesh_inbox\` /
\`azureclaw_mesh_inbox\`.

Without this nudge, models routinely fabricate a fresh response
instead of picking up the parent's KNOCK message, which breaks
inter-agent handoff. Tool semantics unchanged — description only.

### 2. BYO strict-mode reference example

Adds:

- \`examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml\` —
  intentionally-invalid CR with \`contractVersion: v999\`
- New §5 walkthrough in the example README that flips
  \`controller.byoStrict=true\`, applies the demo CR, and observes the
  \`BYOContractInvalid\` Degraded condition.

The strict-mode controller code, 12 unit tests, and full doc at
\`docs/operations/byo-strict.md\` already exist; this PR makes it a
production-deployment recipe a user can copy-paste.

### 3. Stale comment cleanup in \`controller/src/reconciler/runtime.rs\`

The LangGraph dispatch was annotated \"TypeScript flavour is gated as
ShapeInvalid until the TS adapter image ships\" from before #182
landed. Updated to reflect that both Python and TypeScript are now
wired end-to-end.

### Verification

- \`cargo check --package azureclaw-controller\` ✅
- \`cd cli && npx tsc --noEmit\` ✅
- \`cd mesh-plugin && npx tsc --noEmit\` ✅
- No behavioural change to wired runtimes; no new public API.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>