### PR TITLE
docs(r5): mdbook documentation site under docs/site/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -483,3 +483,6 @@ runtimes/langgraph-ts/dist/
 
 # Helm chart packaging output (deploy/helm/package.sh) — not committed
 /dist/charts/
+
+# mdbook documentation site output (docs/site/book.toml writes here)
+/target/book/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ First release candidate cut for the v1.0.0 line. No new feature surface beyond w
 - `deploy/helm/azureclaw/Chart.yaml` — `version` and `appVersion` bumped to `1.0.0-rc.1`.
 - New `make helm-package` target wraps `bash deploy/helm/package.sh` (lint + package + sha256). Output goes to gitignored `dist/charts/`.
 - New manually-runnable E2E suite at `tests/e2e-manual/` (PR #189). The CI Kind suite at `tests/e2e/run.sh` is unchanged.
+- `docs/site/` — mdbook configuration for rendering the canonical `docs/` tree as a browsable static site. `make docs-site` builds to `./target/book/`; `make docs-site-serve` previews live. The site uses the existing markdown as-is — no content duplication.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,14 @@ test-e2e-manual: ## Run the manual E2E matrix against an existing cluster (see t
 helm-package: ## Lint + package the AzureClaw Helm chart into ./dist/charts/
 	bash deploy/helm/package.sh
 
+docs-site: ## Build the mdbook documentation site into target/book/ (requires mdbook)
+	@command -v mdbook >/dev/null 2>&1 || { echo "mdbook not installed: cargo install mdbook"; exit 1; }
+	cd docs/site && mdbook build
+
+docs-site-serve: ## Live-preview the documentation site at http://localhost:3000
+	@command -v mdbook >/dev/null 2>&1 || { echo "mdbook not installed: cargo install mdbook"; exit 1; }
+	cd docs/site && mdbook serve --port 3000 --open
+
 # ─── Lint ─────────────────────────────────────────────────────────────────────
 
 lint: ## Run linters

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,79 @@
+# Summary
+
+[Introduction](README.md)
+
+# Getting started
+
+- [Getting Started](getting-started.md)
+- [CLI reference](cli-reference.md)
+- [Demo](DEMO.md)
+- [Demo guide](DEMO-GUIDE.md)
+- [Use cases](use-cases.md)
+- [Migration from NemoClaw](migration-from-nemoclaw.md)
+
+# Agent capabilities
+
+- [Channels & plugins](channels-plugins.md)
+- [Operator TUI](operator-tui.md)
+- [Permissions model](permissions.md)
+
+# Architecture
+
+- [Architecture overview](architecture.md)
+- [Architecture diagrams](architecture-diagrams.md)
+- [A2A gateway (architecture)](architecture/a2a-gateway.md)
+- [AGT boundary](architecture/agt-boundary.md)
+- [CRD versioning](architecture/crd-versioning.md)
+- [Multi-tenant model](multi-tenant.md)
+- [Egress proxy](egress-proxy.md)
+- [Any OpenClaw cloud offload](any-openclaw-cloud-offload.md)
+
+# Security
+
+- [Security overview](security.md)
+- [Threat model](threat-model.md)
+- [STRIDE × trust boundaries](security/stride.md)
+- [Red team playbook](security/red-team.md)
+- [E2E encryption proof](e2e-encryption-proof.md)
+- [Security validation](security-validation.md)
+- [MCP top-10](security-mcp-top10.md)
+- [SIGs / agent-sandbox compat](sigs-agent-sandbox-compat.md)
+
+# Operations
+
+- [A2A gateway (operations)](operations/a2a-gateway.md)
+- [BYO strict mode](operations/byo-strict.md)
+- [Branch protection](operations/branch-protection.md)
+- [Chaos tier](operations/chaos-tier.md)
+- [GitOps](operations/gitops.md)
+- [Helm packaging](operations/helm-packaging.md)
+- [Image versioning](operations/image-versioning.md)
+- [Secret rotation](operations/secret-rotation.md)
+- [Supply chain](operations/supply-chain.md)
+
+# API & policy
+
+- [CRD reference](api/crd-reference.md)
+- [Conditions](api/conditions.md)
+- [Backwards compatibility](api/backwards-compatibility.md)
+- [Policy canonical format](policy-canonical-format.md)
+
+# Blueprints
+
+- [Index](blueprints/00-index.md)
+- [Developer inner loop](blueprints/01-developer-inner-loop.md)
+- [Enterprise self-hosted](blueprints/02-enterprise-self-hosted.md)
+- [Managed public offload](blueprints/03-managed-public-offload.md)
+- [Cross-org federation](blueprints/04-cross-org-federation.md)
+- [Sovereign / air-gapped](blueprints/05-sovereign-airgapped.md)
+
+# Roadmap & ADRs
+
+- [Roadmap](roadmap.md)
+- [Upstream alignment](upstream-alignment.md)
+- [ADR index](adr/README.md)
+  - [ADR-0001: A2A ingress front edge](adr/0001-a2a-ingress-front-edge.md)
+
+# Reference
+
+- [AGT vendored patch audit](agt-vendored-patch-audit.md)

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,0 +1,69 @@
+# AzureClaw documentation site
+
+The `docs/site/` directory contains the **mdbook** configuration that turns the canonical markdown tree under `docs/` into a browsable HTML site.
+
+## Why mdbook
+
+- Same source files as on GitHub — no duplication, no drift.
+- Searchable, themed, and navigable from a single index.
+- Trivial to host: the output is plain static HTML.
+- Zero runtime dependencies — `cargo install mdbook` and you have a builder.
+
+## Building locally
+
+```bash
+make docs-site
+# → renders to ./target/book/
+```
+
+Live preview with hot-reload:
+
+```bash
+make docs-site-serve
+# → http://localhost:3000
+```
+
+If `mdbook` is not on your `$PATH`, the Makefile target prints how to install it:
+
+```bash
+cargo install mdbook
+```
+
+## Layout
+
+```
+docs/
+├── SUMMARY.md          # mdbook chapter index — single source of truth for the site nav
+├── README.md           # rendered as the site introduction page
+├── getting-started.md  # …everything else here is rendered as-is
+├── architecture/
+├── security/
+├── operations/
+├── api/
+├── adr/
+└── site/
+    ├── README.md       # this file
+    └── book.toml       # mdbook config (src = "..", build-dir = "../../target/book")
+```
+
+The `src = ".."` setting in `book.toml` tells mdbook to use the entire `docs/` directory as the source tree. That way the same `.md` files reviewers see on GitHub also become the chapters of the rendered site.
+
+The build output (`/target/book/`) is gitignored.
+
+## Updating the site
+
+1. Edit any `.md` under `docs/` as you would normally.
+2. If you added a **new top-level page** that should appear in the site navigation, add it to `docs/SUMMARY.md` under the appropriate section.
+3. Run `make docs-site` and skim `target/book/index.html` to confirm the page renders.
+
+There is no separate publication step; deploying the rendered HTML to a hosting target (GitHub Pages, an Azure Static Web App, or a private archive) is performed by a release manager outside this repo.
+
+## Validation in CI
+
+The Helm Lint and other docs-touching workflows do not run mdbook, but `make docs-site` is fast (≈ 1s) and always runnable locally. A future CI job can wrap it as a build-only check; for now the contract is "it builds locally before merge".
+
+## Limitations
+
+- Cross-repo links must be absolute URLs.
+- mdbook does not follow links *outside* the `src` tree, so any docs that need to live elsewhere (e.g. `CHANGELOG.md` at repo root) must be referenced via absolute GitHub URLs.
+- `docs/internal/` is intentionally **not** included in `SUMMARY.md` — it is a holding area for internal/legacy material and should not appear in the public site.

--- a/docs/site/book.toml
+++ b/docs/site/book.toml
@@ -1,0 +1,41 @@
+[book]
+title = "AzureClaw — Documentation"
+description = "AzureClaw — secure AI agent runtime on Azure AKS. Sandbox isolation, AGT governance, AgentMesh E2E encryption."
+authors = ["AzureClaw Team"]
+language = "en"
+
+# The book sources live one level up — the existing docs/ tree is the
+# canonical content. The site only adds book.toml + SUMMARY.md +
+# theme overrides; chapter pages are the same .md files reviewers
+# already see on GitHub. This avoids drift between the rendered site
+# and the in-repo browsing experience.
+src = ".."
+
+[build]
+# Build output lives outside the source tree to avoid mdbook recursing
+# into its own previous output (since src = ".." traverses sibling
+# directories of book.toml).
+build-dir = "../../target/book"
+create-missing = false
+
+[output.html]
+default-theme = "navy"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/Azure/azureclaw"
+edit-url-template = "https://github.com/Azure/azureclaw/edit/dev/docs/{path}"
+no-section-label = false
+mathjax-support = false
+
+[output.html.fold]
+enable = true
+level = 1
+
+[output.html.search]
+enable = true
+limit-results = 30
+use-boolean-and = true
+boost-title = 2
+boost-hierarchy = 1
+boost-paragraph = 1
+expand = true
+heading-split-level = 3


### PR DESCRIPTION
## Summary
Renders the canonical `docs/` tree as a browsable static site via **mdbook**, with no content duplication.

## Build
- `make docs-site` → `./target/book/` (52 pages)
- `make docs-site-serve` → live preview on :3000

## Layout
- `docs/site/book.toml` — `src = '..'`, output to `target/book/` (gitignored).
- `docs/SUMMARY.md` — chapter index covering Getting Started, Architecture, Security, Operations, API, Blueprints, Roadmap, ADRs. **`docs/internal/` is intentionally excluded.**
- `docs/site/README.md` — author guide.

## Out of scope
Hosting the rendered output (GitHub Pages / Static Web App / private archive) is a release-engineering step outside this PR.