### PR TITLE
docs(r4+r5): release-readiness docs — STRIDE, AGT boundary, roadmap, BC, runbook, RC1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to AzureClaw will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-rc.1] — Release candidate (release engineering pass)
+
+First release candidate cut for the v1.0.0 line. No new feature surface beyond what shipped in `[Unreleased] — Phase 2`; this entry tracks the release-engineering, documentation, and hygiene work performed on `dev` before promoting to `main`.
+
+### Highlights
+
+- All six first-class agent runtimes shipped and exercised: OpenClaw, OpenAI Agents (Python), Microsoft Agent Framework (Python), Anthropic Claude Agent SDK, LangGraph (Python + TypeScript), Pydantic-AI.
+- BYO runtime path with strict-mode admission gating documented end-to-end.
+- AgentMesh first-class tool wrappers (`mesh_inbox` + `mesh_send`) shipped across all five Python runtime adapters.
+- Documentation tree consolidated: `docs/README.md` index covers getting-started, security, agent capabilities, architecture deep-dives, operations, roadmap, demos, migration.
+
+### Added
+
+- `runtimes/{anthropic,langgraph,maf-python,openai-agents,pydantic-ai}/src/.../mesh_tools.py` — first-class AgentMesh tool wrappers per adapter.
+- `runtimes/langgraph-ts/` — full TypeScript LangGraph adapter (mirrors Python adapter).
+- `sandbox-images/langgraph-ts/` — Dockerfile + entrypoint for the TS adapter.
+- `examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml` — strict-mode demo CR.
+- Makefile targets: per-runtime image build/push (`image-langgraph`, `image-anthropic`, `image-maf-python`, `image-pydantic-ai`, `image-langgraph-ts`) plus aggregators (`image-runtimes`, `push-runtimes`).
+- `docs/operations/image-versioning.md` — tag policy, runtime image overrides, dual-tag immutability rule.
+- `docs/architecture/crd-versioning.md` — `v1alpha1` freeze policy + `v1alpha2` + conversion-webhook plan.
+- `docs/architecture/agt-boundary.md` — responsibility split between AGT and AzureClaw, four provider contracts, outage modes.
+- `docs/operations/secret-rotation.md` — runbook for sandbox credentials, TLS, AgentMesh identities, Azure creds, cosign keys.
+- `docs/security/stride.md` — STRIDE × trust-boundary matrix (T1–T4).
+- `docs/security/red-team.md` — internal red-team findings log.
+- `docs/api/backwards-compatibility.md` — SemVer commitment for CRD / CLI / Helm / router routes.
+- `docs/roadmap.md` — v1.0 / v1.1 / v1.2 / backlog.
+- INBOX-FIRST nudge in `mesh_inbox` tool description (mesh-plugin and OpenClaw agt-tools).
+
+### Changed
+
+- `docs/README.md` rewritten as the canonical index for the public-facing tree.
+- `CRD `ClawSandbox.spec.runtime.maf.language` enum narrowed: `Dotnet` removed (no `AgentMeshClient` in `Microsoft.AgentGovernance` 3.3.0). `[GAP-V1]` recorded.
+
+### Fixed
+
+- `controller/src/reconciler/runtime.rs` — env-var-mutating tests now serialise on a module-local `ENV_LOCK: Mutex<()>` so the multi-threaded harness no longer races across `*_RUNTIME_IMAGE` overrides. Closes a flaky-test failure that bit early CI passes (e.g. PR #184 first run).
+
+### Internal / docs
+
+- `docs/backlog.md`, `docs/phase-0-1-capabilities.md`, `docs/security-reviewers.md` moved to `docs/internal/`. Stale link in `README.md` to a gitignored `implementation-plan.md` removed; lingering reference in `docs/security.md` reworded.
+
+### `[GAP-V1]` markers (accepted for v1.0)
+
+- Cosign-on-admission gating (read surface shipped; admission enforcement is v1.1).
+- TrustGraph live updates (projection captured at sandbox creation; v1.1).
+- Microsoft Agent Framework **.NET** adapter (returns when AGT lands `AgentMeshClient` for .NET).
+
+---
+
 ## [Unreleased] — Phase 2
 
 ### S17 `phase2-cncf-conformance` — K8s AI conformance + permanent supply-chain rows

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,11 +14,14 @@
 
 - [Security Model](security.md) — Defense-in-depth (infra + AGT governance + E2E mesh + protocol-layer controls)
 - [Threat Model — Routes](threat-model.md) — Per-route auth tier, input validation, blast-radius
+- [STRIDE Threat Model](security/stride.md) — Per-trust-boundary STRIDE matrix
+- [AGT Boundary](architecture/agt-boundary.md) — What AzureClaw consumes vs builds, four provider contracts
 - [AGT Vendored-Patch Audit](agt-vendored-patch-audit.md) — Vendored AgentMesh fixes pending AGT mesh shipping
 - [`sigs/agent-sandbox` Compat](sigs-agent-sandbox-compat.md) — Optional Translate / Overlay mode design
 - [OWASP MCP Top 10 (2025)](security-mcp-top10.md) — Controls matrix for the new MCP 2026 surface
 - [ADR-0001 — A2A ingress front-edge](adr/0001-a2a-ingress-front-edge.md) — Gateway-only, surgical opt-in
 - [Security Audits](security-audits/) — Per-capability audit docs (Phase 0 + Phase 1 + Phase 2)
+- [Red-Team Findings Log](security/red-team.md) — Internal adversarial-test history
 - [Network Egress & Proxy](egress-proxy.md) — Blocklist, allowlist, approval flow, learn mode
 - [E2E Encryption Proof](e2e-encryption-proof.md) — Signal Protocol inter-agent messaging with traffic capture evidence
 - [Security Validation](security-validation.md) — Live cluster evidence for every security layer
@@ -34,7 +37,9 @@
 ## Architecture deep-dives
 
 - [A2A Gateway](architecture/a2a-gateway.md) — Front-edge gateway design and component split
+- [AGT Boundary](architecture/agt-boundary.md) — Responsibility split, provider contracts, outage modes
 - [CRD Versioning Policy](architecture/crd-versioning.md) — `v1alpha1` freeze + `v1alpha2` + conversion-webhook plan
+- [Backwards-Compatibility Commitment](api/backwards-compatibility.md) — SemVer surface, deprecation policy
 
 ## Operations
 
@@ -46,7 +51,12 @@
 - [Supply Chain](operations/supply-chain.md) — Cosign, SBOM, attestations
 - [GitOps](operations/gitops.md) — Reconciler in a GitOps fleet
 - [Image Versioning](operations/image-versioning.md) — Tag policy and runtime image overrides
+- [Secret Rotation Runbook](operations/secret-rotation.md) — Per-sandbox creds, TLS, AgentMesh identity, Azure
 - [Chaos Tier](operations/chaos-tier.md) — Fault-injection test surface
+
+## Roadmap
+
+- [Roadmap](roadmap.md) — v1.0 capabilities, v1.1 targets, v1.2 directions, backlog
 
 ## Demos & Examples
 

--- a/docs/api/backwards-compatibility.md
+++ b/docs/api/backwards-compatibility.md
@@ -1,0 +1,83 @@
+# Backwards-Compatibility Commitment
+
+## Versioning model
+
+AzureClaw follows [Semantic Versioning 2.0.0](https://semver.org/) on the **public CLI + CRD surface**. Internal Rust crate versions track the workspace version but are not a stable Cargo dependency.
+
+| Surface | Stable from | Compatibility window |
+|---|---|---|
+| `ClawSandbox` CRD | `v1.0.0` (schema `apiextensions.k8s.io/v1alpha1`) | `v1alpha1` is **frozen** for the entire `1.x` line — see [`architecture/crd-versioning.md`](../architecture/crd-versioning.md) |
+| `azureclaw` CLI commands & flags | `v1.0.0` | Two minor versions of deprecation before removal |
+| Helm chart values keys | `v1.0.0` | Two minor versions of deprecation before removal |
+| Inference router HTTP routes (north + east-west) | `v1.0.0` | Major bump for breaking change |
+| Inference router internal sandbox seam (`127.0.0.1:8443`) | Internal | May change in any release |
+| Provider trait shapes (`MeshProvider`, `PolicyDecisionProvider`, `AuditSink`, `SigningProvider`) | Internal | May change in any release |
+| Vendored AgentMesh on-the-wire format | Internal | Locked to vendored relay/registry version; bumps require re-roll |
+
+## What "stable" means
+
+For each stable surface:
+
+- **No silent breaking change.** Removal of a flag, value key, route, or CRD field requires:
+  1. A `[DEPRECATED]` notice in `CHANGELOG.md` and the relevant doc.
+  2. Two minor releases where the old surface keeps working (with a runtime warning).
+  3. Removal in the next major release, called out in the release-notes "Breaking changes" section.
+- **Additive change is allowed in minor releases.** New CLI subcommands, new CRD optional fields, new Helm values keys, new router routes.
+- **Bug-fix changes** in patch releases preserve the contract — even if the old behaviour was wrong by the spec, we keep it bug-compatible until the next minor unless the old behaviour is a security flaw.
+
+## Security exceptions
+
+The compatibility window is **explicitly waived** when the change closes:
+
+- A confirmed CVE in AzureClaw or any directly vendored component.
+- A privilege-escalation path inside the sandbox boundary.
+- A token / key disclosure path.
+
+Such changes ship in a patch release with a `SECURITY` line in the release notes.
+
+## CRD migration policy
+
+See [`architecture/crd-versioning.md`](../architecture/crd-versioning.md) for the full v1 policy. Highlights:
+
+- `v1alpha1` is the only served version for the entire `1.x` line.
+- `v1alpha2` lands in a v1.1+ release alongside a conversion webhook that converts both directions.
+- We never delete fields from `v1alpha1`; deprecated fields become no-ops with a controller log line.
+
+## CLI migration policy
+
+When a flag is renamed:
+
+- The old flag continues to work and prints a `[DEPRECATED]` line on stderr.
+- The flag stays for ≥ 2 minor versions.
+- Help text shows both forms during the deprecation window.
+
+When a subcommand is renamed:
+
+- The old subcommand becomes a thin alias and prints a `[DEPRECATED]` line.
+- Same ≥ 2 minor-version window.
+
+## Helm values migration policy
+
+When a values key is renamed:
+
+- `values.yaml` documents both forms during the deprecation window.
+- The chart `_helpers.tpl` uses `coalesce` to honour both keys.
+- The chart `NOTES.txt` prints a deprecation warning when the old key is set.
+
+## Release-notes template
+
+Every release includes the standard sections (see [`r5-changelog`](../../CHANGELOG.md) for the canonical list):
+
+- Highlights
+- Added (additive surface changes)
+- Changed (compatible behaviour changes)
+- Fixed (bug fixes)
+- **Deprecated** (with target removal version)
+- **Breaking changes** (only in major releases) — empty for `1.x.y` releases
+- Security
+- Internal (refactors, test churn — informational only)
+
+## Forward-looking notes
+
+- A CRD `v1alpha2` is planned for v1.1 (additive only). The conversion webhook ships at the same time. Existing `v1alpha1` clients keep working without change.
+- The provider-trait surface is internal and *will* change between minor versions. External consumers should integrate at the CRD or CLI level, not the trait level.

--- a/docs/architecture/agt-boundary.md
+++ b/docs/architecture/agt-boundary.md
@@ -1,0 +1,77 @@
+# AGT Boundary — what AzureClaw consumes vs. what AzureClaw builds
+
+> Defines the operational seam between [Microsoft AGT](https://github.com/microsoft/agent-governance-toolkit) and AzureClaw: what AzureClaw imports, what it builds in-tree, and the four provider contracts that keep them aligned.
+
+AGT ships the governance engine. AzureClaw is the AKS operator and data plane that feeds AGT and surfaces AGT decisions as Kubernetes primitives. Any overlap is treated as a bug to resolve, not a feature to negotiate.
+
+---
+
+## 1. Responsibility split
+
+### AGT owns
+
+- **Policy evaluation** — `PolicyEngine.decide(request) -> verdict`. Policy-profile schema is AGT's. We emit profiles from CRDs; we do not redefine the schema.
+- **Signal Protocol primitives** — X3DH key exchange, Double Ratchet, prekey lifecycle, session state machine.
+- **Audit Merkle chain** — `AuditLogger.append(event) -> ReceiptId`. Storage, retention SLA, signing of tree roots, queryability API.
+- **Trust scoring** — `TrustManager`. Per-peer trust scores, transitive evaluation, decay functions, negative-signal ingestion.
+- **Behavior anomaly detection** — `BehaviorMonitor`. Baseline capture, deviation detection, Shadow-MCP behavioral signals.
+- **Rate-limit token bucket** — per-identity, per-tool, per-mesh counters. We configure caps; AGT enforces.
+- **Signing keys** — HSM / HW-backed key custody, key rotation, signing primitives for A2A cards and AP2 transfers.
+- **A2A 1.2 Signed Agent Card signing** — when AGT ships this primitive. Until then we implement via the `SigningProvider` seam and document the gap.
+- **AP2 policy grammar** — if AGT defines it. Until then AzureClaw defines a private schema designed to be portable to a future AGT definition.
+
+### AzureClaw owns
+
+- **Kubernetes operator** — controller, CRDs, admission policies, reconcilers.
+- **Router data plane** — L7 proxy, IMDS / Workload-Identity auth, Foundry calls, MCP transport (Streamable HTTP + SSE compat), A2A transport, OpenAI-SDK sandbox-provider adapter, channel plugins.
+- **Sandbox image** — Dockerfile layout, seccomp profiles, Landlock policy, egress-guard iptables, UID layout, init containers.
+- **CLI (`azureclaw`)** — including `operator` TUI, `up`, `add`, `push`, `dev`, `handoff`, `offload`, `policy learn`, `migrate`, `convert`, `claw attest`.
+- **Confidential-compute integration** — Kata + SEV-SNP runtime class, attestation-document handling.
+- **`sigs/agent-sandbox` compatibility mode** — translator / overlay / vendored reconciler for the upstream schema. Opt-in; default stays Native.
+
+---
+
+## 2. Provider contracts
+
+AzureClaw exposes four provider traits, each with three implementations (`Vendored*`, `Agt*`, `Null*`). `Null*` is test-only and blocked in production by admission policy.
+
+| Trait | Current implementations | Role |
+|---|---|---|
+| `MeshProvider` | `VendoredAgentMesh` · `Agt` (pending AGT AgentMesh delivery) | E2E session establishment + message send/receive |
+| `PolicyDecisionProvider` | `Vendored` · `AgtRustSdk` · `Null` | Allow / Deny / Approval / RateLimit evaluation |
+| `AuditSink` | `Vendored` · `AgtRustSdk` · `Null` | Append-only audit events → receipt id |
+| `SigningProvider` | `Vendored` · `AgtRustSdk` · `Null` | Sign `(key_ref, payload)` and verify |
+
+Providers are selected per-tenant via feature flag. The vendored path is a **permanent alternate architecture**, not migration staging — it is never scheduled for deletion.
+
+## 3. Outage semantics
+
+Every provider call passes through an outage-mode layer:
+
+| Mode | Behaviour on provider outage | Default |
+|---|---|---|
+| `Strict` | Fail-closed. Refuse the operation. | **Production (default)** |
+| `CachedRead` | Use last-known decision for read-only paths; fail-close on mutation. | Opt-in, regulated tenants |
+| `DegradedDev` | Allow, mark event `degraded=true`, emit loud metric. | `azureclaw dev` |
+
+Per-tenant override via `ClawSandbox.spec.agt.outageMode`.
+
+## 4. What AzureClaw never builds
+
+- Signal / X3DH / Double-Ratchet primitives (no custom crypto).
+- A standalone audit chain (we emit into AGT's).
+- A trust-score computation engine.
+- A rate-limit enforcement bucket outside AGT.
+- Key custody or HSM integration outside AGT.
+
+## 5. What AzureClaw always builds
+
+- The Kubernetes-primitive surface (CRDs) for anything AGT exposes.
+- The router data-plane enforcement point for every AGT decision.
+- The sandbox isolation substrate AGT assumes.
+
+## 6. Working mode with AGT
+
+- This file is shared with the AGT team for confirmation as a living seam document.
+- Disagreements are resolved by: (a) AGT's ownership wins if they commit to shipping; (b) AzureClaw picks it up temporarily if they cannot commit; (c) the scope is documented here and in the relevant security-audit doc.
+- AGT Rust SDK releases trigger `ci/vendored-patch-audit.sh` re-runs (see [`docs/agt-vendored-patch-audit.md`](../agt-vendored-patch-audit.md)).

--- a/docs/operations/secret-rotation.md
+++ b/docs/operations/secret-rotation.md
@@ -1,0 +1,133 @@
+# Secret Rotation Runbook
+
+This runbook covers rotation of every secret AzureClaw materialises: per-sandbox credentials, TLS certs, AgentMesh identities, and Azure-side credentials. Rotation never requires recompiling the controller or router.
+
+> **Scope.** Production AKS clusters running AzureClaw `v1alpha1`. Local `azureclaw dev` stacks rotate by deleting the ephemeral cluster.
+
+---
+
+## 1. Inventory
+
+| Secret | Where it lives | Owner | Rotation cadence |
+|---|---|---|---|
+| Sandbox channel/plugin credentials | K8s `Secret` `<name>-credentials` in `azureclaw-<name>` | Tenant operator | On token issuance / leak |
+| Inference Router TLS cert | cert-manager `Certificate` (chart default) or external SecretStoreCSI | Cluster admin | 90 days (cert-manager auto) |
+| AgentMesh identity (Ed25519 + X25519) | Sandbox in-memory; prekey bundle in registry | Per-sandbox, ephemeral | On each sandbox roll |
+| Foundry / Azure RBAC | Workload Identity federated credential | Cluster admin | When the project changes |
+| Cosign signing key (if static-key signing is enabled) | Azure Key Vault | Release engineer | 180 days |
+| Webhook signing keys (admission webhook) | cert-manager-managed | Cluster admin | 90 days |
+| `azureclaw up` operator AAD client (if used) | Azure Key Vault → Helm value | Cluster admin | 90 days |
+
+---
+
+## 2. Per-sandbox credentials
+
+Update a single channel/plugin secret without restarting the sandbox:
+
+```bash
+azureclaw credentials update <name> --telegram-token <new-token>
+azureclaw credentials update <name> --brave-key      <new-key>
+```
+
+The CLI patches the `Secret` and triggers a rolling restart of the sandbox `Deployment`. Pods read the new value via `envFrom` (`optional: true` so the rollout is non-blocking even if the secret is briefly missing).
+
+Verification:
+
+```bash
+kubectl -n azureclaw-<name> rollout status deploy/<name>
+kubectl -n azureclaw-<name> exec deploy/<name> -c openclaw -- env | grep <CREDENTIAL_PREFIX>
+```
+
+If the sandbox has multiple channels/plugins, run `update` for each — the CLI is idempotent.
+
+---
+
+## 3. TLS rotation
+
+cert-manager handles automatic rotation. To force a manual rotation:
+
+```bash
+kubectl -n cert-manager annotate certificate azureclaw-router-tls \
+    cert-manager.io/issue-temporary-certificate=true --overwrite
+```
+
+The controller picks up the renewed `Secret` automatically (no restart needed); the router watches its TLS file and reloads the listener.
+
+---
+
+## 4. AgentMesh identity rotation
+
+Identities are ephemeral per sandbox. To rotate:
+
+```bash
+kubectl -n azureclaw-<name> rollout restart deploy/<name>
+```
+
+This causes the sandbox to:
+1. Generate a fresh Ed25519 + X25519 keypair.
+2. Re-register with the AgentMesh registry, uploading new prekeys.
+3. Tear down all existing Double-Ratchet sessions; peers re-establish via X3DH on first KNOCK.
+
+Persistent peer-to-peer trust scores survive rotation as long as the agent's DID (registry identifier) is unchanged.
+
+---
+
+## 5. Azure / Foundry credential rotation
+
+Use the federated-credential model (default), not static client secrets. To rotate:
+
+```bash
+az identity federated-credential update \
+    --name azureclaw-controller \
+    --identity-name <controller-uami> \
+    --resource-group <rg> \
+    --issuer https://<aks-oidc-issuer>/ \
+    --subject system:serviceaccount:azureclaw-system:azureclaw-controller
+```
+
+Static-secret rotation (deprecated path):
+
+```bash
+az ad sp credential reset --id <appId> --years 1
+# update K8s secret
+kubectl -n azureclaw-system create secret generic azureclaw-azure-creds \
+  --from-literal=clientSecret='<new>' --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n azureclaw-system rollout restart deploy/azureclaw-controller
+```
+
+---
+
+## 6. Cosign signing-key rotation (static-key path only)
+
+If `cosign.signing.mode=keyless` (default), nothing to rotate. For static-key signing:
+
+```bash
+az keyvault key rotate --vault-name <kv> --name azureclaw-cosign
+# update Helm values to the new key URI
+helm upgrade azureclaw deploy/helm/azureclaw \
+  --set cosign.signing.keyRef=azurekms://<kv>.vault.azure.net/azureclaw-cosign/<new-version>
+```
+
+The next image build uses the new key. Old images stay valid until their tag is overwritten.
+
+---
+
+## 7. Compromise procedure
+
+If a credential is suspected compromised:
+
+1. **Rotate immediately** using the procedure in the relevant section above.
+2. **Roll the sandbox** (`kubectl rollout restart deploy/<name>`) so any in-process cache is invalidated.
+3. **Audit the AGT receipt chain** for the affected window (`AuditLogger` exposes a query API; see [`docs/security.md`](../security.md) §Audit).
+4. **Revoke the AgentMesh identity** if the compromise reaches the agent's keypair: drop the registry record, then roll the sandbox to issue a fresh DID.
+5. **File an incident**: see [`SECURITY.md`](../../SECURITY.md) — report through MSRC.
+
+---
+
+## 8. Verification checklist after any rotation
+
+- [ ] Sandbox `Deployment` reaches `Ready=True` within 60s
+- [ ] Inference router `/health` returns 200
+- [ ] Last AGT audit receipt is signed under the **new** key
+- [ ] Channel/plugin smoke test succeeds (e.g. `/start` to Telegram bot)
+- [ ] No `policy.fetch.failed` or `auth.imds.failed` events in App Insights for 5 minutes

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,54 @@
+# AzureClaw Roadmap
+
+> Living document. Updated each release. Items in **v1.0.0 (current)** are shipped; everything else is intent, not commitment.
+
+## v1.0.0 — General Availability of the runtime substrate
+
+Shipped capabilities (high-level):
+
+- ClawSandbox CRD `v1alpha1` (frozen for v1) — see [`docs/architecture/crd-versioning.md`](architecture/crd-versioning.md).
+- Six first-class agent runtimes: OpenClaw, OpenAI Agents (Python), Microsoft Agent Framework (Python), Anthropic Claude Agent SDK, LangGraph (Python + TypeScript), Pydantic-AI.
+- BYO runtime path with strict-mode admission gating ([`docs/operations/byo-strict.md`](operations/byo-strict.md)).
+- Inference router with IMDS / Workload-Identity broker, content-safety floor, per-sandbox token budgets, 18 Foundry API groups, MCP Streamable-HTTP + SSE compat, A2A transport.
+- E2E-encrypted inter-agent messaging via vendored AgentMesh (Signal Protocol — X3DH + Double Ratchet) with TrustGraph projection.
+- Defense-in-depth sandbox: read-only rootfs, UID-1000 + UID-1001 split, drop-ALL caps, custom seccomp (`azureclaw-strict`), Landlock, iptables UID-based egress, optional Kata.
+- AGT integration: `PolicyEngine`, `TrustManager`, `AuditLogger`, `RateLimiter`, `BehaviorMonitor` consumed via four provider traits (`MeshProvider`, `PolicyDecisionProvider`, `AuditSink`, `SigningProvider`).
+- Operator TUI + `azureclaw up / add / dev / connect / handoff / mesh / policy learn / migrate / convert / claw attest`.
+- Supply-chain: cosign keyless OIDC signatures, SBOM (CycloneDX) per image, Trivy + Container Image Scan + Rust Supply-Chain Gate (cargo-deny) + RustSec advisory audit in CI.
+
+Documented v1.0 gaps (`[GAP-V1]` markers in source):
+
+- Cosign-on-admission gating (CRD-side admission webhook) — read surface is shipped; enforcement is post-v1.
+- TrustGraph live updates — projection is mounted at sandbox creation; topology changes require sandbox re-roll until v1.1.
+- Microsoft Agent Framework **.NET** — `Microsoft.AgentGovernance` 3.3.0 ships no `AgentMeshClient`. Adapter trimmed; will return when AGT lands inter-agent comms for .NET.
+
+## v1.1 — Topology + signed CRD upgrades
+
+Targets:
+
+- **CRD `v1alpha2` + conversion webhook** — see [`docs/architecture/crd-versioning.md`](architecture/crd-versioning.md). Converts in both directions; existing `v1alpha1` objects continue to round-trip.
+- **TrustGraph dynamic projection** — controller watches mesh edges and patches the in-pod projection without a sandbox restart.
+- **Cosign-on-admission** — ValidatingAdmissionPolicy that rejects sandboxes whose images lack a cosign signature matching configured identity / issuer.
+- **CrewAI runtime adapter** — first-class.
+- **MAF .NET adapter** — re-introduce when AGT ships `AgentMeshClient` for .NET.
+- **Observability dashboards** — App Insights workbooks shipped under `deploy/workbooks/`.
+
+## v1.2 — Multi-cluster + DR
+
+Targets (subject to revisit):
+
+- **Multi-cluster federation** — federated mesh registry, cross-cluster TrustGraph, cross-cluster `azureclaw handoff`.
+- **AgentMesh registry/relay disaster recovery** — backup / restore path for relay state, regional failover playbook.
+- **Per-cluster token budget** — global token budget enforced at the router, in addition to per-tenant.
+- **Public certification harness** — Kubernetes AI Conformance suite once the upstream certification programme is published.
+
+## Backlog (no timeline)
+
+- Confidential controller + router-mediated controller egress.
+- Native Strands / Google ADK runtime adapters when their tool-loop SDKs stabilise.
+- Public AAIF / CNCF Sandbox filing.
+- Signed reconcile audit-chain *emission* (the read surface is already shipped).
+
+---
+
+This roadmap is intentionally short. AzureClaw's v1.0 surface is large; we'd rather ship fewer v1.1 capabilities at high quality than chase a wide v1.1 wishlist.

--- a/docs/security/red-team.md
+++ b/docs/security/red-team.md
@@ -1,0 +1,61 @@
+# Internal Red-Team — Findings Log
+
+> Living log of internal red-team / adversarial-test exercises against AzureClaw. Each entry records what was tested, what was found, and how it was closed. Findings that are still open carry an `OPEN` tag and link to a tracking issue.
+
+This is **not** a coordinated-disclosure inbox. External researchers please use the procedure in [`SECURITY.md`](../../SECURITY.md).
+
+---
+
+## Cadence
+
+- Every release cuts an internal red-team window of at least 1 week.
+- Every "agent capability" addition (new runtime adapter, new tool surface, new channel) gets a focused exercise.
+- Findings are tracked in this file with stable IDs of the form `RT-YYYY-NN`.
+
+## Severity
+
+- **Critical** — sandbox escape, token disclosure, cross-tenant data path, signed-payload forgery.
+- **High** — privilege escalation inside sandbox, audit-chain bypass, persistent denial of service.
+- **Medium** — single-tenant DoS, log-only information disclosure, governance bypass that another layer catches.
+- **Low** — UX or hardening gaps without a clear exploitation path.
+
+Each finding records: ID, date, surface, severity, summary, status, fix commit / PR.
+
+---
+
+## Findings
+
+### Phase 0 + Phase 1 baseline
+
+The Phase 0 + 1 surface was exercised against the threat model in [`docs/threat-model.md`](../threat-model.md) and [`security/stride.md`](../security/stride.md) before v1.0 cut. Findings closed during that window are not enumerated here individually — the per-capability sign-off lives under [`docs/security-audits/`](../security-audits/).
+
+### Phase 2
+
+Phase 2 capabilities were exercised against the per-route threat model. Per-capability audit docs (CRD, ClawEval reconciler, ClawMemory reconciler, A2A gateway, runtime adapters, MCP reconciler, content-safety floor, leader election, conditions/SSA, requeue jitter, chaos tier, controller metrics, runtime-CLI hotspots) are committed under `docs/security-audits/2026-04-*-phase2-*.md`. Each carries two-reviewer sign-off.
+
+### v1.0 cut (open list)
+
+| ID | Date | Surface | Severity | Summary | Status |
+|----|------|---------|----------|---------|--------|
+| `RT-2026-01` | 2026-04-25 | Sandbox seccomp | Low | `azureclaw-strict` allows `getpid` (necessary for libc); confirmed not exploitable | **Closed** — by-design |
+| `RT-2026-02` | 2026-04-26 | Inference router | Low | Long header values caused 100ms latency spikes; bounded buffer added | **Closed** — see PR archive |
+| `RT-2026-03` | 2026-04-28 | AgentMesh KNOCK | Medium | Anonymous peer (trust 0) could trigger registry lookups before policy check | **Closed** — by routing trust-evaluation before lookup; see vendored-patch audit |
+| `RT-2026-04` | 2026-04-30 | A2A gateway | Low | Non-allowlisted scheme echoed in error response | **Closed** — sanitised |
+
+### v1.0 — accepted as `[GAP-V1]`
+
+These items were caught and explicitly deferred (each is documented in [`security/stride.md`](../security/stride.md) §Residual risk):
+
+- **Cosign-on-admission gating** — admission does not yet enforce a signed-image requirement.
+- **Static TrustGraph projection** — live edge changes require a sandbox roll.
+- **Per-cluster token budget** — only per-tenant exists.
+
+---
+
+## How to file an internal finding
+
+1. Open a private issue under the `red-team` label.
+2. Reference the stable ID (`RT-YYYY-NN`).
+3. Include: trust boundary affected (T1–T4 from STRIDE doc), repro steps, observed vs expected, severity rationale, suggested mitigation.
+4. CC the security-audit reviewer roster (internal only).
+5. Once landed, add a row to the **Findings** table above with the closing PR.

--- a/docs/security/stride.md
+++ b/docs/security/stride.md
@@ -1,0 +1,85 @@
+# STRIDE Threat Model — AzureClaw
+
+> Companion to [`docs/threat-model.md`](../threat-model.md) (per-route inference-router model) and [`docs/security.md`](../security.md) (defense-in-depth layers). This document classifies the threats AzureClaw mitigates using STRIDE (Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege) across the four primary trust boundaries.
+
+## Trust boundaries
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  T1  External user / channel ↔ Inference Router (north edge)     │
+├──────────────────────────────────────────────────────────────────┤
+│  T2  Sandbox Agent (UID 1000) ↔ Inference Router (UID 1001)      │
+├──────────────────────────────────────────────────────────────────┤
+│  T3  Inference Router ↔ Azure / Foundry (south edge)             │
+├──────────────────────────────────────────────────────────────────┤
+│  T4  Sandbox A ↔ Sandbox B via AgentMesh (east-west)             │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## STRIDE × boundary matrix
+
+### T1 — North edge
+
+| Category | Threat | Mitigation |
+|---|---|---|
+| **S** | Attacker forges channel webhook | Per-channel HMAC verification + Azure Front Door TLS |
+| **T** | Tampered request body | Schema validation + size cap + content-type allowlist |
+| **R** | Inbound action not auditable | Every request hashed into AGT receipt chain |
+| **I** | API key in URL leaks via logs | Request URI redacted before logging; tokens accepted only via headers |
+| **D** | Channel flood | Per-tenant token budget + global rate-limiter (500 rps, 50 rps/agent) |
+| **E** | Cross-tenant request | Tenant header bound at the gateway; sandbox namespace isolated |
+
+### T2 — Agent ↔ Router
+
+| Category | Threat | Mitigation |
+|---|---|---|
+| **S** | Agent impersonates the router | Loopback-only socket (`127.0.0.1:8443`); UID-1001 listener; egress-guard iptables blocks UID 1000 from any other socket |
+| **T** | Agent injects forged auth header | Router authenticates via IMDS / Workload Identity; agent never holds tokens |
+| **R** | Tool calls not attributable | AGT policy receipt + per-tool span emitted to App Insights |
+| **I** | Agent reads cluster metadata (IMDS) | UID-1000 iptables block on `169.254.169.254` except via router |
+| **D** | Agent spam-saturates router | Per-agent rate limit + circuit-breaker on tool failures |
+| **E** | Agent escapes UID-1000 jail | seccomp `azureclaw-strict` (28 blocked syscalls), Landlock RO mount, drop-ALL caps, read-only rootfs |
+
+### T3 — Router ↔ Azure
+
+| Category | Threat | Mitigation |
+|---|---|---|
+| **S** | Spoofed Azure endpoint via DNS hijack | Router uses pinned host names + system trust roots; egress proxy allowlist |
+| **T** | MITM of model traffic | mTLS to Foundry, public CA pinning where supported |
+| **R** | Foundry call not linked to agent | Trace ID propagated end-to-end → App Insights |
+| **I** | Token leak via response body | Router strips `Authorization` from outbound response; SDK tests cover it |
+| **D** | Router stampede on retry | Bounded retry + circuit breaker per upstream |
+| **E** | Stolen IMDS token used outside cluster | Tokens are workload-identity scoped + short-lived (≤ 1 hour) |
+
+### T4 — East-west (AgentMesh)
+
+| Category | Threat | Mitigation |
+|---|---|---|
+| **S** | Peer claims someone else's identity | Ed25519 signed prekey bundle; KNOCK signature check; trust score gating |
+| **T** | Tampered ciphertext | Double Ratchet AEAD (XSalsa20-Poly1305) |
+| **R** | Encrypted message not auditable | Outer envelope (sender, recipient, mesh, ts, receipt) emitted to AGT — content stays sealed |
+| **I** | Relay reads message content | Relay sees only encrypted blobs; it has no session keys |
+| **D** | Relay flooded by malicious peer | Per-identity rate limit at the relay + AGT global limit |
+| **E** | Compromised peer escalates trust | Score clamped ±200 per signal; transitive paths capped; signed updates only |
+
+---
+
+## Residual risk (`[GAP-V1]`)
+
+Items accepted for v1.0 with explicit user-visible markers in source/docs:
+
+- **Cosign-on-admission** — image signatures are produced and verifiable; admission does not yet *require* a signature on `ClawSandbox` reconciliation. Mitigation: cluster admins gate image pulls at the registry (ACR signed-content policy).
+- **Static TrustGraph projection** — captured at sandbox creation; live edge changes require a sandbox roll. Mitigation: operators can roll affected sandboxes.
+- **Per-cluster token budget** — only per-tenant budgets exist. A noisy tenant cannot starve the cluster but could starve its own peers. Mitigation: namespace ResourceQuota.
+
+These gaps are tracked in [`docs/roadmap.md`](../roadmap.md) under v1.1.
+
+---
+
+## Re-evaluation cadence
+
+This model is reviewed:
+
+1. On every PR that introduces a new route / provider / external surface (gated by `ci/security-audit-required.sh`).
+2. On every AGT Rust SDK release (`ci/vendored-patch-audit.sh`).
+3. Quarterly, regardless of change volume.


### PR DESCRIPTION
Release-readiness documentation pass. Pure docs, no code changes, no version bump (kept separate so the version-bump PR is reviewable in isolation).

## New documents

- **`docs/security/stride.md`** — STRIDE × trust-boundary matrix across the four primary boundaries (north edge / agent↔router / router↔Azure / east-west mesh). Includes accepted `[GAP-V1]` items.
- **`docs/security/red-team.md`** — Internal red-team findings log with cadence, severity rubric, and template.
- **`docs/architecture/agt-boundary.md`** — Responsibility split between AGT and AzureClaw, the four provider contracts (`MeshProvider`, `PolicyDecisionProvider`, `AuditSink`, `SigningProvider`), and outage modes. Promoted from an internal draft.
- **`docs/operations/secret-rotation.md`** — Runbook covering per-sandbox credentials, TLS, AgentMesh identity, Azure / Foundry creds, cosign keys, plus a compromise procedure.
- **`docs/api/backwards-compatibility.md`** — SemVer commitment for CRD, CLI, Helm values keys, router routes; deprecation windows; migration policy.
- **`docs/roadmap.md`** — v1.0 (current), v1.1 targets, v1.2 directions, backlog. Each `[GAP-V1]` is explicitly tied to a v1.1 milestone.

## Updates

- **`docs/README.md`** — index links the new docs (new Security entries, new Architecture deep-dive entries, expanded Operations section, new Roadmap section).
- **`CHANGELOG.md`** — `[1.0.0-rc.1]` entry summarising the release-eng work done in this cycle (mesh tools across runtimes, LangGraph TS adapter, BYO strict-mode demo, image-versioning policy, `v1alpha2` plan, controller env-test isolation fix, `[GAP-V1]` markers). Existing `[Unreleased] — Phase 2` content untouched.

## Out of scope

- Version bumps (workspace 0.1.0 → 1.0.0-rc.1, CLI, helm chart) — deliberately deferred to a separate PR after this lands so the bump diff is small and clean.
- E2E matrix work, cargo-udeps, ts-prune — tracked separately.