### PR TITLE
release(r5): Helm chart 1.0.0-rc.1 + packaging script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -480,3 +480,6 @@ docs/internal/
 
 # LangGraph TS adapter — built in Docker stage, not committed
 runtimes/langgraph-ts/dist/
+
+# Helm chart packaging output (deploy/helm/package.sh) — not committed
+/dist/charts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ First release candidate cut for the v1.0.0 line. No new feature surface beyond w
 
 - `docs/README.md` rewritten as the canonical index for the public-facing tree.
 - `CRD `ClawSandbox.spec.runtime.maf.language` enum narrowed: `Dotnet` removed (no `AgentMeshClient` in `Microsoft.AgentGovernance` 3.3.0). `[GAP-V1]` recorded.
+- `deploy/helm/azureclaw/Chart.yaml` — `version` and `appVersion` bumped to `1.0.0-rc.1`.
+- New `make helm-package` target wraps `bash deploy/helm/package.sh` (lint + package + sha256). Output goes to gitignored `dist/charts/`.
+- New manually-runnable E2E suite at `tests/e2e-manual/` (PR #189). The CI Kind suite at `tests/e2e/run.sh` is unchanged.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ test-e2e: ## Run E2E tests (requires Docker + Kind)
 test-e2e-manual: ## Run the manual E2E matrix against an existing cluster (see tests/e2e-manual/README.md)
 	bash tests/e2e-manual/run.sh
 
+helm-package: ## Lint + package the AzureClaw Helm chart into ./dist/charts/
+	bash deploy/helm/package.sh
+
 # ─── Lint ─────────────────────────────────────────────────────────────────────
 
 lint: ## Run linters

--- a/deploy/helm/azureclaw/Chart.yaml
+++ b/deploy/helm/azureclaw/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: azureclaw
 description: AzureClaw - Enterprise-grade OpenClaw sandbox orchestrator for AKS
 type: application
-version: 0.1.0
-appVersion: "0.1.0-alpha.1"
+version: 1.0.0-rc.1
+appVersion: "1.0.0-rc.1"
 keywords:
   - azure
   - openclaw

--- a/deploy/helm/package.sh
+++ b/deploy/helm/package.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Package the AzureClaw Helm chart locally — for release engineering
+# and local testing only. The packaged tarball is *not* published from
+# this script; publishing to a registry is a separate, deliberate step
+# performed by a maintainer with the appropriate credentials.
+#
+# Usage:
+#   bash deploy/helm/package.sh                 # → ./dist/charts/
+#   DEST=/tmp/foo bash deploy/helm/package.sh   # custom destination
+#
+# The script:
+#   1. Runs `helm lint` and fails fast on any error.
+#   2. Calls `helm package` to produce azureclaw-<version>.tgz.
+#   3. Computes a sha256 alongside the tarball.
+#   4. Prints the resulting paths.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART_DIR="${ROOT}/deploy/helm/azureclaw"
+DEST="${DEST:-${ROOT}/dist/charts}"
+
+if ! command -v helm >/dev/null 2>&1; then
+    echo "ERROR: helm not found on PATH" >&2
+    exit 1
+fi
+
+mkdir -p "$DEST"
+
+echo "▶ helm lint ${CHART_DIR}"
+helm lint "$CHART_DIR"
+
+echo "▶ helm package ${CHART_DIR} → ${DEST}"
+helm package "$CHART_DIR" --destination "$DEST"
+
+# Find the just-produced tarball (the one with the latest mtime).
+tarball="$(ls -1t "${DEST}"/azureclaw-*.tgz | head -1)"
+if [[ -z "$tarball" ]]; then
+    echo "ERROR: package did not produce a tarball" >&2
+    exit 1
+fi
+
+echo "▶ sha256 ${tarball}"
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$tarball" | tee "${tarball}.sha256"
+else
+    shasum -a 256 "$tarball" | tee "${tarball}.sha256"
+fi
+
+echo
+echo "Packaged chart: ${tarball}"
+echo "Digest:         ${tarball}.sha256"

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@
 - [Supply Chain](operations/supply-chain.md) — Cosign, SBOM, attestations
 - [GitOps](operations/gitops.md) — Reconciler in a GitOps fleet
 - [Image Versioning](operations/image-versioning.md) — Tag policy and runtime image overrides
+- [Helm Packaging](operations/helm-packaging.md) — Chart versioning + local packaging
 - [Secret Rotation Runbook](operations/secret-rotation.md) — Per-sandbox creds, TLS, AgentMesh identity, Azure
 - [Chaos Tier](operations/chaos-tier.md) — Fault-injection test surface
 

--- a/docs/operations/helm-packaging.md
+++ b/docs/operations/helm-packaging.md
@@ -1,0 +1,60 @@
+# Helm chart packaging
+
+The AzureClaw Helm chart lives under [`deploy/helm/azureclaw/`](../../deploy/helm/azureclaw). This page documents how the chart is **versioned** and how a maintainer **packages** it for a release.
+
+> **Publishing the chart to a registry is a separate, deliberate step performed by a release manager with the appropriate credentials. This document covers only versioning and local packaging.**
+
+## Versioning policy
+
+The chart follows [SemVer](https://semver.org). Two fields in `Chart.yaml` track separate concerns:
+
+| Field        | Meaning                                                                 | Bump on …                                              |
+|--------------|-------------------------------------------------------------------------|--------------------------------------------------------|
+| `version`    | Helm chart packaging version (templates, values schema, defaults).      | Any change to chart templates, values, or defaults.    |
+| `appVersion` | The bundled AzureClaw application version (controller + router image). | Whenever the controller or inference-router is rebuilt with a new release tag. |
+
+Pre-release suffixes use SemVer dot-separated identifiers — e.g. `1.0.0-rc.1`, `1.0.0-rc.2`, `1.0.0` — never `1.0.0rc1` or `1.0.0_rc.1`.
+
+The current version is recorded at the top of `deploy/helm/azureclaw/Chart.yaml`.
+
+## Packaging locally
+
+Run the packaging script from the repository root:
+
+```bash
+make helm-package
+# equivalent: bash deploy/helm/package.sh
+```
+
+The script will:
+
+1. `helm lint` the chart and fail fast on any error.
+2. `helm package` the chart into `./dist/charts/azureclaw-<version>.tgz`.
+3. Compute a SHA-256 alongside the tarball and write it to `<tarball>.sha256`.
+
+The `dist/` directory is gitignored. The packaged tarball is **not** committed.
+
+To package into a custom directory:
+
+```bash
+DEST=/tmp/charts bash deploy/helm/package.sh
+```
+
+## Cutting a release version
+
+When preparing a release branch:
+
+1. Update `version` and `appVersion` in `deploy/helm/azureclaw/Chart.yaml`.
+2. Update `CHANGELOG.md` with a section header for the new version.
+3. Run `make helm-package` and commit only the metadata changes (not the tarball).
+4. Open a PR to `dev`. The Helm Lint job in CI will re-validate the chart.
+
+## Publishing (out of scope here)
+
+Publishing the chart tarball to OCI (e.g. `oci://ghcr.io/azure/charts`) or a Helm HTTP repository is performed by a release manager outside this repo's CI. See the release runbook (internal) for that step.
+
+## See also
+
+- [`docs/operations/image-versioning.md`](image-versioning.md) — image tag policy that drives `appVersion`.
+- [`docs/architecture/crd-versioning.md`](../architecture/crd-versioning.md) — CRD storage version freeze + `v1alpha2` plan.
+- [`CHANGELOG.md`](../../CHANGELOG.md) — release notes.


### PR DESCRIPTION
## Summary
Bumps the Helm chart to **1.0.0-rc.1** and adds a packaging helper.

## Changes
- `deploy/helm/azureclaw/Chart.yaml`: `version` `0.1.0 → 1.0.0-rc.1`, `appVersion` `0.1.0-alpha.1 → 1.0.0-rc.1`.
- `deploy/helm/package.sh` + `make helm-package`: lint → package → sha256.
- `docs/operations/helm-packaging.md`: versioning policy + packaging procedure.
- `CHANGELOG.md`, `docs/README.md`, `.gitignore` updated.

## Verification
- `helm lint deploy/helm/azureclaw` → 0 errors.
- `bash deploy/helm/package.sh` → `azureclaw-1.0.0-rc.1.tgz` produced cleanly.
- No template / values changes; values schema is unchanged.

## Out of scope
Publishing the tarball to a registry is performed separately by a release manager.