### PR TITLE
release(r1): cross-runtime AgentMesh first-class tool wrappers

### DIFF
--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -375,9 +375,10 @@ pub fn build_runtime_plan(
         }
         RuntimeKind::SemanticKernel => Err(RuntimePlanError::AdapterMissing("SemanticKernel")),
         RuntimeKind::LangGraph => {
-            // Phase H#2: LangGraph Python adapter wired end-to-end.
-            // TypeScript flavour is gated as ShapeInvalid until the
-            // TS adapter image ships (mirrors the MAF .NET strategy).
+            // LangGraph adapters wired end-to-end for both Python
+            // (`runtimes/langgraph/`) and TypeScript / Node 22
+            // (`runtimes/langgraph-ts/`). `plan_langgraph` matches on
+            // `language` and selects the matching image.
             let cfg = runtime.lang_graph.as_ref().expect("validated above");
             plan_langgraph(cfg)
         }

--- a/controller/src/reconciler/runtime.rs
+++ b/controller/src/reconciler/runtime.rs
@@ -685,6 +685,17 @@ mod tests {
         MafLanguage, MicrosoftAgentFrameworkConfig, OciAgentCode, OpenAIAgentsConfig,
         OpenClawConfig, PydanticAiConfig, SemanticKernelConfig,
     };
+    use std::sync::Mutex;
+
+    /// Serialises tests that mutate process-wide image-override env vars
+    /// (e.g. `OPENAI_AGENTS_RUNTIME_IMAGE`). Without this guard, the
+    /// default multi-threaded test harness lets one test's `set_var`
+    /// leak into another test's `*_default_image()` call, producing
+    /// flaky failures of the shape:
+    ///   left: "myacr.azurecr.io/openai-agents:pinned"
+    ///   right: "azureclawacr.azurecr.io/azureclaw-runtime-openai-agents:latest"
+    /// All env-mutating tests in this module take the lock at the top.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn rt_openclaw(image: Option<&str>) -> RuntimeSpec {
         RuntimeSpec {
@@ -913,6 +924,7 @@ mod tests {
 
     #[test]
     fn anthropic_default_image_falls_back_when_env_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // SAFETY: this test does not run in parallel with env writers
         // (no other test sets ANTHROPIC_RUNTIME_IMAGE).
         unsafe {
@@ -999,6 +1011,7 @@ mod tests {
 
     #[test]
     fn langgraph_default_image_falls_back_when_env_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("LANGGRAPH_RUNTIME_IMAGE");
         }
@@ -1039,6 +1052,7 @@ mod tests {
 
     #[test]
     fn plan_langgraph_typescript_dispatches_to_ts_image() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("LANGGRAPH_TS_RUNTIME_IMAGE");
         }
@@ -1095,6 +1109,7 @@ mod tests {
 
     #[test]
     fn pydantic_ai_default_image_falls_back_when_env_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("PYDANTIC_AI_RUNTIME_IMAGE");
         }
@@ -1281,6 +1296,7 @@ mod tests {
 
     #[test]
     fn plan_openai_agents_uses_default_adapter_image_when_env_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // Defensive: clear the env var so the test isn't influenced by
         // an operator-side override leaking from the dev shell.
         // SAFETY: serial-test is not on this crate; tests in the same
@@ -1308,6 +1324,7 @@ mod tests {
 
     #[test]
     fn plan_openai_agents_passes_through_python_version_and_extra_env() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
         }
@@ -1333,6 +1350,7 @@ mod tests {
 
     #[test]
     fn plan_openai_agents_user_extra_env_overrides_python_version_key_when_explicitly_set() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // Defensive: if a user explicitly puts RUNTIME_PYTHON_VERSION in
         // extra_env, their value wins over the producer's
         // python_version-derived default. The merge order
@@ -1359,6 +1377,7 @@ mod tests {
 
     #[test]
     fn plan_openai_agents_carries_user_entrypoint_into_command() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
         }
@@ -1381,6 +1400,7 @@ mod tests {
 
     #[test]
     fn plan_openai_agents_propagates_agent_code() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
         }
@@ -1403,6 +1423,7 @@ mod tests {
 
     #[test]
     fn openai_agents_default_image_honours_env_override() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::set_var(
                 "OPENAI_AGENTS_RUNTIME_IMAGE",
@@ -1420,6 +1441,7 @@ mod tests {
 
     #[test]
     fn openai_agents_default_image_treats_blank_env_as_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::set_var("OPENAI_AGENTS_RUNTIME_IMAGE", "   ");
         }
@@ -1432,6 +1454,7 @@ mod tests {
 
     #[test]
     fn build_runtime_plan_dispatches_openai_agents_to_producer() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("OPENAI_AGENTS_RUNTIME_IMAGE");
         }
@@ -1460,6 +1483,7 @@ mod tests {
 
     #[test]
     fn plan_maf_uses_default_python_image_when_env_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("MAF_RUNTIME_IMAGE");
         }
@@ -1482,6 +1506,7 @@ mod tests {
 
     #[test]
     fn plan_maf_explicit_python_language_succeeds() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("MAF_RUNTIME_IMAGE");
         }
@@ -1495,6 +1520,7 @@ mod tests {
 
     #[test]
     fn plan_maf_default_language_is_python() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("MAF_RUNTIME_IMAGE");
         }
@@ -1511,6 +1537,7 @@ mod tests {
 
     #[test]
     fn plan_maf_passes_entrypoint_and_extra_env() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("MAF_RUNTIME_IMAGE");
         }
@@ -1548,6 +1575,7 @@ mod tests {
 
     #[test]
     fn plan_maf_user_extra_env_overrides_controller_default() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("MAF_RUNTIME_IMAGE");
         }
@@ -1574,6 +1602,7 @@ mod tests {
 
     #[test]
     fn maf_python_default_image_honours_env_override() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::set_var("MAF_RUNTIME_IMAGE", "myacr.azurecr.io/maf-python:pinned");
         }
@@ -1587,6 +1616,7 @@ mod tests {
 
     #[test]
     fn maf_python_default_image_treats_blank_env_as_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::set_var("MAF_RUNTIME_IMAGE", "  ");
         }
@@ -1599,6 +1629,7 @@ mod tests {
 
     #[test]
     fn build_runtime_plan_dispatches_maf_python_to_producer() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         unsafe {
             std::env::remove_var("MAF_RUNTIME_IMAGE");
         }

--- a/examples/byo-quickstart/README.md
+++ b/examples/byo-quickstart/README.md
@@ -76,3 +76,36 @@ Tear down with:
 ```bash
 kubectl delete clawsandbox byo-quickstart
 ```
+
+## 5. Verify strict-mode admission (recommended for production)
+
+The example above runs cleanly under either `byoStrict=false` (default
+— Phase 2 behaviour, advisory warnings only) or `byoStrict=true`
+(Phase 3 — rejection at admission time). For production we recommend
+the latter. To see strict mode actually reject a malformed CR, use the
+intentionally-invalid demo manifest:
+
+```bash
+# Roll the controller with strict mode on:
+helm upgrade azureclaw deploy/helm/azureclaw \
+  --reuse-values --set controller.byoStrict=true
+kubectl rollout status deploy/azureclaw-controller -n azureclaw-system
+
+# Apply a CR with a bogus contractVersion:
+kubectl apply -f k8s/clawsandbox-strict-demo.yaml
+
+# Confirm the controller refused:
+kubectl get clawsandbox byo-strict-demo -n azureclaw-system \
+  -o jsonpath='{.status.conditions}' | jq
+# Expect: type=Degraded, status=True, reason=BYOContractInvalid
+
+# No Deployment / Service / NetworkPolicy should exist:
+kubectl get all -n azureclaw-byo-strict-demo 2>/dev/null || echo "namespace empty (as expected)"
+
+# Tear down:
+kubectl delete -f k8s/clawsandbox-strict-demo.yaml
+```
+
+See [`docs/operations/byo-strict.md`](../../docs/operations/byo-strict.md)
+for the full list of CR-level checks and the Phase 4 roadmap for
+registry-side label introspection.

--- a/examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml
+++ b/examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml
@@ -1,0 +1,51 @@
+# Strict-mode demo: this CR is INTENTIONALLY invalid.
+#
+# When the controller is rolled out with `controller.byoStrict=true`,
+# applying this manifest must NOT produce a half-rendered Deployment.
+# Instead the ClawSandbox is stamped:
+#
+#   status.conditions:
+#     - type: Degraded
+#       status: "True"
+#       reason: BYOContractInvalid
+#       message: "byo.contractVersion=`v999` is not in the supported set ..."
+#
+# Use this to verify strict-mode admission end-to-end before deploying
+# real workloads. With `byoStrict=false` (default) the same manifest is
+# accepted with a `WARN` advisory in controller logs — strict mode is
+# what gives the rejection teeth.
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: InferencePolicy
+metadata:
+  name: byo-strict-demo
+  namespace: azureclaw-system
+  labels:
+    azureclaw.azure.com/sandbox: byo-strict-demo
+spec:
+  appliesTo:
+    sandboxName: byo-strict-demo
+  modelPreference:
+    primary:
+      provider: azure-openai
+      deployment: gpt-4.1
+  tokenBudget:
+    perRequestMax: 4000
+    perDayMax: 200000
+---
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawSandbox
+metadata:
+  name: byo-strict-demo
+  namespace: azureclaw-system
+spec:
+  runtime:
+    kind: BYO
+    byo:
+      # Intentionally bogus contract version. Strict mode rejects.
+      image: ghcr.io/example/byo-quickstart:v1
+      contractVersion: v999
+  sandbox:
+    isolation: standard
+  inferenceRef:
+    name: byo-strict-demo

--- a/mesh-plugin/src/index.ts
+++ b/mesh-plugin/src/index.ts
@@ -420,15 +420,19 @@ export function definePluginEntry() {
         name: "mesh_inbox",
         description:
           "Read messages received via the E2E encrypted AGT mesh. ALWAYS call " +
-          "this tool when the user asks about inbox, replies, or peer messages — " +
-          "do NOT rely on what you remember from earlier turns, because new " +
-          "messages may have arrived since then. Default behaviour is *peek-only* " +
-          "and shows only entries you haven't read yet; messages stay in the " +
-          "inbox so you can re-read them. Pass mark_read=true once you have " +
-          "acted on the contents to flag them as seen, or unread_only=false to " +
-          "also see entries from previous turns. The response includes a " +
-          "`diagnostics` block with lifecycle counters so you can tell apart " +
-          "'never received' from 'already consumed by an offload waiter'.",
+          "this tool FIRST whenever your task description says a peer agent " +
+          "has sent you data, output, or a reply — peer messages always " +
+          "arrive before you process them, so checking the inbox is your " +
+          "default opening move whenever you're told to consume something " +
+          "from another agent. Do NOT rely on what you remember from earlier " +
+          "turns, because new messages may have arrived since then. Default " +
+          "behaviour is *peek-only* and shows only entries you haven't read " +
+          "yet; messages stay in the inbox so you can re-read them. Pass " +
+          "mark_read=true once you have acted on the contents to flag them " +
+          "as seen, or unread_only=false to also see entries from previous " +
+          "turns. The response includes a `diagnostics` block with lifecycle " +
+          "counters so you can tell apart 'never received' from 'already " +
+          "consumed by an offload waiter'.",
         parameters: {
           type: "object",
           properties: {

--- a/runtimes/anthropic/src/azureclaw_runtime_anthropic/__init__.py
+++ b/runtimes/anthropic/src/azureclaw_runtime_anthropic/__init__.py
@@ -23,6 +23,7 @@ from azureclaw_runtime_anthropic.mesh import (
     receive_messages,
     send_message,
 )
+from azureclaw_runtime_anthropic.mesh_tools import build_mesh_tools
 from azureclaw_runtime_anthropic.otel import init_telemetry
 from azureclaw_runtime_anthropic.runtime import bootstrap
 
@@ -35,6 +36,7 @@ __all__ = [
     "PLATFORM_MCP_URL",
     "__version__",
     "bootstrap",
+    "build_mesh_tools",
     "get_token",
     "init_telemetry",
     "receive_messages",

--- a/runtimes/anthropic/src/azureclaw_runtime_anthropic/mesh_tools.py
+++ b/runtimes/anthropic/src/azureclaw_runtime_anthropic/mesh_tools.py
@@ -1,0 +1,73 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+First-class AgentMesh tools for the Anthropic Claude Agent SDK.
+
+Wraps :mod:`mesh` as ``claude_agent_sdk.tool``-decorated callables. See
+``runtimes/openai-agents/.../mesh_tools.py`` for the rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List
+
+from azureclaw_runtime_anthropic.mesh import receive_messages, send_message
+
+logger = logging.getLogger(__name__)
+
+
+_MESH_INBOX_DESCRIPTION = (
+    "Drain pending AgentMesh messages addressed to this agent. "
+    "ALWAYS call this tool FIRST whenever your task description says a "
+    "peer agent has sent you data, when you were just resumed after a "
+    "handoff, or when you suspect a parent agent is waiting for a reply. "
+    "Returns a JSON array of message envelopes; an empty array means no "
+    "pending messages. Calling this is cheap and idempotent — when in "
+    "doubt, call it."
+)
+
+_MESH_SEND_DESCRIPTION = (
+    "Send an AgentMesh A2A TaskEnvelope to a peer agent identified by "
+    "their DID (e.g. ``did:mesh:<name>``). Use this to delegate work to a "
+    "sub-agent or reply to a parent agent. Returns the relay's "
+    "acknowledgement."
+)
+
+
+def build_mesh_tools() -> List[Any]:
+    """Return ``claude_agent_sdk`` tool definitions."""
+    from claude_agent_sdk import tool  # type: ignore
+
+    @tool(
+        name="mesh_inbox",
+        description=_MESH_INBOX_DESCRIPTION,
+        input_schema={"type": "object", "properties": {}, "required": []},
+    )
+    async def mesh_inbox(_args: dict) -> dict:
+        msgs = receive_messages()
+        return {"content": [{"type": "text", "text": json.dumps(msgs)}]}
+
+    @tool(
+        name="mesh_send",
+        description=_MESH_SEND_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "target_agent": {"type": "string"},
+                "content": {"type": "string"},
+                "skill_id": {"type": "string", "default": "chat"},
+            },
+            "required": ["target_agent", "content"],
+        },
+    )
+    async def mesh_send(args: dict) -> dict:
+        ack = send_message(
+            args["target_agent"],
+            args["content"],
+            skill_id=args.get("skill_id", "chat"),
+        )
+        return {"content": [{"type": "text", "text": json.dumps(ack)}]}
+
+    return [mesh_inbox, mesh_send]

--- a/runtimes/langgraph/src/azureclaw_runtime_langgraph/__init__.py
+++ b/runtimes/langgraph/src/azureclaw_runtime_langgraph/__init__.py
@@ -22,6 +22,7 @@ from azureclaw_runtime_langgraph.mesh import (
     receive_messages,
     send_message,
 )
+from azureclaw_runtime_langgraph.mesh_tools import build_mesh_tools
 from azureclaw_runtime_langgraph.otel import init_telemetry
 from azureclaw_runtime_langgraph.runtime import bootstrap
 
@@ -34,6 +35,7 @@ __all__ = [
     "PLATFORM_MCP_URL",
     "__version__",
     "bootstrap",
+    "build_mesh_tools",
     "get_token",
     "init_telemetry",
     "receive_messages",

--- a/runtimes/langgraph/src/azureclaw_runtime_langgraph/mesh_tools.py
+++ b/runtimes/langgraph/src/azureclaw_runtime_langgraph/mesh_tools.py
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+First-class AgentMesh tools for LangGraph / LangChain.
+
+Wraps :mod:`mesh` as ``langchain_core.tools.tool``-decorated callables
+that LangGraph nodes can register via the standard ``ToolNode`` flow.
+See ``runtimes/openai-agents/.../mesh_tools.py`` for the rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List
+
+from azureclaw_runtime_langgraph.mesh import receive_messages, send_message
+
+logger = logging.getLogger(__name__)
+
+
+_MESH_INBOX_DESCRIPTION = (
+    "Drain pending AgentMesh messages addressed to this agent. "
+    "ALWAYS call this tool FIRST whenever your task description says a "
+    "peer agent has sent you data, when you were just resumed after a "
+    "handoff, or when you suspect a parent agent is waiting for a reply. "
+    "Returns a JSON array of message envelopes; an empty array means no "
+    "pending messages. Calling this is cheap and idempotent — when in "
+    "doubt, call it."
+)
+
+_MESH_SEND_DESCRIPTION = (
+    "Send an AgentMesh A2A TaskEnvelope to a peer agent identified by "
+    "their DID (e.g. ``did:mesh:<name>``). Use this to delegate work to a "
+    "sub-agent or reply to a parent agent. Returns the relay's "
+    "acknowledgement."
+)
+
+
+def build_mesh_tools() -> List[Any]:
+    """Return ``langchain_core.tools.tool``-decorated callables."""
+    from langchain_core.tools import tool  # type: ignore
+
+    @tool("mesh_inbox", description=_MESH_INBOX_DESCRIPTION)
+    def mesh_inbox() -> str:
+        """Drain pending AgentMesh messages."""
+        msgs = receive_messages()
+        return json.dumps(msgs)
+
+    @tool("mesh_send", description=_MESH_SEND_DESCRIPTION)
+    def mesh_send(target_agent: str, content: str, skill_id: str = "chat") -> str:
+        """Send a message to a peer agent."""
+        ack = send_message(target_agent, content, skill_id=skill_id)
+        return json.dumps(ack)
+
+    return [mesh_inbox, mesh_send]

--- a/runtimes/maf-python/src/azureclaw_runtime_maf_python/__init__.py
+++ b/runtimes/maf-python/src/azureclaw_runtime_maf_python/__init__.py
@@ -15,6 +15,10 @@ from azureclaw_runtime_maf_python.mesh import (
 )
 from azureclaw_runtime_maf_python.otel import init_telemetry
 from azureclaw_runtime_maf_python.runtime import bootstrap
+from azureclaw_runtime_maf_python.mesh_tools import (
+    build_mesh_tools,
+    register_mesh_tools,
+)
 from azureclaw_runtime_maf_python.tools import (
     FOUNDRY_TOOL_NAMES,
     register_foundry_tools,
@@ -27,9 +31,11 @@ __all__ = [
     "MeshClient",
     "__version__",
     "bootstrap",
+    "build_mesh_tools",
     "get_token",
     "init_telemetry",
     "receive_messages",
     "register_foundry_tools",
+    "register_mesh_tools",
     "send_message",
 ]

--- a/runtimes/maf-python/src/azureclaw_runtime_maf_python/mesh_tools.py
+++ b/runtimes/maf-python/src/azureclaw_runtime_maf_python/mesh_tools.py
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+First-class AgentMesh tools for the Microsoft Agent Framework Python SDK.
+
+Wraps :mod:`mesh` as ``agent_framework.ai_function``-decorated callables
+so MAF agents pick them up automatically. See
+``runtimes/openai-agents/.../mesh_tools.py`` for the design rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List
+
+from azureclaw_runtime_maf_python.mesh import receive_messages, send_message
+
+logger = logging.getLogger(__name__)
+
+
+_MESH_INBOX_DESCRIPTION = (
+    "Drain pending AgentMesh messages addressed to this agent. "
+    "ALWAYS call this tool FIRST whenever your task description says a "
+    "peer agent has sent you data, when you were just resumed after a "
+    "handoff, or when you suspect a parent agent is waiting for a reply. "
+    "Returns a JSON array of message envelopes; an empty array means no "
+    "pending messages. Calling this is cheap and idempotent — when in "
+    "doubt, call it."
+)
+
+_MESH_SEND_DESCRIPTION = (
+    "Send an AgentMesh A2A TaskEnvelope to a peer agent identified by "
+    "their DID (e.g. ``did:mesh:<name>``). Use this to delegate work to a "
+    "sub-agent or reply to a parent agent. Returns the relay's "
+    "acknowledgement."
+)
+
+
+def build_mesh_tools() -> List[Any]:
+    """Return ``ai_function``-decorated callables for the mesh tools."""
+    from agent_framework import ai_function  # type: ignore
+
+    @ai_function(name="mesh_inbox", description=_MESH_INBOX_DESCRIPTION)
+    async def mesh_inbox() -> str:
+        msgs = receive_messages()
+        return json.dumps(msgs)
+
+    @ai_function(name="mesh_send", description=_MESH_SEND_DESCRIPTION)
+    async def mesh_send(target_agent: str, content: str, skill_id: str = "chat") -> str:
+        ack = send_message(target_agent, content, skill_id=skill_id)
+        return json.dumps(ack)
+
+    mesh_inbox.__azureclaw_tool_name__ = "mesh_inbox"  # type: ignore[attr-defined]
+    mesh_send.__azureclaw_tool_name__ = "mesh_send"  # type: ignore[attr-defined]
+    return [mesh_inbox, mesh_send]
+
+
+def register_mesh_tools(agent: Any) -> None:
+    """Attach mesh tools to *agent*'s ``tools`` list (idempotent)."""
+    if not hasattr(agent, "tools"):
+        raise TypeError(
+            "agent must expose a mutable `tools` list (got "
+            f"{type(agent).__name__})"
+        )
+    existing = set()
+    for tool in agent.tools or []:
+        nm = getattr(tool, "name", None) or getattr(
+            tool, "__azureclaw_tool_name__", None
+        )
+        if nm:
+            existing.add(nm)
+    new = [
+        t
+        for t in build_mesh_tools()
+        if (getattr(t, "name", None) or getattr(t, "__azureclaw_tool_name__", None))
+        not in existing
+    ]
+    if agent.tools is None:
+        agent.tools = []
+    agent.tools = list(agent.tools) + new
+    logger.info("registered %d mesh tools on agent", len(new))

--- a/runtimes/maf-python/tests/test_mesh_tools.py
+++ b/runtimes/maf-python/tests/test_mesh_tools.py
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Smoke tests for the MAF-Python AgentMesh first-class tool wrappers."""
+
+from __future__ import annotations
+
+import pytest
+
+from azureclaw_runtime_maf_python import build_mesh_tools, register_mesh_tools
+
+
+def test_mesh_tools_re_exported_via_package_init():
+    assert callable(build_mesh_tools)
+    assert callable(register_mesh_tools)
+
+
+def test_register_mesh_tools_requires_tools_attr():
+    class Bogus:
+        pass
+
+    with pytest.raises(TypeError):
+        register_mesh_tools(Bogus())
+
+
+def test_build_mesh_tools_returns_two_named_tools():
+    pytest.importorskip("agent_framework")
+    tools = build_mesh_tools()
+    names = [
+        getattr(t, "__azureclaw_tool_name__", None) or getattr(t, "name", None)
+        for t in tools
+    ]
+    assert sorted(n for n in names if n) == ["mesh_inbox", "mesh_send"]

--- a/runtimes/openai-agents/README.md
+++ b/runtimes/openai-agents/README.md
@@ -21,11 +21,15 @@ into the AzureClaw sandbox. It ships inside the
    `a2a_agentmesh` types (`AgentCard`, `TaskEnvelope`, `TrustGate`).
    Sends and receives messages over the router's `/agt/relay` and
    `/agt/registry` reverse-proxy endpoints.
-4. **Foundry tools** (`tools.py`) — registers the 9 platform Foundry
+4. **AgentMesh tools** (`mesh_tools.py`) — registers `mesh_send` and
+   `mesh_inbox` as `function_tool`s on a user-supplied `Agent`. The
+   `mesh_inbox` description includes an explicit "INBOX-FIRST" nudge so
+   models reliably pick up parent messages on resume.
+5. **Foundry tools** (`tools.py`) — registers the 9 platform Foundry
    tools as `function_tool`s on a user-supplied `Agent` instance. Each
    tool fans out to the platform MCP server at `/platform/mcp` over
    streamable-HTTP MCP.
-5. **Router base URL** — sets `OPENAI_BASE_URL` to the local router so
+6. **Router base URL** — sets `OPENAI_BASE_URL` to the local router so
    the vanilla `openai` SDK (used by `openai-agents`) routes everything
    through the AzureClaw governance gate.
 
@@ -37,12 +41,17 @@ already set in the environment it is a no-op.
 ```python
 # main.py — user agent code
 from agents import Agent, Runner
-from azureclaw_runtime_openai_agents import bootstrap, register_foundry_tools
+from azureclaw_runtime_openai_agents import (
+    bootstrap,
+    register_foundry_tools,
+    register_mesh_tools,
+)
 
 bootstrap()  # invoked from entrypoint.sh in production; here for local dev
 
 agent = Agent(name="Researcher", instructions="...")
 register_foundry_tools(agent)
+register_mesh_tools(agent)  # mesh_send + mesh_inbox first-class tools
 
 result = Runner.run_sync(agent, "What is the weather in Seattle?")
 print(result.final_output)

--- a/runtimes/openai-agents/src/azureclaw_runtime_openai_agents/__init__.py
+++ b/runtimes/openai-agents/src/azureclaw_runtime_openai_agents/__init__.py
@@ -20,6 +20,10 @@ from azureclaw_runtime_openai_agents.mesh import (
 )
 from azureclaw_runtime_openai_agents.otel import init_telemetry
 from azureclaw_runtime_openai_agents.runtime import bootstrap
+from azureclaw_runtime_openai_agents.mesh_tools import (
+    build_mesh_tools,
+    register_mesh_tools,
+)
 from azureclaw_runtime_openai_agents.tools import (
     FOUNDRY_TOOL_NAMES,
     register_foundry_tools,
@@ -32,9 +36,11 @@ __all__ = [
     "MeshClient",
     "__version__",
     "bootstrap",
+    "build_mesh_tools",
     "get_token",
     "init_telemetry",
     "receive_messages",
     "register_foundry_tools",
+    "register_mesh_tools",
     "send_message",
 ]

--- a/runtimes/openai-agents/src/azureclaw_runtime_openai_agents/mesh_tools.py
+++ b/runtimes/openai-agents/src/azureclaw_runtime_openai_agents/mesh_tools.py
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+First-class AgentMesh tools for the OpenAI Agents SDK.
+
+The plain :mod:`mesh` module exposes ``send_message`` / ``receive_messages``
+as Python functions so user code can call them directly. This module
+wraps them as ``agents.function_tool`` objects so they become first-class
+tools the agent can pick up automatically — same UX as the Foundry tools
+in :mod:`tools`.
+
+Two tools are registered:
+
+* ``mesh_send(target_agent, content, skill_id)`` — send an A2A
+  ``TaskEnvelope`` to a peer agent via the relay.
+* ``mesh_inbox()`` — drain pending messages for the current sandbox
+  identity. The description includes the explicit "INBOX-FIRST" nudge:
+  models routinely fabricate a fresh response instead of reading the
+  parent's KNOCK message without it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List
+
+from azureclaw_runtime_openai_agents.mesh import receive_messages, send_message
+
+logger = logging.getLogger(__name__)
+
+
+_MESH_INBOX_DESCRIPTION = (
+    "Drain pending AgentMesh messages addressed to this agent. "
+    "ALWAYS call this tool FIRST whenever your task description says a "
+    "peer agent has sent you data, when you were just resumed after a "
+    "handoff, or when you suspect a parent agent is waiting for a reply. "
+    "Returns a JSON array of message envelopes; an empty array means no "
+    "pending messages. Calling this is cheap and idempotent — when in "
+    "doubt, call it."
+)
+
+_MESH_SEND_DESCRIPTION = (
+    "Send an AgentMesh A2A TaskEnvelope to a peer agent identified by "
+    "their DID (e.g. ``did:mesh:<name>``). Use this to delegate work to a "
+    "sub-agent or reply to a parent agent. Returns the relay's "
+    "acknowledgement."
+)
+
+
+def build_mesh_tools() -> List[Any]:
+    """Return ``function_tool`` objects for ``mesh_send`` + ``mesh_inbox``."""
+    from agents import function_tool  # type: ignore
+
+    @function_tool(name_override="mesh_inbox", description_override=_MESH_INBOX_DESCRIPTION)
+    async def mesh_inbox() -> str:
+        """Return pending AgentMesh messages as a JSON string."""
+        msgs = receive_messages()
+        return json.dumps(msgs)
+
+    @function_tool(name_override="mesh_send", description_override=_MESH_SEND_DESCRIPTION)
+    async def mesh_send(target_agent: str, content: str, skill_id: str = "chat") -> str:
+        """Send ``content`` to ``target_agent`` (DID) via the relay."""
+        ack = send_message(target_agent, content, skill_id=skill_id)
+        return json.dumps(ack)
+
+    # Stash the canonical names for introspection.
+    mesh_inbox.__azureclaw_tool_name__ = "mesh_inbox"  # type: ignore[attr-defined]
+    mesh_send.__azureclaw_tool_name__ = "mesh_send"  # type: ignore[attr-defined]
+    return [mesh_inbox, mesh_send]
+
+
+def register_mesh_tools(agent: Any) -> None:
+    """Attach mesh tools to *agent*'s tool list (idempotent per agent)."""
+    if not hasattr(agent, "tools"):
+        raise TypeError(
+            "agent must expose a mutable `tools` list (got "
+            f"{type(agent).__name__})"
+        )
+    existing = set()
+    for tool in agent.tools or []:
+        nm = getattr(tool, "name", None) or getattr(
+            tool, "__azureclaw_tool_name__", None
+        )
+        if nm:
+            existing.add(nm)
+    new = []
+    for tool in build_mesh_tools():
+        nm = getattr(tool, "name", None) or getattr(
+            tool, "__azureclaw_tool_name__", None
+        )
+        if nm in existing:
+            continue
+        new.append(tool)
+    if agent.tools is None:
+        agent.tools = []
+    agent.tools = list(agent.tools) + new
+    logger.info("registered %d mesh tools on agent", len(new))

--- a/runtimes/openai-agents/tests/test_mesh_tools.py
+++ b/runtimes/openai-agents/tests/test_mesh_tools.py
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Smoke tests for the AgentMesh first-class tool wrappers.
+
+These tests import :mod:`mesh_tools` and verify the module is wired
+through the package ``__init__``. Building the actual ``function_tool``
+objects requires the ``agents`` SDK at runtime; the build is exercised
+in the integration test harness and skipped here when the SDK is
+unavailable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from azureclaw_runtime_openai_agents import build_mesh_tools, register_mesh_tools
+
+
+def test_mesh_tools_re_exported_via_package_init():
+    # Re-exports must be present so user code can do
+    # `from azureclaw_runtime_openai_agents import build_mesh_tools`.
+    assert callable(build_mesh_tools)
+    assert callable(register_mesh_tools)
+
+
+def test_register_mesh_tools_requires_tools_attr():
+    class Bogus:
+        pass
+
+    with pytest.raises(TypeError):
+        register_mesh_tools(Bogus())
+
+
+def test_build_mesh_tools_returns_two_named_tools():
+    pytest.importorskip("agents")
+    tools = build_mesh_tools()
+    names = [getattr(t, "__azureclaw_tool_name__", None) for t in tools]
+    assert sorted(names) == ["mesh_inbox", "mesh_send"]
+
+
+def test_register_mesh_tools_idempotent():
+    pytest.importorskip("agents")
+
+    class FakeAgent:
+        def __init__(self):
+            self.tools = []
+
+    agent = FakeAgent()
+    register_mesh_tools(agent)
+    after_first = len(agent.tools)
+    register_mesh_tools(agent)
+    after_second = len(agent.tools)
+    assert after_first == 2
+    assert after_second == 2, "second registration must be a no-op"

--- a/runtimes/openclaw/src/core/agt-tools/agt.ts
+++ b/runtimes/openclaw/src/core/agt-tools/agt.ts
@@ -680,16 +680,21 @@ export function registerAgtTools(api: AnyApi, deps: AgtToolsDeps): void {
     name: "azureclaw_mesh_inbox",
     label: "Check Mesh Inbox",
     description:
-      "Read messages received via the E2E encrypted AGT mesh inbox. ALWAYS call " +
-      "this tool whenever you need to know whether a peer has sent you anything — " +
-      "do NOT rely on what you remember from previous turns, because new messages " +
-      "may have arrived since then. By default the tool is *peek-only* and shows " +
-      "only unread entries; messages stay in the inbox so you can read them again. " +
-      "Pass mark_read=true once you have acted on the contents to flag them as " +
-      "seen, or unread_only=false to also show entries you have already read on " +
-      "earlier turns. The response includes a `diagnostics` block with the " +
-      "gateway instance id and counters so you can tell apart 'no message has " +
-      "ever arrived' from 'I already consumed the message earlier'.",
+      "Read messages received via the E2E encrypted AGT mesh inbox. ALWAYS " +
+      "call this tool FIRST whenever your task description says a peer agent " +
+      "has sent you data, output, or a reply — peer messages always arrive " +
+      "before you process them, so checking the inbox is your default opening " +
+      "move whenever you're told to consume something from another agent. " +
+      "Also call it whenever you need to know whether a peer has sent you " +
+      "anything at all — do NOT rely on what you remember from previous " +
+      "turns, because new messages may have arrived since then. By default " +
+      "the tool is *peek-only* and shows only unread entries; messages stay " +
+      "in the inbox so you can read them again. Pass mark_read=true once you " +
+      "have acted on the contents to flag them as seen, or unread_only=false " +
+      "to also show entries you have already read on earlier turns. The " +
+      "response includes a `diagnostics` block with the gateway instance id " +
+      "and counters so you can tell apart 'no message has ever arrived' from " +
+      "'I already consumed the message earlier'.",
     parameters: {
       type: "object",
       properties: {

--- a/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/__init__.py
+++ b/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/__init__.py
@@ -22,6 +22,7 @@ from azureclaw_runtime_pydantic_ai.mesh import (
     receive_messages,
     send_message,
 )
+from azureclaw_runtime_pydantic_ai.mesh_tools import build_mesh_tools
 from azureclaw_runtime_pydantic_ai.otel import init_telemetry
 from azureclaw_runtime_pydantic_ai.runtime import bootstrap
 
@@ -34,6 +35,7 @@ __all__ = [
     "PLATFORM_MCP_URL",
     "__version__",
     "bootstrap",
+    "build_mesh_tools",
     "get_token",
     "init_telemetry",
     "receive_messages",

--- a/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/mesh_tools.py
+++ b/runtimes/pydantic-ai/src/azureclaw_runtime_pydantic_ai/mesh_tools.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+First-class AgentMesh tools for Pydantic-AI.
+
+Wraps :mod:`mesh` as ``pydantic_ai.Tool`` instances. See
+``runtimes/openai-agents/.../mesh_tools.py`` for the rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List
+
+from azureclaw_runtime_pydantic_ai.mesh import receive_messages, send_message
+
+logger = logging.getLogger(__name__)
+
+
+_MESH_INBOX_DESCRIPTION = (
+    "Drain pending AgentMesh messages addressed to this agent. "
+    "ALWAYS call this tool FIRST whenever your task description says a "
+    "peer agent has sent you data, when you were just resumed after a "
+    "handoff, or when you suspect a parent agent is waiting for a reply. "
+    "Returns a JSON array of message envelopes; an empty array means no "
+    "pending messages. Calling this is cheap and idempotent — when in "
+    "doubt, call it."
+)
+
+_MESH_SEND_DESCRIPTION = (
+    "Send an AgentMesh A2A TaskEnvelope to a peer agent identified by "
+    "their DID (e.g. ``did:mesh:<name>``). Use this to delegate work to a "
+    "sub-agent or reply to a parent agent. Returns the relay's "
+    "acknowledgement."
+)
+
+
+def _mesh_inbox_impl() -> str:
+    """Drain pending AgentMesh messages."""
+    return json.dumps(receive_messages())
+
+
+def _mesh_send_impl(target_agent: str, content: str, skill_id: str = "chat") -> str:
+    """Send a message to a peer agent."""
+    return json.dumps(send_message(target_agent, content, skill_id=skill_id))
+
+
+def build_mesh_tools() -> List[Any]:
+    """Return ``pydantic_ai.Tool`` instances for the mesh tools."""
+    from pydantic_ai import Tool  # type: ignore
+
+    return [
+        Tool(
+            _mesh_inbox_impl,
+            name="mesh_inbox",
+            description=_MESH_INBOX_DESCRIPTION,
+        ),
+        Tool(
+            _mesh_send_impl,
+            name="mesh_send",
+            description=_MESH_SEND_DESCRIPTION,
+        ),
+    ]


### PR DESCRIPTION
## R1 Batch 3 — cross-runtime mesh tool exposure

Stacked on #182 (R1 batch 1) and #183 (R1 batch 2).

Adds a `mesh_tools.py` module to all 5 Python runtime adapters
(openai-agents, maf-python, langgraph, anthropic, pydantic-ai). Each
exposes `build_mesh_tools()` returning native Tool objects of the
runtime's framework. Two tools are registered per runtime:

- `mesh_inbox()` — drains pending AgentMesh messages. Description
  carries the explicit "INBOX-FIRST" nudge (matching the mesh-plugin
  / OpenClaw nudge in #183).
- `mesh_send(target_agent, content, skill_id)` — sends an A2A
  TaskEnvelope to a peer agent.

Framework SDKs are imported lazily inside `build_mesh_tools()` (matches
the existing Foundry-tools pattern in `tools.py`).

### Verification

- AST syntax check on all 10 modified files: ✅
- Existing `test_tools.py` pattern mirrored.
- No behavioural change to wired runtimes; new public API is purely
  additive.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>