### PR TITLE
chore(r3): cargo-machete cleanup — remove unused workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,11 +327,7 @@ dependencies = [
  "axum",
  "azureclaw-a2a-core",
  "base64 0.22.1",
- "chrono",
  "ed25519-dalek",
- "futures",
- "futures-util",
- "http-body-util",
  "hyper",
  "hyper-util",
  "notify",
@@ -340,15 +336,12 @@ dependencies = [
  "reqwest 0.12.28",
  "rustls",
  "rustls-pemfile",
- "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
- "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -358,16 +351,10 @@ name = "azureclaw-chaos-tests"
 version = "0.1.0"
 dependencies = [
  "axum",
- "bytes",
- "futures",
- "futures-util",
- "hyper",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
- "tokio-test",
- "tokio-tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -376,7 +363,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",
- "serde_json",
  "serde_yaml",
  "walkdir",
 ]
@@ -396,7 +382,6 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "idna",
  "k8s-openapi",
  "kube",
  "oci-client 0.16.1",
@@ -434,7 +419,6 @@ dependencies = [
  "flate2",
  "futures",
  "hkdf",
- "hyper",
  "jsonwebtoken",
  "k8s-openapi",
  "kube",
@@ -454,7 +438,6 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tower",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "wiremock",
@@ -5062,17 +5045,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/a2a-gateway/Cargo.toml
+++ b/a2a-gateway/Cargo.toml
@@ -19,17 +19,12 @@ azureclaw-a2a-core = { path = "../azureclaw-a2a-core", version = "0.1.0" }
 # HTTP server / proxy
 axum.workspace = true
 tower.workspace = true
-tower-http.workspace = true
 hyper = { workspace = true, features = ["server", "client", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "tokio", "http1", "http2"] }
-http-body-util = "0.1"
 reqwest = { workspace = true, features = ["rustls-tls-native-roots"] }
 
 # Async
 tokio.workspace = true
-tokio-util = { version = "0.7", features = ["rt"] }
-futures.workspace = true
-futures-util.workspace = true
 
 # TLS — workspace-wide constraint: rustls only. ADR forbids
 # introducing a second TLS implementation.
@@ -40,10 +35,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 # Cert / key file watching for hot reload.
 notify = { version = "8", default-features = false, features = ["macos_kqueue"] }
 
-# Serialisation
-serde.workspace = true
-serde_json.workspace = true
-
 # Observability
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -53,9 +44,6 @@ prometheus.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 
-# Time / rate-limit bookkeeping
-chrono.workspace = true
-
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
@@ -63,3 +51,11 @@ rand.workspace = true
 base64.workspace = true
 serde_json.workspace = true
 tempfile = "3"
+
+[package.metadata.cargo-machete]
+# `azureclaw-a2a-core` is the dependency this crate exists to wrap (see
+# src/verify.rs doc comment). The wiring through `verify::ReplayCache` is
+# intentional and the explicit dep keeps the gateway aligned with the
+# router's verification path even though the import is not yet active in
+# the proxy hot path.
+ignored = ["azureclaw-a2a-core"]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -64,7 +64,6 @@ oci-client = { version = "0.16", default-features = false, features = ["rustls-t
 # refuse to auto-detect and panic on first TLS handshake. Pin to
 # `aws-lc-rs` to align with the rest of the workspace.
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
-idna = "1"
 
 [features]
 # S16 — chaos tier. Default `cargo test` does NOT enable this feature; the

--- a/inference-router/Cargo.toml
+++ b/inference-router/Cargo.toml
@@ -12,8 +12,6 @@ rust-version.workspace = true
 axum.workspace = true
 reqwest.workspace = true
 tower.workspace = true
-tower-http.workspace = true
-hyper.workspace = true
 bytes = "1"
 
 # Async

--- a/tests/chaos/Cargo.toml
+++ b/tests/chaos/Cargo.toml
@@ -29,11 +29,10 @@ axum = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-futures = { workspace = true }
-futures-util = { workspace = true }
-tokio-tungstenite = { workspace = true }
-hyper = { workspace = true }
-bytes = "1"
 
 [dev-dependencies]
-tokio-test = "0.4"
+
+[package.metadata.cargo-machete]
+# `serde` is used via `#[derive(Serialize, Deserialize)]` in tests/k8s_api_flakes.rs;
+# cargo-machete does not detect derive-macro usage of the parent crate.
+ignored = ["serde"]

--- a/tests/cncf-conformance/Cargo.toml
+++ b/tests/cncf-conformance/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 anyhow = { workspace = true }
 walkdir = "2"


### PR DESCRIPTION
## Summary
`cargo machete` audit pass across the workspace. Removed deps that have zero `use` sites and zero derive-macro consumers; kept the rest with explicit `[package.metadata.cargo-machete]` ignores so future audits stay clean.

## Removed
- **inference-router**: `tower-http`, `hyper`
- **controller**: `idna`
- **tests/cncf-conformance**: `serde_json`
- **tests/chaos**: `futures`, `futures-util`, `tokio-tungstenite`, `hyper`, `bytes`, `tokio-test`
- **a2a-gateway**: `tower-http`, `http-body-util`, `tokio-util`, `futures`, `futures-util`, `serde`, `serde_json`, `chrono`

## Ignored (kept intentionally)
- `tests/chaos` → `serde` (derive macro)
- `a2a-gateway` → `azureclaw-a2a-core` (architectural intent)

## Verification
- `cargo build --workspace --all-targets` ✅
- `cargo test --workspace --no-fail-fast` ✅ all pass
- `cargo clippy --all-targets -- -D warnings` ✅ clean
- `Cargo.lock` shrinks by 28 lines

## Untouched
`vendor/agentmesh-*` are upstream forks; we don't edit their Cargo.toml.