### PR TITLE
docs(r3): align A2A gateway docs with reality + GAP-V1 markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,14 @@ First release candidate cut for the v1.0.0 line. No new feature surface beyond w
 ### Internal / docs
 
 - `docs/backlog.md`, `docs/phase-0-1-capabilities.md`, `docs/security-reviewers.md` moved to `docs/internal/`. Stale link in `README.md` to a gitignored `implementation-plan.md` removed; lingering reference in `docs/security.md` reworded.
+- A2A gateway architectural picture aligned with reality: `a2a-gateway/src/lib.rs`, `a2a-gateway/src/verify.rs`, and `docs/architecture/a2a-gateway.md` no longer claim the gateway binary runs the JWS verifier in its hot path. The verifier remains complete and tested at the `azureclaw-a2a-core` library level; in-binary wiring is documented as a v1.1 follow-up. `docs/roadmap.md` reflects the same.
 
 ### `[GAP-V1]` markers (accepted for v1.0)
 
 - Cosign-on-admission gating (read surface shipped; admission enforcement is v1.1).
 - TrustGraph live updates (projection captured at sandbox creation; v1.1).
 - Microsoft Agent Framework **.NET** adapter (returns when AGT lands `AgentMeshClient` for .NET).
+- A2A gateway in-binary JWS verifier (`azureclaw_a2a_core::verify_inbound_card` is library-complete & tested; the gateway binary today consumes the verified-caller subject from the upstream Gateway-API mTLS handshake. Wiring the verifier as an opt-in axum layer inside the gateway is a v1.1 task).
 
 ---
 

--- a/a2a-gateway/src/lib.rs
+++ b/a2a-gateway/src/lib.rs
@@ -12,7 +12,8 @@
 //!                          ┌────────────────────────┐
 //!                          │   azureclaw-a2a-gateway │
 //!                          │   • TLS termination     │
-//!                          │   • JWS verify          │
+//!                          │   • subject extraction  │
+//!                          │   • replay cache        │
 //!                          │   • per-subject limits  │
 //!                          └──────────┬──────────────┘
 //!                                     │ mTLS
@@ -23,11 +24,26 @@
 //!                                 sandbox pod
 //! ```
 //!
-//! The gateway's *only* authentication boundary is the JWS verifier
-//! (`azureclaw_a2a_core::verify_inbound_card`). Everything downstream
-//! of `verify::verify_or_reject` is treated as authenticated and
-//! tagged with the verified subject claim, which the router uses as
-//! the policy key for inbound A2A.
+//! The gateway extracts the verified-caller subject from the
+//! `X-A2A-Agent-Subject` request header, applies replay protection via
+//! [`verify::ReplayCache`], rate-limits per subject, then forwards
+//! over mTLS to the inference router.
+//!
+//! ## `[GAP-V1]` JWS verifier wiring
+//!
+//! The standalone JWS path (`azureclaw_a2a_core::verify_inbound_card`)
+//! is **complete and tested** as a library function — every router
+//! that needs it can call it directly. The gateway *binary*, however,
+//! does **not** yet run that verifier in its proxy hot path; it
+//! consumes the `X-A2A-Agent-Subject` header written by an upstream
+//! component (today: the cluster Gateway API mTLS handshake; tomorrow:
+//! a verifying axum layer inside this binary).
+//!
+//! Wiring `verify_inbound_card` directly into the gateway as an
+//! opt-in axum layer is tracked as a v1.1 follow-up; the placeholder
+//! is the unused `azureclaw-a2a-core` workspace dependency declared
+//! in `Cargo.toml`. The `[GAP-V1]` marker is mirrored in
+//! `docs/architecture/a2a-gateway.md`.
 //!
 //! ## Hardening checklist
 //!

--- a/a2a-gateway/src/verify.rs
+++ b/a2a-gateway/src/verify.rs
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Inbound JWS verification + replay protection.
+//! Replay-protection cache for inbound A2A traffic.
 //!
-//! Wraps [`azureclaw_a2a_core::verify_inbound_card`] and adds a
-//! short-TTL nonce cache so identical signed envelopes cannot be
-//! replayed even within their `nbf..exp` window.
+//! `[GAP-V1]` — this module currently provides only the
+//! [`ReplayCache`]. Wrapping [`azureclaw_a2a_core::verify_inbound_card`]
+//! as an axum layer that runs inside this binary is a v1.1 task;
+//! today the verified-caller subject is consumed from the
+//! `X-A2A-Agent-Subject` header populated by the upstream Gateway
+//! API mTLS handshake (see `docs/architecture/a2a-gateway.md`).
+//! [`VerifyError`] enumerates the failure surface that wiring will
+//! emit; nothing in this module raises `MissingSignature`,
+//! `Invalid`, or `UnknownIssuer` yet.
 
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/docs/architecture/a2a-gateway.md
+++ b/docs/architecture/a2a-gateway.md
@@ -65,7 +65,7 @@ reaching ours) terminate at a single, narrow surface that:
 |---|---|
 | Eavesdropping on the public path | TLS 1.2/1.3 via rustls. |
 | Stolen TLS leaf | `notify::Watcher` triggers `Arc<ServerConfig>` swap on cert rotation; old sessions drain. |
-| Forged AgentCard | JWS Ed25519 verify against the pinned trust store; `alg` allow-list is hard-coded to `EdDSA`. |
+| Forged AgentCard | JWS Ed25519 verify in `azureclaw_a2a_core::verify_inbound_card` (library complete & tested) against a pinned trust store; `alg` allow-list is hard-coded to `EdDSA`. **`[GAP-V1]`** the gateway *binary* does not yet run this verifier in its proxy hot path — see "Out of scope in S3.5" below. |
 | Replay of a valid envelope | Nonce cache with 5 min TTL and 100k entry cap. |
 | Untrusted gateway impersonating router | Router :8445 verifies client cert against the gateway-only CA bundle at `/etc/azureclaw/a2a-gateway-ca.pem`. |
 | Burst flood from one subject | Per-subject token bucket (60 burst / 5 rps); over-budget calls return 429. |
@@ -75,6 +75,7 @@ reaching ours) terminate at a single, narrow surface that:
 
 | Concern | Resolution path |
 |---|---|
+| **`[GAP-V1]` JWS verifier wired as an axum layer** | The verifier is implemented and tested in `azureclaw-a2a-core`; the gateway binary today consumes the verified subject from the `X-A2A-Agent-Subject` header populated by the upstream Gateway API mTLS handshake. Wiring `verify_inbound_card` directly inside the gateway as an opt-in axum layer is a v1.1 task. The unused `azureclaw-a2a-core` workspace dependency in `a2a-gateway/Cargo.toml` is the placeholder. |
 | Cross-replica rate-limit sync | Helm value `a2aGateway.rateLimits.sharedRedisUrl` is reserved; impl is `unimplemented!()`. Replicas in v1 enforce in-memory only — the router's downstream limiter is the second line of defence. |
 | SAN pinning beyond CA chain on :8445 | The gateway CA is single-purpose (issued only to gateway pods) so chain-of-trust is sufficient for v1. |
 | Mandatory mTLS on :8443 | Out of scope — :8443 stays exactly as it is in the dev branch. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,7 @@ Documented v1.0 gaps (`[GAP-V1]` markers in source):
 - Cosign-on-admission gating (CRD-side admission webhook) — read surface is shipped; enforcement is post-v1.
 - TrustGraph live updates — projection is mounted at sandbox creation; topology changes require sandbox re-roll until v1.1.
 - Microsoft Agent Framework **.NET** — `Microsoft.AgentGovernance` 3.3.0 ships no `AgentMeshClient`. Adapter trimmed; will return when AGT lands inter-agent comms for .NET.
+- A2A gateway in-binary JWS verification — `azureclaw_a2a_core::verify_inbound_card` is library-complete & tested; the gateway binary today consumes the verified-caller subject from the upstream Gateway-API mTLS handshake (`X-A2A-Agent-Subject` header). Wiring the verifier as an opt-in axum layer inside the gateway is a v1.1 task; see [`docs/architecture/a2a-gateway.md`](architecture/a2a-gateway.md).
 
 ## v1.1 — Topology + signed CRD upgrades
 
@@ -29,6 +30,7 @@ Targets:
 - **CRD `v1alpha2` + conversion webhook** — see [`docs/architecture/crd-versioning.md`](architecture/crd-versioning.md). Converts in both directions; existing `v1alpha1` objects continue to round-trip.
 - **TrustGraph dynamic projection** — controller watches mesh edges and patches the in-pod projection without a sandbox restart.
 - **Cosign-on-admission** — ValidatingAdmissionPolicy that rejects sandboxes whose images lack a cosign signature matching configured identity / issuer.
+- **A2A gateway in-binary JWS verifier** — opt-in axum layer in `azureclaw-a2a-gateway` that calls `azureclaw_a2a_core::verify_inbound_card`, removes reliance on upstream Gateway-API mTLS for the trust decision, and lets the gateway run in non-AGC topologies.
 - **CrewAI runtime adapter** — first-class.
 - **MAF .NET adapter** — re-introduce when AGT ships `AgentMeshClient` for .NET.
 - **Observability dashboards** — App Insights workbooks shipped under `deploy/workbooks/`.


### PR DESCRIPTION
## Summary

The standalone JWS verifier (`azureclaw_a2a_core::verify_inbound_card`) is **complete and tested as a library**, but the gateway *binary* does not run it in its proxy hot path today — it consumes the verified-caller subject from the `X-A2A-Agent-Subject` header populated by the upstream Gateway API mTLS handshake.

This PR closes `p2-s35-a2a-gateway-component` for v1.0 by **honestly documenting** the architectural picture rather than under-the-radar wiring a security-critical layer in a docs PR. In-binary verifier wire-up is now an explicit v1.1 follow-up.

## Files

- **`a2a-gateway/src/lib.rs`** — call-graph block updated; `JWS verify` bullet replaced with `subject extraction + replay cache`; `[GAP-V1]` note added pointing at the `azureclaw-a2a-core` placeholder workspace dep.
- **`a2a-gateway/src/verify.rs`** — module doc no longer claims to wrap `verify_inbound_card`. File currently exports only `ReplayCache`.
- **`docs/architecture/a2a-gateway.md`** — threat-model "Forged AgentCard" row qualified; `[GAP-V1]` row added under "Out of scope in S3.5".
- **`docs/roadmap.md`** — v1.0 gap added; v1.1 target row added for the in-binary verifier wiring.
- **`CHANGELOG.md`** — gap row + internal/docs row.

## Verification

```text
cargo build -p azureclaw-a2a-gateway   # clean
cargo test  -p azureclaw-a2a-gateway   # 38 passed; 0 failed
```

No code changes. No CI surface change.

Targets `dev`. Repo stays private.