### PR TITLE
docs(revamp-B): rewrite README, docs/README, getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,688 +2,199 @@
 
 # 🔱 AzureClaw
 
-**Secure AI Agent Runtime for Azure**
+**A secure runtime for AI agents on Azure Kubernetes Service.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-0078D4.svg)](LICENSE)
 [![CI](https://github.com/Azure/azureclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/Azure/azureclaw/actions/workflows/ci.yml)
 [![Azure](https://img.shields.io/badge/Azure-AKS%20%7C%20Foundry%20%7C%20Kata-0078D4)](https://azure.microsoft.com)
 
-Run AI agents in hardened sandboxes on AKS with defense-in-depth security.<br>
-Zero-credential inference through Azure AI Foundry. Optional Kata VM isolation. Multi-agent governance via AGT.<br>
-Eight Kubernetes CRDs, a public-ingress A2A gateway, and an inference router that runs in the data path of every external call.
+Hardened sandbox per agent. Zero credentials in the agent. Every external call goes through a Rust router that enforces identity, content safety, governance, and audit. End-to-end encrypted inter-agent messaging. One CLI for the whole loop — laptop to AKS.
+
+[**Try it on your laptop →**](#try-it-in-five-minutes) &nbsp;·&nbsp; [**Run it on AKS →**](docs/getting-started.md#deploy-to-aks) &nbsp;·&nbsp; [**Architecture →**](docs/architecture.md) &nbsp;·&nbsp; [**Blueprints →**](docs/blueprints/00-index.md)
 
 </div>
 
 ---
 
-> **Not a fork.** AzureClaw extends [OpenClaw](https://openclaw.ai) using its native
-> plugin API and `tools.deny` config — no OpenClaw source is modified, patched, or
-> vendored. Any upstream OpenClaw release is drop-in compatible. See
-> [Upstream Alignment](docs/upstream-alignment.md) for the full rationale.
+## What problem does this solve?
+
+Giving an AI agent real tools today means giving it real credentials and a real network. That blast radius is unacceptable for any production workload — one prompt-injected agent and your Azure subscription, your GitHub org, your customer data are reachable.
+
+AzureClaw is the runtime that lets you ship agents with the same operational discipline you ship the rest of your services: namespace isolation, NetworkPolicies, signed admission, audit, RBAC. The agent never sees an Azure key. Every model call, every web fetch, every peer message passes through a control plane you can reason about, version, and roll back.
+
+It is built for three audiences:
+
+- **Platform teams** — host LLM agents on AKS without inventing a new operational model.
+- **Security teams** — one opinionated, layered control plane for identity, egress, content safety, governance, mesh trust.
+- **Agent builders** — build the agent, not the boring-but-load-bearing infrastructure underneath it.
 
 ---
 
-## What is AzureClaw?
-
-AzureClaw is a **secure runtime for AI agents on Azure Kubernetes Service**. It answers a single question: *how do you give an AI agent real tools without giving it the keys to the kingdom?*
-
-Every agent runs inside a hardened sandbox pod. A Rust inference router sits in front of every external call — Azure model inference, web fetches, peer messaging — and applies **defense-in-depth controls** at the network, kernel, identity, content-safety, and governance layers. Agents never see Azure credentials. All inter-agent messaging is end-to-end encrypted with the Signal Protocol. One CLI command (`azureclaw up`) takes you from zero to a fully provisioned, secured runtime.
-
-AzureClaw is **not a fork of OpenClaw** — it extends OpenClaw via its native plugin API and `tools.deny` config, so any upstream OpenClaw release is drop-in compatible. See [Upstream Alignment](docs/upstream-alignment.md).
-
-> **Today: a multi-runtime hosting platform.** AzureClaw 2.x ships first-class adapters for OpenClaw (default), OpenAI Agents Python, and Microsoft Agent Framework, plus a documented BYO contract for any custom runtime image. The guardrails — Workload-Identity-fronted inference, Confidential-Container sandboxing, Signal-Protocol mesh, AGT governance, tamper-evident audit, signed OCI egress allowlists — apply uniformly across runtimes via `ClawSandbox.spec.runtime.kind`. **MCP**, **A2A 1.2**, and **AP2** are wired and exercised by CI, with `McpServer` / `A2AAgent` / `ToolPolicy` / `InferencePolicy` / `ClawMemory` / `ClawEval` as first-class CRDs. See [Capabilities](#capabilities--phase-2-shipped) and [Scenario 4 in `docs/use-cases.md`](docs/use-cases.md).
-
-### Who is this for?
-
-- **Platform teams** who need to host LLM agents on AKS with the same operational rigour as the rest of their workloads — namespace isolation, RBAC, NetworkPolicies, audit, signed admission.
-- **Security teams** who want a single, opinionated, layered control plane (egress, content safety, governance, mesh trust) instead of stitching point products together.
-- **Agent builders** who want to ship without writing the boring-but-load-bearing infrastructure: identity, secret rotation, policy, trust, audit, multi-tenant isolation.
-
-### What problems does it solve?
-
-1. **Credential blast radius** — agents talk to Azure via Workload Identity through the router, not via API keys. Compromise of an agent does not compromise the cloud account.
-2. **Tool-call governance** — every shell exec / HTTP fetch / sub-agent spawn passes through a policy decision point with audit. No invisible side effects.
-3. **Inter-agent trust** — agents talk over a Signal-Protocol mesh with explicit KNOCK trust handshake, trust scoring, and tamper-evident audit chain. No plaintext fallback.
-4. **Operational footprint** — `azureclaw up` provisions AKS + ACR + Foundry + Foundry-side Content Safety + sandbox in one go; `azureclaw operator` gives a live TUI for running fleets.
-5. **Multi-runtime out of the box** — see [Capabilities](#capabilities--phase-2-shipped): native adapters for OpenClaw, OpenAI Agents Python, and Microsoft Agent Framework, plus a BYO contract — same governance, same isolation, same audit chain.
-6. **Hardware-isolated cloud offload** — run customer agents in Kata + AMD SEV-SNP confidential containers so even a compromised cluster-admin cannot read prompts in flight. See [Blueprint 03 — Managed public offload](docs/blueprints/03-managed-public-offload.md): not just for enterprises, but for **any managed provider** — small MSPs, indie SaaS, hobbyist co-ops — letting end users offload tasks that don't fit a home setup (heavier models, longer runs, parallel fan-out, jobs requiring premium quota) to a sandbox they don't have to operate themselves.
-
-> 📖 **See [`docs/use-cases.md`](docs/use-cases.md)** for the four end-to-end scenarios — AzureClaw-native agents, **any-OpenClaw → AzureClaw cloud offload** (no AzureClaw CLI on the laptop), AzureClaw ↔ AzureClaw mesh, and the roadmap for non-OpenClaw runtimes via MCP / A2A / AP2. For deployment shapes (developer inner-loop, enterprise self-hosted, managed public offload, cross-org federation, sovereign / air-gapped) with topology + trust-boundary + flow diagrams, see [`docs/blueprints/`](docs/blueprints/00-index.md).
-
----
-
-## Architecture
+## How it works (in one diagram)
 
 ```
-  External A2A peer ──┐                ┌──── User (TUI / Telegram / Web UI)
-                      │                │
-                      ▼                ▼
-   ┌──────────────────────────────────────────────────────────────────────────┐
-   │  AKS Cluster (Azure Linux · Cilium)                                      │
-   │                                                                          │
-   │  ┌─ a2a-gateway ─────────────────┐   (opt-in, ADR-0001 · mTLS to router) │
-   │  │  Public ingress edge          │                                       │
-   │  │  Verifies inbound A2A 1.2 JWS │                                       │
-   │  └──────────────┬────────────────┘                                       │
-   │                 │ mTLS (cluster-internal)                                │
-   │                 ▼                                                        │
-   │  ┌─ Sandbox Pod (per agent · runtime: OpenClaw│OpenAIAgents│MAF│BYO) ─┐  │
-   │  │                                                                    │  │
-   │  │  init: egress-guard (iptables, UID 1000 → localhost + DNS only)    │  │
-   │  │                                                                    │  │
-   │  │  ┌──────────────┐   localhost    ┌──────────────────────┐          │  │
-   │  │  │  Agent       │──────:8443────►│  Inference Router    │──────────┼──┼──► Azure AI Foundry
-   │  │  │  (runtime    │                │  (Rust · in-data-path)│         │  │     (200+ models)
-   │  │  │   adapter)   │                │                       │         │  │
-   │  │  └──────────────┘                │ • WI/IMDS auth        │         │  │
-   │  │   read-only rootfs               │ • Content Safety floor│         │  │
-   │  │   drop ALL caps                  │ • Token budgets       │         │  │
-   │  │   no Azure credentials           │ • Egress allowlist    │         │  │
-   │  │                                  │   (signed OCI ref)    │         │  │
-   │  │                                  │ • Platform MCP shim   │         │  │
-   │  │                                  │   (Foundry tools)     │         │  │
-   │  │                                  │ • AGT governance      │         │  │
-   │  │                                  │   PolicyEngine /      │         │  │
-   │  │                                  │   TrustManager /      │         │  │
-   │  │                                  │   AuditLogger /       │         │  │
-   │  │                                  │   RateLimiter /       │         │  │
-   │  │                                  │   BehaviorMonitor     │         │  │
-   │  │                                  └───────────────────────┘         │  │
-   │  │  NetworkPolicy: default-deny egress · seccomp strict               │  │
-   │  └────────────────────────────────────────────────────────────────────┘  │
-   │                                                                          │
-   │  ┌─ AgentMesh (E2E encrypted, Signal Protocol) ─────────────────────────┐│
-   │  │  agent-alpha ◄── X3DH + Double Ratchet, KNOCK trust-gated ──► agent-β││
-   │  │  agentmesh-relay (WS) · agentmesh-registry (REST + Postgres)         ││
-   │  └──────────────────────────────────────────────────────────────────────┘│
-   │                                                                          │
-   │  Controller (Rust · kube-rs) — reconciles 8 CRDs:                        │
-   │    ClawSandbox · ClawPairing · McpServer · ToolPolicy ·                  │
-   │    InferencePolicy · A2AAgent · ClawMemory · ClawEval                    │
-   │    + leader-election · SSA field managers · jittered backoff · metrics   │
-   └──────────────────────────────────────────────────────────────────────────┘
+                    ┌──────────────── Sandbox pod ────────────────┐
+   User / TUI ────► │  agent container (UID 1000, no network)     │
+                    │              │                              │
+                    │              │  localhost only              │
+                    │              ▼                              │
+                    │  ┌────────────────────────────────────┐     │
+                    │  │  Inference Router (Rust)           │     │
+                    │  │                                    │     │
+                    │  │  Identity (Workload Identity)      │     │
+                    │  │  Content Safety (Foundry)          │     │
+                    │  │  Token budget · rate limit         │     │
+                    │  │  Tool policy · governance (AGT)    │     │
+                    │  │  Audit (tamper-evident chain)      │     │
+                    │  └─────────────────┬──────────────────┘     │
+                    │                    │                        │
+                    │            init: egress-guard               │
+                    │       (iptables: only the router            │
+                    │        can talk to the outside)             │
+                    └────────────────────┼────────────────────────┘
+                                         │
+                            Workload Identity (no keys)
+                                         │
+                  ┌──────────────────────┼─────────────────────────┐
+                  ▼                      ▼                         ▼
+           Azure AI Foundry        AgentMesh relay            A2A peers
+           (model + Content        (Signal-Protocol           (signed
+            Safety + tools)         E2E messages)              AgentCards)
 ```
 
-> 📐 **[Architecture & Flow Diagrams](docs/architecture-diagrams.md)** — Mermaid diagrams for all core flows: pod architecture, agent creation, sub-agent spawning, E2E encrypted communication, inference routing, egress control, bidirectional handoff with sub-agents, and defense-in-depth layers.
+**The agent has no network of its own.** Every byte that leaves the pod leaves through the router. Compromise of the agent does not compromise the cloud account, the model, the audit log, or the peer mesh.
+
+For the full picture (control plane, data plane, mesh, A2A, MCP), see **[`docs/architecture.md`](docs/architecture.md)** and **[`docs/architecture-diagrams.md`](docs/architecture-diagrams.md)**.
 
 ---
 
-## 🚀 Get started in 60 seconds
+## Two modes, one mental model
 
-```bash
-# Clone, install CLI
-git clone https://github.com/Azure/azureclaw.git && cd azureclaw/cli
-npm install && npm run build && npm link
+You write the same `ClawSandbox` YAML for both. The difference is where it runs and what isolates it.
 
-# Local dev (Docker, no Azure needed)
-azureclaw dev
-
-# Or deploy to AKS (provisions AKS + ACR + Foundry end-to-end)
-azureclaw up
-```
-
-Full instructions, prerequisites, and the **Path A (local Docker)** vs **Path B (production AKS)** breakdown are in the [Quick Start](#quick-start) section below.
-
----
-
-## Docker Images
-
-| Image | Language | Purpose |
-|-------|----------|---------|
-| `azureclaw-controller` | Rust | K8s operator — reconciles all 8 CRDs (ClawSandbox, ClawPairing, McpServer, ToolPolicy, InferencePolicy, A2AAgent, ClawMemory, ClawEval); periodic federated-credential reaper GCs orphan credentials against the Azure 20-fedcred-per-MI cap |
-| `azureclaw-inference-router` | Rust | Inference proxy — Workload Identity auth, Content Safety floor, AGT governance, signed-OCI egress allowlist, platform MCP shim for Foundry tools |
-| `azureclaw-a2a-gateway` | Rust | Public ingress edge for inbound A2A 1.2 federation (axum + rustls; mTLS to router; opt-in via `azureclaw up --enable-a2a-ingress`; see [ADR-0001](docs/adr/0001-a2a-ingress-front-edge.md)) |
-| `azureclaw-sandbox` (built from `sandbox-images/openclaw`) | Node.js | Default OpenClaw runtime container (OpenClaw + AGT SDK + Python tools) |
-| `agentmesh-relay` | Rust | WebSocket relay for E2E encrypted inter-agent messaging — see *AgentMesh & vendoring* below |
-| `agentmesh-registry` | Rust + PostgreSQL | Agent discovery, prekey storage, React admin UI — see *AgentMesh & vendoring* below |
-
-`azureclaw push` builds the 5 images above by default. The shared
-`sandbox-base` image is built only when `--include-base` is passed. A separate
-`sandbox-images/nemoclaw/` image exists for any-OpenClaw-host clients (laptop,
-NemoClaw, etc.) that want to offload to AzureClaw — see
-[`docs/internal/any-openclaw-cloud-offload.md`](docs/internal/any-openclaw-cloud-offload.md).
-
-All images build on Azure Linux 3 (`mcr.microsoft.com/azurelinux/base/core:3.0`).
-
----
-
-## Key Features
-
-### 🔒 Security (defense-in-depth)
-
-**Always on (all isolation levels):**
-
-- **iptables egress guard** — agent process can only reach `localhost`; all external traffic forced through router
-- **NetworkPolicy** — default-deny egress at the cluster level
-- **Read-only rootfs** — non-root, drop ALL capabilities, no privilege escalation
-- **Domain blocklist** — 51k+ domains auto-refreshed from OISD + URLhaus every 6h
-- **Content Safety + Prompt Shields** — Azure AI Content Safety on every inference call
-- **Zero Azure credentials** — agents never see Azure auth tokens; the router authenticates via IMDS/Workload Identity
-
-**Per isolation level (`--isolation`):**
-
-| Level | Runtime | What it adds |
-|-------|---------|-------------|
-| `standard` | runc | Kernel-default seccomp filter |
-| `enhanced` (default) | runc | Custom strict seccomp profile (~219 allowed syscalls) |
-| `confidential` | Kata VM | Per-pod dedicated kernel on AMD SEV-SNP hardware — container escapes hit a VM boundary |
-
-> **Note on plugin credentials:** Channel tokens (Telegram, Slack) and third-party API keys (Brave, Tavily) are accessible to the agent process — plugins need them to function. However, the agent cannot exfiltrate them: iptables blocks all outbound traffic except through the governed router. Azure auth tokens remain isolated in the router at all times.
-
-### 🤖 AI Agent
-
-- **Messaging channels** — Telegram, Slack, Discord, WhatsApp (auto-configured via CLI flags)
-- **Third-party plugins** — Brave, Tavily, Exa, Firecrawl, Perplexity (API key → auto-enabled)
-- **Foundry web search** — Bing Grounding via Responses API (zero-config, no API key needed)
-- **Sub-agent spawning** — agents create child agents via CRD (isolated, governed, full tool access via native delegation)
-- **10 Foundry skills** — web search (Bing Grounding), code execute, image generation, file search, memory, conversations, evaluations, knowledge, and more — all via Workload Identity (no API keys)
-- **Python 3** — 43 packages pre-installed: pandas, numpy, scipy, matplotlib, pdfplumber, pypdf, python-docx, openpyxl, python-pptx, Pillow, sqlalchemy, tiktoken, cryptography, networkx, and more
-- **200+ models** — hot-switch between GPT-4.1, GPT-5-mini, DeepSeek-V3.2, Phi-4, Llama, etc.
-- **Multi-frontend** — TUI, Telegram, Web UI at `localhost:18789`
-
-### 🏛️ Governance (AGT — native Rust)
-
-- **Native governance** — policy evaluation, trust management, and audit run in-process inside the Rust inference router (no sidecar, <1µs eval latency)
-- **Trust scoring** — per-agent scores 0–1000, threshold 500, clamped ±200/update, Ed25519 signed
-- **Policy engine** — YAML-driven rules (hot-reloaded) covering shell safety, inference rate-limiting, content safety, mesh trust gates
-- **Audit trail** — SHA-256 Merkle tree append-only chain with tamper detection and integrity verification
-- **Components** — PolicyEngine, TrustManager, AuditLogger, RateLimiter, BehaviorMonitor (native Rust, compiled into the inference router)
-- **Prometheus metrics** — `azureclaw_agt_policy_evaluations_total`, `azureclaw_agt_eval_latency_seconds`, `azureclaw_agt_behavior_alerts_total`, and more
-
-### 🔐 E2E Encryption (Signal Protocol)
-
-- **X3DH key exchange** — identity, signed-prekey, and one-time prekey bundles for session setup
-- **Double Ratchet** — per-message forward secrecy via ratchet rotation
-- **KNOCK protocol** — policy-gated session establishment (trust score ≥ 500 required)
-- **AgentMesh relay** — untrusted WebSocket relay (`:8765`) routes encrypted payloads without decryption
-- **AgentMesh registry** — agent discovery and prekey storage (REST `:8080` + PostgreSQL)
-
-### ⚙️ Operations
-
-- **One-command deploy** — `azureclaw up` provisions AKS + ACR + Foundry + sandbox end-to-end, with a preflight RBAC check that fails fast (~30 s) if your Azure permissions are insufficient
-- **Live handoff** — `azureclaw handoff <name> --to cloud|local` migrates agents between local Docker and AKS with sub-agent state, E2E encrypted workspace transfer, and task resumption
-- **Operator dashboard** — `azureclaw operator` launches a live TUI for managing all agents
-- **Credential management** — `azureclaw credentials update` rotates tokens for running sandboxes; gateway tokens are mounted via `secretKeyRef`, never in plain pod env
-- **Image pipeline** — `azureclaw push` builds and pushes images to ACR with optional rollout
-- **Monitoring** — Prometheus metrics, OpenTelemetry GenAI semantic conventions on every router span, Log Analytics, eBPF tracing via `azureclaw trace`
-- **Federated-credential reaper** — controller periodically GCs orphan federated credentials so sandbox managed identities never hit the Azure 20-fedcred-per-MI cap
-
----
-
-## Capabilities — Phase 2 shipped
-
-AzureClaw started as a secure runtime for OpenClaw agents. Phase 2 generalised the substrate so the same governance and isolation guarantees apply to any agent runtime that speaks open protocols (MCP, A2A, AP2). The platform-level work is **shipped, default-on where safe, and exercised by CI** — not scaffolding.
-
-| Capability | State | Surface |
+| Aspect | **Dev mode** (`azureclaw dev`) | **Prod mode** (`azureclaw up` → AKS) |
 |---|---|---|
-| **Multi-runtime hosting** | ✅ shipped | `ClawSandbox.spec.runtime.kind ∈ { OpenClaw, OpenAIAgents, MicrosoftAgentFramework, BYO }` — `OpenClaw` is default; `BYO` requires the documented [runtime contract](docs/runtime-contract.md). OpenAI Agents Python and Microsoft Agent Framework adapters live under `runtimes/` |
-| **MCP 2026 server CRD** | ✅ shipped | `McpServer` reconciler emits JWKS Secret + signing keypair; router mounts `/mcp` once Secret exists; per-tool OAuth 2.1 scope checks |
-| **A2A 1.2 + AP2** | ✅ shipped | `A2AAgent` reconciler signs and publishes Agent Cards at `/.well-known/agent.json`; `ToolPolicy` carries AP2 `commerce` / `approval` / `rateLimit` precedence rules; inbound federation goes through the dedicated `a2a-gateway` component (opt-in) |
-| **Inference policy as a CRD** | ✅ shipped | `InferencePolicy` carries token budgets, content-safety floor, model preference; hot-reloads into the router via informer; admission policy enforces a cluster-level Content Safety floor |
-| **Memory binding** | ✅ shipped | `ClawMemory` is a *binding* CR over Foundry Memory Store — never an in-cluster store. Scope, retention, RBAC, delete-on-sandbox-delete are preserved in the compiled binding |
-| **Eval-as-CRD** | ✅ shipped | `ClawEval` runs one-shot or scheduled eval suites (promptfoo / inspect-ai / Foundry Evals) over a `sandboxRef` and reports pass/score on status |
-| **Signed OCI egress allowlist** | ✅ shipped | `azureclaw egress … --sign` builds a canonical allowlist artifact, pushes it to ACR, cosign-signs it (keyless / OIDC token / KMS) and patches `ClawSandbox.spec.networkPolicy.allowlistRef`. Controller verifies signer identity against a `SignerPolicy` ConfigMap and derives `allowedEndpoints` fail-closed |
-| **Operator TUI** | ✅ shipped | `azureclaw operator` renders all 8 CRDs + provider status with per-CRD modular panels |
-| **`kubectl claw attest`** | ✅ shipped (read surface) | `azureclaw attest <name>` returns spec hash, SSA field-owner map, most-recent reconcile-span trace, policy version, AGT receipt id (signed-chain *emission* lands in Phase 3) |
-| **CNCF K8s AI Conformance v1.35+** | ✅ shipped | Suite wired into CI under `tests/cncf-conformance/`; evidence archived per run. Public certification filing is deferred to post-OSS |
-| **Chaos / fault-injection tier** | ✅ shipped | `tests/chaos/` exercises K8s API flakes, Foundry 429 storms, Entra token rotation races, AGT provider timeouts; reconcilers asserted idempotent + eventually consistent |
-| **Sigs/agent-sandbox compat** | ✅ shipped | `ClawSandbox.spec.upstreamCompatibility ∈ { Native, Translate, Overlay }`; `azureclaw convert` translates ClawSandbox ↔ upstream `Sandbox` CR; `azureclaw migrate from-kagent` ports kagent CRs |
-| **Pluggable governance providers** | ✅ shipped | `PolicyDecisionProvider`, `AuditSink`, `SigningProvider`, `MeshProvider` traits; in-tree implementations are the production path; native AGT-Rust 3.x compiled in |
+| Where | One Docker container on your laptop | An AKS cluster in your subscription |
+| Pod shape | **Single container** — agent + router co-located in one image | **Multi-container pod** — agent (UID 1000) + router (UID 1001) + init `egress-guard` |
+| Network isolation | Docker network, no egress guard | NetworkPolicy + `egress-guard` initContainer + per-namespace isolation |
+| Identity | Resource-level API key (you provide once, mounted from secret) | Workload Identity (federated, no keys on disk) |
+| Optional VM isolation | n/a | Kata + AMD SEV-SNP (Confidential Containers) |
+| Use it for | Inner-loop dev, plugin authoring, demos | Real workloads, multi-tenant, production |
 
-What is *not* in the box for v1.0 (some of these are tracked as `[GAP-V1]` in source for reviewer visibility):
-
-- Cosign-on-admission for pod images, SLSA-on-CRs, signed reconcile audit chain *emission* (Phase 2 ships only the read surface).
-- Confidential controller; router-mediated controller egress.
-- Native runtime adapters beyond OpenAI Agents Python + MAF (Semantic Kernel, Anthropic, LangGraph, Google ADK, Pydantic AI, Strands).
-- Public AAIF / CNCF Sandbox filing (gated on OSS publication).
+Same CRDs. Same router code path. Same audit format. Same governance profiles. The graduation from `dev` to `up` is a one-line CLI change, not a port to a new system.
 
 ---
 
-## AgentMesh & vendoring (transitional)
-
-Inter-agent messaging today runs on a vendored fork of [AgentMesh](https://github.com/amitayks/agentmesh) (relay + registry + SDK). AgentMesh is pre-release; while integrating it we contributed bug fixes and protocol corrections that are tracked in this tree until they land upstream. Each fix is documented in `vendor/<component>/README.md`, and an index lives at [`docs/internal/agt-vendored-patch-audit.md`](docs/internal/agt-vendored-patch-audit.md).
-
-**Direction of travel:** Microsoft's Agent Governance Toolkit (AGT) is shipping a first-party AgentMesh transport. Once it stabilises, AzureClaw's `MeshProvider` seam (defined plugin-side; the router has no in-tree mesh implementation) will allow operators to switch to the AGT mesh per-tenant without breaking existing deployments. Until then, the vendored stack is the supported production path.
-
----
-
-## Engineering & quality posture
-
-We treat security and code health as product-grade concerns:
-
-- **Six blocking CI gates** — LOC budget, anti-stub (no `TODO`/`unimplemented!` on production paths), no custom crypto outside provider seams, no `Null*` providers in production, mandatory security-audit document per capability-introducing PR, vendored-patch re-audit on every AGT SDK bump.
-- **Per-capability security audits** — every PR that introduces a new CRD, router route, admission policy, or sandbox-image change ships a `docs/internal/security-audits/<date>-<slug>.md` with threat-model delta, OWASP mapping, AuthN/Z path, secret custody, audit events, failure mode, and two engineer sign-offs.
-- **Behavioral conformance corpus** — `tests/conformance/` covers Signal Protocol (X3DH / KNOCK / negative cases), sandbox isolation, and the protocol scaffolding above with mandatory negative tests (tampered ciphertext, replayed message, expired mandate).
-- **Compat suite** — `tests/compat/` regression-tests user-visible flows (today: the operator TUI; growing per phase).
-- **Fuzz targets** — cargo-fuzz coverage for handoff state deserialization, chat sanitisation, JWS parsing, base64url decoding, streaming response parsing.
-
-A complete inventory of these controls is in [`docs/architecture.md`](docs/architecture.md) and the per-slice security audits under [`docs/internal/security-audits/`](docs/internal/security-audits/).
-
----
-
-## Quick Start
-
-### Prerequisites
-
-| Tool | Version | Required For |
-|------|---------|--------------|
-| Node.js | 22+ | CLI (both paths) |
-| Docker | Latest | Local dev + image builds |
-| Azure CLI | 2.60+ | AKS path only |
-| kubectl | 1.28+ | AKS path only |
-| Helm | 3.14+ | AKS path only |
-| Rust | 1.88+ (edition 2024) | Building from source (both paths) |
-
-> **Azure RBAC:** `azureclaw up` needs `Contributor` **and** `User Access Administrator` at subscription scope (or `Owner`). See [`docs/permissions.md`](docs/permissions.md) for the full breakdown, a least-privilege custom role, and common failure modes. The CLI runs a preflight check automatically and fails fast in ≤30s if anything is missing.
-
-### Step 1: Install the CLI
+## Try it in five minutes
 
 ```bash
-git clone https://github.com/Azure/azureclaw.git
-cd azureclaw
-
-# Build the CLI
+# Build the CLI (Node 22+, Rust 1.88+)
+git clone https://github.com/Azure/azureclaw.git && cd azureclaw
 cd cli && npm ci && npm run build && npm link
-cd ..
 
-# Verify
-azureclaw --help
+# Launch a sandbox locally — Docker only, no Azure, no AKS
+azureclaw dev --name hello
+
+# Talk to it (TUI auto-opens; or use the CLI directly)
+azureclaw connect hello
 ```
+
+On first run `azureclaw dev` prompts for your Azure OpenAI endpoint, deployment name, and a resource-level API key — that is the only credential the local mode ever sees, and it never leaves your laptop. From here, every tool call the agent makes is governed by the same router code path that runs in production.
+
+When you are ready for the real thing:
+
+```bash
+azureclaw up --name prod-agent --location swedencentral
+```
+
+`azureclaw up` provisions the AKS cluster, ACR, Foundry resource, Foundry-side Content Safety, controller, A2A gateway, AgentMesh relay+registry, and your first sandbox — Workload Identity wired end-to-end. See **[`docs/getting-started.md`](docs/getting-started.md)** for the full walkthrough including how to bring your own AKS / Foundry / ACR.
 
 ---
 
-### Path A: Local Dev (Docker) — no Azure needed
+## What is built in
 
-Start a sandboxed agent locally in under a minute:
+### Eight CRDs
 
-```bash
-# Build the sandbox image and start it
-azureclaw dev --build
+`ClawSandbox` is the unit of work — one CRD per agent. Everything else binds policy, identity, or peer relationships to it.
 
-# First run will prompt for Azure OpenAI credentials:
-#   Endpoint: https://your-resource.openai.azure.com
-#   API Key:  sk-...
-# Or set them beforehand:
-azureclaw credentials
-
-# You're now in a chat session with a governed AI agent
-🦞 You: What's the latest news about AI security?
-```
-
-**Optional enhancements:**
-
-```bash
-# Add Telegram channel
-azureclaw dev --build --channels telegram --telegram-token "BOT_TOKEN"
-
-# Add third-party search plugins
-azureclaw dev --build --brave-api-key "KEY" --tavily-api-key "KEY"
-
-# Use a specific model
-azureclaw dev --build --model gpt-5-mini
-```
-
-> **What happens:** Docker builds the sandbox image (Azure Linux 3 + inference router + OpenClaw), starts a container with iptables egress filtering, and connects you via the TUI. No Kubernetes needed.
-
----
-
-### Path B: Deploy to AKS (Production)
-
-Full production deployment with all 9 security layers:
-
-```bash
-# 1. Login to Azure
-az login
-
-# 2. Build all 5 container images (controller, router, sandbox, relay, registry)
-#    First run takes ~10 min; subsequent builds are cached
-azureclaw push
-
-# 3. Deploy everything — AKS cluster, ACR, Key Vault, Azure OpenAI, Helm chart
-#    Prompts for region, subscription, and agent name
-azureclaw up
-
-# 4. Verify the cluster is healthy
-azureclaw operator    # live TUI — press 'c' for cluster health
-
-# 5. Connect to your first agent
-azureclaw connect my-assistant
-```
-
-**What `azureclaw up` does (in order):**
-1. Preflight checks (az, kubectl, helm, subscription, SKU availability)
-2. Deploys Azure infrastructure via Bicep (AKS, ACR, Key Vault, AOAI)
-3. Installs AzureClaw Helm chart (CRD, controller, RBAC, seccomp profiles)
-4. Deploys AgentMesh (relay + registry) for E2E encrypted inter-agent comms
-5. Creates your first agent sandbox with native AGT governance
-
-**After deployment:**
-
-```bash
-# Add more agents
-azureclaw add research-bot --model gpt-4.1 --governance --learn-egress
-
-# Add channels
-azureclaw credentials update research-bot --telegram-token "BOT_TOKEN"
-
-# Add a confidential agent (auto-provisions Kata nodepool)
-azureclaw add helper --model gpt-5-mini --isolation confidential
-
-# Review egress activity
-azureclaw egress research-bot --learned
-
-# Multi-agent communication (E2E encrypted)
-azureclaw connect research-bot
-🦞 You: @helper can you review this code for security issues?
-```
-
-### Operator Dashboard
-
-```bash
-azureclaw operator
-```
-
-Live TUI for managing all agents across your cluster:
-
-```
-┌─────────────── 🔱 AzureClaw Operator │ azureclaw-aks │ ● API 5/5 ──┐
-│ ● research-bot    Running   gpt-4.1     enhanced   tg    2h         │
-│ └ kernel-checker  Running   gpt-5-mini  enhanced          45m       │
-│ ● helper          Running   gpt-5-mini  confidential      30m       │
-├── Security ────────┬── Egress ──────────┬── Activity ────────────────┤
-│ Isolation enhanced │ ●P api.openai.com  │ ✓ Approved 3 domains      │
-│ Seccomp   strict   │ ✓A graph.microsoft │ ↻ Refreshed 3 agents      │
-├────────────────────┴────────────────────┴────────────────────────────┤
-│ [Tab] Focus [↑↓] Nav [Enter] Connect [c] Cluster [n] Spawn [q] Quit│
-└─────────────────────────────────────────────────────────────────────-┘
-```
-
-**Keyboard:** `Enter` connect to agent TUI · `Tab` switch panels · `a` approve egress · `Shift+A` approve all · `d` delete/deny · `e` enforce egress · `n` spawn agent · `m` switch model · `c` cluster health · `l` logs · `r` refresh · `q` quit
-
-### Update Credentials
-
-Rotate channel tokens or plugin API keys on running sandboxes without redeploying:
-
-```bash
-azureclaw credentials update my-agent \
-  --telegram-token "NEW_TOKEN" \
-  --brave-api-key "NEW_KEY"
-```
-
----
-
-## CLI Reference
-
-`azureclaw` ships **23 top-level commands** (`cli/src/commands/`):
-`a2a · add · attest · connect · convert · credentials · destroy · dev · egress · eval · handoff · list · logs · mesh · migrate · model · operator · pair · policy · push · status · trace · up`.
-
-| Command | Description |
+| CRD | Purpose |
 |---|---|
-| **Lifecycle** | |
-| `azureclaw up` | Deploy full stack — preflight, AKS + ACR + Foundry + sandbox |
-| `azureclaw up --upgrade` | Fast upgrade — reuse cached context, Helm + RBAC + fedcred sync |
-| `azureclaw up --enable-a2a-ingress` | Provision the public A2A gateway component (off by default) |
-| `azureclaw dev` | Local Docker sandbox with same security controls |
-| `azureclaw add <name>` | Add sandbox to existing cluster (`--runtime openclaw\|openai-agents\|microsoft-agent-framework\|byo`) |
-| `azureclaw destroy [name]` | Tear down sandbox or entire resource group (`--all`) |
-| `azureclaw push` | Build and push images to ACR (`--apply` restarts deployments, `--only <image>` for single image, `--include-base` to also build the shared base) |
-| `azureclaw convert` | Translate between `ClawSandbox` and `sigs/agent-sandbox` `Sandbox` shapes |
-| `azureclaw migrate to-overlay\|from-overlay\|to-translate\|to-observe\|to-native` | Switch a sandbox's `upstreamCompatibility` mode in place |
-| `azureclaw migrate from-kagent <file>` | Port a kagent CR to a `ClawSandbox` |
-| **Operations** | |
-| `azureclaw operator` | Live TUI dashboard — renders all 8 CRDs + provider status |
-| `azureclaw connect <name>` | TUI, shell (`--shell`), or Web UI (`--web`) — surfaces `kubectl` stderr on port-forward failure |
-| `azureclaw handoff <name> --to cloud\|local` | Live-migrate agent + sub-agents between local Docker and AKS |
-| `azureclaw handoff <name> --status\|--abort` | Show progress / abort an in-flight handoff |
-| `azureclaw status <name>` | Health, model, tokens used |
-| `azureclaw list` | All sandboxes across Docker and AKS |
-| `azureclaw logs <name>` | Stream logs (`-f`, `--service router\|gateway\|openclaw`) |
-| `azureclaw attest <name>` | Read-side attestation — spec hash, SSA owner map, reconcile-trace, policy version, AGT receipt id |
-| **Configuration** | |
-| `azureclaw credentials` | Set Azure OpenAI credentials (interactive) |
-| `azureclaw credentials update <name>` | Rotate channel/plugin keys on running sandbox |
-| `azureclaw model set\|get\|list` | Switch / inspect model (hot-swap, no restart) |
-| `azureclaw policy allow\|deny\|get` | Manage per-sandbox egress policy |
-| `azureclaw egress <name>` | Egress management (`--learned`, `--pending`, `--blocked`, `--approve`, `--enforce`) |
-| `azureclaw egress sign <name>` | Build a canonical allowlist artifact, push to ACR, cosign-sign (keyless / OIDC token / KMS), patch `allowlistRef`. Add `--emit-manifest` for GitOps |
-| **Observability** | |
-| `azureclaw trace <name>` | eBPF tracing (`--network`, `--dns`, `--files`, `--exec`) |
-| `azureclaw eval <name>` | Run Foundry evaluations against agent (one-shot or via `ClawEval` CR) |
-| **Multi-Agent** | |
-| `azureclaw mesh auth\|identity\|oauth\|health\|promote` | Mesh identity / OAuth / health / promotion subcommands |
-| `azureclaw mesh send <amid>` | Send E2E encrypted message to another agent |
-| `azureclaw pair <a> <b>` | Pair two existing sandboxes via `ClawPairing` CR |
-| `azureclaw a2a list-exposed\|tail\|schema` | List exposed A2A endpoints, tail gateway access logs, print local A2A schema |
+| **`ClawSandbox`** | The agent itself: runtime kind, model, tools, mesh membership, governance profile. |
+| **`A2AAgent`** | Public-ingress A2A endpoint for peer-to-peer agent communication (A2A 1.2). |
+| **`McpServer`** | An external MCP server the agent is allowed to call, with auth + scope. |
+| **`ToolPolicy`** | Allow/deny/approval rules for shell, HTTP, file, sub-agent spawn. |
+| **`InferencePolicy`** | Per-tenant model routing, token budgets, region pinning, cost caps. |
+| **`ClawMemory`** | Memory-store binding (Foundry Memory Store) with project-MI auth. |
+| **`ClawEval`** | Reproducible evaluation runs against a sandbox spec. |
+| **`TrustGraph`** | Cross-namespace / cross-cluster trust topology for the AgentMesh layer. |
 
-### Common Flags
+Full schema in **[`docs/api/crd-reference.md`](docs/api/crd-reference.md)**.
 
-These flags are shared across `dev`, `add`, and `credentials update`:
+### Seven first-class agent runtimes (plus BYO)
 
-| Flag | Description |
-|---|---|
-| `--channels telegram,slack,discord,whatsapp` | Enable messaging channels |
-| `--telegram-token`, `--slack-token`, `--discord-token` | Channel credentials |
-| `--brave-api-key`, `--tavily-api-key`, `--exa-api-key` | Search plugins |
-| `--firecrawl-api-key`, `--perplexity-api-key`, `--openai-api-key` | Additional plugins |
-| `--governance` / `--no-governance` | AGT governance (trust, policy, audit) |
-| `--learn-egress` | Enable egress learn mode |
-| `--isolation standard\|enhanced\|confidential` | Pod isolation level |
-| `--model <model>` | AI model (default: `gpt-4.1`) |
+You pick the runtime via `ClawSandbox.spec.runtime.kind`. The router, governance, isolation, and audit chain are identical across all of them.
+
+| Runtime | Language | Image dir | Status |
+|---|---|---|---|
+| **OpenClaw** (default) | Python | `sandbox-images/openclaw/` | ✅ |
+| **OpenAI Agents SDK** | Python | `sandbox-images/openai-agents/` | ✅ |
+| **Microsoft Agent Framework** | Python | `sandbox-images/maf-python/` | ✅ (`.NET` deferred) |
+| **LangGraph** | Python | `sandbox-images/langgraph/` | ✅ |
+| **LangGraph.js** | TypeScript | `sandbox-images/langgraph-ts/` | ✅ |
+| **Anthropic Claude Agent SDK** | Python | `sandbox-images/anthropic/` | ✅ |
+| **Pydantic-AI** | Python | `sandbox-images/pydantic-ai/` | ✅ |
+| **BYO** | any | your image, our contract | ✅ |
+
+The BYO contract is documented in **[`docs/runtimes.md`](docs/runtimes.md)**. Semantic Kernel and MAF .NET are wired in the CRD enum but the adapter images are deferred — the controller emits a clear `ShapeInvalid` condition rather than silently mis-imaging the pod.
+
+### One mesh, one gateway, one CLI
+
+- **AgentMesh** — Signal Protocol (X3DH + Double Ratchet) over a small relay/registry, KNOCK trust handshake, per-message forward secrecy. No plaintext fallback.
+- **A2A 1.2 gateway** — public-ingress for peer-to-peer agent traffic with signed `AgentCard` verification, tenant routing, observability.
+- **CLI (`azureclaw …`)** — 26 commands covering the whole lifecycle: `dev`, `up`, `add`, `connect`, `handoff`, `mesh`, `policy`, `egress`, `eval`, `attest`, `migrate`, `operator` (live TUI), `destroy`. Full reference in **[`docs/cli-reference.md`](docs/cli-reference.md)**.
 
 ---
 
-## Channels & Plugins
+## What it is *not*
 
-### Messaging Channels
-
-| Channel | Flag | Credential |
-|---------|------|-----------|
-| Telegram | `--channels telegram` | `--telegram-token` (BotFather) |
-| Slack | `--channels slack` | `--slack-token` (Bot OAuth) |
-| Discord | `--channels discord` | `--discord-token` |
-| WhatsApp | `--channels whatsapp` | QR code pairing at runtime |
-
-On AKS, channel tokens are stored as K8s secrets and injected into the sandbox pod automatically.
-
-### Third-Party Plugins
-
-| Plugin | Flag |
-|--------|------|
-| Brave Search | `--brave-api-key` |
-| Tavily | `--tavily-api-key` |
-| Exa | `--exa-api-key` |
-| Firecrawl | `--firecrawl-api-key` |
-| Perplexity | `--perplexity-api-key` |
-| OpenAI | `--openai-api-key` |
-
-Plugins auto-activate when their API key is present. No additional configuration needed.
-
-### Foundry Web Search (Bing Grounding)
-
-Built-in web search via Azure AI Foundry's Responses API. **No API key needed** — auto-discovers the Foundry project's Bing connection at runtime.
-
-See [docs/channels-plugins.md](docs/channels-plugins.md) for setup and details.
+- **Not a fork of OpenClaw.** AzureClaw extends [OpenClaw](https://openclaw.ai) through its native plugin API and `tools.deny` config. No OpenClaw source is modified, patched, or vendored. Any upstream OpenClaw release is drop-in compatible. See **[`docs/upstream-alignment.md`](docs/upstream-alignment.md)**.
+- **Not a managed service.** It is a runtime you operate yourself, in your subscription, in your AKS cluster.
+- **Not a model provider.** Models come from Azure AI Foundry (or any compatible provider through the BYO contract). AzureClaw governs the data path; it does not host the model.
 
 ---
 
 ## Documentation
 
-| Document | Description |
+| If you want to… | Read |
 |---|---|
-| [Use Cases](docs/use-cases.md) | Canonical scenarios: AzureClaw-native, any-OpenClaw → AzureClaw offload, AzureClaw ↔ AzureClaw mesh, multi-runtime |
-| [Architecture](docs/architecture.md) | Component design, CRD schema, API routes, four-seam providers, MCP/A2A modules, operator dashboard, auth flow |
-| [Architecture Diagrams](docs/architecture-diagrams.md) | Mermaid flow diagrams: pod layout, agent creation, spawn, mesh, egress, inference, A2A ingress |
-| [CRD Reference](docs/api/crd-reference.md) | Full schema, validation, conditions and field-manager split for all 8 CRDs |
-| [CLI Reference](docs/cli-reference.md) | Every flag, option, and subcommand of the 23 top-level commands |
-| [Runtime Contract](docs/runtime-contract.md) | The `org.azureclaw.runtime.contract=v1` BYO contract — what any custom runtime image must satisfy |
-| [Blueprints](docs/blueprints/00-index.md) | Five deployment shapes: developer inner-loop, enterprise self-hosted, managed public offload, cross-org federation, sovereign / air-gapped |
-| [Security](docs/security.md) | Defense-in-depth model, OWASP coverage, threat mitigations, CI gates, security-audit framework |
-| [Threat Model — Routes](docs/internal/threat-model.md) | Per-route auth tier, input validation, blast-radius analysis |
-| [AGT Vendored-Patch Audit](docs/internal/agt-vendored-patch-audit.md) | Index of fixes applied to the vendored AgentMesh stack pending AGT mesh shipping |
-| [`sigs/agent-sandbox` Compat](docs/internal/sigs-agent-sandbox-compat.md) | Native / Translate / Overlay modes; `azureclaw convert` and `azureclaw migrate` |
-| [OWASP MCP Top 10 (2025)](docs/security-mcp-top10.md) | Controls matrix for the MCP 2026 surface |
-| [ADR-0001 — A2A ingress front-edge](docs/adr/0001-a2a-ingress-front-edge.md) | Gateway-only, surgical opt-in posture for inbound A2A |
-| [Channels & Plugins](docs/channels-plugins.md) | Telegram, Slack, Discord, search plugins, Foundry Bing |
-| [Egress Proxy](docs/egress-proxy.md) | Blocklist, allowlist, learn mode, approval flow, signed-OCI allowlist refs |
-| [E2E Encryption](docs/internal/e2e-encryption-proof.md) | Signal Protocol inter-agent encryption proof |
-| [Multi-Tenant](docs/multi-tenant.md) | Namespace isolation, credential and channel separation |
-| [Security Validation](docs/security-validation.md) | Live cluster evidence for every security layer |
-| [Permissions](docs/permissions.md) | Required Azure RBAC for `azureclaw up` |
-| [Demo](docs/internal/DEMO.md) | "Operation Claw Shield" — multi-tenant attack simulation |
+| Understand the design in 15 minutes | [`docs/architecture.md`](docs/architecture.md) |
+| See the diagrams (dev, prod, mesh, A2A) | [`docs/architecture-diagrams.md`](docs/architecture-diagrams.md) |
+| Pick a deployment shape | [`docs/blueprints/00-index.md`](docs/blueprints/00-index.md) |
+| Read the CRD schema | [`docs/api/crd-reference.md`](docs/api/crd-reference.md) |
+| Understand security guarantees | [`docs/security.md`](docs/security.md) |
+| Build your own runtime | [`docs/runtimes.md`](docs/runtimes.md) |
+| Look up a CLI command | [`docs/cli-reference.md`](docs/cli-reference.md) |
+| Operate a fleet | [`docs/operations/`](docs/operations/) |
+
+The full site index is in **[`docs/README.md`](docs/README.md)**.
 
 ---
 
-## Project Structure
+## Project status
 
-```
-azureclaw/
-├── ci/                   # blocking CI gates + LOC budget
-├── cli/                  # operator CLI (TypeScript · @azureclaw/cli — 23 commands)
-├── runtimes/openclaw/    # AzureClaw runtime adapter for OpenClaw (in-sandbox plugin + skills)
-├── controller/           # Rust K8s operator (kube-rs) — reconcilers for all 8 CRDs
-│   └── src/{crd,reconciler,mesh_peer,status,providers,fedcred,fedcred_reaper,
-│            mcp_server_reconciler,tool_policy_reconciler,inference_policy_reconciler,
-│            a2a_agent_reconciler,claw_memory_reconciler,claw_eval_reconciler,
-│            policy_fetcher,leader_election,backoff,metrics,...}.rs
-├── inference-router/     # Rust inference proxy (axum) — in the data path of every external call
-│   └── src/{a2a,mcp,providers,routes,handoff,governance,trust,audit,
-│            rate_limiter,behavior_monitor,safety,budget,...}/
-│   └── fuzz/             # cargo-fuzz targets
-├── a2a-gateway/          # Rust public ingress edge — JWS verifier, mTLS to router (opt-in)
-├── azureclaw-a2a-core/   # Pure A2A JWS verifier + types, shared by router and gateway
-├── sandbox-images/       # OpenClaw + nemoclaw container images
-├── deploy/               # Bicep IaC, Helm chart (CRDs · admission · network policies · gateway)
-├── docs/                 # Architecture, security, threat model, ADRs, security-audits/, blueprints/
-├── examples/             # Sample agents (basic, confidential, telegram, demo)
-├── tests/                # compat/, conformance/, e2e/, chaos/, cncf-conformance/
-└── vendor/               # AgentMesh SDK (21 patches), registry (4), relay (transitional fixes)
-```
+`v1.0.0-rc.1` — release candidate. The core data path (router, controller, A2A gateway, mesh) is feature-complete and exercised by CI (Kind E2E + manual matrix). See **[`CHANGELOG.md`](CHANGELOG.md)** for the per-release change log and **[`docs/api/backwards-compatibility.md`](docs/api/backwards-compatibility.md)** for the API stability contract.
 
-> **About `vendor/`:** AzureClaw is *not* a fork of OpenClaw. The `vendor/` directory only carries our patched copies of the pre-release AgentMesh stack (relay, registry, SDK) — see *AgentMesh & vendoring* above. Each patch is documented in `vendor/<component>/README.md`, indexed in [`docs/internal/agt-vendored-patch-audit.md`](docs/internal/agt-vendored-patch-audit.md), and re-validated on every AGT SDK version bump.
+## Contributing & support
 
----
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions, test process, and PR guidelines.
-
-```bash
-make build    # Rust + TypeScript
-make test     # Unit tests
-make lint     # clippy + oxlint
-make images   # Docker images
-```
-
----
-
-## Third-Party Notices
-
-AzureClaw bundles four vendored upstream packages under `vendor/`. Full license texts, copyright notices, and a summary of local patches applied to each are in [`THIRD_PARTY_NOTICES.txt`](THIRD_PARTY_NOTICES.txt).
+- Contributing guide: **[`CONTRIBUTING.md`](CONTRIBUTING.md)**
+- Security policy: **[`SECURITY.md`](SECURITY.md)**
+- Support: **[`SUPPORT.md`](SUPPORT.md)**
+- Code of Conduct: **[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)**
 
 ## License
 
-[MIT](LICENSE) · [Code of Conduct](CODE_OF_CONDUCT.md)
+MIT. See **[`LICENSE`](LICENSE)** and **[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)**.
 
 ---
 
-## Trademarks
-
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
-trademarks or logos is subject to and must follow
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
-
----
-
-## Data Collection
-
-The software may collect information about you and your use of the software and send it to Microsoft.
-Microsoft may use this information to provide services and improve our products and services.
-You may turn off the telemetry as described in the repository.
-There are also some features in the software that may enable you and Microsoft to collect data from users of your applications.
-If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement.
-Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>.
-You can learn more about data collection and use in the help documentation and our privacy statement.
-Your use of the software operates as your consent to these practices.
-
-### AzureClaw telemetry details
-
-#### What is collected
-
-AzureClaw is a **self-hosted Kubernetes operator**. The inference router (`azureclaw-inference-router`) emits the following telemetry within your own cluster:
-
-**Prometheus metrics** (scraped from the pod's `/metrics` endpoint by your own Prometheus instance):
-
-| Metric | Labels | Description |
-|---|---|---|
-| `azureclaw_inference_requests_total` | `sandbox`, `model`, `status` | Counter of inference requests |
-| `azureclaw_inference_latency_seconds` | `sandbox`, `model` | Latency histogram (buckets: 0.1–30 s) |
-| `azureclaw_tokens_total` | `sandbox`, `model`, `direction` (`input`/`output`) | Token counts from the model's `usage` field |
-| `azureclaw_upstream_retries_total` | `sandbox`, `reason` (`transport`/`status`) | Upstream retry count |
-| `azureclaw_agt_policy_evaluations_total` | `decision` | AGT governance policy decisions |
-| `azureclaw_agt_eval_latency_seconds` | — | AGT policy evaluation latency |
-| `azureclaw_agt_known_agents` | — | Agents in the trust store |
-| `azureclaw_agt_audit_entries_total` | — | Cumulative AGT audit log entries |
-| `azureclaw_agt_content_flags_total` | `category` | Content Safety flags |
-| `azureclaw_agt_behavior_alerts_total` | — | Behavior anomaly alerts |
-| `azureclaw_agt_policy_rules` | — | Loaded policy rules |
-| `azureclaw_agt_redactions_total` | `kind` | Credential redactions from output |
-| `azureclaw_agt_response_threats_total` | `type` | Response threat detections |
-| `azureclaw_agt_tool_rate_limits_total` | `tool` | Per-tool rate-limit denials |
-| `azureclaw_agt_message_signatures_total` | `action` | Ed25519 sign/verify operations |
-| `azureclaw_handoff_pending_events_total` | `action` | Handoff lifecycle events |
-| `azureclaw_handoff_phase_transitions_total` | `from`, `to`, `result` | Handoff session phase transitions |
-
-**Structured JSON logs** (written to pod stdout via `tracing`). Each log line contains: timestamp, severity, `trace_id` (16-hex correlation id), `sandbox`, `model`, HTTP status, latency, Azure correlation ids (`x-ms-request-id`, `apim-request-id`), and AGT governance verdicts.
-
-**OTel GenAI Semantic Convention span attributes** are defined in `inference-router/src/telemetry/gen_ai.rs` following the [OpenTelemetry GenAI SemConv specification](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/gen-ai.md). Call-site wiring for OTLP span emission will be added in a future release; as of this writing, no OTLP spans are exported.
-
-#### What is NOT collected
-
-**No prompt text or completion text is ever captured.** The router reads only the `usage` object (`prompt_tokens`, `completion_tokens`) from upstream responses to record token counts. Message content (`messages[].content`, `choices[].message.content`) is forwarded transparently to the agent and is never read, logged, or stored by the router.
-
-Source reference: `inference-router/src/proxy.rs` — `record_metrics()` and the SSE streaming path both parse only `body_json["usage"]["prompt_tokens"]` and `body_json["usage"]["completion_tokens"]`.
-
-#### Where telemetry goes — NOT sent to Microsoft by default
-
-AzureClaw runs entirely in **your own AKS cluster**. Microsoft has no cloud-side ingestion of these metrics or logs.
-
-- **Prometheus metrics** are scraped by whichever Prometheus instance you configure (or Azure Monitor managed Prometheus if you enable `monitoring.containerInsights: true` in `deploy/helm/azureclaw/values.yaml`). If no scraper is configured, the `/metrics` endpoint is never read.
-- **Structured logs** go to your cluster's log pipeline (e.g., Azure Monitor Container Insights, your SIEM). Microsoft only receives these logs if you configure Azure Monitor Container Insights.
-- **OTLP spans** are not currently emitted. When OTLP emission is added, it will respect `OTEL_EXPORTER_OTLP_ENDPOINT`; if that variable is unset, no spans leave the pod.
-
-#### How to disable telemetry / opt out
-
-**Option 1 — Disable Prometheus scraping (Helm):**
-
-```yaml
-# deploy/helm/azureclaw/values.yaml
-monitoring:
-  enabled: false
-  prometheus:
-    enabled: false
-  containerInsights: false
-```
-
-**Option 2 — Do not configure a Prometheus scraper:**
-
-Simply do not configure a Prometheus `ServiceMonitor` or pod-annotation scraping for the `azureclaw-inference-router` pods. The `/metrics` endpoint exists but is never read.
-
-**Option 3 — Disable Azure Monitor Container Insights:**
-
-If you are not using Azure Monitor Container Insights to collect container logs, structured log output stays within your cluster's internal log pipeline and is not forwarded to Microsoft.
-
-**Future OTLP opt-out (when span emission is added):**
-
-Do not set `OTEL_EXPORTER_OTLP_ENDPOINT` on the inference-router pods. When that environment variable is absent, the OpenTelemetry SDK will be configured with a no-op exporter and no spans will leave the pod.
-
-#### Source-of-truth files
-
-| File | What it documents |
-|---|---|
-| `inference-router/src/metrics.rs` | All Prometheus metric definitions, labels, and descriptions |
-| `inference-router/src/proxy.rs` | Token count extraction — confirms only `usage.*_tokens` fields are read |
-| `inference-router/src/telemetry/gen_ai.rs` | OTel GenAI SemConv constants (not yet emitted) |
-| `inference-router/src/main.rs` | JSON structured log initialisation (`tracing_subscriber`) |
-| `deploy/helm/azureclaw/values.yaml` | `monitoring.*` Helm knobs for Prometheus and Container Insights |
+> *AzureClaw, the AzureClaw logo, and the trident mark are project marks. See **[`TRADEMARKS.md`](TRADEMARKS.md)** for usage guidance.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,71 +1,75 @@
-# AzureClaw Documentation
+# AzureClaw documentation
 
-## Getting Started
+A secure runtime for AI agents on Azure Kubernetes Service. This is the documentation index. The top-level [`README`](../README.md) is a faster on-ramp; come here when you need depth.
 
-- [Quick Start](../README.md#quick-start) — Install, deploy, connect in 5 minutes
-- [Getting Started Guide](getting-started.md) — Walkthrough from `azureclaw up` to first agent
-- [CLI Reference](cli-reference.md) — Every command and flag
-- [Use Cases](use-cases.md) — Canonical scenarios with code citations
-- [Architecture](architecture.md) — Components, CRD schema, four-seam providers, MCP/A2A modules, API endpoints
-- [Architecture Diagrams](architecture-diagrams.md) — Mermaid flow diagrams
-- [API & CRD Reference](api/crd-reference.md) — `ClawSandbox` schema (v1alpha1)
+## Choose your path
 
-## Security
+### Read in order if you are new
+1. [Getting started](getting-started.md) — laptop in five minutes, then AKS.
+2. [Architecture](architecture.md) — the design and why.
+3. [Architecture diagrams](architecture-diagrams.md) — every component, dev and prod side by side.
+4. [Use cases](use-cases.md) — the four scenarios AzureClaw was built for.
 
-- [Security Model](security.md) — Defense-in-depth (infra + AGT governance + E2E mesh + protocol-layer controls)
-- [Threat Model — Routes](threat-model.md) — Per-route auth tier, input validation, blast-radius
-- [STRIDE Threat Model](security/stride.md) — Per-trust-boundary STRIDE matrix
-- [AGT Boundary](architecture/agt-boundary.md) — What AzureClaw consumes vs builds, four provider contracts
-- [AGT Vendored-Patch Audit](agt-vendored-patch-audit.md) — Vendored AgentMesh fixes pending AGT mesh shipping
-- [`sigs/agent-sandbox` Compat](sigs-agent-sandbox-compat.md) — Optional Translate / Overlay mode design
-- [OWASP MCP Top 10 (2025)](security-mcp-top10.md) — Controls matrix for the new MCP 2026 surface
-- [ADR-0001 — A2A ingress front-edge](adr/0001-a2a-ingress-front-edge.md) — Gateway-only, surgical opt-in
-- [Security Audits](security-audits/) — Per-capability audit docs (Phase 0 + Phase 1 + Phase 2)
-- [Red-Team Findings Log](security/red-team.md) — Internal adversarial-test history
-- [Network Egress & Proxy](egress-proxy.md) — Blocklist, allowlist, approval flow, learn mode
-- [E2E Encryption Proof](e2e-encryption-proof.md) — Signal Protocol inter-agent messaging with traffic capture evidence
-- [Security Validation](security-validation.md) — Live cluster evidence for every security layer
-- [Permissions](permissions.md) — Required Azure RBAC for `azureclaw up`
-- [Upstream Alignment](upstream-alignment.md) — How AzureClaw extends OpenClaw via upstream extension points (no fork)
+### By audience
 
-## Agent Capabilities
+| You are a… | Start here |
+|---|---|
+| **Executive / decision-maker** | [Architecture](architecture.md) → [Blueprints](blueprints/00-index.md) → [Use cases](use-cases.md) |
+| **Platform engineer** | [Getting started](getting-started.md) → [Operations](operations/) → [CLI reference](cli-reference.md) |
+| **Security engineer** | [Security model](security.md) → [STRIDE](security/stride.md) → [Red-team playbook](security/red-team.md) → [MCP top-10](security-mcp-top10.md) |
+| **Agent builder** | [Runtimes](runtimes.md) → [CRD reference](api/crd-reference.md) → [CLI reference](cli-reference.md) |
+| **Site reliability** | [Operations / GitOps](operations/gitops.md) → [Conditions](api/conditions.md) → [Egress proxy](egress-proxy.md) |
 
-- [Channels & Plugins](channels-plugins.md) — Telegram, Slack, Discord, WhatsApp, search plugins, Foundry Bing Grounding
-- [Architecture — Foundry Integration](architecture.md#foundry-standalone-apis-18-api-groups-imds-auth) — Responses API, Memory Store, Foundry IQ
-- [Any-OpenClaw + Cloud Offload](any-openclaw-cloud-offload.md) — Run the `azureclaw-mesh` plugin in *any* OpenClaw host (NemoClaw, laptop, …) and offload tasks to AzureClaw sandboxes over Signal E2E
+## Reference
 
-## Architecture deep-dives
+### Architecture & design
+- [Architecture](architecture.md) — the canonical design doc.
+- [Architecture diagrams](architecture-diagrams.md) — dev, prod, mesh, A2A, MCP.
+- [A2A gateway](architecture/a2a-gateway.md) — public-ingress topology and trust model.
+- [AGT boundary](architecture/agt-boundary.md) — what AGT enforces vs what AzureClaw enforces.
+- [CRD versioning](architecture/crd-versioning.md) — v1.0 stability commitments.
 
-- [A2A Gateway](architecture/a2a-gateway.md) — Front-edge gateway design and component split
-- [AGT Boundary](architecture/agt-boundary.md) — Responsibility split, provider contracts, outage modes
-- [CRD Versioning Policy](architecture/crd-versioning.md) — `v1alpha1` freeze + `v1alpha2` + conversion-webhook plan
-- [Backwards-Compatibility Commitment](api/backwards-compatibility.md) — SemVer surface, deprecation policy
+### API
+- [CRD reference](api/crd-reference.md) — all eight CRDs with schema and examples.
+- [Conditions reference](api/conditions.md) — every status condition the controller emits.
+- [Backwards compatibility](api/backwards-compatibility.md) — what we promise and what we do not.
 
-## Operations
+### Runtimes
+- [Runtime catalog](runtimes.md) — seven first-class adapters and the BYO contract.
 
-- [Egress Management](egress-proxy.md#operator-workflow) — Learn → review → approve → lock down
-- [Agent Handoff](architecture.md#cloud-handoff) — Live migration between local Docker and AKS
-- [Multi-Tenant Isolation](multi-tenant.md) — Per-namespace security boundaries
-- [BYO Strict Mode](operations/byo-strict.md) — Validating-only admission for non-default runtimes
-- [Branch Protection](operations/branch-protection.md) — Repo guardrails
-- [Supply Chain](operations/supply-chain.md) — Cosign, SBOM, attestations
-- [GitOps](operations/gitops.md) — Reconciler in a GitOps fleet
-- [Image Versioning](operations/image-versioning.md) — Tag policy and runtime image overrides
-- [Helm Packaging](operations/helm-packaging.md) — Chart versioning + local packaging
-- [Secret Rotation Runbook](operations/secret-rotation.md) — Per-sandbox creds, TLS, AgentMesh identity, Azure
-- [Chaos Tier](operations/chaos-tier.md) — Fault-injection test surface
+### Blueprints
+- [Index](blueprints/00-index.md)
+- [01 — Developer inner loop](blueprints/01-developer-inner-loop.md)
+- [02 — Enterprise self-hosted](blueprints/02-enterprise-self-hosted.md)
+- [03 — Managed public offload](blueprints/03-managed-public-offload.md)
+- [04 — Cross-org federation](blueprints/04-cross-org-federation.md)
+- [05 — Sovereign / air-gapped](blueprints/05-sovereign-airgapped.md)
 
-## Roadmap
+### Security
+- [Security model](security.md) — the layered control plane.
+- [STRIDE](security/stride.md) — threat model.
+- [Red-team playbook](security/red-team.md) — adversarial scenarios.
+- [Security validation](security-validation.md) — what CI verifies.
+- [MCP top-10](security-mcp-top10.md) — how AzureClaw addresses each item.
+- [Upstream alignment](upstream-alignment.md) — the OpenClaw extension contract.
 
-- [Roadmap](roadmap.md) — v1.0 capabilities, v1.1 targets, v1.2 directions, backlog
+### Operations
+- [Operations index](operations/) — fleet operations, GitOps, upgrades.
+- [Operator TUI](operator-tui.md) — `azureclaw operator`.
+- [Egress proxy](egress-proxy.md) — outbound network controls.
 
-## Demos & Examples
+### CLI
+- [CLI reference](cli-reference.md) — every command, every flag.
 
-- [ClawShield Demo](DEMO.md) — Full walkthrough with screenshots
-- [Demo Guide](DEMO-GUIDE.md) — 30-minute first-launch → multi-agent flow
-- [Demo Script](demo-script.md) — 3-act, ~15-minute live presentation
-- [Example Agents](../examples/) — `basic-agent`, `confidential-agent`, `demo-clawshield`, `byo-quickstart`
+## What is **not** here
 
-## Migration
+`docs/internal/` holds historical phase audits, migration logs, and one-off proofs that exist for traceability but are not part of the public surface. They are excluded from the rendered site.
 
-- [Migration from NemoClaw](migration-from-nemoclaw.md) — What changed and how to migrate
+## Reading the site offline
+
+```bash
+make docs-site-serve   # serves at http://localhost:3000
+make docs-site         # builds to target/book/index.html
+```
+
+The site is built with [mdBook](https://rust-lang.github.io/mdBook/). The chapter index is **[`SUMMARY.md`](SUMMARY.md)**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,609 +1,186 @@
-# Getting Started with AzureClaw
+# Getting started
 
-By the end of this guide you will have a working AzureClaw sandbox — either
-running locally on Docker in about 5 minutes (Path A), or deployed on AKS in
-about 15–20 minutes (Path B). You will be able to chat with a governed AI
-agent, spawn a sub-agent, send an E2E encrypted mesh message, and hand off a
-session from laptop to cloud. **Estimated total time: 30 minutes or less.**
+This guide takes you from a clean machine to a working AzureClaw agent in two steps:
 
-Prerequisites at a glance: Node.js 22+, Docker, a terminal. For the AKS path,
-add Azure CLI, kubectl, Helm, and an Azure subscription where you hold
-Contributor + User Access Administrator (or Owner).
+1. **[Local — five minutes](#step-1--local-five-minutes)** — `azureclaw dev` runs a sandbox in one Docker container on your laptop. No Azure subscription, no AKS, no Kubernetes.
+2. **[AKS — half an hour](#step-2--deploy-to-aks)** — `azureclaw up` provisions AKS + ACR + Foundry + the AzureClaw control plane in your subscription, and runs the same sandbox under Workload Identity, NetworkPolicies, and the egress guard.
+
+The sandbox YAML you wrote in step 1 runs unchanged in step 2. That is the whole point.
 
 ---
 
 ## Prerequisites
 
-### All paths
+| For | You need |
+|---|---|
+| Local mode | Docker Desktop (or any OCI runtime), Node.js 22+, Rust 1.88+, an Azure OpenAI endpoint + deployment + key. |
+| AKS mode | The above, plus the [Azure CLI](https://learn.microsoft.com/cli/azure/) (`az`), [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [Helm 3.14+](https://helm.sh/), and an Azure subscription where you can create resource groups. |
 
-| Tool | Version | Install |
-|------|---------|---------|
-| **Node.js** | 22+ | [nodejs.org](https://nodejs.org) or `nvm install 22` |
-| **Docker Desktop** | Latest | [docker.com/get-docker](https://www.docker.com/get-docker) |
-| **git** | Any | [git-scm.com](https://git-scm.com) |
-
-### Path B (AKS) only
-
-| Tool | Version | Install |
-|------|---------|---------|
-| **Azure CLI** | 2.60+ | `curl -sL https://aka.ms/InstallAzureCLIDeb \| sudo bash` |
-| **kubectl** | 1.28+ | `az aks install-cli` |
-| **Helm** | 3.14+ | [helm.sh/docs/intro/install](https://helm.sh/docs/intro/install) |
-
-### Azure RBAC (Path B)
-
-`azureclaw up` provisions AKS, ACR, Key Vault, Foundry, Workload Identity,
-and role assignments in one shot. It needs:
-
-```bash
-# Contributor + User Access Administrator at subscription scope
-SUB=$(az account show --query id -o tsv)
-USER=$(az account show --query user.name -o tsv)
-az role assignment create --assignee "$USER" --role "Contributor" \
-  --scope "/subscriptions/$SUB"
-az role assignment create --assignee "$USER" \
-  --role "User Access Administrator" \
-  --scope "/subscriptions/$SUB"
-```
-
-`Owner` at subscription scope covers both. See
-[`docs/permissions.md`](permissions.md) for the full list of required
-actions, a least-privilege custom role JSON, required resource providers, and
-the preview feature (`EncryptionAtHost`, `KataVMIsolationPreview`) registration
-steps. The CLI runs a preflight check automatically and fails fast in ≤30 s if
-anything is missing — use `azureclaw up --dry-run` to check without deploying.
+The CLI bootstraps everything else (Helm chart install, Foundry resource creation, ACR build/push, federated identity wiring). You do not need to provision any of it by hand.
 
 ---
 
-## Step 0 — Install the CLI
+## Step 1 — Local (five minutes)
 
-Both paths need the CLI:
+### 1.1 Build the CLI
 
 ```bash
 git clone https://github.com/Azure/azureclaw.git
 cd azureclaw/cli
-
-npm ci
-npm run build
-npm link          # puts `azureclaw` on your $PATH
-
-# Verify
-azureclaw --version
-azureclaw --help
+npm ci && npm run build
+npm link    # exposes `azureclaw` on your PATH
 ```
 
-> **Tip:** `npm link` writes a symlink into your global Node.js bin directory
-> (e.g. `~/.nvm/versions/node/v22.x.x/bin/azureclaw`). If `azureclaw` is not
-> found after this step, ensure that directory is on your `$PATH`.
+The CLI is a Node 22 ESM build with a small Rust dependency for the local router. `npm run build` compiles both.
+
+### 1.2 Launch a sandbox
+
+```bash
+azureclaw dev --name hello
+```
+
+On the first run you are prompted for:
+
+- **Endpoint** — your Azure OpenAI / Foundry endpoint, e.g. `https://my-resource.openai.azure.com`.
+- **Deployment name** — the model deployment you want the agent to use, e.g. `gpt-4.1`.
+- **API key** — a resource-level key. **This is the only credential local mode ever sees, and it is mounted from a local secret file — it never leaves your machine.**
+
+The CLI then builds (or pulls cached) the local sandbox image and starts a single container. In dev mode the agent runtime and the inference router are co-located in that one image — there is no separate router pod, no init container, no NetworkPolicy. You get the same router code path, the same governance profile, the same audit format.
+
+### 1.3 Talk to the agent
+
+```bash
+azureclaw connect hello   # opens the TUI
+```
+
+Or drive it from another terminal:
+
+```bash
+azureclaw list               # see running sandboxes
+azureclaw logs hello -f      # tail logs (router + agent)
+azureclaw policy show hello  # what is allowed / denied / approval-gated
+```
+
+When you are done:
+
+```bash
+azureclaw destroy hello
+```
+
+### 1.4 What you just ran
+
+The local sandbox is the right place to:
+
+- Author plugins / tools and watch them go through the policy decision point.
+- Iterate on `ToolPolicy` and `InferencePolicy` YAML before you push it to a cluster.
+- Run smoke tests in CI without standing up Kubernetes.
+
+It is **not** the right place to run multi-tenant workloads, accept untrusted prompts at scale, or rely on hardware-isolated execution. Those are AKS-mode properties.
+
+A side-by-side breakdown of what is and is not isolated in dev mode is in **[Architecture — Two modes](architecture.md#two-modes)**.
 
 ---
 
-## Path A — Local development with Docker (≈5 minutes)
+## Step 2 — Deploy to AKS
 
-No Azure account needed. You get the same AGT governance, the same egress
-guard, and the same inference router — just pointed at an Azure OpenAI
-resource you already have (not AKS).
-
-### Step A-1: Build the sandbox image
-
-```bash
-# Run from the repo root (not cli/)
-cd ..
-azureclaw dev --build
-```
-
-The first `--build` takes 2–3 minutes to pull the Azure Linux base image and
-compile the OpenClaw runtime layer. Subsequent runs skip the rebuild unless
-you pass `--build` again or `--build-base` when upgrading heavy deps.
-
-### Step A-2: Provide Azure OpenAI credentials
-
-On first run the CLI prompts interactively:
-
-```
-  No Azure OpenAI credentials found. Let's set them up.
-  You need an existing Azure OpenAI resource with a deployed model (e.g. gpt-4.1).
-
-  ? Azure OpenAI endpoint: https://my-resource.openai.azure.com
-  ? Model deployment name: gpt-4.1
-  ? API key: ********
-```
-
-To provide them non-interactively instead:
-
-```bash
-azureclaw credentials set endpoint https://my-resource.openai.azure.com
-azureclaw credentials set model gpt-4.1
-azureclaw credentials set api-key "YOUR_KEY"
-```
-
-Credentials are stored encrypted in `~/.azureclaw/credentials.json` and
-re-used on every subsequent `azureclaw dev` run.
-
-### Step A-3: Start a sandbox
-
-If you already ran `--build` in A-1, the image is cached — this starts
-immediately:
-
-```bash
-azureclaw dev
-```
-
-You are now connected to the OpenClaw TUI. The agent is fully governed: every
-inference call flows through the Rust inference router, which applies the
-`developer` policy preset (Content Safety, token budgets, domain blocklist)
-before forwarding to Azure OpenAI.
-
-**End state:**
-
-```
-  ✔  Credentials loaded
-  ✔  Sandbox image resolved
-  ✔  AgentMesh relay/registry started
-  ✔  Sandbox container running
-
-  🦞 AzureClaw local sandbox › dev-agent
-  You:
-```
-
-### Step A-4: Optional enhancements
-
-```bash
-# Connect via Telegram instead of TUI
-azureclaw dev --channels telegram --telegram-token "123456:ABC-DEF..."
-
-# Enable Brave + Tavily search plugins
-azureclaw dev --brave-api-key "$BRAVE_KEY" --tavily-api-key "$TAVILY_KEY"
-
-# Use a different model
-azureclaw dev --model gpt-5-mini
-
-# Name your sandbox
-azureclaw dev --name research-local
-```
-
----
-
-## Path B — Production AKS deployment (≈15–20 minutes)
-
-`azureclaw up` is a single command that provisions the entire Azure stack and
-drops you into a running cluster.
-
-### Step B-1: Log in to Azure
+### 2.1 Sign in to Azure
 
 ```bash
 az login
-az account set --subscription "YOUR_SUBSCRIPTION_ID"
+az account set --subscription <your-subscription-id>
 ```
 
-### Step B-2: Run `azureclaw up`
+You need permission to create resource groups, AKS clusters, ACRs, Foundry resources, and federated credentials in your subscription. (`Contributor` + `User Access Administrator` is sufficient; tighter scoping is documented in [`docs/operations/least-privilege.md`](operations/least-privilege.md) when present.)
+
+### 2.2 Bring it up
 
 ```bash
-# From the repo root (azureclaw/)
-azureclaw up
+azureclaw up --name prod-agent --location swedencentral
 ```
 
-The CLI runs interactive prompts first:
+What this does, in order:
 
-```
-  ? Azure region   [eastus2]
-  ? Cluster name   [azureclaw]
-  ? Sandbox name   [my-assistant]
-  ? Isolation      [enhanced] (standard / enhanced / confidential)
-  ? Foundry backend  [provision new] (or enter an existing endpoint)
-```
+1. Creates a resource group `azureclaw-<name>-rg`.
+2. Creates an ACR (your private registry) and an AKS cluster with Workload Identity and OIDC issuer enabled.
+3. Creates an Azure AI Foundry project, Content Safety binding, and a model deployment.
+4. Builds and pushes the controller, inference-router, A2A gateway, and sandbox images to the new ACR.
+5. Installs the AzureClaw Helm chart (controller + AgentMesh relay/registry + A2A gateway + CRDs).
+6. Creates the federated credentials so each sandbox's pod identity can call Foundry without keys.
+7. Submits your first `ClawSandbox` and waits until it is `Ready`.
 
-Then the 9-phase deployment:
+The whole flow is idempotent. If it fails halfway through (a quota error, an IAM hiccup), re-running picks up where it left off.
 
-```
-  [1/9] Setting up resource group 'azureclaw-rg'...         ✔
-  [2/9] Running Bicep deployment...                          ✔  (~8 min)
-  [3/9] Configuring network / ACR attach...                  ✔
-  [4/9] Fetching AKS credentials...                          ✔
-  [5/9] Importing images from azureclawacr.azurecr.io...     ✔
-  [6/9] Helm install (controller + seccomp DaemonSet)...     ✔
-  [7/9] Deploying AgentMesh relay + registry...              ✔
-  [8/9] Creating ClawSandbox CR (my-assistant)...            ✔
-  [9/9] Waiting for sandbox Running...                       ✔
-```
+### 2.3 The pod you get
 
-Total elapsed: ~15–20 minutes on a fresh subscription.
+In AKS mode the sandbox is a multi-container pod, **not** a single container:
 
-### Step B-3: Open the operator TUI
+- `init: egress-guard` — installs iptables rules so only the router can reach the cluster network.
+- `agent` — your runtime (OpenClaw, OpenAI Agents, MAF, LangGraph, Anthropic, Pydantic-AI, or BYO), running as **UID 1000** with no direct egress.
+- `inference-router` — the Rust router, running as **UID 1001** on `127.0.0.1:8443`. It is the only container in the pod that can talk to Foundry, the mesh, or A2A peers.
+
+A NetworkPolicy on the namespace pins the pod's allowed egress to exactly: cluster DNS, Foundry, the AgentMesh relay, the A2A gateway. Nothing else. See **[Architecture diagrams](architecture-diagrams.md)** for the full picture.
+
+### 2.4 Talk to the AKS sandbox
 
 ```bash
-azureclaw operator
+azureclaw connect prod-agent      # tunnels the TUI through kubectl port-forward
+azureclaw list                     # all sandboxes in your AKS cluster
+azureclaw logs prod-agent -f       # router + agent logs
+azureclaw operator                 # full-fleet TUI
 ```
 
-The live TUI shows all sandboxes with status, model, policy preset, egress
-domains learned, and a scrolling inference log per sandbox.
-
-### Step B-4: Connect to the sandbox
+### 2.5 Add another sandbox
 
 ```bash
-# TUI session (interactive chat)
-azureclaw connect my-assistant
-
-# Web UI on localhost:18789 (browser)
-azureclaw connect my-assistant --web
+azureclaw add another-agent --runtime LangGraph --model gpt-4.1
 ```
 
-### Step B-5: Add a second agent with Telegram
+`azureclaw add` reuses the existing AKS cluster and Foundry project — only the pod is new. See **[CLI reference](cli-reference.md)** for the full surface.
+
+### 2.6 Tear it down
 
 ```bash
-# Add a sandbox with Telegram channel enabled
-azureclaw add research-bot \
-  --model gpt-4.1 \
-  --channels telegram \
-  --telegram-token "123456:ABC-DEF..." \
-  --learn-egress
-
-# The agent is now reachable via your Telegram bot
-```
-
-See [`docs/channels-plugins.md`](channels-plugins.md) for Slack, Discord,
-WhatsApp, and third-party plugin (Brave, Tavily, Exa) setup.
-
-### Preflight and dry-run
-
-```bash
-# Check permissions without deploying
-azureclaw up --dry-run
-
-# Re-deploy after an upgrade (skips prompts and infra, reruns Helm only)
-azureclaw up --upgrade
-
-# Skip preflight for CI / federated identity environments
-azureclaw up --skip-preflight
-```
-
-### Troubleshooting Path B
-
-See [Troubleshooting common errors](#troubleshooting-common-errors) below.
-
----
-
-## Trying out a non-default runtime
-
-AzureClaw ships first-class adapters for three runtimes. The same
-governance, isolation, and audit chain apply regardless of which you pick.
-
-### OpenAI Agents (Python)
-
-```bash
-# On an existing AKS cluster (after azureclaw up)
-azureclaw add oai-bot \
-  --runtime openai-agents \
-  --model gpt-4.1 \
-  --isolation enhanced
-
-# Dry-run to inspect the ClawSandbox YAML
-azureclaw add oai-bot --runtime openai-agents --dry-run
-```
-
-The controller patches the sandbox pod to run the `openai-agents` Python
-adapter instead of OpenClaw. The inference router, egress guard, AGT
-governance, and AgentMesh mesh endpoint are identical to the default runtime.
-
-### Microsoft Agent Framework (MAF)
-
-```bash
-azureclaw add maf-bot \
-  --runtime microsoft-agent-framework \
-  --maf-language python \
-  --model gpt-4.1 \
-  --isolation enhanced
-```
-
-`dotnet` language support is planned for Phase 3. Until then, use `python`.
-
-### BYO (Bring Your Own)
-
-Any container image that declares the AzureClaw runtime contract label can
-be hosted as a first-class sandbox:
-
-```bash
-azureclaw add custom-agent \
-  --runtime byo \
-  --byo-image myacr.azurecr.io/my-agent:latest \
-  --byo-contract-version v1
-```
-
-The contract requires `LABEL org.azureclaw.runtime.contract=v1` in the
-Dockerfile and a small HTTP health endpoint. Full specification:
-[`docs/runtime-contract.md`](runtime-contract.md).
-
-### What changes vs the OpenClaw default
-
-| Aspect | openclaw (default) | openai-agents | microsoft-agent-framework | byo |
-|--------|--------------------|---------------|---------------------------|-----|
-| Agent entrypoint | `entrypoint.sh` (Node.js) | OpenAI Agents Python SDK | MAF Python SDK | Custom image |
-| Plugin auto-config | ✅ via entrypoint | ❌ manage in image | ❌ manage in image | ❌ manage in image |
-| Inference router | ✅ same | ✅ same | ✅ same | ✅ same |
-| AGT governance | ✅ same | ✅ same | ✅ same | ✅ same |
-| AgentMesh E2E | ✅ same | ✅ same | ✅ same | ✅ same |
-| Egress guard | ✅ same | ✅ same | ✅ same | ✅ same |
-
----
-
-## Hello-world workflows
-
-These workflows work on both local Docker (`azureclaw dev`) and AKS
-(`azureclaw add`/`azureclaw up`). Where commands differ, the AKS variant is
-shown; swap `my-assistant` for the name you chose.
-
-### 1 — Spawn a sub-agent
-
-Sub-agents are isolated sandboxes spawned programmatically by the parent
-agent. They inherit the parent's isolation level and cannot downgrade it.
-
-```bash
-# From TUI or a tool call, the agent issues a ClawSandbox spawn. You can
-# also trigger it directly from the CLI (AKS):
-azureclaw add worker-1 \
-  --model gpt-5-mini \
-  --token-budget-per-request 8000 \
-  --isolation enhanced
-
-# Watch the controller reconcile it
-azureclaw operator --panels status
-```
-
-The controller creates namespace `azureclaw-worker-1`, deploys the sandbox
-pod, and the parent agent can reach `worker-1` via the E2E encrypted mesh.
-
-### 2 — Send an E2E encrypted mesh message between two agents
-
-```bash
-# Check mesh status (shows registered agents and trust scores)
-azureclaw mesh status
-
-# List agents on the mesh
-azureclaw mesh list
-
-# Set the relay to strict mode (only registered agents can send)
-azureclaw mesh security strict
-```
-
-Messages flow through the AgentMesh relay over X3DH + Double Ratchet. The
-relay sees only ciphertext; decryption happens inside each sandbox pod. The
-trust-gated KNOCK handshake requires trust score ≥ 500 (configurable via
-`--trust-threshold`).
-
-To observe a mesh exchange live:
-
-```bash
-# In terminal 1 — connect to agent alpha
-azureclaw connect my-assistant
-
-# In terminal 2 — connect to research-bot (if running)
-azureclaw connect research-bot
-```
-
-Ask `my-assistant` to "send a task to research-bot" and watch the E2E
-encrypted round-trip in both TUI windows.
-
-### 3 — Approve a previously-blocked egress endpoint
-
-By default, `networkPolicy.approvalRequired: true` blocks all new endpoints
-not in the allowlist. With `--learn-egress`, the router observes but does not
-block; review and promote to the allowlist:
-
-```bash
-# See what the agent tried to reach (learn mode must have been enabled)
-azureclaw egress my-assistant --learned
-
-# Approve a specific domain permanently
-azureclaw policy allow my-assistant api.github.com
-
-# Or with a specific port
-azureclaw policy allow my-assistant internal.corp.com --port 8443
-
-# Enforce the approved list (blocks everything else)
-azureclaw egress my-assistant --enforce
-```
-
-### 4 — Hot-swap models
-
-Switch the active model without restarting the sandbox:
-
-```bash
-# List available model deployments in the Foundry project
-azureclaw model list my-assistant
-
-# Switch to a smaller model for cost control
-azureclaw model set my-assistant gpt-5-mini
-
-# Switch back to the full model
-azureclaw model set my-assistant gpt-4.1
-
-# Verify
-azureclaw model get my-assistant
-```
-
-The inference router picks up the new model on the next request — no pod
-restart, no session interruption.
-
-### 5 — Live-handoff agent from local Docker to AKS
-
-Transfer a running local session to the cloud cluster with no dropped
-requests. Both sides must share an AgentMesh registry:
-
-```bash
-# 1. On the AKS side — expose the registry so the laptop can reach it
-azureclaw mesh promote --port-forward
-
-# 2. On the laptop — start local dev pointing at the shared registry
-azureclaw dev --global-registry "http://localhost:8080" --name my-assistant
-
-# 3. Initiate handoff to cloud (from the laptop)
-azureclaw handoff my-assistant --to cloud
-
-# 4. Check status
-azureclaw handoff my-assistant --status
-```
-
-The AgentMesh relay transfers session state; the local container is torn
-down only after the cloud sandbox confirms it has taken over. To reverse:
-
-```bash
-azureclaw handoff my-assistant --to local
+azureclaw destroy prod-agent           # one sandbox
+azureclaw destroy --all --purge-rg     # everything, including the resource group
 ```
 
 ---
 
-## Where to go next
+## Bring your own AKS / Foundry / ACR
 
-| Document | What you'll find |
-|----------|-----------------|
-| [`docs/use-cases.md`](use-cases.md) | Four end-to-end scenarios — AzureClaw-native agent, any-OpenClaw cloud offload, AzureClaw ↔ AzureClaw mesh, and the roadmap for non-OpenClaw runtimes |
-| [`docs/blueprints/00-index.md`](blueprints/00-index.md) | Five deployment shapes (developer inner-loop, enterprise self-hosted, managed public offload, cross-org federation, sovereign/air-gapped) with topology + trust-boundary + flow diagrams |
-| [`docs/architecture.md`](architecture.md) | Deep-dive into all four components, the four-seam provider architecture, and how the defense-in-depth layers compose |
-| [`docs/api/crd-reference.md`](api/crd-reference.md) | Schema reference for all 8 CRDs: `ClawSandbox`, `ClawPairing`, `McpServer`, `ToolPolicy`, `InferencePolicy`, `A2AAgent`, `ClawMemory`, `ClawEval` |
-| [`docs/cli-reference.md`](cli-reference.md) | Every flag of every command across all 23 CLI commands |
-| [`docs/security.md`](security.md) | Defense-in-depth breakdown: egress guard, NetworkPolicy, seccomp, Workload Identity, Content Safety, AGT governance, Kata confidential isolation |
-| [`docs/channels-plugins.md`](channels-plugins.md) | Telegram, Slack, Discord, WhatsApp setup; Brave, Tavily, Exa, Firecrawl, Perplexity plugin config |
-| [`docs/permissions.md`](permissions.md) | Detailed Azure RBAC requirements, custom role JSON, resource provider checklist |
-| [`docs/runtime-contract.md`](runtime-contract.md) | BYO runtime contract — labels, health endpoint, inference API shape |
-| [`CONTRIBUTING.md`](../CONTRIBUTING.md) | How to contribute: build environment, test commands, PR process |
+If you already have an AKS cluster and a Foundry project, you can install AzureClaw into them directly with the Helm chart:
+
+```bash
+helm install azureclaw deploy/helm/azureclaw \
+  --namespace azureclaw-system --create-namespace \
+  --set acr.loginServer=<youracr>.azurecr.io \
+  --set foundry.endpoint=https://<your>.openai.azure.com \
+  --set foundry.deploymentName=gpt-4.1 \
+  --set workloadIdentity.clientId=<federated-mi-client-id>
+```
+
+Then submit `ClawSandbox` resources directly with `kubectl apply`. The CLI is convenient but optional — every action it takes is a Helm value, a Kubernetes resource, or an `az` call you can perform yourself. See **[Operations / GitOps](operations/gitops.md)**.
 
 ---
 
-## Troubleshooting common errors
+## What to read next
 
-### "address already in use" on port-forward
+- **[Architecture](architecture.md)** — the design in 15 minutes.
+- **[CRD reference](api/crd-reference.md)** — every spec field of every CRD.
+- **[Runtimes](runtimes.md)** — choosing between the seven adapters and BYO.
+- **[Blueprints](blueprints/00-index.md)** — five reference deployment shapes (developer inner loop → sovereign air-gapped).
+- **[Security model](security.md)** — what each layer enforces and what it does not.
 
-```
-Error: listen tcp 127.0.0.1:18789: bind: address already in use
-```
+---
 
-A previous `azureclaw dev` or port-forward is still running:
+## Troubleshooting
 
-```bash
-# Find the process holding the port
-lsof -ti tcp:18789
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `azureclaw dev` hangs on first run | Docker Desktop is not running | Start Docker. |
+| `azureclaw up` fails on `az login` | Stale CLI session | `az logout && az login --use-device-code`. |
+| Sandbox stays `Pending` | Foundry quota / model not deployed | `kubectl describe clawsandbox <name>` — the controller surfaces the cause as a `Condition`. |
+| Agent gets `403` on tool call | `ToolPolicy` denies it | `azureclaw policy show <name>` and adjust. |
+| Mesh KNOCK fails | Trust score below threshold | See **[AGT boundary](architecture/agt-boundary.md#trust-scoring)**. |
 
-# Kill it (replace PID with the value from lsof output)
-kill <PID>
-
-# Then retry
-azureclaw dev
-```
-
-### `AADSTS500011` — scope not found in tenant
-
-```
-AADSTS500011: The resource principal named api://agentmesh was not found
-```
-
-The `api://agentmesh` Entra application is not registered in your tenant.
-Sandboxes still start and fall back to the AGT **anonymous tier** (dev/test
-only). For production, a tenant admin must run:
-
-```bash
-az ad app create --display-name "AgentMesh" --identifier-uris "api://agentmesh"
-APP_ID=$(az ad app list --display-name AgentMesh --query "[0].appId" -o tsv)
-az ad sp create --id "$APP_ID"
-```
-
-See [`docs/permissions.md`](permissions.md#tenant-level-entra-id-considerations) for full details.
-
-### `ImagePullBackOff` in sandbox pod
-
-```bash
-kubectl get events -n azureclaw-my-assistant --field-selector reason=Failed
-```
-
-Common causes:
-
-1. **ACR credentials expired** — re-attach ACR to the cluster:
-   ```bash
-   az aks update --name azureclaw --resource-group azureclaw-rg \
-     --attach-acr $(az acr list -g azureclaw-rg --query "[0].name" -o tsv)
-   ```
-
-2. **Wrong image tag** — AzureClaw always uses `:latest`. Never hardcode
-   version tags or set `SANDBOX_IMAGE` / `INFERENCE_ROUTER_IMAGE` env vars
-   manually; let the controller resolve them.
-
-3. **Node image cache** — AKS nodes cache `:latest`. Force a fresh pull:
-   ```bash
-   kubectl rollout restart deployment/my-assistant -n azureclaw-my-assistant
-   ```
-
-### "wrong secret key for the given ciphertext"
-
-```
-wrong secret key for the given ciphertext
-```
-
-The AgentMesh SDK ratchet key is mismatched — a session was started before the
-vendored SDK patch was applied. Patch files are in `vendor/agentmesh-sdk/`;
-they are overlaid automatically in the sandbox Dockerfile. If you are running
-custom images, ensure the overlay step is present:
-
-```dockerfile
-COPY vendor/agentmesh-sdk/dist/ \
-  /app/node_modules/@agentmesh/sdk/dist/
-```
-
-To reset all mesh sessions (drops all ratchet state):
-
-```bash
-azureclaw mesh reset
-```
-
-### `AuthorizationFailed` during `azureclaw up`
-
-```
-The client '...' does not have authorization to perform action
-'Microsoft.Authorization/roleAssignments/write'
-```
-
-`User Access Administrator` is missing. Grant it (see
-[Prerequisites — Azure RBAC](#prerequisites) above) and retry. The preflight
-check (`azureclaw up --dry-run`) will catch this without deploying.
-
-### `FeatureNotRegistered` during Bicep
-
-```
-Feature 'Microsoft.Compute/EncryptionAtHost' is not registered
-```
-
-Register and wait for propagation (5–15 minutes):
-
-```bash
-az feature register --namespace Microsoft.Compute --name EncryptionAtHost
-az provider register -n Microsoft.Compute
-```
-
-Poll with `az feature show --namespace Microsoft.Compute --name EncryptionAtHost`
-until `"state": "Registered"`, then re-run `azureclaw up`.
-
-### Duplicate messages in agent inbox
-
-The OpenClaw plugin is being loaded twice without the singleton guard.
-Check that `process.env.__AGT_INITIALIZED` is set on first load in
-`runtimes/openclaw/src/index.ts`. If you are using a custom plugin build,
-do not remove the singleton guard.
-
-### Sub-agent does not receive mesh messages
-
-The background `openclaw agent --local` session in `entrypoint.sh` is not
-running. Check the `openclaw` container logs:
-
-```bash
-kubectl logs -n azureclaw-my-assistant \
-  deployment/my-assistant -c openclaw --tail=50
-```
-
-Look for `relay listener started`. If it is absent, the entrypoint likely
-exited early. Re-run with `azureclaw push --only sandbox --apply` to redeploy
-the sandbox image.
-
-### Node.js 22 fetch ignores `HTTPS_PROXY`
-
-Node.js 22's built-in `fetch()` does not read `HTTPS_PROXY`. The sandbox
-ships `proxy-bootstrap.js` to handle this; it is loaded via `NODE_OPTIONS`.
-If you see network timeouts in a proxy environment, verify the container
-has `NODE_OPTIONS=--require /app/proxy-bootstrap.js` set.
+The complete operational runbook is in **[`docs/operations/`](operations/)**.


### PR DESCRIPTION
Wave B of the docs revamp. Top-of-funnel rewrite for OSS launch.

**README.md** — fresh, problem-first lead; canonical ASCII diagram; dev-vs-prod table; honest 8-CRD / 7-runtime tables grounded in `controller/src/reconciler/runtime.rs`; 'what it is not' section to kill OpenClaw-fork confusion.

**docs/README.md** — audience-routed index (exec / platform / security / agent-builder / SRE).

**docs/getting-started.md** — strict two-step (laptop → AKS); the seven things `azureclaw up` actually does; explicit UID 1000 / UID 1001 / egress-guard naming for the prod pod shape; BYO AKS path; troubleshooting table.

Pure content rewrite — no code, no link-target moves.
