### PR TITLE
release(r1): runtime adapter Makefile targets + image-versioning doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,57 @@ fmt: ## Format code
 
 # ─── Container Images ────────────────────────────────────────────────────────
 
-images: image-controller image-router image-sandbox image-relay image-registry ## Build all container images
+images: image-controller image-router image-sandbox image-relay image-registry image-runtimes ## Build all container images
+
+image-runtimes: image-runtime-anthropic image-runtime-langgraph image-runtime-maf-python image-runtime-openai-agents image-runtime-pydantic-ai ## Build all runtime adapter images
+
+image-runtime-anthropic: ## Build Anthropic Claude Agent SDK runtime image
+	docker build --platform linux/amd64 \
+		-t $(REGISTRY)/azureclaw-runtime-anthropic:$(IMAGE_TAG) \
+		-t $(REGISTRY)/azureclaw-runtime-anthropic:latest \
+		--label "org.opencontainers.image.version=$(VERSION)" \
+		--label "org.opencontainers.image.revision=$(GIT_SHA)" \
+		-f sandbox-images/anthropic/Dockerfile .
+
+image-runtime-langgraph: ## Build LangGraph (Python) runtime image
+	docker build --platform linux/amd64 \
+		-t $(REGISTRY)/azureclaw-runtime-langgraph:$(IMAGE_TAG) \
+		-t $(REGISTRY)/azureclaw-runtime-langgraph:latest \
+		--label "org.opencontainers.image.version=$(VERSION)" \
+		--label "org.opencontainers.image.revision=$(GIT_SHA)" \
+		-f sandbox-images/langgraph/Dockerfile .
+
+image-runtime-langgraph-ts: ## Build LangGraph (TypeScript) runtime image
+	docker build --platform linux/amd64 \
+		-t $(REGISTRY)/azureclaw-runtime-langgraph-ts:$(IMAGE_TAG) \
+		-t $(REGISTRY)/azureclaw-runtime-langgraph-ts:latest \
+		--label "org.opencontainers.image.version=$(VERSION)" \
+		--label "org.opencontainers.image.revision=$(GIT_SHA)" \
+		-f sandbox-images/langgraph-ts/Dockerfile .
+
+image-runtime-maf-python: ## Build Microsoft Agent Framework (Python) runtime image
+	docker build --platform linux/amd64 \
+		-t $(REGISTRY)/azureclaw-runtime-maf-python:$(IMAGE_TAG) \
+		-t $(REGISTRY)/azureclaw-runtime-maf-python:latest \
+		--label "org.opencontainers.image.version=$(VERSION)" \
+		--label "org.opencontainers.image.revision=$(GIT_SHA)" \
+		-f sandbox-images/maf-python/Dockerfile .
+
+image-runtime-openai-agents: ## Build OpenAI Agents SDK runtime image
+	docker build --platform linux/amd64 \
+		-t $(REGISTRY)/azureclaw-runtime-openai-agents:$(IMAGE_TAG) \
+		-t $(REGISTRY)/azureclaw-runtime-openai-agents:latest \
+		--label "org.opencontainers.image.version=$(VERSION)" \
+		--label "org.opencontainers.image.revision=$(GIT_SHA)" \
+		-f sandbox-images/openai-agents/Dockerfile .
+
+image-runtime-pydantic-ai: ## Build Pydantic-AI runtime image
+	docker build --platform linux/amd64 \
+		-t $(REGISTRY)/azureclaw-runtime-pydantic-ai:$(IMAGE_TAG) \
+		-t $(REGISTRY)/azureclaw-runtime-pydantic-ai:latest \
+		--label "org.opencontainers.image.version=$(VERSION)" \
+		--label "org.opencontainers.image.revision=$(GIT_SHA)" \
+		-f sandbox-images/pydantic-ai/Dockerfile .
 
 image-controller: ## Build controller Docker image
 	docker build --platform linux/amd64 \
@@ -93,7 +143,7 @@ image-registry: ## Build AgentMesh registry image
 		-t $(REGISTRY)/agentmesh-registry:latest \
 		-f vendor/agentmesh-registry/Dockerfile vendor/agentmesh-registry
 
-push: ## Push all images to ACR
+push: ## Push all images to ACR (controller + router + sandbox-base + sandbox + relay + registry + runtimes)
 	docker push $(REGISTRY)/azureclaw-controller:$(IMAGE_TAG)
 	docker push $(REGISTRY)/azureclaw-controller:latest
 	docker push $(REGISTRY)/azureclaw-inference-router:$(IMAGE_TAG)
@@ -106,6 +156,18 @@ push: ## Push all images to ACR
 	docker push $(REGISTRY)/agentmesh-relay:latest
 	docker push $(REGISTRY)/agentmesh-registry:$(IMAGE_TAG)
 	docker push $(REGISTRY)/agentmesh-registry:latest
+
+push-runtimes: ## Push all runtime adapter images to ACR
+	docker push $(REGISTRY)/azureclaw-runtime-anthropic:$(IMAGE_TAG)
+	docker push $(REGISTRY)/azureclaw-runtime-anthropic:latest
+	docker push $(REGISTRY)/azureclaw-runtime-langgraph:$(IMAGE_TAG)
+	docker push $(REGISTRY)/azureclaw-runtime-langgraph:latest
+	docker push $(REGISTRY)/azureclaw-runtime-maf-python:$(IMAGE_TAG)
+	docker push $(REGISTRY)/azureclaw-runtime-maf-python:latest
+	docker push $(REGISTRY)/azureclaw-runtime-openai-agents:$(IMAGE_TAG)
+	docker push $(REGISTRY)/azureclaw-runtime-openai-agents:latest
+	docker push $(REGISTRY)/azureclaw-runtime-pydantic-ai:$(IMAGE_TAG)
+	docker push $(REGISTRY)/azureclaw-runtime-pydantic-ai:latest
 
 apply: ## Apply Helm chart to AKS (fast upgrade)
 	azureclaw up --upgrade

--- a/docs/operations/image-versioning.md
+++ b/docs/operations/image-versioning.md
@@ -1,0 +1,77 @@
+# Image versioning & release tagging
+
+AzureClaw produces eight container images: the controller, the
+inference router, the sandbox base + slim overlay, the AgentMesh relay
++ registry, and the five runtime adapter images
+(`azureclaw-runtime-{anthropic,langgraph,langgraph-ts,maf-python,openai-agents,pydantic-ai}`).
+
+The build system supports two parallel tag channels for every image:
+
+| Channel | Tag form | Purpose |
+|---|---|---|
+| **Floating** | `:latest` | Track-the-tip channel for development clusters and CI; the controller's image-default constants point here so a `helm upgrade` always picks up the newest sandbox/runtime build. |
+| **Pinned** | `:$(VERSION)-$(GIT_SHA)` | Immutable per-build tag for production rollouts, audit trails, and Cosign signature provenance. `VERSION` is read from `cli/package.json`; `GIT_SHA` is the abbreviated commit hash. |
+
+Both tags are produced by every `make image-*` target. Operators choose
+which channel to follow per environment by setting the corresponding
+override env var on the controller (e.g. `OPENAI_AGENTS_RUNTIME_IMAGE`,
+`LANGGRAPH_RUNTIME_IMAGE`, `LANGGRAPH_TS_RUNTIME_IMAGE`,
+`ANTHROPIC_RUNTIME_IMAGE`, `MAF_RUNTIME_IMAGE`,
+`PYDANTIC_AI_RUNTIME_IMAGE`, `INFERENCE_ROUTER_IMAGE`,
+`SANDBOX_IMAGE`).
+
+## Recommended channels per environment
+
+| Environment | Controller / router | Sandbox / runtimes | Why |
+|---|---|---|---|
+| Local dev / Kind | `:latest` | `:latest` | Fastest iteration. |
+| Shared dev / staging | `:$(VERSION)-$(GIT_SHA)` | `:latest` | Pin the control plane (rare changes); float the data plane (frequent rebuilds). |
+| Production | `:$(VERSION)-$(GIT_SHA)` for everything | same | Immutable rollouts, signature-pinnable, easy rollback. |
+
+## Tagging a release
+
+Releases are cut by bumping `cli/package.json` and pushing a git tag:
+
+```bash
+# 1. Bump version in cli/package.json (e.g. 1.0.0)
+# 2. Commit + push to dev
+# 3. After dev → main merge:
+git tag v1.0.0
+git push origin v1.0.0
+
+# 4. Build + push every image with the pinned tag:
+make images push push-runtimes  # uses VERSION from package.json + GIT_SHA
+```
+
+> **Repo policy:** images are pushed to a **private** ACR. The
+> upstream OSS repo is and stays private. Public mirroring is done via
+> a separate (non-default) workflow that the maintainers run manually.
+
+## Why `:latest` is also kept
+
+- The controller's image-default constants (`controller/src/reconciler/runtime.rs`)
+  fall back to `:latest` when no override env var is set. This is the
+  zero-config developer-experience path — `azureclaw up` against a
+  freshly-built ACR Just Works without the operator computing a SHA.
+- Every Helm chart override (`controller.image.tag` etc.) silently
+  defaults to the chart's own version when omitted; explicit `:latest`
+  via env override is the documented escape hatch.
+- Removing `:latest` would force operators to thread `IMAGE_TAG`
+  through every dev workflow. Not worth it.
+
+## Verifying a deployed image's provenance
+
+```bash
+# Resolve the floating tag to a digest:
+docker buildx imagetools inspect $(REGISTRY)/azureclaw-controller:latest
+
+# Verify the Cosign signature on the digest (keyless OIDC):
+cosign verify $(REGISTRY)/azureclaw-controller@sha256:<digest> \
+  --certificate-identity-regexp '^https://github.com/Azure/azureclaw' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+See [`supply-chain.md`](./supply-chain.md) for the full Cosign /
+SBOM / cargo-deny gates. The Cosign **admission** gate (verify on
+`kubectl apply`) is tracked as a v1.1 deliverable — see `[GAP-V1]
+cosign-admission` in the release plan.


### PR DESCRIPTION
## R1 Batch 4 — image versioning

Stacked on #182, #183, #184. Independent of all of them.

Two changes:

1. **Makefile**: adds image-build targets for the five runtime adapter
   images that weren't covered (`image-runtime-anthropic`,
   `image-runtime-langgraph`, `image-runtime-langgraph-ts` (with #182),
   `image-runtime-maf-python`, `image-runtime-openai-agents`,
   `image-runtime-pydantic-ai`), plus aggregator `image-runtimes` and
   `push-runtimes`. Each gets the same dual-tag treatment (`:$(IMAGE_TAG)`
   for immutable pin + `:latest` for floating channel) as the rest.

2. **`docs/operations/image-versioning.md`**: documents the dual-tag
   policy, recommended per-environment channels, release-tagging flow,
   and Cosign provenance verification.

`make help` smoke test confirms targets are wired:

```
image-runtime-anthropic   Build Anthropic Claude Agent SDK runtime image
image-runtime-langgraph   Build LangGraph (Python) runtime image
image-runtime-langgraph-ts Build LangGraph (TypeScript) runtime image
image-runtime-maf-python  Build Microsoft Agent Framework (Python) runtime image
image-runtime-openai-agents Build OpenAI Agents SDK runtime image
image-runtime-pydantic-ai Build Pydantic-AI runtime image
image-runtimes            Build all runtime adapter images
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>