### PR TITLE
docs(revamp-C): rewrite architecture.md and architecture-diagrams.md

### DIFF
--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -1,1616 +1,317 @@
-# AzureClaw — Architecture & Flow Diagrams
+# Architecture diagrams
 
-Visual reference for AzureClaw's core flows: sandbox architecture, agent lifecycle, inter-agent communication, inference routing, and egress control.
+Every diagram on this page is rendered from Mermaid in the source markdown. The rendered site (mdBook) shows them as SVG; on GitHub they render natively. If you are reading the source, paste any code block into [mermaid.live](https://mermaid.live) for a rendered preview.
 
----
-
-## 1. Sandbox Pod Architecture
-
-The fundamental building block — every agent runs in this pod structure.
-
-```mermaid
-graph TB
-    subgraph pod["Pod: azureclaw-‹name›"]
-        direction TB
-
-        subgraph init["Init Container: egress-guard (UID 0)"]
-            ipt["iptables rules:<br/>UID 1000 → localhost + DNS only<br/>TCP 80/443 → REDIRECT :8444"]
-        end
-
-        subgraph oc["Container: openclaw (UID 1000)"]
-            gw["OpenClaw Gateway<br/>:18789"]
-            plugin["AzureClaw Plugin<br/>+ Foundry Skills"]
-            agt_client["AgentMesh SDK<br/>(Signal Protocol)"]
-        end
-
-        subgraph ir["Container: inference-router (UID 1001)"]
-            api["/v1/chat/completions<br/>/v1/responses<br/>/v1/images/generations<br/>:8443"]
-            proxy["Forward Proxy<br/>:8444"]
-            safety["Content Safety<br/>+ Token Budget"]
-            blocklist["Domain Blocklist<br/>51K+ domains"]
-            spawn_ep["/sandbox/spawn<br/>/agt/trust"]
-            metrics_ep["Prometheus<br/>:9090"]
-            policy["AGT PolicyEngine"]
-            trust_store["Trust Store<br/>/tmp/agt/"]
-            audit["Audit Chain<br/>(SHA-256 Merkle)"]
-        end
-    end
-
-    subgraph volumes["Volumes"]
-        v1["sandbox-data<br/>(emptyDir)"]
-        v2["tmp<br/>(Memory, 1Gi)"]
-        v3["admin-token<br/>(Secret)"]
-        v4["blocklist-seed<br/>(ConfigMap)"]
-        v5["agt-policy<br/>(ConfigMap)"]
-    end
-
-    init --> oc
-    init --> ir
-    oc --- v1
-    oc --- v2
-    ir --- v3
-    ir --- v4
-    ir --- v5
-
-    style init fill:#f9f,stroke:#333,stroke-width:1px
-    style oc fill:#4a9eff,stroke:#333,stroke-width:2px,color:#fff
-    style ir fill:#ff6b35,stroke:#333,stroke-width:2px,color:#fff
-```
-
-### Network Access Matrix
-
-```mermaid
-graph LR
-    subgraph "UID 1000 (Agent)"
-        A[openclaw]
-    end
-
-    subgraph "UID 1001 (Router)"
-        R[inference-router]
-    end
-
-    A -->|"localhost only"| R
-    A -.->|"❌ BLOCKED"| IMDS["IMDS<br/>169.254.169.254"]
-    A -.->|"❌ BLOCKED"| Internet["Internet"]
-    A -->|"TCP 80/443<br/>REDIRECT"| FP["Forward Proxy<br/>:8444"]
-
-    R -->|"✅ Workload Identity"| IMDS
-    R -->|"✅ Inference"| Foundry["Azure AI Foundry"]
-    R -->|"✅ Mesh"| Relay["AgentMesh Relay"]
-    R -->|"✅ Governed"| Internet
-
-    style A fill:#4a9eff,color:#fff
-    style R fill:#ff6b35,color:#fff
-    style IMDS fill:#ffd700,color:#000
-    style Internet fill:#e74c3c,color:#fff
-```
+For the prose explanation, see **[Architecture](architecture.md)**.
 
 ---
 
-## 2. Agent Creation Flow (`azureclaw add`)
+## 1. Sandbox pod — dev mode
+
+One container, no network isolation, runs on Docker Desktop.
+
+```mermaid
+flowchart TB
+  subgraph Laptop["💻 Your laptop (Docker Desktop)"]
+    subgraph Sandbox["one container — same image"]
+      Agent["Agent runtime<br/>(OpenClaw / OpenAI / MAF / LangGraph / …)"]
+      Router["Inference router (Rust)<br/>127.0.0.1:8443"]
+      Agent -->|localhost| Router
+    end
+    Secret["mounted secret<br/>(your Foundry key)"]
+    Secret -.-> Router
+  end
+
+  Foundry["Azure AI Foundry<br/>model + content safety"]
+  Router -->|"HTTPS<br/>(your key)"| Foundry
+
+  classDef laptop fill:#fff5e6,stroke:#cc8800
+  class Laptop laptop
+```
+
+**What is real:** the router code path, every policy decision, the audit format, the governance profile. **What is not real:** the network isolation — there is no separate process to break out *to*. Treat dev mode as a development surface, not a security surface.
+
+---
+
+## 2. Sandbox pod — prod mode
+
+Multi-container Kubernetes pod, hard egress isolation, Workload Identity.
+
+```mermaid
+flowchart TB
+  subgraph Cluster["AKS cluster — namespace: azureclaw-&lt;name&gt;"]
+    subgraph Pod["ClawSandbox pod"]
+      Init["init: egress-guard<br/>(iptables — only UID 1001 egresses)"]
+      Agent["agent — UID 1000<br/>no direct egress<br/>(your runtime)"]
+      Router["inference-router — UID 1001<br/>127.0.0.1:8443 + 8444"]
+      Init -.->|runs first| Agent
+      Init -.->|runs first| Router
+      Agent -->|localhost only| Router
+    end
+    NP["NetworkPolicy<br/>egress: DNS · Foundry · relay · A2A gw"]
+    NP -.- Pod
+    SA["projected SA token"]
+    SA -.-> Router
+  end
+
+  WI["Workload Identity<br/>(AAD federated token)"]
+  Foundry["Azure AI Foundry"]
+  Mesh["AgentMesh relay+registry<br/>(another namespace)"]
+  A2A["A2A gateway<br/>(public ingress)"]
+
+  Router -->|exchange SA→AAD| WI
+  WI -.->|no keys on disk| Router
+  Router -->|HTTPS, AAD token| Foundry
+  Router -->|WS, encrypted| Mesh
+  Router -->|HTTPS| A2A
+
+  classDef cluster fill:#e6f0ff,stroke:#0078d4
+  classDef pod fill:#f0fff0,stroke:#2a9d2a
+  class Cluster cluster
+  class Pod pod
+```
+
+**Three containers, one rule:** the agent container has no path to the network. Anything labelled `Foundry` / `Mesh` / `A2A` above leaves through the router. iptables (egress-guard) and NetworkPolicy enforce this in two independent layers.
+
+---
+
+## 3. The data path of one model call
+
+What happens when the agent calls the model. Every other external call (web fetch, MCP tool, sub-agent spawn, A2A peer message) follows the same shape with a different policy module.
 
 ```mermaid
 sequenceDiagram
-    actor User
-    participant CLI as azureclaw CLI
-    participant Azure as Azure AD
-    participant K8s as K8s API Server
-    participant Ctrl as AzureClaw Controller
-    participant NS as Namespace: azureclaw-‹name›
+  autonumber
+  participant Agent as Agent (UID 1000)
+  participant Router as Router (UID 1001)
+  participant Gov as Governance (AGT + InferencePolicy)
+  participant CS as Content Safety (Foundry)
+  participant WI as Workload Identity
+  participant Foundry as Foundry model
 
-    User->>CLI: azureclaw add ‹name› --model gpt-4.1 --isolation enhanced
-
-    rect rgb(240, 248, 255)
-        Note over CLI,Azure: Step 1: Azure Identity
-        CLI->>Azure: az identity federated-credential create
-        Azure-->>CLI: Federated credential linked
-    end
-
-    rect rgb(245, 255, 245)
-        Note over CLI,K8s: Step 2: K8s Secrets
-        CLI->>K8s: Create Secret ‹name›-credentials<br/>(channel tokens, plugin API keys)
-        K8s-->>CLI: Secret created
-    end
-
-    rect rgb(255, 245, 238)
-        Note over CLI,Ctrl: Step 3: CRD + Reconciliation
-        CLI->>K8s: kubectl apply ClawSandbox CRD
-        K8s->>Ctrl: Watch event: ClawSandbox created
-
-        Ctrl->>NS: Create Namespace
-        Ctrl->>NS: Create ServiceAccount (Workload Identity)
-        Ctrl->>NS: Create ClusterRoleBinding (spawner)
-        Ctrl->>NS: Create Secrets (gateway-token, admin-token)
-        Ctrl->>NS: Create NetworkPolicy (default-deny + allowlist)
-        Ctrl->>NS: Create ConfigMap (blocklist seed)
-        Ctrl->>NS: Create ConfigMap (AGT policy)
-        Ctrl->>NS: Create Deployment (3 containers)
-        Ctrl->>NS: Create Service (mesh DNS)
-        Ctrl->>NS: Create CronJob (blocklist refresh)
-    end
-
-    rect rgb(248, 240, 255)
-        Note over CLI,NS: Step 4: Wait for Ready
-        loop Every 2s (max 120s)
-            CLI->>K8s: Get pod status
-            K8s-->>CLI: containerStatuses
-        end
-        NS-->>CLI: All containers Ready ✓
-    end
-
-    CLI-->>User: ✅ Agent running<br/>azureclaw connect ‹name›
+  Agent->>Router: POST /v1/chat (prompt)
+  Router->>CS: prompt safety scan
+  CS-->>Router: ok
+  Router->>Gov: allow? token budget? rate?
+  Gov-->>Router: allow + decision audit
+  Router->>WI: exchange SA token → AAD
+  WI-->>Router: bearer token
+  Router->>Foundry: POST /openai/… + bearer
+  Foundry-->>Router: completion
+  Router->>CS: response safety scan
+  CS-->>Router: ok
+  Router-->>Agent: completion
+  Note over Router: audit record:<br/>hash-chained, signed
 ```
+
+The agent has no direct path to **Foundry**, **WI**, **CS**, or the audit chain. The router brokers all of them.
 
 ---
 
-## 3. Controller Architecture — All 8 Reconcilers (Phase 2)
+## 4. The mesh — encrypted inter-agent messaging
 
-Shows the Phase 2 controller operator structure: all 8 CRD reconcilers running under a single leader-election
-Lease, each with its own SSA field manager to detect out-of-band drift. The metrics server at `:9091` exposes
-Prometheus counters for every reconcile outcome; jittered requeue (±20%) prevents thundering-herd bursts
-against the K8s API server. Source: `controller/src/`.
-
-### 3.1 Reconciler Map
-
-```mermaid
-graph TD
-    subgraph operator["AzureClaw Controller Pod (× 2 replicas, azureclaw-system)"]
-        direction TB
-        LE["Leader Election<br/>coordination.k8s.io/v1 Lease<br/>LEADER_ELECTION_ENABLED env<br/>(default: true)"]
-
-        subgraph reconcilers["Reconciler Tasks (spawned after leader gate)"]
-            direction LR
-            R1["ClawSandbox<br/>fm: azureclaw-controller/clawsandbox"]
-            R2["ClawPairing<br/>fm: azureclaw-controller/pairing"]
-            R3["McpServer<br/>fm: azureclaw-controller/mcp"]
-            R4["ToolPolicy<br/>fm: azureclaw-controller/toolpolicy"]
-            R5["InferencePolicy<br/>fm: azureclaw-controller/inferencepolicy"]
-            R6["A2AAgent<br/>fm: azureclaw-controller/a2aagent"]
-            R7["ClawMemory<br/>fm: azureclaw-controller/clawmemory"]
-            R8["ClawEval<br/>fm: azureclaw-controller/claweval"]
-        end
-
-        MESH["mesh-peer reconciler<br/>(own Lease: agentmesh-mesh-peer-leader)<br/>intentionally outside main gate"]
-
-        METRICS["Metrics + health server<br/>CONTROLLER_METRICS_ADDR<br/>(default: 0.0.0.0:9091)"]
-    end
-
-    LE --> reconcilers
-    LE -.->|"independent"| MESH
-
-    style LE fill:#9b59b6,color:#fff
-    style R1 fill:#e67e22,color:#fff
-    style R3 fill:#3498db,color:#fff
-    style R4 fill:#3498db,color:#fff
-    style R5 fill:#3498db,color:#fff
-    style R6 fill:#3498db,color:#fff
-    style R7 fill:#3498db,color:#fff
-    style R8 fill:#3498db,color:#fff
-    style METRICS fill:#2ecc71,color:#fff
-```
-
-### 3.2 ClawSandbox Reconciliation — Resources Created
-
-```mermaid
-graph TD
-    CRD["ClawSandbox CRD<br/>(azureclaw-system)"] -->|"watch event"| R1["ClawSandbox Reconciler<br/>(SSA fieldManager: azureclaw-controller/clawsandbox)"]
-
-    R1 --> NS["Namespace<br/>azureclaw-‹name›"]
-    R1 --> SA["ServiceAccount<br/>sandbox (Workload Identity)"]
-    R1 --> CRB["ClusterRoleBinding<br/>azureclaw-spawner-‹name›"]
-    R1 --> S1["Secret<br/>gateway-token (32 char)"]
-    R1 --> S2["Secret<br/>router-admin-token (64 char)"]
-    R1 --> NP["NetworkPolicy<br/>sandbox-policy"]
-    R1 --> DEP["Deployment<br/>1 replica, 3 containers"]
-    R1 --> SVC["Service<br/>:8443 (mesh DNS)"]
-    R1 --> A2ASVC["Service :8445<br/>(A2A ClusterIP — only when<br/>spec.a2a.enabled: true)"]
-    R1 --> CM1["ConfigMap<br/>blocklist seed"]
-    R1 --> CM2["ConfigMap<br/>AGT policy profile"]
-    R1 --> CJ["CronJob<br/>blocklist refresh (6h)"]
-    R1 --> FC["Azure Federated Credential"]
-
-    DEP --> IC["Init: egress-guard"]
-    DEP --> C1["Container: openclaw<br/>UID 1000 · :18789"]
-    DEP --> C2["Container: inference-router<br/>UID 1001 · :8443 :8444 :9090<br/>+ :8445 (A2A, conditional)<br/>+ native AGT governance"]
-
-    NP --> NP1["Egress: DNS ✅"]
-    NP --> NP2["Egress: IMDS ✅ (router only)"]
-    NP --> NP3["Egress: HTTPS ✅ (no private IPs)"]
-    NP --> NP4["Egress: Mesh ✅ (other sandboxes)"]
-    NP --> NP5["Egress: Relay/Registry ✅"]
-    NP --> NP6["Ingress: deny all (default)<br/>Ingress :8445 from gateway SA<br/>(when spec.a2a.enabled)"]
-
-    style CRD fill:#9b59b6,color:#fff
-    style R1 fill:#e67e22,color:#fff
-    style DEP fill:#3498db,color:#fff
-    style NP fill:#e74c3c,color:#fff
-    style A2ASVC fill:#f39c12,color:#fff
-```
-
-### 3.3 Operator Polish (Phase 2)
-
-```mermaid
-graph LR
-    subgraph polish["Phase 2 Operator Polish (S7)"]
-        direction TB
-        LE["S7.C — Leader Election<br/>replicas: 2, Lease per controller<br/>fail-fast on renewal loss"]
-        SSA["S7.A — SSA Field Managers<br/>unique suffix per reconciler<br/>detects out-of-band tampering"]
-        JIT["S7.D — Jittered Requeue<br/>±20% multiplicative jitter<br/>spreads retry thundering herd"]
-        COND["S7.B — Progressing=False<br/>stamped once reconcile loop<br/>completes (KEP-1623 compliant)"]
-        METR["S7.E — Metrics :9091<br/>/metrics (Prometheus text)<br/>/healthz (always 200 when live)"]
-    end
-
-    LE --- SSA --- JIT --- COND --- METR
-```
-
----
-
-## 4. Sub-Agent Spawn Flow
+Two AzureClaw agents in (possibly) different clusters that need to talk.
 
 ```mermaid
 sequenceDiagram
-    participant Parent as Parent Agent<br/>(openclaw)
-    participant Plugin as AzureClaw Plugin
-    participant Router as Inference Router<br/>(:8443)
-    participant K8s as K8s API Server
-    participant Ctrl as Controller
-    participant Child as Child Agent Pod
-    participant Registry as AgentMesh Registry
+  autonumber
+  participant A as Alice agent
+  participant Ar as Alice router
+  participant Reg as AgentMesh registry
+  participant Rel as AgentMesh relay
+  participant Br as Bob router
+  participant B as Bob agent
 
-    Parent->>Plugin: azureclaw_spawn("analyst", "gpt-4.1", governance=true)
+  Note over A,B: Setup (once per agent)
+  A->>Ar: register identity + prekeys
+  Ar->>Reg: PUT /agents/alice (Ed25519 sig)
+  B->>Br: register identity + prekeys
+  Br->>Reg: PUT /agents/bob
 
-    rect rgb(255, 245, 238)
-        Note over Plugin,K8s: Step 1: Create Sub-Agent
-        Plugin->>Plugin: Build trusted_peers list<br/>(parent AMID + siblings)
-        Plugin->>Router: POST /sandbox/spawn<br/>{agent_id, model, governance, trusted_peers}
-        Router->>K8s: Create ClawSandbox CRD<br/>(inherits parent isolation level)
-        K8s->>Ctrl: Watch event
-        Ctrl->>Child: Reconcile → create namespace,<br/>deployment, networkpolicy...
-    end
-
-    rect rgb(240, 248, 255)
-        Note over Plugin,Registry: Step 2: Wait for Ready + Discovery
-        loop Every 1s (max 45s)
-            Plugin->>Router: GET /sandbox/analyst/status
-            Router-->>Plugin: phase: Pending → Running
-            Plugin->>Router: GET /agt/registry/search?capability=analyst
-            Router->>Registry: Forward search query
-            Registry-->>Router: [{amid, display_name, tier}]
-            Router-->>Plugin: AMID discovered
-        end
-        Plugin->>Plugin: Cache AMID in nameToAmid map
-    end
-
-    Plugin-->>Parent: ✅ Sub-agent "analyst" running<br/>Ready for mesh communication
+  Note over A,B: Session
+  A->>Ar: send msg → bob
+  Ar->>Reg: GET /agents/bob/prekeys
+  Reg-->>Ar: signed prekeys
+  Ar->>Ar: X3DH → shared secret
+  Ar->>Rel: KNOCK + ciphertext (E2E)
+  Rel->>Br: forward ciphertext (relay sees nothing)
+  Br->>Br: trust score check (AGT_TRUST_THRESHOLD)
+  alt accept
+    Br->>B: deliver plaintext
+    B-->>Br: reply
+    Br->>Rel: ratcheted ciphertext
+    Rel->>Ar: forward
+    Ar-->>A: plaintext reply
+  else deny
+    Br-->>Rel: KNOCK denied (audit)
+  end
 ```
+
+**Forward secrecy:** every message after the first uses a fresh key derived by the Double Ratchet. **Authenticated:** every message carries a libsodium MAC. **Relay-blind:** the relay can route, count, and rate-limit, but cannot read. **Trust-gated:** AGT decides per-peer whether the KNOCK is accepted.
 
 ---
 
-## 5. E2E Encrypted Agent-to-Agent Communication
+## 5. A2A gateway — public-ingress peer traffic
+
+For cross-organisation peers that are not in your AgentMesh.
 
 ```mermaid
-sequenceDiagram
-    participant PA as Parent Agent
-    participant PP as Parent Plugin
-    participant PR as Parent Router<br/>(:8443)
-    participant Relay as AgentMesh Relay<br/>(WebSocket :8765)
-    participant CR as Child Router<br/>(:8443)
-    participant CP as Child Plugin
-    participant CA as Child Agent
+flowchart LR
+  subgraph Internet
+    Peer["external peer agent<br/>(other org)"]
+  end
 
-    Note over PA,CA: Signal Protocol: X3DH Key Exchange + Double Ratchet
-
-    rect rgb(255, 248, 240)
-        Note over PP,CP: First Contact: KNOCK + X3DH Handshake
-        PP->>Relay: KNOCK {from: parentAMID, to: childAMID}
-        Relay->>CP: Forward KNOCK
-        CP->>CP: Check trust score ≥ 500?
-        CP-->>Relay: ACCEPT + prekey bundle
-        Relay-->>PP: Forward ACCEPT
-        PP->>PP: X3DH: compute shared secret<br/>(ECDH + HKDF → session key)
-        Note over PP,CP: 🔐 Session established<br/>Forward secrecy via Double Ratchet
+  subgraph Cluster["AKS cluster"]
+    Ing["Public ingress<br/>(App Gateway / k8s ingress)"]
+    GW["A2A gateway (Rust)<br/>verifies signed AgentCard<br/>routes to A2AAgent CRD<br/>audit · rate limit · CS"]
+    subgraph NS["azureclaw-prod-agent"]
+      Pod["ClawSandbox pod<br/>(agent + router)"]
     end
+  end
 
-    rect rgb(240, 255, 240)
-        Note over PA,CA: Encrypted Task Delegation
-        PA->>PP: mesh_send("analyst", "Analyze market trends")
-        PP->>PP: Encrypt with session key<br/>(Double Ratchet)
-        PP->>Relay: Encrypted envelope<br/>(relay cannot decrypt)
-        Relay->>CP: Route by AMID
-        CP->>CP: Decrypt with session key
-        CP->>CA: Deliver task: "Analyze market trends"
-    end
-
-    rect rgb(240, 240, 255)
-        Note over PA,CA: Encrypted Response
-        CA->>CP: Result: "Market analysis complete..."
-        CP->>CP: Encrypt response
-        CP->>Relay: Encrypted envelope
-        Relay->>PP: Route by AMID
-        PP->>PP: Decrypt response
-        PP->>PA: Deliver: "Market analysis complete..."
-        PP->>PR: POST /agt/trust (reputation +0.9)
-    end
+  Peer -->|signed AgentCard + payload| Ing
+  Ing --> GW
+  GW -->|in-cluster only| Pod
+  GW -.->|reject<br/>untrusted card| Peer
 ```
 
-### Trust Gate Decision Flow
-
-```mermaid
-flowchart TD
-    KNOCK["Incoming KNOCK<br/>from unknown agent"] --> LOOKUP["Look up sender AMID<br/>in Trust Store"]
-    LOOKUP --> REG["Query Registry:<br/>reputation, tier"]
-    REG --> CALC["Calculate effective score:<br/>registry × 0.7 + local × 0.3"]
-    CALC --> BONUS{"Parent-verified<br/>peer?"}
-    BONUS -->|"Yes"| ADD["+100 affinity bonus"]
-    BONUS -->|"No"| CHECK
-    ADD --> CHECK{"Score ≥ threshold<br/>(default 500)?"}
-    CHECK -->|"✅ Yes"| ACCEPT["Accept KNOCK<br/>→ X3DH handshake<br/>→ Establish session"]
-    CHECK -->|"❌ No"| REJECT["Reject KNOCK<br/>→ Log to audit chain<br/>→ Block for 60s"]
-
-    style ACCEPT fill:#2ecc71,color:#fff
-    style REJECT fill:#e74c3c,color:#fff
-    style CALC fill:#f39c12,color:#fff
-```
+The A2A gateway is the only inbound public surface. Every request must carry a signed `AgentCard` that the gateway verifies against a configured trust anchor; every request gets the same content-safety / rate-limit treatment as outbound traffic.
 
 ---
 
-## 6. Inference Router Data Path — Phase 2
-
-Shows the complete Phase 2 inference-router request pipeline for a `POST /v1/chat/completions` call. The AGT
-governance gate now runs a full chain (PolicyEngine → TrustManager → AuditLogger → RateLimiter →
-BehaviorMonitor); InferencePolicy is resolved from a hot-reloadable PolicyEnvelope; the platform MCP shim
-translates Foundry tool calls; and the signed-OCI egress allowlist verifier gates any outbound fetch. Source:
-`inference-router/src/`.
-
-### 6.1 Full Request Sequence
+## 6. Control plane — what the controller does
 
 ```mermaid
-sequenceDiagram
-    participant Agent as Agent<br/>(UID 1000)
-    participant Router as Inference Router<br/>(UID 1001)
-    participant PE as PolicyEnvelope<br/>(ArcSwap hot-reload)
-    participant IMDS as IMDS<br/>(169.254.169.254)
-    participant CS as Content Safety<br/>(Azure AI)
-    participant Foundry as Azure AI Foundry
+flowchart LR
+  User["operator / CLI / GitOps"]
+  CRD[("8 CRDs<br/>ClawSandbox · A2AAgent · McpServer<br/>ToolPolicy · InferencePolicy<br/>ClawMemory · ClawEval · TrustGraph")]
+  Ctrl["azureclaw-controller<br/>(kube-rs)"]
 
-    Agent->>Router: POST /v1/chat/completions<br/>{model, messages, stream}
+  User -->|kubectl apply / azureclaw cli| CRD
+  CRD --> Ctrl
+  Ctrl --> NS["Namespace + RBAC"]
+  Ctrl --> Dep["Deployment / Pod<br/>(agent + router + egress-guard)"]
+  Ctrl --> Svc["Service"]
+  Ctrl --> NP["NetworkPolicy"]
+  Ctrl --> CM["ConfigMap<br/>(governance profile)"]
+  Ctrl --> FedCred["Federated credentials<br/>(Workload Identity)"]
+  Ctrl --> Status["CRD status<br/>conditions"]
 
-    rect rgb(255, 235, 235)
-        Note over Router,PE: Gate 1: AGT Governance Chain
-        Router->>PE: snapshot() → InferencePolicy rules
-        Router->>Router: PolicyEngine.evaluate()<br/>{action: "inference:chat_completions"}
-        Router->>Router: TrustManager: sender score check
-        Router->>Router: RateLimiter: token-bucket gate
-        Router->>Router: BehaviorMonitor: anomaly signal
-        Router->>Router: AuditLogger: append event (SHA-256 Merkle)
-        Note right of Router: ❌ 403 deny / 429 rate-limit if gates fail
-    end
-
-    rect rgb(255, 248, 220)
-        Note over Router: Gate 2: Token Budget
-        Router->>Router: Check daily budget (TOKEN_BUDGET_DAILY)<br/>Check per-request limit (TOKEN_BUDGET_PER_REQUEST)
-        Note right of Router: ❌ 429 if exceeded
-    end
-
-    rect rgb(240, 248, 255)
-        Note over Router,IMDS: Gate 3: IMDS Auth Chain
-        Router->>IMDS: GET /metadata/identity/oauth2/token<br/>(federated token → Workload Identity exchange)
-        IMDS-->>Router: Bearer token (cached per scope)<br/>Agent never sees this token
-    end
-
-    rect rgb(235, 255, 240)
-        Note over Router,CS: Gate 4: Content Safety Floor
-        Router->>CS: Analyze prompt (DefaultV2 policy)<br/>Prompt Shields jailbreak detection
-        CS-->>Router: category scores + action
-        Note right of CS: ❌ 400 if threshold breached<br/>(always-on — InferencePolicy can tighten)
-    end
-
-    rect rgb(240, 240, 255)
-        Note over Router,Foundry: Gate 5: Inference + Foundry Tools
-        Router->>Foundry: POST /chat/completions + Bearer token
-        Foundry-->>Router: Response (may include tool_calls)
-        Router->>Router: Platform MCP shim: translate<br/>Foundry tool_calls → MCP dispatch
-        Foundry-->>Router: Final response + usage
-    end
-
-    Router->>Router: Record token usage to budget
-    Router->>Router: Trust penalty if content flags present
-    Router-->>Agent: Response (filtered)
+  Status --> User
 ```
 
-### 6.2 AGT Governance Gate Detail
-
-```mermaid
-flowchart TD
-    REQ["Incoming request<br/>(inference / mesh / spawn)"] --> PE["Load PolicyEnvelope snapshot<br/>(ArcSwap — zero-lock read)"]
-    PE --> POL["PolicyEngine.evaluate()<br/>match action against InferencePolicy rules"]
-    POL --> DENY{"Decision?"}
-    DENY -->|"deny"| R403["❌ 403 Forbidden<br/>audit event: Deny"]
-    DENY -->|"allow"| TRUST["TrustManager<br/>sender score ≥ threshold?"]
-    TRUST -->|"below threshold"| R403B["❌ 403 Forbidden<br/>audit event: TrustDeny"]
-    TRUST -->|"ok"| RL["RateLimiter<br/>token-bucket per sandbox"]
-    RL -->|"exceeded"| R429["❌ 429 Too Many Requests"]
-    RL -->|"ok"| BM["BehaviorMonitor<br/>anomaly / prompt injection signal"]
-    BM -->|"alert"| AUD["AuditLogger<br/>append to SHA-256 Merkle chain"]
-    BM -->|"ok"| AUD
-    AUD --> NEXT["Continue pipeline<br/>(budget → auth → safety → Foundry)"]
-
-    style R403 fill:#e74c3c,color:#fff
-    style R403B fill:#e74c3c,color:#fff
-    style R429 fill:#f39c12,color:#fff
-    style NEXT fill:#2ecc71,color:#fff
-```
+The controller is a vanilla kube-rs reconciler. It owns the eight CRDs, watches them, and produces the boring Kubernetes objects that make a sandbox real. The CRD `status.conditions` chain is the operator-facing source of truth; every condition is documented in **[`docs/api/conditions.md`](api/conditions.md)**.
 
 ---
 
-## 7. Egress Control Flow
+## 7. CRD relationships
+
+How the eight CRDs reference each other.
 
 ```mermaid
-flowchart TD
-    REQ["Agent (UID 1000)<br/>curl https://api.github.com"] --> IPT{"iptables<br/>NAT REDIRECT"}
-    IPT -->|"TCP 443 → :8444"| FP["Forward Proxy<br/>(inference-router :8444)"]
-    FP --> EXTRACT["Extract domain<br/>from CONNECT request"]
-    EXTRACT --> BL{"Domain in<br/>blocklist?<br/>(51K+ domains)"}
+flowchart TB
+  CS["ClawSandbox<br/>(the agent)"]
+  TP["ToolPolicy<br/>(allow / deny / approval)"]
+  IP["InferencePolicy<br/>(model · tokens · region)"]
+  CM["ClawMemory<br/>(memory store binding)"]
+  Mcp["McpServer<br/>(allowed MCP backends)"]
+  A2A["A2AAgent<br/>(public-ingress endpoint)"]
+  TG["TrustGraph<br/>(mesh trust topology)"]
+  CE["ClawEval<br/>(reproducible eval run)"]
 
-    BL -->|"❌ Yes"| BLOCK["403 Forbidden<br/>Log: blocked domain<br/>+ reason (OISD/URLhaus/TLD)"]
-    BL -->|"No"| TLD{"High-risk TLD?<br/>(.tk .ml .ga .cf .gq)"}
-
-    TLD -->|"❌ Yes"| BLOCK
-    TLD -->|"No"| MODE{"Egress mode?"}
-
-    MODE -->|"Learn"| LOG["Log domain access<br/>→ operator review"]
-    LOG --> TUNNEL
-
-    MODE -->|"Enforce"| AL{"In allowlist?"}
-    AL -->|"✅ Yes"| TUNNEL["Create TCP tunnel<br/>→ relay to destination"]
-    AL -->|"❌ No"| PENDING["PendingApproval<br/>→ operator notified"]
-
-    TUNNEL --> RELAY["Bidirectional relay<br/>agent ↔ destination<br/>(1h max, 256 concurrent)"]
-
-    style BLOCK fill:#e74c3c,color:#fff
-    style PENDING fill:#f39c12,color:#fff
-    style TUNNEL fill:#2ecc71,color:#fff
-    style LOG fill:#3498db,color:#fff
+  CS -->|policyRef| TP
+  CS -->|inferenceRef| IP
+  CS -->|memoryRef| CM
+  CS -->|mcpRefs| Mcp
+  CS -->|trustRef| TG
+  A2A -->|sandboxRef| CS
+  CE -->|sandboxRef| CS
 ```
 
-### Learn → Enforce Lifecycle
+`ClawSandbox` is the unit of work; the other seven CRDs bind policy, identity, peers, or evaluation to it. You can build a complete deployment with just `ClawSandbox` + `ToolPolicy` + `InferencePolicy`; the rest are opt-in for richer scenarios.
 
-```mermaid
-stateDiagram-v2
-    [*] --> LearnMode: azureclaw add ‹name›
-
-    LearnMode: 🔍 Learn Mode
-    LearnMode: All domains logged
-    LearnMode: Blocklist still enforced
-    LearnMode: Operator observes traffic
-
-    Review: 📋 Operator Review
-    Review: azureclaw egress ‹name› --learned
-    Review: See all accessed domains
-    Review: Approve / Deny each
-
-    EnforceMode: 🔒 Enforce Mode
-    EnforceMode: Only approved domains pass
-    EnforceMode: Everything else blocked
-    EnforceMode: New domains → PendingApproval
-
-    LearnMode --> Review: Operator inspects learned domains
-    Review --> Review: Approve (a) / Deny (d) domains
-    Review --> EnforceMode: azureclaw egress --enforce
-    EnforceMode --> LearnMode: azureclaw egress --learn
-```
+Schema details in **[`docs/api/crd-reference.md`](api/crd-reference.md)**.
 
 ---
 
-## 8. Full Deployment Flow (`azureclaw up`)
+## 8. Cluster topology — what `azureclaw up` produces
 
 ```mermaid
-flowchart TD
-    UP["azureclaw up<br/>--name my-agent --model gpt-4.1"] --> RG
-
-    subgraph azure["Azure Resources"]
-        RG["Resource Group"] --> AKS["AKS Cluster<br/>(system + sandbox pools)"]
-        RG --> ACR["Container Registry<br/>(ACR)"]
-        RG --> AI["AI Foundry Project<br/>+ AI Services"]
-        RG --> MI["Managed Identity<br/>(Workload Identity)"]
-        RG --> ST["Storage Account"]
+flowchart TB
+  subgraph RG["Resource group: azureclaw-&lt;name&gt;-rg"]
+    ACR["ACR<br/>(your private registry)"]
+    Foundry["Azure AI Foundry<br/>+ Content Safety"]
+    KV["Key Vault<br/>(optional)"]
+    subgraph AKS["AKS cluster (Workload Identity + OIDC issuer)"]
+      subgraph Sys["azureclaw-system"]
+        CtrlPod["controller"]
+        GwPod["a2a-gateway"]
+      end
+      subgraph Mesh["agentmesh"]
+        Relay["agentmesh-relay"]
+        Reg["agentmesh-registry"]
+      end
+      subgraph Tenant1["azureclaw-prod-agent (one per sandbox)"]
+        Pod1["ClawSandbox pod<br/>(agent + router + egress-guard)"]
+      end
+      subgraph TenantN["azureclaw-&lt;other&gt;"]
+        PodN["…"]
+      end
     end
+  end
 
-    subgraph images["Container Images → ACR"]
-        ACR --> I1["azureclaw-controller:latest"]
-        ACR --> I2["azureclaw-inference-router:latest"]
-        ACR --> I3["openclaw-sandbox:latest"]
-        ACR --> I4["agentmesh-relay:latest"]
-        ACR --> I5["agentmesh-registry:latest"]
-        ACR --> I6["postgres:16-alpine"]
-    end
+  CtrlPod -.->|reconciles| Tenant1
+  CtrlPod -.->|reconciles| TenantN
+  Pod1 -->|encrypted| Relay
+  PodN -->|encrypted| Relay
+  Pod1 -->|HTTPS, WI| Foundry
+  PodN -->|HTTPS, WI| Foundry
+  GwPod -->|in-cluster| Pod1
 
-    subgraph k8s["K8s Cluster Resources"]
-        AKS --> CRD["ClawSandbox CRD"]
-        AKS --> CTRL["Controller Deployment"]
-        AKS --> SEC["Seccomp DaemonSet<br/>(azureclaw-strict profile)"]
-        AKS --> MESH["AgentMesh Namespace"]
-        MESH --> PG["PostgreSQL"]
-        MESH --> RL["Relay (:8765)"]
-        MESH --> REG["Registry (:8080)"]
-        MESH --> DB_SEC["DB Credentials Secret<br/>(auto-generated)"]
-        AKS --> GADGET["Inspektor Gadget<br/>(eBPF, optional)"]
-    end
-
-    subgraph sandbox["First Sandbox"]
-        CRD --> SB["ClawSandbox: my-agent"]
-        SB --> NS["Namespace + Pod<br/>+ NetworkPolicy<br/>+ Secrets + ConfigMaps"]
-    end
-
-    style UP fill:#9b59b6,color:#fff
-    style AKS fill:#0078d4,color:#fff
-    style ACR fill:#0078d4,color:#fff
-    style AI fill:#0078d4,color:#fff
-    style CTRL fill:#e67e22,color:#fff
-    style SB fill:#2ecc71,color:#fff
+  classDef sys fill:#e6f0ff,stroke:#0078d4
+  classDef tenant fill:#f0fff0,stroke:#2a9d2a
+  classDef mesh fill:#fff0f5,stroke:#9933cc
+  class Sys sys
+  class Tenant1 tenant
+  class TenantN tenant
+  class Mesh mesh
 ```
+
+**Three classes of namespace:** `azureclaw-system` (the control plane, one per cluster), `agentmesh` (the relay/registry, one per cluster), and one tenant namespace per `ClawSandbox`. NetworkPolicy isolates them; the controller has Cluster-scoped RBAC; everything else is namespace-scoped.
 
 ---
 
-## 9. Multi-Agent Topology
+## 9. Trust boundaries
 
-What a production mesh looks like with parent + sub-agents.
+Where each layer's authority ends.
 
 ```mermaid
-graph TB
-    subgraph cluster["AKS Cluster"]
-        subgraph ns1["ns: azureclaw-orchestrator"]
-            P["🔱 orchestrator<br/>gpt-4.1 · enhanced<br/>UID 1000 + Router + AGT"]
-        end
+flowchart TB
+  subgraph Trust1["Trusted: cluster operator"]
+    Ctrl["controller"]
+    GW["A2A gateway"]
+    Relay["AgentMesh relay/registry"]
+  end
+  subgraph Trust2["Trusted: per-pod (one fault domain per sandbox)"]
+    Router["inference-router"]
+    EG["egress-guard"]
+  end
+  subgraph Untrust["Untrusted: anything inside the agent container"]
+    Agent["agent runtime + plugins + LLM output"]
+  end
 
-        subgraph ns2["ns: azureclaw-researcher"]
-            C1["📊 researcher<br/>gpt-4.1 · enhanced"]
-        end
-
-        subgraph ns3["ns: azureclaw-analyst"]
-            C2["🔍 analyst<br/>gpt-5-mini · enhanced"]
-        end
-
-        subgraph ns4["ns: azureclaw-writer"]
-            C3["✍️ writer<br/>gpt-4.1 · enhanced"]
-        end
-
-        subgraph mesh["ns: agentmesh"]
-            Relay["Relay<br/>WebSocket :8765"]
-            Registry["Registry<br/>REST :8080"]
-            PG["PostgreSQL<br/>:5432"]
-        end
-    end
-
-    P ===|"🔐 E2E Encrypted<br/>Signal Protocol"| Relay
-    C1 ===|"🔐"| Relay
-    C2 ===|"🔐"| Relay
-    C3 ===|"🔐"| Relay
-
-    C1 -.->|"register AMID<br/>+ prekeys"| Registry
-    C2 -.->|"register"| Registry
-    C3 -.->|"register"| Registry
-    P -.->|"discover AMIDs"| Registry
-    Registry --- PG
-
-    P -->|"spawn"| C1
-    P -->|"spawn"| C2
-    P -->|"spawn"| C3
-
-    style P fill:#e67e22,color:#fff,stroke-width:3px
-    style C1 fill:#3498db,color:#fff
-    style C2 fill:#3498db,color:#fff
-    style C3 fill:#3498db,color:#fff
-    style Relay fill:#9b59b6,color:#fff
-    style Registry fill:#9b59b6,color:#fff
+  Untrust --> Trust2
+  Trust2 --> Trust1
+  Trust1 --> Ext["external (Foundry, peers)"]
 ```
+
+We treat the agent as **adversarial** — anything that comes out of the model could be a prompt-injection payload, a plugin could be malicious, a sub-agent spawn could be hostile. The router is the trust boundary: it does not run model output; it enforces policy *on* model output. Every class of bug above the line is a security bug; bugs in the agent runtime are availability bugs.
 
 ---
 
-## 10. Defense-in-Depth Layers
-
-```mermaid
-graph TB
-    subgraph L0["Layer 0: Azure Infrastructure"]
-        AKS_SEC["AKS API IP restriction<br/>NSG · DDoS Protection"]
-    end
-
-    subgraph L1["Layer 1: Node OS"]
-        OS["Azure Linux<br/>SELinux enforcing"]
-    end
-
-    subgraph L2["Layer 2: VM Isolation (optional)"]
-        KATA["Kata Containers<br/>Cloud Hypervisor<br/>AMD SEV-SNP"]
-    end
-
-    subgraph L3["Layer 3: Container Hardening"]
-        CH["Read-only rootfs<br/>Non-root (UID 1000)<br/>Drop ALL capabilities"]
-    end
-
-    subgraph L4["Layer 4: Kernel Confinement"]
-        SECC["Seccomp: 219 allowed, 28 blocked<br/>Blocks: ptrace, mount, bpf,<br/>unshare, kexec, chroot"]
-    end
-
-    subgraph L5["Layer 5: Network Segmentation"]
-        NET["iptables UID guard<br/>NetworkPolicy per-namespace<br/>Forward proxy + blocklist"]
-    end
-
-    subgraph L6["Layer 6: Inference Safety"]
-        INF["Content Safety (every call)<br/>Prompt Shields (jailbreak)<br/>Token budgets (daily + per-req)"]
-    end
-
-    subgraph L7["Layer 7: Zero Credentials"]
-        CRED["Workload Identity via router<br/>Agent never sees tokens<br/>IMDS blocked for agent"]
-    end
-
-    subgraph L8["Layer 8: E2E Encryption"]
-        E2E["Signal Protocol (X3DH + Ratchet)<br/>Trust-gated messaging<br/>Untrusted relay"]
-    end
-
-    subgraph L9["Layer 9: Behavioral Governance"]
-        GOV["AGT policy evaluation<br/>Dynamic trust scoring<br/>Tamper-evident audit chain"]
-    end
-
-    L0 --> L1 --> L2 --> L3 --> L4 --> L5 --> L6 --> L7 --> L8 --> L9
-
-    style L0 fill:#ecf0f1,stroke:#bdc3c7
-    style L1 fill:#dfe6e9,stroke:#b2bec3
-    style L2 fill:#ffeaa7,stroke:#fdcb6e
-    style L3 fill:#fab1a0,stroke:#e17055
-    style L4 fill:#ff7675,stroke:#d63031
-    style L5 fill:#fd79a8,stroke:#e84393
-    style L6 fill:#a29bfe,stroke:#6c5ce7
-    style L7 fill:#74b9ff,stroke:#0984e3
-    style L8 fill:#55efc4,stroke:#00b894
-    style L9 fill:#81ecec,stroke:#00cec9
-```
-
----
-
-## 11. A2A Inbound Flow — Phase 2
-
-Shows the inbound A2A 1.2 request path from an external foreign agent to a sandboxed AzureClaw agent.
-The a2a-gateway is the single public TLS endpoint; it verifies the caller's AgentCard JWS signature
-and forwards over cluster-internal mTLS to the per-sandbox router on port 8445. The router then
-delivers to the OpenClaw agent via the plugin on port 18789. Applies when `spec.a2a.enabled: true`
-on the target ClawSandbox. See [ADR-0001](adr/0001-a2a-ingress-front-edge.md) for the full rationale.
-
-### 11.1 Network Topology
-
-```mermaid
-flowchart TD
-    subgraph internet["Internet"]
-        FA["Foreign Agent<br/>(LangChain / Google ADK / OpenAI Agents)"]
-    end
-
-    subgraph cilium_l7["Cilium L7 Policy — azureclaw-system ns"]
-        direction TB
-        CL7["Method allow-list (POST/GET/OPTIONS)<br/>Path regex pinning<br/>Body cap: 4 MiB<br/>Per-source-IP rate limit + connection limit"]
-    end
-
-    subgraph gw["azureclaw-a2a-gateway (azureclaw-system)"]
-        direction TB
-        TLS_TERM["Public TLS termination<br/>(cert-manager, rustls)"]
-        JWS_V["Verify caller AgentCard JWS<br/>(RFC 7515, EdDSA/RFC 8037)"]
-        REPLAY["ReplayCache<br/>(300s window, 100k entries)"]
-        SUBJ_RL["SubjectLimiter<br/>(per-caller token bucket)"]
-        AGT_TRUST["AGT trust score gate<br/>(minimumTrustScore check)"]
-        ROUTE["Route by sandbox-id<br/>(controller-owned ConfigMap<br/>gateway: get/watch only)"]
-        GW_METRICS["Admin + metrics :9090<br/>/healthz /readyz /metrics"]
-    end
-
-    subgraph cilium_sbx["Cilium CCNP — sandbox ns"]
-        CNP["Permit TCP 8445 only from<br/>azureclaw-a2a-gateway SA<br/>(ADR-0001 D3)"]
-    end
-
-    subgraph sandbox["Sandbox Pod"]
-        direction TB
-        IR["inference-router (UID 1001)<br/>0.0.0.0:8445 — A2A inbound<br/>routes/a2a/ingress.rs<br/>forbid(unsafe_code)<br/>module-isolated from auth::ImdsToken"]
-        OC["openclaw (UID 1000)<br/>plugin :18789"]
-    end
-
-    FA --> CL7 --> TLS_TERM --> JWS_V --> REPLAY --> SUBJ_RL --> AGT_TRUST --> ROUTE
-    ROUTE -->|"mTLS (Workload Identity certs)"| CNP
-    CNP --> IR
-    IR -->|"127.0.0.1:18789"| OC
-
-    style FA fill:#e74c3c,color:#fff
-    style gw fill:#f39c12,color:#000
-    style IR fill:#ff6b35,color:#fff
-    style OC fill:#4a9eff,color:#fff
-    style cilium_sbx fill:#9b59b6,color:#fff
-```
-
-### 11.2 Inbound A2A Request Sequence
-
-```mermaid
-sequenceDiagram
-    participant FA as Foreign Agent
-    participant GW as a2a-gateway
-    participant CNP as CiliumNetworkPolicy<br/>(sandbox ns)
-    participant Router as Router :8445<br/>(inference-router)
-    participant OC as openclaw :18789
-
-    FA->>GW: HTTPS POST /a2a/v1/{sandbox-id}/send<br/>AgentCard JWS header + JSON-RPC body
-
-    rect rgb(255, 245, 238)
-        Note over GW: Gateway checks
-        GW->>GW: Verify JWS (EdDSA, RFC 8037)<br/>Check ReplayCache (jti + iat)<br/>SubjectLimiter token-bucket<br/>allowedCallers thumbprint pin<br/>advertisedSkills allow-list<br/>AGT minimumTrustScore gate
-        Note right of GW: ❌ 401/403/429 if any gate fails
-    end
-
-    rect rgb(240, 248, 255)
-        Note over GW,Router: mTLS forward (cluster-internal)
-        GW->>CNP: TCP 8445 (Workload Identity cert)
-        CNP->>Router: permitted (gateway SA only)
-        GW->>Router: POST /a2a/v1/{sandbox-id}/send<br/>mTLS mutual auth, sandbox-id in path
-    end
-
-    rect rgb(240, 255, 240)
-        Note over Router: Router re-validates
-        Router->>Router: Re-verify JWS + body cap (4 MiB)<br/>JSON-RPC dispatch (message/send,<br/>tasks/get, tasks/cancel)<br/>ToolPolicy gate via PolicyEnvelope<br/>AuditLogger append
-        Note right of Router: module-isolated: cannot import auth::ImdsToken
-    end
-
-    Router->>OC: Deliver A2A task<br/>(127.0.0.1:18789)
-    OC-->>Router: Task result / streaming SSE
-    Router-->>GW: JSON-RPC response
-    GW-->>FA: HTTPS response
-
-    Note over FA,OC: /.well-known/agents/{sandbox-id}/agent.json
-    FA->>GW: GET /.well-known/agents/{sandbox-id}/agent.json
-    GW->>Router: Fetch signed AgentCard (cluster-internal mTLS)
-    Router-->>GW: JWS-signed AgentCard (cached)
-    GW-->>FA: AgentCard JSON
-```
-
-### 11.3 A2A Exposure Lifecycle
-
-```mermaid
-stateDiagram-v2
-    [*] --> Disabled: ClawSandbox created<br/>(spec.a2a.enabled: false, default)
-
-    Disabled: 🔒 A2A Disabled
-    Disabled: No :8445 Service
-    Disabled: No CiliumNetworkPolicy
-    Disabled: No gateway route entry
-
-    OptIn: ✅ A2A Enabled
-    OptIn: Controller emits :8445 ClusterIP Service
-    OptIn: Controller emits CiliumNetworkPolicy
-    OptIn: Controller writes gateway ConfigMap entry
-    OptIn: expiresAt mandatory (≤ 30d)
-
-    Expired: ⏰ A2A Expired
-    Expired: Controller removes Service + NetworkPolicy
-    Expired: Removes gateway ConfigMap entry
-    Expired: status.a2a.state = Expired
-
-    Disabled --> OptIn: spec.a2a.enabled true\n+ allowedCallers + expiresAt set
-    OptIn --> Expired: expiresAt passes\n(controller reconcile < 30s)
-    OptIn --> Disabled: spec.a2a.enabled flipped false\nor ClawSandbox deleted
-    Expired --> OptIn: operator sets new expiresAt\n(audited as fresh opt-in)
-```
-
----
-
-## 12. Multi-Runtime Dispatch — Phase 2
-
-Shows how `spec.runtime.kind` on a ClawSandbox CR is resolved by the controller into a concrete container
-image, adapter env vars, and runtime-specific sidecar configuration. Tier-1 adapters (OpenClaw,
-OpenAIAgents, MicrosoftAgentFramework) are fully wired; Tier-2 variants (SemanticKernel, LangGraph,
-Anthropic, BYO) are schema stubs that stamp `RuntimeReady=False/AdapterMissing`. Source:
-`controller/src/reconciler/runtime.rs`.
-
-```mermaid
-flowchart TD
-    CS["ClawSandbox CR<br/>spec.runtime.kind: ?"] --> VALIDATE["validate_runtime_shape()<br/>CEL mirror: kind ↔ variant struct coherence"]
-
-    VALIDATE -->|"shape invalid"| DEGRADE["Stamp Degraded/SpecInvalid<br/>RuntimeReady=False"]
-
-    VALIDATE -->|"shape ok"| DISPATCH{"spec.runtime.kind"}
-
-    DISPATCH -->|"OpenClaw"| OC_PLAN["RuntimeDeploymentPlan<br/>image: SANDBOX_IMAGE (controller default :latest)<br/>entrypoint: entrypoint.sh<br/>env: AGT_*, AZURE_*, AZURECLAW_*<br/>runtime injection: router sidecar + egress-guard"]
-
-    DISPATCH -->|"OpenAIAgents"| OAI_PLAN["RuntimeDeploymentPlan<br/>image: azureclaw-runtime-openai-agents:latest<br/>(override: OPENAI_AGENTS_RUNTIME_IMAGE)<br/>agentCode: OCI image or git.url/ref/path<br/>env: OPENAI_AGENTS_* + shared AGT env<br/>+ inference-router sidecar injected"]
-
-    DISPATCH -->|"MicrosoftAgentFramework"| MAF_PLAN["RuntimeDeploymentPlan<br/>image: azureclaw-runtime-maf-python:latest<br/>(override: MAF_RUNTIME_IMAGE)<br/>language: python (dotnet deferred to Phase 3)<br/>env: MAF_* + shared AGT env<br/>+ inference-router sidecar injected"]
-
-    DISPATCH -->|"SemanticKernel\nLangGraph\nAnthropic\nBYO"| MISSING["RuntimePlanError::AdapterMissing<br/>stamp RuntimeReady=False/AdapterMissing<br/>Degraded condition on ClawSandbox"]
-
-    OC_PLAN --> BUILD["Build Deployment spec<br/>(deployment builder consumes RuntimeDeploymentPlan<br/>— no runtime-specific logic outside this module)"]
-    OAI_PLAN --> BUILD
-    MAF_PLAN --> BUILD
-
-    BUILD --> POD["Pod: agent-runtime container<br/>+ inference-router sidecar (all runtimes)<br/>+ egress-guard init container (all runtimes)"]
-
-    style OC_PLAN fill:#4a9eff,color:#fff
-    style OAI_PLAN fill:#2ecc71,color:#fff
-    style MAF_PLAN fill:#9b59b6,color:#fff
-    style MISSING fill:#e74c3c,color:#fff
-    style BUILD fill:#e67e22,color:#fff
-```
-
----
-
-## 13. Signed OCI Egress Allowlist — Phase 2
-
-Shows the full lifecycle of a signed egress allowlist: from the operator running `azureclaw egress --sign`
-through ACR push + cosign signing, to the controller fetching and verifying the artifact, and finally
-deriving `allowedEndpoints` for the NetworkPolicy. Source: `controller/src/policy_fetcher.rs`,
-`controller/src/signer_policy.rs`.
-
-### 13.1 CLI → ACR → Controller Flow
-
-```mermaid
-flowchart TD
-    CLI["azureclaw egress ‹name› --sign<br/>--allowlist api.github.com,pypi.org"] --> BUILD["CLI builds canonical artifact<br/>(JSON, byte-stable canonical form<br/>per docs/internal/policy-canonical-format.md)"]
-
-    BUILD --> PUSH["Push OCI artifact to ACR<br/>azureclawacr.azurecr.io/allowlists/‹name›:‹sha›"]
-
-    PUSH --> SIGN{"Signing method"}
-    SIGN -->|"--keyless (default)"| KL["cosign sign (keyless)<br/>Fulcio CA + Rekor transparency log<br/>GitHub Actions OIDC issuer"]
-    SIGN -->|"--token"| TK["cosign sign --key k8s://…<br/>OIDC token from Azure Workload Identity"]
-    SIGN -->|"--kms"| KMS["cosign sign --key azurekms://…<br/>Azure Key Vault signing key"]
-
-    KL --> PATCH["CLI patches ClawSandbox<br/>spec.networkPolicy.allowlistRef:<br/>  registry: azureclawacr.azurecr.io<br/>  repository: allowlists/‹name›<br/>  digest: sha256:…"]
-    TK --> PATCH
-    KMS --> PATCH
-
-    PATCH --> RECONCILE["Controller reconcile triggered<br/>(watch event on ClawSandbox)"]
-
-    RECONCILE --> ACR_AUTH["acr_token_for_pull()<br/>4-step Workload Identity token exchange:<br/>1. Read federated token from AZURE_FEDERATED_TOKEN_FILE<br/>2. Exchange at Entra oauth2/v2.0/token<br/>3. Exchange at ACR /oauth2/exchange (refresh token)<br/>4. Exchange at ACR /oauth2/token (access token, pull scope)"]
-
-    ACR_AUTH --> FETCH["policy_fetcher: pull OCI artifact<br/>verify cosign signature"]
-
-    FETCH --> SIGPOL["Load SignerPolicy ConfigMap<br/>azureclaw-signer-policy (watched)<br/>fulcioIssuers + sanPatterns<br/>(malformed → SignerPolicyMalformed, fail closed)"]
-
-    SIGPOL --> VERIFY{"Signature valid?"}
-    VERIFY -->|"❌ fail"| LKG["Preserve last-known-good (LKG)<br/>endpoint set from prior reconcile<br/>stamp AllowlistVerified=False<br/>Degraded if no LKG exists"]
-    VERIFY -->|"✅ pass"| CANONICAL["Validate canonical form<br/>(byte-stable JSON rules)"]
-
-    CANONICAL --> DRIFT{"inline allowedEndpoints<br/>also set?"}
-    DRIFT -->|"yes and differs"| DRIFT_COND["AllowlistDrift=True/InlineDiffersFromArtifact"]
-    DRIFT -->|"no or matches"| APPLY["Derive allowedEndpoints<br/>from verified artifact<br/>(inline ignored in authoritative mode)"]
-
-    DRIFT_COND --> APPLY
-    APPLY --> NP["Update NetworkPolicy<br/>AllowlistVerified=True/Verified"]
-
-    style LKG fill:#f39c12,color:#fff
-    style APPLY fill:#2ecc71,color:#fff
-    style NP fill:#2ecc71,color:#fff
-    style VERIFY fill:#3498db,color:#fff
-```
-
-### 13.2 SignerPolicy ConfigMap Wire Shape
-
-```mermaid
-classDiagram
-    class SignerPolicyConfigMap {
-        name: azureclaw-signer-policy
-        namespace: azureclaw-system
-        data.fulcioIssuers: string (newline-separated)
-        data.sanPatterns: string (newline-separated)
-    }
-    class SignerPolicy {
-        fulcio_issuers: Vec~String~
-        san_patterns: Vec~String~
-        is_configured() bool
-    }
-    class FetchError {
-        SignerPolicyMissing
-        SignerPolicyMalformed(reason)
-        SignatureVerificationFailed
-        ArtifactFetchFailed
-        CanonicalFormInvalid
-    }
-    SignerPolicyConfigMap --> SignerPolicy : watched by controller\n(malformed → FetchError)
-    SignerPolicy --> FetchError : empty lists → reject all
-```
-
----
-
-## 14. InferencePolicy / ToolPolicy Ref Resolution — Phase 2
-
-Shows how `ClawSandbox.spec.inference.policyRef` and `spec.governance.toolPolicy.policyRef` are resolved
-at reconcile time. Each policy CRD has its own reconciler that compiles the spec to an AGT profile
-ConfigMap; the ClawSandbox reconciler resolves the ref, stamps a condition, and mounts the ConfigMap
-into the router pod. The router loads it via `PolicyEnvelope` (ArcSwap-backed hot reload). Source:
-`controller/src/inference_policy_reconciler.rs`, `controller/src/tool_policy_reconciler.rs`.
-
-### 14.1 Reconcile-Time Ref Resolution
-
-```mermaid
-sequenceDiagram
-    participant Ops as Operator
-    participant K8s as K8s API
-    participant IPR as InferencePolicy Reconciler<br/>fm: azureclaw-controller/inferencepolicy
-    participant TPR as ToolPolicy Reconciler<br/>fm: azureclaw-controller/toolpolicy
-    participant CSR as ClawSandbox Reconciler<br/>fm: azureclaw-controller/clawsandbox
-    participant Router as inference-router<br/>(PolicyEnvelope ArcSwap)
-
-    Ops->>K8s: kubectl apply InferencePolicy/my-policy
-    K8s->>IPR: watch event: InferencePolicy upserted
-
-    rect rgb(240, 248, 255)
-        Note over IPR: InferencePolicy reconcile
-        IPR->>IPR: compile_to_profile() → AGT profile JSON
-        IPR->>K8s: SSA patch ConfigMap<br/>inferencepolicy-my-policy-profile<br/>(key: profile.json, label: router-pod selector)
-        IPR->>K8s: SSA patch status:<br/>observedGeneration, phase=Ready<br/>profileConfigMapRef, versionHash, lastCompiledAt
-        IPR->>K8s: Set conditions: Ready=True, Degraded=False
-    end
-
-    Ops->>K8s: kubectl apply ClawSandbox with<br/>spec.inference.policyRef: my-policy
-
-    K8s->>CSR: watch event: ClawSandbox upserted
-
-    rect rgb(255, 248, 220)
-        Note over CSR: ClawSandbox reconcile — policy resolution
-        CSR->>K8s: GET InferencePolicy/my-policy
-        K8s-->>CSR: CR + status.profileConfigMapRef
-        CSR->>K8s: GET ConfigMap inferencepolicy-my-policy-profile
-        K8s-->>CSR: profile.json payload
-        CSR->>K8s: Mount ConfigMap as volume in Deployment<br/>inject INFERENCE_POLICY_CM env var to router
-        CSR->>K8s: Set conditions on ClawSandbox:<br/>Ready=True (or Degraded/InferencePolicyNotFound)
-    end
-
-    Note over CSR,Router: Hot reload path (no pod restart needed)
-    Router->>K8s: Watch ConfigMap changes via informer
-    K8s-->>Router: ConfigMap updated (versionHash changed)
-    Router->>Router: apply_policy_change(PolicyChange::Upserted)<br/>replace_snapshot() on PolicyEnvelope (ArcSwap store)<br/>next snapshot() call sees new rules immediately
-```
-
-### 14.2 PolicyEnvelope Hot-Reload State Machine
-
-```mermaid
-stateDiagram-v2
-    [*] --> Empty: Router startup\n(no policies loaded)
-
-    Empty: PolicyEnvelope generation 0\nNo InferencePolicy rules
-
-    Loaded: PolicyEnvelope generation N\nInferencePolicy rules active\nBTreeMap keyed by PolicyId
-
-    Updated: PolicyEnvelope generation N+1\nNew snapshot (ArcSwap store)\nIn-flight requests hold prior Arc
-
-    Empty --> Loaded: PolicyChange.Upserted\n(first policy)
-    Loaded --> Updated: PolicyChange.Upserted\nor PolicyChange.Deleted
-    Updated --> Updated: Additional changes\n(each bumps generation by 1)
-    Loaded --> Empty: PolicyChange.Reset\n(all policies removed)
-    Updated --> Empty: PolicyChange.Reset
-
-    note right of Updated
-        ArcSwap guarantees:
-        replace_snapshot() = single store op
-        snapshot() = zero-lock read
-        In-flight requests see prior Arc
-        until their scope drops
-    end note
-```
-
----
-
-## 15. Cloud Handoff Flow (Dev → AKS)
-
-LLM-driven agent migration from local Docker to AKS cloud. The LLM requests the handoff, the user confirms with a code, and the plugin orchestrates the transfer asynchronously — reporting live progress via emoji status updates.
-
-### 11.1 End-to-End Sequence
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant User as 👤 User (webchat)
-    participant LLM as 🤖 LLM
-    participant Plugin as 🔌 Plugin (source)
-    participant Router as 🛡️ Source Router
-    participant K8s as ☸️ K8s API
-    participant Ctrl as 🎛️ Controller
-    participant Reg as 📋 Global Registry
-    participant Relay as 📡 Relay (E2E)
-    participant TPlugin as 🔌 Plugin (target)
-    participant TRouter as 🛡️ Target Router
-
-    Note over User,TRouter: ──── Phase 1: Two-Stage Confirmation Gate ────
-
-    User->>LLM: "move to the cloud"
-    LLM->>Plugin: azureclaw_handoff_request(direction=cloud)
-    Plugin->>Router: POST /agt/handoff/pending
-    Note right of Router: Rate limit: 1 req / 300s<br/>Token: random 8-hex, TTL 5min
-    Router-->>Plugin: {confirmation_token, expires_in}
-    Plugin-->>LLM: "confirm with code: f913b1f9"
-    LLM-->>User: "🔄 To confirm, reply: f913b1f9"
-    User->>LLM: "f913b1f9"
-    LLM->>Plugin: azureclaw_handoff_confirm(code=f913b1f9)
-    Plugin->>Router: POST /agt/handoff/confirm
-    Note right of Router: Min 3s delay enforced<br/>Constant-time comparison
-    Router-->>Plugin: {handoff_token 🔒, direction}
-
-    Note over User,TRouter: ──── Phase 2: Async Background Orchestration ────
-    Note over Plugin: Plugin returns immediately<br/>LLM polls handoff_status every 3-5s
-
-    Plugin-->>LLM: "started — poll handoff_status"
-
-    Note over Plugin,Router: Step 1: Snapshot (timeout: 60s)
-    Plugin->>Router: POST /agt/handoff/snapshot
-    Note right of Router: AES-256-GCM encrypted<br/>key = HKDF(SHA256(admin‖handoff))
-    Router-->>Plugin: {blob, verification_hash, size_bytes}
-
-    LLM->>Plugin: azureclaw_handoff_status
-    Plugin-->>LLM: "📦 Snapshot ready (13.7 KB)"
-    LLM-->>User: 📦 Snapshot ready (13.7 KB)
-
-    Note over Plugin,Router: Step 2: Drain (timeout: 30s)
-    Plugin->>Router: POST /agt/handoff/drain
-    Note right of Router: Stop accepting new work<br/>⚠️ No undrain if aborted
-
-    Note over Plugin,Ctrl: Step 3: Spawn AKS Target
-    Plugin->>Router: POST /sandbox/spawn
-    Note right of Router: {handoff: {mode: restore}}<br/>Dev mode bypasses Docker → K8s CRD
-    Router->>K8s: Create ClawSandbox CRD
-    Note right of K8s: labels: spawned-by=handoff<br/>governance.trustedPeers = source AMID<br/>governance.registryMode = global
-    Ctrl->>K8s: Reconcile → Pod + NetworkPolicy
-    Note right of Ctrl: Both openclaw AND router get:<br/>AGT_TRUSTED_PEERS, AGT_REGISTRY_MODE
-
-    LLM->>Plugin: azureclaw_handoff_status
-    Plugin-->>LLM: "🚀 CRD created, waiting for pod..."
-    LLM-->>User: 🚀 Cloud target spawning...
-
-    Note over Plugin,Reg: Step 4: Mesh Discovery (90s max)
-    TPlugin->>Reg: Register AMID (Ed25519)
-    loop Poll registry every 2s
-        Plugin->>Reg: search for target AMID
-    end
-    Reg-->>Plugin: target AMID found ✓
-
-    LLM->>Plugin: azureclaw_handoff_status
-    Plugin-->>LLM: "🌐 Cloud target online"
-    LLM-->>User: 🌐 Cloud target online
-
-    Note over Plugin,TPlugin: Step 5: E2E State Transfer (5 retries × 2s)
-    Plugin->>Relay: mesh_send(handoff_transfer, blob, secret, hash)
-    Note over Relay: 🔐 Signal Protocol (X3DH + Double Ratchet)<br/>Relay is zero-knowledge
-    Relay->>TPlugin: deliver encrypted message
-
-    Note over TPlugin,TRouter: Step 5b: Target Restores State
-    TPlugin->>TRouter: POST /agt/handoff/init
-    TPlugin->>TRouter: POST /agt/handoff/restore {blob, secret}
-    Note right of TRouter: Decrypt, decompress,<br/>sanitize chat (anti-injection),<br/>trust scores capped at 750
-    TPlugin->>TRouter: POST /agt/handoff/verify {expected_hash}
-    Note right of TRouter: SHA-256 integrity match
-
-    Note over TPlugin,Plugin: Step 5c: Verification via E2E Mesh
-    TPlugin->>Relay: mesh_send(handoff_verification)
-    Note right of TPlugin: {matches, successor_amid,<br/>trust_scores_count, audit_entries_count}
-    Relay->>Plugin: deliver verification ✓
-    Note over Plugin: Filter: from_amid AND<br/>from_agent must BOTH match
-
-    LLM->>Plugin: azureclaw_handoff_status
-    Plugin-->>LLM: "✅ State verified — hash match"
-    LLM-->>User: ✅ State verified
-
-    Note over Plugin,Reg: Step 6: Identity Succession
-    Plugin->>Reg: POST /registry/succession
-    Note right of Reg: Ed25519 signed<br/>Copies reputation, marks predecessor Dormant
-
-    Note over Plugin,Router: Step 7: Decommission
-    Plugin->>Router: POST /agt/handoff/decommission
-    Note right of Router: Dormant — keys preserved<br/>Ghost cleanup skips dormant agents
-
-    LLM->>Plugin: azureclaw_handoff_status
-    Plugin-->>LLM: "🎉 Handoff complete!"
-    LLM-->>User: 🎉 I'm now running on AKS! Your keys are preserved for reverse handoff.
-```
-
-### 11.2 Handoff State Machine
-
-The router tracks handoff phases. **Note:** phase ordering is enforced by convention in the plugin, not by the router — endpoints are currently callable in any order (documented improvement area).
-
-```mermaid
-stateDiagram-v2
-    [*] --> Idle
-    Idle --> PendingConfirmation: POST /pending
-    PendingConfirmation --> Confirmed: POST /confirm (code match, ≥3s delay)
-    PendingConfirmation --> Idle: timeout (5min) / cancel
-    Confirmed --> Snapshotting: POST /snapshot
-    Snapshotting --> Draining: POST /drain
-    Draining --> Transferring: mesh_send(handoff_transfer)
-    Transferring --> Restoring: POST /restore (on target)
-    Restoring --> Verifying: POST /verify (on target)
-    Verifying --> Succession: POST /registry/succession
-    Succession --> Decommissioning: POST /decommission
-    Decommissioning --> [*]
-
-    Confirmed --> Aborted: POST /abort
-    Snapshotting --> Aborted: POST /abort
-    Draining --> Aborted: POST /abort or error
-    Transferring --> Aborted: POST /abort
-    Verifying --> Aborted: timeout (60s)
-    Aborted --> [*]
-
-    note right of Draining
-        ⚠️ No undrain mechanism.
-        Abort after drain leaves agent
-        in drained state until restart.
-    end note
-
-    note right of Transferring
-        ⚠️ If mesh transfer fails after spawn,
-        orphaned CRD must be manually deleted:
-        kubectl delete clawsandbox <name>
-    end note
-```
-
-### 11.3 Security Model
-
-```mermaid
-%%{init: {'theme': 'default'}}%%
-graph TB
-    subgraph gate["Layer 1: Human-in-the-Loop Gate"]
-        direction LR
-        pending["POST /pending<br/>Rate limit: 1 req / 300s"]
-        confirm["POST /confirm<br/>Min 3s delay, constant-time compare"]
-        pending --> confirm
-    end
-
-    subgraph isolation["Layer 2: LLM Isolation"]
-        direction LR
-        token_iso["Handoff token stays in<br/>plugin memory — LLM never sees it"]
-        admin_iso["Admin token read from<br/>/run/secrets/ (K8s mount)"]
-        execute["LLM can REQUEST<br/>but never EXECUTE"]
-    end
-
-    subgraph auth["Layer 3: Three-Layer Endpoint Auth"]
-        direction LR
-        l1["Init: admin token<br/>(no localhost bypass)"]
-        l2["Mutations: admin + handoff token<br/>(no localhost bypass)"]
-        l3["Status: admin token<br/>(localhost bypass OK — read-only)"]
-    end
-
-    subgraph encryption["Layer 4: Double Encryption"]
-        direction LR
-        aes["Snapshot: AES-256-GCM<br/>key = HKDF-SHA256(admin‖handoff)"]
-        signal["Transport: Signal Protocol<br/>X3DH + Double Ratchet per session"]
-        relay_zk["Relay is zero-knowledge<br/>cannot decrypt payloads"]
-    end
-
-    subgraph injection["Layer 5: State Blob Hardening"]
-        direction LR
-        sanitize["Chat history sanitized<br/>(strip system prompts, JSON injection)"]
-        trust_cap["Trust scores capped at 750<br/>(prevent score inflation)"]
-        size_limit["50MB blob limit<br/>100 files max, 10MB/file"]
-    end
-
-    subgraph identity["Layer 6: Identity & Trust"]
-        direction LR
-        ed25519["Ed25519 keypairs<br/>AMIDs = public keys"]
-        trusted["AGT_TRUSTED_PEERS<br/>K8s-injected to BOTH containers"]
-        knock["KNOCK enforcement<br/>+500 bonus for trusted peers"]
-        verify_both["Verification filter:<br/>from_amid OR from_agent mismatch → reject"]
-    end
-
-    subgraph infra["Layer 7: Infrastructure"]
-        direction LR
-        netpol["NetworkPolicy: default-deny<br/>mesh egress only"]
-        readonly["Read-only rootfs<br/>seccomp + non-root"]
-        kube["Kubeconfig: read-only mount<br/>dev mode only"]
-        validated["registry_mode validated: local|global<br/>trusted_peers: control chars rejected"]
-    end
-
-    gate --> isolation --> auth --> encryption --> injection --> identity --> infra
-```
-
-### 11.4 Env Var Propagation (Controller → Containers)
-
-Both containers in the sandbox pod receive governance env vars. This is critical for handoff — the router needs `AGT_REGISTRY_MODE` to gate handoff endpoints, and `AGT_TRUSTED_PEERS` for KNOCK authentication.
-
-```mermaid
-%%{init: {'theme': 'default'}}%%
-graph LR
-    CRD["ClawSandbox CRD<br/>governance spec"] --> Ctrl["Controller<br/>reconciler.rs"]
-
-    Ctrl --> OC["OpenClaw Container"]
-    Ctrl --> IR["Inference Router"]
-
-    subgraph OC_env["OpenClaw Env Vars"]
-        direction TB
-        oc1["AGT_GOVERNANCE_ENABLED"]
-        oc2["AGT_POLICY_PROFILE"]
-        oc3["AGT_TRUST_THRESHOLD"]
-        oc4["AGT_TRUSTED_PEERS ✅"]
-        oc5["AGT_REGISTRY_MODE ✅"]
-    end
-
-    subgraph IR_env["Router Env Vars"]
-        direction TB
-        ir1["AGT_GOVERNANCE_ENABLED"]
-        ir2["AGT_POLICY_PROFILE"]
-        ir3["AGT_TRUST_THRESHOLD"]
-        ir4["AGT_TRUSTED_PEERS ✅"]
-        ir5["AGT_REGISTRY_MODE ✅"]
-        ir6["AGT_MESH_NAMESPACE"]
-        ir7["AGT_RELAY_URL"]
-        ir8["AGT_REGISTRY_URL"]
-    end
-
-    OC --> OC_env
-    IR --> IR_env
-
-    subgraph validation["CRD Validation"]
-        direction TB
-        v1["trusted_peers: reject \\n \\r \\0"]
-        v2["registry_mode: only local|global"]
-    end
-
-    CRD --> validation
-    validation --> Ctrl
-```
-
-### 11.5 Two Orchestration Paths
-
-There are two independent orchestration paths for handoff — both valid, serving different use cases:
-
-```mermaid
-%%{init: {'theme': 'default'}}%%
-graph TB
-    subgraph llm_path["LLM-Driven (plugin.ts — interactive webchat)"]
-        direction TB
-        L1["handoff_request tool<br/>→ POST /agt/handoff/pending"]
-        L2["handoff_confirm tool<br/>→ POST /agt/handoff/confirm"]
-        L3["_runHandoffOrchestration()<br/>runs async in background"]
-        L4["handoff_status tool<br/>polled every 3-5s by LLM"]
-        L1 --> L2 --> L3
-        L3 -.-> L4
-    end
-
-    subgraph cli_path["CLI-Driven (handoff.ts — operator terminal)"]
-        direction TB
-        C1["azureclaw handoff ‹name›<br/>→ POST /agt/handoff/init"]
-        C2["Direct snapshot + drain<br/>→ POST /snapshot, /drain"]
-        C3["kubectl apply CRD<br/>+ port-forward + restore"]
-        C4["Terminal progress bar<br/>(Stepper class)"]
-        C1 --> C2 --> C3
-        C3 -.-> C4
-    end
-
-    subgraph differences["Key Differences"]
-        direction TB
-        D1["LLM path: two-stage gate<br/>(pending → confirm with code)"]
-        D2["CLI path: direct init<br/>(operator trusted, no gate)"]
-        D3["LLM path: mesh transfer<br/>(E2E encrypted via relay)"]
-        D4["CLI path: port-forward restore<br/>(direct HTTP to target)"]
-    end
-
-    llm_path --- differences
-    cli_path --- differences
-```
-
-### 11.6 Trust Flow — Current vs Future
-
-Currently agents register anonymously (trust score = 0), so `AGT_TRUSTED_PEERS` provides the +500 KNOCK bonus. With Entra OAuth deployed, agents get verified identities and real reputation.
-
-```mermaid
-%%{init: {'theme': 'default'}}%%
-graph LR
-    subgraph current["Current — Unauthenticated"]
-        S1["Source AMID<br/>registry score: 0"] -->|KNOCK| T1["Target<br/>threshold: 500"]
-        T1 -->|"+500 trusted_peers bonus"| A1["✅ 500 ≥ 500"]
-    end
-
-    subgraph future["Future — Entra OAuth"]
-        S2["Source AMID<br/>Entra-verified"] -->|KNOCK| T2["Target<br/>threshold: 500"]
-        T2 -->|"registry reputation: 800"| A2["✅ 800 ≥ 500"]
-        Note1["No trusted_peers needed<br/>Real identity = real trust"]
-    end
-```
-
-### 11.7 Error Recovery & Known Limitations
-
-```mermaid
-%%{init: {'theme': 'default'}}%%
-graph TB
-    subgraph failure_modes["Failure Modes"]
-        F1["Mesh send fails<br/>(5 retries exhausted)"]
-        F2["Target doesn't register<br/>(90s timeout)"]
-        F3["Verification timeout<br/>(60s)"]
-        F4["Restore decrypt fails<br/>(wrong key / tampered blob)"]
-        F5["Abort after drain"]
-    end
-
-    subgraph recovery["Current Recovery"]
-        R1["Abort → token revoked,<br/>phase reset"]
-        R2["Abort → phase reset,<br/>target pod orphaned ⚠️"]
-        R3["Status = partial,<br/>target may still restore"]
-        R4["Target sends error<br/>via mesh → abort"]
-        R5["Agent stuck in drained<br/>state until restart ⚠️"]
-    end
-
-    subgraph improvements["Planned Improvements"]
-        I1["Auto-cleanup orphaned CRDs<br/>on abort"]
-        I2["POST /agt/handoff/resume<br/>to cancel drain"]
-        I3["Router enforces phase<br/>ordering (state machine)"]
-    end
-
-    F1 --> R1
-    F2 --> R2
-    F3 --> R3
-    F4 --> R4
-    F5 --> R5
-
-    R2 --> I1
-    R5 --> I2
-    recovery --> I3
-```
-
----
-
-## 16. Bidirectional Handoff with Sub-Agents
-
-Full roundtrip handoff: local Docker ↔ AKS cloud, including sub-agent lifecycle (snapshot, destroy, re-spawn, workspace inject, task resume). The local Docker parent is the permanent "home base" — everything else is ephemeral.
-
-### 12.1 Agent Lifecycle Across Handoff
-
-```mermaid
-%%{init: {'theme': 'default'}}%%
-graph LR
-    subgraph local["🐳 Local Docker — Home Base"]
-        LP["🏠 Parent Agent<br/>permanent — goes dormant,<br/>never deleted"]
-        LS1["Sub-Agent 1<br/>ephemeral"]
-        LS2["Sub-Agent 2<br/>ephemeral"]
-    end
-
-    subgraph cloud["☁️ AKS Cloud — Ephemeral"]
-        CP["Parent Agent<br/>created by forward handoff,<br/>CRD deleted on reverse"]
-        CS1["Sub-Agent 1<br/>re-spawned from snapshot"]
-        CS2["Sub-Agent 2<br/>re-spawned from snapshot"]
-    end
-
-    LP -->|"forward: snapshot + spawn"| CP
-    LS1 -.->|"destroyed"| CS1
-    LS2 -.->|"destroyed"| CS2
-    CP -->|"reverse: snapshot + wake"| LP
-    CS1 -.->|"CRD deleted"| LS1
-    CS2 -.->|"CRD deleted"| LS2
-```
-
-**Key principle:** Sub-agents are never migrated — they are destroyed and re-spawned. Only the parent's snapshot (which includes sub-agent definitions and workspace tars) crosses the boundary.
-
-### 12.2 Forward Handoff: Local → Cloud (with Sub-Agents)
-
-CLI-driven path (`azureclaw handoff <name> --to cloud`). 7 stepper steps.
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant CLI as 🖥️ CLI (handoff.ts)
-    participant SrcR as 🛡️ Source Router<br/>(Docker)
-    participant Sub as 🐳 Docker Sub-Agents
-    participant K8s as ☸️ K8s API
-    participant Ctrl as 🎛️ Controller
-    participant TgtR as 🛡️ Target Router<br/>(AKS)
-    participant Plugin as 🔌 Target Plugin<br/>(AKS)
-    participant Reg as 📋 Registry
-    participant Relay as 📡 Relay
-
-    Note over CLI,Relay: Step 1: Verify source agent
-
-    CLI->>SrcR: GET /agt/handoff/status
-    SrcR-->>CLI: handoff_available=true, registry_mode=global
-
-    Note over CLI,Relay: Step 2: Initialize handoff session
-
-    CLI->>SrcR: POST /agt/handoff/init {direction: local_to_aks}
-    SrcR-->>CLI: {handoff_token, token_hash}
-
-    Note over CLI,Relay: Step 3: Create state snapshot
-
-    CLI->>SrcR: GET /agt/handoff/sub-agents
-    SrcR-->>CLI: [{name, capabilities, amid}]
-    CLI->>Sub: write .handoff-interrupt to each workspace
-    Note right of Sub: 3s pause for agents<br/>to save checkpoints
-    CLI->>Sub: docker exec tar workspace (each sub-agent)
-    CLI->>SrcR: docker exec tar workspace (parent)
-    CLI->>SrcR: POST /memory_stores/{store}:search_memories
-    CLI->>SrcR: docker exec env (credential refs)
-    CLI->>SrcR: POST /agt/handoff/snapshot {workspace_tar, sub_agent_snapshots[], credentials}
-    SrcR-->>CLI: {blob, snapshot_size_bytes} (AES-256-GCM encrypted)
-
-    Note over CLI,Relay: Step 4: Drain active work
-
-    CLI->>SrcR: POST /agt/handoff/drain
-    SrcR-->>CLI: drained ✓
-
-    Note over CLI,Relay: Step 5: Provision target + restore
-
-    CLI->>K8s: kubectl apply ClawSandbox CRD<br/>(handoff.mode=restore, predecessor AMID)
-    Ctrl->>K8s: Reconcile → namespace, deployment, service, NetworkPolicy
-    CLI->>K8s: kubectl create secret (credentials)
-    CLI->>K8s: Wait for pod Ready (up to 120s)
-    CLI->>TgtR: kubectl port-forward → POST /agt/handoff/restore {blob, shared_secret}
-    Note right of TgtR: Decrypt blob → restore trust scores,<br/>audit entries, re-spawn sub-agents<br/>via POST /sandbox/spawn per snapshot
-
-    TgtR-->>CLI: {trust_scores_count, sub_agent_results[]}
-    TgtR->>K8s: Create sub-agent ClawSandbox CRDs
-    Ctrl->>K8s: Reconcile → sub-agent pods
-
-    Note over CLI,Relay: Plugin IIFE: async post-restore hydration
-
-    Plugin->>Plugin: Parse chat_snapshot → replay to Foundry Conversation
-    Plugin->>Plugin: Store handoff event in Foundry Memory
-    Plugin->>Plugin: Extract workspace tar to /sandbox/
-    Plugin->>Plugin: Write MEMORY.md + .handoff-state.json
-
-    Note over CLI,Relay: Plugin: Sub-agent trust + resume loop
-
-    Plugin->>Plugin: Collect original_amid from snapshots → staleAmids Set
-    Plugin->>Plugin: Clear stale entries from nameToAmid cache
-
-    loop For each sub-agent (reject stale AMIDs, 90s timeout)
-        Plugin->>Reg: GET /registry/search?capability={name}
-        Reg-->>Plugin: candidates (filter out staleAmids)
-    end
-    Note right of Plugin: Cache NEW AMIDs in nameToAmid
-
-    loop Prekey gate (20 attempts × 3s)
-        Plugin->>Relay: ping sub-agent (verify E2E session)
-    end
-
-    loop Workspace inject (3 attempts × 20s ack wait)
-        Plugin->>Relay: mesh_send(workspace_inject, tar)
-        Relay->>Sub: deliver workspace tar (E2E encrypted)
-        Sub->>Sub: Extract tar + promote incoming/ + write HANDOFF_FILES.md
-        Sub->>Relay: mesh_send(workspace_inject_ack, {file_count})
-        Relay->>Plugin: deliver ack ✓
-    end
-
-    Plugin->>Relay: mesh_send(handoff:resume, {task_context, checkpoint})
-    Relay->>Sub: deliver resume signal
-    Sub->>Sub: Resume interrupted task (processTaskWithTools)
-
-    Note over CLI,Relay: Step 6: Identity succession
-
-    CLI->>Reg: POST /registry/succession (Ed25519 signed)
-    Note right of Reg: Copy reputation, mark predecessor dormant
-
-    Note over CLI,Relay: Step 7: Summary + local cleanup
-
-    CLI->>SrcR: POST /agt/handoff/decommission
-    Note right of SrcR: Parent goes dormant<br/>(Docker container preserved for reverse)
-    CLI->>Sub: docker stop + rm sub-agent containers
-```
-
-### 12.3 Reverse Handoff: Cloud → Local (with Sub-Agents)
-
-CLI-driven path (`azureclaw handoff <name> --to local`). 13 stepper steps.
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant CLI as 🖥️ CLI (handoff.ts)
-    participant SrcR as 🛡️ Source Router<br/>(AKS)
-    participant Sub as ☁️ AKS Sub-Agents
-    participant K8s as ☸️ K8s API
-    participant Docker as 🐳 Docker
-    participant TgtR as 🛡️ Target Router<br/>(Docker)
-    participant Plugin as 🔌 Target Plugin<br/>(Docker)
-    participant Reg as 📋 Registry
-    participant Relay as 📡 Relay
-
-    Note over CLI,Relay: Step 1: Connect to AKS
-
-    CLI->>K8s: kubectl port-forward svc/{name} 18445:8443
-    CLI->>SrcR: GET /readyz (poll until healthy)
-
-    Note over CLI,Relay: Step 2: Verify source agent
-
-    CLI->>SrcR: GET /agt/handoff/status (via port-forward)
-    SrcR-->>CLI: handoff_available=true
-
-    Note over CLI,Relay: Step 3: Initialize handoff
-
-    CLI->>SrcR: POST /agt/handoff/init {direction: aks_to_local}
-    SrcR-->>CLI: {handoff_token, token_hash}
-
-    Note over CLI,Relay: Step 4: Create state snapshot
-
-    CLI->>SrcR: GET /agt/handoff/sub-agents
-    SrcR-->>CLI: [{name, capabilities, amid}]
-    CLI->>Sub: kubectl exec: write .handoff-interrupt
-    Note right of Sub: 3s pause
-    CLI->>Sub: kubectl exec: tar workspace (each sub-agent)
-    CLI->>SrcR: kubectl exec: tar workspace (parent)
-    CLI->>SrcR: POST /memory_stores/{store}:search_memories
-    CLI->>SrcR: POST /agt/handoff/snapshot {workspace_tar, sub_agent_snapshots[]}
-    SrcR-->>CLI: {blob, snapshot_size_bytes}
-
-    Note over CLI,Relay: Step 5: Drain
-
-    CLI->>SrcR: POST /agt/handoff/drain
-
-    Note over CLI,Relay: Steps 6-9: Wake local + restore
-
-    CLI->>Docker: docker start (wake dormant parent)
-    CLI->>K8s: kubectl get secret → decode credentials
-    CLI->>Docker: docker exec: write credentials to env file
-    CLI->>TgtR: POST /agt/handoff/init {direction: aks_to_local}
-    TgtR-->>CLI: {localHandoffToken}
-    CLI->>TgtR: docker exec curl POST /agt/handoff/restore {blob, shared_secret}
-    Note right of TgtR: Decrypt blob → restore state,<br/>re-spawn sub-agents as Docker containers
-    TgtR-->>CLI: {trust_scores_count, sub_agent_results[]}
-
-    Note over CLI,Relay: Plugin IIFE: async post-restore (same as §12.2)
-
-    Plugin->>Plugin: Chat replay + memory + workspace extraction
-    Plugin->>Plugin: Sub-agent trust+resume loop<br/>(stale AMID filter → prekey gate →<br/>workspace inject → resume)
-
-    Note over CLI,Relay: Step 10: Identity succession
-
-    CLI->>Reg: POST /registry/succession (Ed25519 signed)
-
-    Note over CLI,Relay: Steps 11-13: Cloud teardown
-
-    CLI->>SrcR: POST /agt/handoff/decommission
-    CLI->>K8s: kubectl delete clawsandbox {parent}
-    CLI->>K8s: kubectl delete clawsandbox {sub-agent-1}
-    CLI->>K8s: kubectl delete clawsandbox {sub-agent-2}
-    Note right of K8s: Controller cascades: delete<br/>namespace, deploy, svc, NetworkPolicy
-    CLI->>CLI: aksPortForwardStop()
-```
-
-### 12.4 Stale AMID Cache Poisoning — Problem & Fix
-
-After handoff, the predecessor's sub-agents leave stale AMIDs in the registry (5-minute heartbeat timeout). The successor's trust+resume loop could cache these dead AMIDs, causing all mesh messages to silently drop.
-
-```mermaid
-sequenceDiagram
-    participant Old as Old Sub-Agent<br/>(AMID: 3FFu...)
-    participant Reg as 📋 Registry
-    participant New as New Sub-Agent<br/>(AMID: 4SKY...)
-    participant Parent as Successor Parent
-
-    Note over Old,Parent: T+0: Docker containers destroyed
-
-    Old->>Reg: Last heartbeat at T-30s
-    Note right of Reg: AMID 3FFu... still "online"<br/>(heartbeat timeout = 5 min)
-
-    Parent->>Reg: search("researcher")
-    Reg-->>Parent: 3FFu... (STALE ❌)
-    Note right of Parent: original_amid filter rejects!<br/>Keeps searching...
-
-    Note over Old,Parent: T+27s: New AKS sub-agent registers
-
-    New->>Reg: Register AMID 4SKY...
-    Note right of Reg: Ghost cleanup deletes 3FFu...<br/>4SKY... is now "online"
-
-    Parent->>Reg: search("researcher")
-    Reg-->>Parent: 4SKY... (NEW ✅)
-    Parent->>Parent: Cache 4SKY... in nameToAmid
-```
-
-**Three-layer fix:**
-1. **Stale AMID rejection** — `original_amid` from snapshots used to filter registry results by identity, not time
-2. **Prekey readiness gate** — 20 attempts × 3s to verify E2E session before workspace_inject
-3. **Workspace inject retry** — 3 attempts with 20s ack wait, catches send errors
-
-### 12.5 Workspace Injection Detail
-
-```mermaid
-%%{init: {'theme': 'default'}}%%
-graph TB
-    subgraph sender["Parent — sender side"]
-        S1["Collect workspace tar<br/>from snapshot"] --> S2["mesh_send(workspace_inject,<br/>base64 tar)"]
-        S2 --> S3{"Ack received<br/>within 20s?"}
-        S3 -->|No| S4["Retry (max 3)"]
-        S4 --> S2
-        S3 -->|Yes| S5["Send handoff:resume<br/>with task_context"]
-    end
-
-    subgraph receiver["Sub-Agent — receiver side"]
-        R1["Receive workspace_inject"] --> R2["Validate tar entries<br/>(no path traversal)"]
-        R2 --> R3["Extract to /sandbox/<br/>(--no-overwrite-dir)"]
-        R3 --> R4["Promote incoming/ files<br/>to workspace root"]
-        R4 --> R5["Write HANDOFF_FILES.md<br/>(file manifest)"]
-        R5 --> R6["Send workspace_inject_ack<br/>{success, file_count}"]
-    end
-
-    S2 -.->|E2E encrypted<br/>via relay| R1
-    R6 -.->|E2E encrypted<br/>via relay| S3
-```
+## See also
+
+- **[Architecture](architecture.md)** — the prose explanation.
+- **[Security model](security.md)** — per-layer guarantees.
+- **[STRIDE threat model](security/stride.md)**.
+- **[Blueprints](blueprints/00-index.md)** — five reference deployment shapes built from these primitives.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,802 +1,126 @@
 # Architecture
 
-> **Cross-links:** [README](../README.md) · [CRD Reference](api/crd-reference.md) · [CLI Reference](cli-reference.md) · [Security](security.md) · [Threat Model](threat-model.md) · [Architecture Diagrams](architecture-diagrams.md) · [SIGS Agent Sandbox Compat](sigs-agent-sandbox-compat.md) · [ADR-0001](adr/0001-a2a-ingress-front-edge.md) · [Runtime Contract](runtime-contract.md) · [MCP Top 10](security-mcp-top10.md)
+This document explains *what AzureClaw is made of* and *why each part exists*. For diagrams, see **[Architecture diagrams](architecture-diagrams.md)**. For a faster on-ramp, see **[Getting started](getting-started.md)**.
+
+## Design goals (in priority order)
+
+1. **The agent must not see Azure credentials.** Compromise of any agent must not grant access to the Azure subscription.
+2. **Every external call must pass a policy decision point.** No invisible side effects, no silent network egress.
+3. **Inter-agent communication must be confidential, authenticated, and forward-secret.** No plaintext fallback.
+4. **The same code path runs in dev and in prod.** Local mode is *easier*, not *different*.
+5. **Operability over cleverness.** Standard Kubernetes primitives (CRDs, NetworkPolicies, RBAC, Helm) so platform teams can operate AzureClaw the way they operate the rest of the cluster.
+
+Everything below follows from those five.
 
 ---
 
-## 1. System Overview
+## Components
 
-AzureClaw is a Kubernetes operator that runs sandboxed AI agents with defence-in-depth isolation, a per-sandbox inference/governance proxy, and native Azure AI Foundry integration. It ships as four deployable components across two languages, plus a test infrastructure.
+AzureClaw has four code components, two languages, and one rule that ties them together.
 
-### Component map
+| Component | Language | Crate / package | Responsibility |
+|---|---|---|---|
+| **Controller** | Rust (kube-rs) | `azureclaw-controller` | Watches `ClawSandbox` and the seven peer CRDs; reconciles them into namespaces, pods, services, NetworkPolicies, ConfigMaps, federated identities. |
+| **Inference router** | Rust (axum) | `azureclaw-inference-router` | Sits in the data path of every external call. Identity, content safety, governance, audit, mesh, A2A — all of it. |
+| **A2A gateway** | Rust (axum) | `azureclaw-a2a-gateway` + `azureclaw-a2a-core` | Public-ingress entry point for A2A 1.2 peer traffic. Verifies signed `AgentCard`s, routes to the correct sandbox, emits audit. |
+| **CLI** | TypeScript | `@azureclaw/cli` | Lifecycle of clusters, sandboxes, policies. 26 commands. The CLI is convenience; everything it does is achievable with `az` + `helm` + `kubectl`. |
 
-| Component | Language | Binary / Package | Runs on | Role |
-|-----------|----------|-----------------|---------|------|
-| **Controller** | Rust (kube-rs, edition 2024) | `azureclaw-controller` | `azureclaw-system` namespace | K8s operator — reconciles 8 CRDs; two replicas with leader election |
-| **Inference Router** | Rust (axum) | `azureclaw-inference-router` | sidecar in every sandbox pod | Per-sandbox proxy and policy choke-point |
-| **A2A Gateway** | Rust (axum + rustls) | `azureclaw-a2a-gateway` | `azureclaw-system` (shared) | Public TLS ingress for inbound A2A 1.0 federation |
-| **CLI** | TypeScript (Node.js 22+) | `@azureclaw/cli` | operator's laptop | 23 CLI commands; deploys and manages AzureClaw clusters |
-| **OpenClaw Adapter** | TypeScript | `runtimes/openclaw/` | inside sandbox container | OpenClaw plugin — tools, provider, mesh wiring |
-| **Additional Runtime Adapters** | TypeScript | `runtimes/{openai-agents,maf}/` | inside sandbox container | Native Phase 2 adapters for OpenAI Agents SDK and Microsoft Agent Framework |
-
-The `cli/` package is the operator CLI only (`@azureclaw/cli`). All runtime
-adapters live under `runtimes/` and are independently versioned. See
-[`docs/runtime-contract.md`](runtime-contract.md) for the BYO adapter contract.
-
-### Cluster topology
-
-```
-┌─ AKS Cluster (Azure Linux, Cilium CNI) ──────────────────────────────────┐
-│                                                                           │
-│  azureclaw-system namespace                                               │
-│  ┌─────────────────────────────────────────────────────┐                  │
-│  │ Controller × 2 replicas (leader-elected)            │                  │
-│  │  • Watches 8 CRDs (ClawSandbox, ClawPairing,        │                  │
-│  │    McpServer, ToolPolicy, A2AAgent, InferencePolicy, │                  │
-│  │    ClawMemory, ClawEval)                             │                  │
-│  │  • Metrics: :9091/metrics                           │                  │
-│  └─────────────────────────────────────────────────────┘                  │
-│  ┌─────────────────────────────────────────────────────┐                  │
-│  │ A2A Gateway (opt-in, --enable-a2a-ingress)          │                  │
-│  │  • Public TLS :8443, mTLS → router :8444            │                  │
-│  │  • JWS AgentCard verifier + replay cache            │                  │
-│  │  • Prometheus: :9090                                │                  │
-│  └─────────────────────────────────────────────────────┘                  │
-│  seccomp DaemonSet → azureclaw-strict.json on every node                 │
-│                                                                           │
-│  azureclaw-<name> namespace (one per sandbox)                             │
-│  ┌──────────────────────────────────────────────────────────────────┐     │
-│  │ Pod (2 containers + 1 init)                                      │     │
-│  │                                                                  │     │
-│  │  init: egress-guard (runs as root, then exits)                   │     │
-│  │   └─ iptables: UID 1000 → localhost + DNS + ESTABLISHED only     │     │
-│  │                                                                  │     │
-│  │  container: agent (UID 1000, network-restricted)                 │     │
-│  │   ├─ Runtime selected by ClawSandbox.spec.runtime.kind           │     │
-│  │   │    OpenClaw | OpenAIAgents | MicrosoftAgentFramework | BYO   │     │
-│  │   ├─ Gateway :18789 (WebSocket + Control UI)  [OpenClaw only]    │     │
-│  │   ├─ Python 3 (43 packages pre-installed)                        │     │
-│  │   └─ All external access → localhost:8443 only                   │     │
-│  │                                                                  │     │
-│  │  container: inference-router (UID 1001, unrestricted network)    │     │
-│  │   ├─ Inference proxy (/v1/*)              ───────────────────────┼──► Foundry
-│  │   ├─ Egress proxy (/egress/fetch)         ───────────────────────┼──► External HTTP (audited)
-│  │   ├─ AGT relay (/agt/relay)               ───────────────────────┼──► agentmesh-relay (WS)
-│  │   ├─ Content Safety floor + Prompt Shields ──────────────────────┼──► Azure AI Content Safety
-│  │   ├─ Token budgets, audit logging, Prometheus metrics            │     │
-│  │   ├─ Signed OCI egress-allowlist verifier                        │     │
-│  │   └─ Sub-agent spawn (/sandbox/spawn)     ───────────────────────┼──► K8s API (CRD create)
-│  └──────────────────────────────────────────────────────────────────┘     │
-│  NetworkPolicy: default-deny egress + allowlist                           │
-│  ServiceAccount: Workload Identity (azure.workload.identity/client-id)    │
-│  Blocklist ConfigMap + CronJob (6h refresh from OISD + URLhaus)           │
-│                                                                           │
-└───────────────────────────────────────────────────────────────────────────┘
-```
+The rule that ties them together: **the agent has no network of its own**. The router is the only process in the sandbox pod that can talk to the outside. Every other property of AzureClaw is a downstream consequence of holding that line.
 
 ---
 
-## 2. The Inference Data Path
+## Two modes
 
-Every external call an agent makes flows through a single choke-point: the
-inference router running in the same pod as UID 1001. The agent (UID 1000)
-is iptables-walled to `localhost:8443` — it can reach nothing else.
+`azureclaw dev` and `azureclaw up` produce sandboxes that are observably the same to the agent code, but architecturally very different to a security reviewer.
 
-```mermaid
-sequenceDiagram
-    participant A as Agent (UID 1000)
-    participant R as Inference Router (UID 1001)
-    participant F as Azure AI Foundry
+### Dev mode (`azureclaw dev`)
 
-    A->>R: POST /v1/chat/completions (localhost:8443)
-    R->>R: InferencePolicy check (ref → compiled profile)
-    R->>R: Token budget check (daily + per-request)
-    R->>R: Content Safety floor (prompt-shield)
-    R->>R: AGT governance gate (PolicyDecisionProvider)
-    R->>R: Acquire IMDS/WI token (cached per scope)
-    R->>F: Forward request (Bearer token, no API key)
-    F-->>R: Response (content-filter annotations)
-    R->>R: Parse flags → AuditSink → Prometheus metrics
-    R-->>A: Response (filtered)
-```
+- **Pod shape:** one Docker container.
+- **Inside:** the agent runtime and the inference router are co-located in the same image. They communicate over `127.0.0.1`.
+- **Isolation:** Docker network. Mounted secret file holds the resource-level Azure OpenAI key. No iptables, no NetworkPolicy, no UID separation.
+- **Identity:** key-based (the key you provided on first run).
+- **What it is for:** plugin authoring, policy iteration, smoke tests, demos. Inner loop only.
 
-**Why the router is the sole choke-point:**
-- Agent (UID 1000) has no API keys, no credentials, no direct network path
-  (iptables DROP on all non-loopback, non-DNS egress).
-- The router holds ephemeral IMDS tokens via Workload Identity — they are
-  never visible to UID 1000.
-- All policy decisions, content safety screening, token accounting, and audit
-  logging happen in the router before any byte reaches Foundry.
-- Sub-agent spawning (`/sandbox/spawn`) also runs through the router, so
-  the spawner policy can be enforced at the same gate.
+The router still runs the same code path it does in prod. So the policies, the content-safety rejections, the audit format, the governance decisions are all real. What is not real is the network and identity isolation — there is no separate router process to break out *to*. Treat dev mode as a development surface, not a security surface.
+
+### Prod mode (`azureclaw up` / Helm install)
+
+- **Pod shape:** multi-container Kubernetes pod.
+  - `init: egress-guard` — installs iptables rules so only the router's UID can reach the outside.
+  - `agent` — the runtime, **UID 1000**, no direct egress.
+  - `inference-router` — the Rust router, **UID 1001**, listens on `127.0.0.1:8443` (HTTP) and `127.0.0.1:8444` (forward proxy).
+- **Isolation:** Kubernetes NetworkPolicy on the namespace pins egress to exactly DNS, Foundry, the AgentMesh relay, and the A2A gateway. Optionally Kata + AMD SEV-SNP for hardware-enforced isolation.
+- **Identity:** Workload Identity. The router exchanges the projected service-account token for a federated AAD token. No keys on disk.
+- **What it is for:** real workloads, multi-tenant fleets, anything that touches customer data.
+
+Whichever mode you run in, the CRDs are the same, the audit chain is the same, and the policy profiles are the same. The dev → prod jump is one CLI command, not a re-architecture.
 
 ---
 
-## 3. CRD Overview
+## The data path of one external call
 
-Eight CRDs are registered under `azureclaw.azure.com/v1alpha1`. Full schemas
-live in [`docs/api/crd-reference.md`](api/crd-reference.md).
+Walk through what happens when an agent in prod mode says *"call the model"*:
 
-| CRD | Short Name | Purpose | Key Relationship |
-|-----|-----------|---------|-----------------|
-| `ClawSandbox` | `cs`, `claw` | Declares a sandboxed agent instance | References `InferencePolicy` via `spec.inferenceRef`; optionally references `ToolPolicy` via `spec.governance.toolPolicy` |
-| `ClawPairing` | — | Operator-assisted cross-sandbox pairing as a K8s operation | Owned by a `ClawSandbox` pair |
-| `McpServer` | — | Configures an MCP 2026 endpoint with OAuth 2.1; the reconciler generates an Ed25519 signing key and optional JWKS cache | Referenced from `ClawSandbox.spec.governance` |
-| `ToolPolicy` | — | Carries AGT policy profile (allow/deny/rate-limit/approval rules) + AP2 commerce fields (`dailyCap`, `monthlyCap`, `counterpartyAllowlist`) | Referenced by `ClawSandbox` and `McpServer` |
-| `InferencePolicy` | — | Compiled guardrail bundle: model, content-safety floor, prompt-shield requirement, token budgets | Referenced by `ClawSandbox.spec.inferenceRef` (mandatory post-S13 inline→ref migration) |
-| `A2AAgent` | — | Declares an A2A 1.0 AgentCard (skills, interfaces, trust score) for inbound federation | The reconciler compiles and publishes the card as a ConfigMap |
-| `ClawMemory` | — | Binds a Foundry Memory Store to a sandbox | Owned by a `ClawSandbox` |
-| `ClawEval` | — | Declares an evaluation job (dataset + evaluators + pass criteria) | Owned by a `ClawSandbox`; runtime slice writes `lastScore`, `lastPass` |
+1. The agent SDK is configured (by the runtime adapter) to point at `http://127.0.0.1:8443`. There is no way for it to reach Foundry directly — egress-guard would drop the packet.
+2. The router receives the request. It runs **content safety** (Foundry guardrails on the way in), checks the **token budget** for the tenant, and asks the **governance** layer (`InferencePolicy` + AGT) whether this call is allowed.
+3. If allowed, the router attaches a **Workload Identity** AAD token (which it minted from the projected service-account token) and forwards to Foundry.
+4. The response comes back. Content safety runs on the way out.
+5. The router **audits** the call: prompt-fingerprint, model, tokens-in, tokens-out, decision, latency. The audit record is hash-chained to the previous record so tampering is detectable.
+6. The router returns to the agent. Done.
 
-**Inline → ref migration (S13).** `ClawSandbox.spec.inference` (inline
-inference config) has been superseded by `spec.inferenceRef` (reference to an
-`InferencePolicy` CR in the same namespace). Inline fallback was removed in
-S13; sandboxes without an `inferenceRef` enter `Degraded` with reason
-`InferencePolicyNotFound`. Cross-namespace refs are disallowed (privilege
-escalation vector).
-
-**CRD CEL validation.** kube-rs `CustomResource` derive does not emit
-`x-kubernetes-validations` (upstream kube-rs#1557); CEL rules are
-post-processed by `controller/src/crd_validations.rs` after schema generation.
+Every other external call (web fetch, MCP tool, sub-agent spawn, A2A peer message) goes through the same path with a different policy module. The router is a small Rust crate; its surface is small enough to audit.
 
 ---
 
-## 4. Reconciler Architecture
+## The mesh
 
-### kube-rs controller loop
+Inter-agent communication is **end-to-end encrypted**. Two agents that want to talk:
 
-Every CRD has a dedicated reconciler wired as an independent `kube::runtime::Controller`
-task. The main `tokio::select!` loop in `controller/src/main.rs` drives all
-eight reconcilers in parallel under a single leader election gate.
+1. Each agent registers identity (Ed25519 sign, X25519 KEX) and uploads signed prekeys to the AgentMesh registry.
+2. The initiator looks up the peer in the registry, fetches its prekeys, runs **X3DH** to derive a shared secret.
+3. The initiator sends a **KNOCK** to the peer. The peer's router evaluates trust score against `AGT_TRUST_THRESHOLD`. If the peer is below threshold, the KNOCK is denied (audited).
+4. On accept, both sides advance the **Double Ratchet**. Every subsequent message is encrypted with a fresh key (forward secrecy) and authenticated.
+5. The relay sees only opaque ciphertext blobs and addressing metadata. It cannot read messages and cannot impersonate either party.
 
-**Leader election (S7.C).** Two controller replicas run for HA. Only the
-holder of the `azureclaw-controller-leader` Kubernetes `coordination.k8s.io/v1`
-Lease reconciles. The pure decision function `evaluate_lease(spec, identity, now) →
-LeaseAction::{Acquire,Renew,Yield}` is unit-tested independently of I/O
-(`controller/src/leader_election.rs`). On renewal failure the holder exits —
-fail-stop, no split-brain reconciliation. Disable with
-`LEADER_ELECTION_ENABLED=false`.
+The relay and registry are operated by AzureClaw (`agentmesh` namespace, two small services). They are not trusted with content. The cryptographic primitives are libsodium / Signal Protocol; we vendor a small forked SDK with eight bug-fix patches documented in `vendor/`.
 
-**Reconciler table:**
-
-| Reconciler | File | CRD | What it creates |
-|-----------|------|-----|----------------|
-| ClawSandbox | `reconciler/mod.rs` | `ClawSandbox` | Namespace, SA, Deployment, Service, NetworkPolicy, ConfigMap, CronJob |
-| ClawPairing | `pairing_reconciler.rs` | `ClawPairing` | Pairing lifecycle status |
-| McpServer | `mcp_server_reconciler.rs` | `McpServer` | Ed25519 Secret, JWKS ConfigMap |
-| ToolPolicy | `tool_policy_reconciler.rs` | `ToolPolicy` | Compiled-profile ConfigMap |
-| A2AAgent | `a2a_agent_reconciler.rs` | `A2AAgent` | AgentCard ConfigMap |
-| InferencePolicy | `inference_policy_reconciler.rs` | `InferencePolicy` | Compiled-profile ConfigMap |
-| ClawMemory | `claw_memory_reconciler.rs` | `ClawMemory` | Memory-binding ConfigMap |
-| ClawEval | `claw_eval_reconciler.rs` | `ClawEval` | Eval-binding ConfigMap |
-
-### SSA field managers (S7.A)
-
-Every SSA patch carries a stable `fieldManager` string from
-`controller/src/field_managers.rs`. Convention: `azureclaw-controller/<subsystem>`.
-A uniqueness invariant is asserted in `tests::all_field_managers_are_unique`.
-The legacy `azureclaw-mesh-peer` string is preserved verbatim to avoid an SSA
-ownership transition on existing clusters.
-
-### Conditions matrix (S7.B + S7.B.2)
-
-All CRDs carry `status.conditions[]` (KEP-1623) and `status.observedGeneration`.
-Vocabulary from `controller/src/status/conditions.rs`:
-
-| Type | Meaning |
-|------|---------|
-| `Ready` | CR has reached desired state |
-| `Progressing` | Controller is actively working toward desired state |
-| `Degraded` | Something prevents reconciliation (missing dep, bad spec, quota, …) |
-| `Suspended` | Controller has intentionally stopped driving a sub-resource (e.g. OverlayMode) |
-
-`lastTransitionTime` only advances when `status` changes — not on every
-reconcile. This keeps watch churn low and makes `kubectl wait --for=condition=Ready`
-reliable.
-
-### Jittered requeue (S7.D)
-
-All nine reconcilers call `requeue_secs_with_jitter(N)` instead of
-`Duration::from_secs(N)`. The helper applies ±20% multiplicative jitter
-(matching `k8s.io/apimachinery/pkg/util/wait` defaults) to prevent thundering
-herds on resync. Pure math exposed in `apply_jitter_factor(base, factor, sample)`
-and unit-tested independently of the RNG
-(`controller/src/backoff.rs`).
-
-### Workqueue and duration metrics (S7.E)
-
-Controller pod exposes Prometheus metrics at **`:9091/metrics`** (axum server
-in `controller/src/metrics_server.rs`; override bind with
-`CONTROLLER_METRICS_ADDR`). Metrics:
-
-| Metric | Labels | Meaning |
-|--------|--------|---------|
-| `azureclaw_controller_reconcile_errors_total` | `crd_kind`, `error_class` | Total reconcile errors |
-| `azureclaw_controller_reconcile_retries_total` | `crd_kind` | Total retries scheduled |
-| `azureclaw_controller_reconcile_duration_seconds` | `crd_kind`, `outcome` | Duration histogram (buckets: 1ms → 30s) |
-| `azureclaw_controller_reconcile_total` | `crd_kind`, `outcome` | Total invocations (success + error) |
+See **[`docs/architecture/agt-boundary.md`](architecture/agt-boundary.md)** for what AGT enforces vs what AzureClaw enforces.
 
 ---
 
-## 5. Multi-Runtime Dispatch
+## The A2A gateway
 
-`ClawSandbox.spec.runtime` selects the agent runtime. The `kind` discriminant
-controls which sibling struct the controller reads and which sandbox image +
-adapter the reconciler deploys.
+A2A (Agent-to-Agent, 1.2) is the public-ingress sibling of the mesh. Where the mesh handles intra-fleet traffic with strong cryptographic guarantees, the A2A gateway handles **cross-organisation** traffic where the peer is not part of your AgentMesh.
 
-### Runtime kinds
+- **Public ingress** (Azure-managed Kubernetes ingress / Application Gateway).
+- Every inbound request must carry a signed **`AgentCard`** that the gateway verifies against a configured trust anchor.
+- The gateway routes to the right `A2AAgent` CRD (which binds the public name to a sandbox + policy).
+- Audit, rate limiting, content safety run on the gateway.
 
-| `kind` | Adapter package | Description |
-|--------|----------------|-------------|
-| `OpenClaw` | `runtimes/openclaw/` | Default. OpenClaw gateway + AzureClaw plugin. Gateway :18789. |
-| `OpenAIAgents` | `runtimes/openai-agents/` | OpenAI Agents SDK native adapter (Phase 2) |
-| `MicrosoftAgentFramework` | `runtimes/maf/` | Microsoft Agent Framework native adapter (Phase 2) |
-| `BYO` | caller-supplied | Bring-Your-Own runtime. Must satisfy `docs/runtime-contract.md`. |
-
-### Dispatch flow
-
-1. Reconciler calls `validate_runtime_shape(&spec.runtime)` — rejects unknown
-   `kind` or conflicting sibling fields early, before any K8s writes.
-2. The `deploy_sandbox` function selects the sandbox image tag and adapter
-   entrypoint based on `runtime.kind`. Image tags always use `:latest`
-   (controller default) — no version pinning in `SANDBOX_IMAGE` /
-   `INFERENCE_ROUTER_IMAGE` env vars.
-3. The `runtimes/openclaw/` adapter is the AzureClaw TypeScript plugin
-   (`runtimes/openclaw/src/index.ts`) that wires tools, providers, and
-   `mesh-plugin` into the OpenClaw host. The `OpenAIAgents` and `MAF` adapters
-   follow the same contract surface but target their respective SDKs.
-4. BYO sandboxes must implement the three-endpoint runtime contract (health,
-   inference-proxy routing, sub-agent spawn); see `docs/runtime-contract.md`.
-
-### Isolation levels
-
-| Level | RuntimeClass | seccomp | Node pool |
-|-------|-------------|---------|-----------|
-| `standard` | (default runc) | `RuntimeDefault` | `sandbox` |
-| `enhanced` (default) | (default runc) | Localhost `azureclaw-strict` (~219 allowed syscalls) | `sandbox` |
-| `confidential` | `kata-vm-isolation` | `RuntimeDefault` (VM is the boundary) | `sandbox-kata` |
-
-Isolation inheritance: controller exports `SANDBOX_ISOLATION` into every pod;
-the router enforces it on spawn requests (downgrade from `confidential` is
-blocked). Kata auto-provisioning: `azureclaw add --isolation confidential`
-provisions a `Standard_D4as_v6` nodepool with `--workload-runtime KataVmIsolation`
-if no Kata-capable nodepool exists.
+Two separate channels for two separate trust models. See **[`docs/architecture/a2a-gateway.md`](architecture/a2a-gateway.md)**.
 
 ---
 
-## 6. Inference Router Internals
+## CRDs as the API
 
-Source: `inference-router/src/`. The router is an axum server on `localhost:8443`
-(main), `0.0.0.0:8444` (forward-proxy for A2A inbound), `localhost:8445` (A2A
-inbound from a2a-gateway over mTLS). Every request traverses a fixed middleware
-stack; no path bypasses any layer.
+You operate AzureClaw by writing eight CRDs, not by clicking through a dashboard. The full schema is in **[`docs/api/crd-reference.md`](api/crd-reference.md)**; the role of each is summarised in the README. The important property: every component (controller, router, gateway, CLI, operator TUI) reads the same source of truth. There is no separate config store.
 
-### Auth chain (`auth.rs`)
-
-```
-Request arrives at router
-  └─ API key present in /run/secrets/ → dev mode (API key forwarded)
-  └─ No key → AKS Workload Identity:
-       1. Read federated token from AZURE_FEDERATED_TOKEN_FILE (WI webhook mount)
-       2. Exchange at Entra /oauth2/v2.0/token (client_credentials + JWT assertion)
-       3. Token cached per scope in Arc<RwLock<HashMap<scope, CachedToken>>>
-       4. Token set as Authorization: Bearer on every upstream call
-```
-
-No API keys are ever injected into the sandbox pod spec. The router is the sole
-credential holder.
-
-### Middleware stack (inference path)
-
-```
-InferencePolicy check → token budget (daily + per-request, 429 on exceed)
-  → Content Safety floor (prompt-shield, configurable per InferencePolicy)
-  → AGT governance gate (PolicyDecisionProvider::decide)
-  → IMDS/WI token acquisition (cached)
-  → Forward to Foundry (18 API groups, all covered by egress NetworkPolicy)
-  → Parse content-filter annotations
-  → AuditSink::append (hash-chained receipt)
-  → Prometheus metrics (OTel GenAI SemConv 1.x spans)
-  → Return to agent
-```
-
-### AGT governance components (all native Rust, `inference-router/src/`)
-
-The four components live inside `Governance` and are accessible through the
-provider seams (see §8):
-
-| Component | File | Role |
-|-----------|------|------|
-| `PolicyEngine` | `governance.rs` / `providers/policy_impl.rs` | Evaluates tool requests against the compiled ToolPolicy profile |
-| `TrustManager` | `trust.rs` | Maintains per-agent trust scores; triggers re-evaluation on threshold breach |
-| `AuditLogger` | `audit.rs` / `audit_impl.rs` | Hash-chained tamper-evident log; Merkle-proof retrievable via `kubectl claw attest` |
-| `RateLimiter` | `rate_limiter.rs` | Per-subject token-bucket rate limiting |
-| `BehaviorMonitor` | `behavior_monitor.rs` | Detects anomalous call patterns; feeds TrustManager |
-
-### Content Safety floor (`safety.rs`)
-
-A floor is enforced regardless of per-request settings. The floor threshold is
-set by `InferencePolicy.spec.contentSafety` and cannot be disabled on production
-sandboxes (admission policy rejects `contentSafety: false` without a
-`dev-only` label). Prompt Shields (jailbreak + prompt injection detection) run
-server-side at Azure AI Content Safety; the router parses the `content-filter`
-annotations in the Foundry response and gates on them.
-
-### Token budget (`budget.rs`)
-
-Per-sandbox budgets (daily + per-request) are enforced before forwarding.
-Counters are persisted in the router's in-process store; daily reset is
-scheduled via tokio timer. Exceeding either limit returns HTTP 429 to the
-agent. Budget counters are available on `ClawSandbox.status.tokensUsed`.
-
-### Signed OCI egress-allowlist verifier (`policy_fetcher.rs`, `signer_policy.rs`)
-
-When `ClawSandbox.spec.networkPolicy.allowlistRef` is set, the controller
-fetches a content-addressed OCI artifact, verifies its cosign signature against
-the cluster `SignerPolicy` ConfigMap (`azureclaw-signer-policy` in
-`azureclaw-system`), and promotes the artifact as the **authoritative** egress
-allowlist. The inline `allowedEndpoints` is ignored when `allowlistRef` is set;
-a drift between inline and artifact surfaces as `AllowlistDrift=True` on the
-sandbox status. Failure is **fail-closed**: the controller preserves the last
-known-good allowlist if available, otherwise stamps `Degraded` without writing
-a permissive NetworkPolicy.
-
-The `SignerPolicy` ConfigMap provides Fulcio issuer URLs and SAN glob patterns.
-A malformed ConfigMap surfaces as `SignerPolicyMalformed` — no silent env-var
-fallback. ACR authentication uses the same four-step Workload Identity token
-exchange as inference auth (`acr_token_for_pull`).
-
-### Platform MCP shim (`mcp/platform.rs`)
-
-The router exposes Foundry built-in tools (Memory Store, Bing Grounding, Code
-Interpreter) as MCP tools via `POST /mcp`. OAuth 2.1 BCP gating is controlled
-by `McpServer.spec.productionMode: true`. The MCP module is 8 files under
-`inference-router/src/mcp/`: `streamable_http.rs`, `jsonrpc.rs`, `oauth.rs`,
-`oauth_layer.rs` (tower::Layer), `initialize.rs`, `pipeline.rs`, `tools.rs`,
-`error.rs`.
-
-### Egress proxy pipeline
-
-```
-POST /egress/fetch
-  → blocklist check (hard deny — OISD + URLhaus, 6h refresh CronJob)
-  → signed OCI allowlist (authoritative when allowlistRef set)
-  → learn mode? log + allow
-  → inline allowedEndpoints check (approved domains pass)
-  → unknown domain → deny + create PendingApproval record
-```
-
-Blocked attempts are recorded in a bounded ring buffer
-(`egress_blocked.rs`), deduped by `(source, host, port)`, surfaced at
-`GET /egress/learned/blocked`.
+The CRDs are at `v1alpha1` for `v1.0.0`. The stability contract — what we promise to keep working, what we may change, and how we will migrate — is in **[`docs/api/backwards-compatibility.md`](api/backwards-compatibility.md)** and **[`docs/architecture/crd-versioning.md`](architecture/crd-versioning.md)**.
 
 ---
 
-## 7. A2A Architecture
+## The boring parts that matter
 
-A2A 1.0 (<https://a2a-protocol.org/v1.0.0/specification>) is the cross-runtime
-agent interop protocol. AzureClaw handles A2A on two distinct paths:
-outbound (initiated by the agent) and inbound (initiated by foreign runtimes).
-The design rationale is in [ADR-0001](adr/0001-a2a-ingress-front-edge.md).
-
-### Outbound A2A (router-internal)
-
-The agent calls A2A APIs via the router's existing inference and egress paths.
-The router implements the A2A client side (`inference-router/src/a2a/`):
-- `agent_card.rs` / `card_signing.rs` — Ed25519 AgentCard signing (RFC 7515, EdDSA)
-- `card_server.rs` — serves `GET /.well-known/agent.json`
-- `jsonrpc_dispatch.rs` — routes A2A 1.0 JSON-RPC method calls
-- `trust_store.rs` — pins verified caller AgentCards by thumbprint
-- AP2 extensions: `ap2.rs`, `mandate_signing.rs`, `mandate_trust_store.rs`,
-  `message_send_ap2.rs`
-
-All outbound A2A traffic flows through the standard governance gate
-(PolicyDecisionProvider → AuditSink).
-
-### Inbound A2A (a2a-gateway + mTLS)
-
-The inference router is **never** on the public internet — the `a2a-gateway`
-component is the sole public TLS endpoint for inbound A2A. This is a firm
-security invariant (ADR-0001 §D2).
-
-```
-Foreign Agent ──TLS :8443──► a2a-gateway (azureclaw-system)
-                                  │
-                                  │  JWS AgentCard verify
-                                  │  Replay cache check (5 min window)
-                                  │  Per-subject rate limit (token bucket)
-                                  │
-                              mTLS :8444 ──► inference-router (sandbox pod)
-                                              │
-                                              │  PolicyDecisionProvider
-                                              │  AuditSink
-                                              │  ClawSandbox.spec.a2a allowed callers
-                                              ▼
-                                          Agent (UID 1000)
-```
-
-The gateway binary (`a2a-gateway/src/main.rs`) is configured via env vars
-(Helm → Deployment → env). It verifies the caller's JWS-signed AgentCard using
-primitives from the shared `azureclaw-a2a-core` crate, then proxies
-authenticated requests to the target sandbox router over mTLS.
-
-**`azureclaw-a2a-core`** (`azureclaw-a2a-core/src/lib.rs`) is a library-only
-crate that lifts the A2A JWS verifier, AgentCard schema, signer, and error
-catalogue out of the router into a shared dependency used by both the gateway
-and the router. `#![forbid(unsafe_code)]` is enforced at the crate root.
-
-**Opt-in.** The a2a-gateway Deployment is created only when
-`azureclaw up --enable-a2a-ingress` is passed. Per-sandbox exposure is
-gated by `ClawSandbox.spec.a2a.enabled: true`; without this field the
-sandbox has no inbound A2A path.
+- **Image tags are always `:latest` in source.** Pinning happens at install time via Helm values or env vars (e.g. `MAF_RUNTIME_IMAGE`). Earlier versions of the project drifted across version tags `v11`–`v25`; we chose convention over per-tag pins to make the tag mismatch class of bug impossible.
+- **The controller default-image lookup is centralised** in `controller/src/reconciler/runtime.rs`. Adding a new runtime is one match arm and one default-image function. The CRD enum is the source of truth for which runtimes exist.
+- **The router does not depend on the Azure SDK.** All Azure calls (IMDS, Workload Identity exchange, Foundry, Content Safety) are direct REST. This keeps the router's dependency surface small and its build deterministic.
+- **No OpenClaw source is patched.** The OpenClaw integration uses the public plugin API and `tools.deny` config only. Any upstream OpenClaw release is drop-in compatible. See **[Upstream alignment](upstream-alignment.md)**.
 
 ---
 
-## 8. AgentMesh Integration
-
-Inter-agent messaging uses the AgentMesh relay/registry (Signal Protocol, E2E
-encrypted). See [`docs/internal/e2e-encryption-proof.md`](e2e-encryption-proof.md) and
-[`docs/internal/agt-vendored-patch-audit.md`](agt-vendored-patch-audit.md) for
-cryptographic details.
-
-### Vendored patches
-
-`vendor/` contains patched forks of three upstream packages — `agentmesh-relay`,
-`agentmesh-registry`, `agentmesh-sdk` — fixing 8 bugs documented in the
-respective `vendor/*/README.md` files. The sandbox Docker build installs
-`@agentmesh/sdk` via npm and then **overlays** the vendored dist files:
-
-```dockerfile
-COPY vendor/agentmesh-sdk/dist/ .../node_modules/@agentmesh/sdk/dist/
-```
-
-Notable patches include: timestamp format mismatch (`Z` vs `+00:00` in relay),
-ratchet key mismatch (session.ts in SDK), and base64Decode `x25519:`/`ed25519:`
-prefix stripping.
-
-### Signal Protocol session ownership
-
-The Signal Protocol X3DH + Double-Ratchet sessions are maintained by the
-**agent** (TypeScript `mesh-plugin/` + `@agentmesh/sdk`), not by the router.
-The router's role is purely transport: it forwards the relay WebSocket
-(`routes/mesh.rs`) and registry HTTPS calls (`agt/registry/*`), applying
-policy + audit hooks around them but never decrypting or holding key material.
-`providers/mesh.rs` documents this contract; it ships no `impl` and should
-not acquire one.
-
-### Singleton guard
-
-`process.env.__AGT_INITIALIZED = '1'` ensures only the first plugin load
-creates the AGT client. OpenClaw loads the plugin twice (tool registry + agent
-session); the guard prevents double-initialisation and duplicate mesh
-connections.
-
-### Upstream cleanup
-
-The goal is to upstream all 8 patches to `amitayks/agentmesh`. Until upstream
-merges, the vendored overlay remains. Progress is tracked in `vendor/*/README.md`.
-Relay/registry require Rust ≥ 1.94 (upstream's 1.83 is too old for the patches).
-
----
-
-## 9. Provider Seams
-
-Four trait seams let operators substitute governance back-ends without changing
-the router. Source: `inference-router/src/providers/`.
-
-| Trait | File | Current production impl | Substitution surface |
-|-------|------|------------------------|---------------------|
-| `PolicyDecisionProvider` | `providers/policy.rs` | `VendoredPolicyDecisionProvider` (PolicyEngine + TrustManager + RateLimiter + BehaviorMonitor, native Rust) | AGT SDK (`AgtPolicyDecisionProvider`); swap via `spec.agt.providers.policy` |
-| `AuditSink` | `providers/audit.rs` | `VendoredAuditSink` (hash-chained log, Merkle proofs) | AGT SDK (`AgtAuditSink`); swap via `spec.agt.providers.audit` |
-| `SigningProvider` | `providers/signing.rs` | `VendoredSigningProvider` (Ed25519 via vendored `@agentmesh/sdk` keys) | AGT SDK (`AgtSigningProvider`); swap via `spec.agt.providers.signing` |
-| `MeshProvider` | `providers/mesh.rs` | **None** — plugin-side only | Contract document only; router never implements this |
-
-`AppState` carries three `Arc<dyn Trait>` views of a single `Arc<Governance>`
-instance. Swapping a provider (`vendored` → `agt` or vice versa) is a hot-
-reload: the router re-creates the provider in-process without a pod rollout.
-`spec.agt.outageMode` controls failure behaviour: `Strict` (fail-closed),
-`CachedRead` (read from last-known-good), `DegradedDev` (dev-only, no-op).
-
-`NullPolicyDecisionProvider` / `NullAuditSink` / `NullSigningProvider` are
-dev-only; the admission policy (`ci/no-null-provider-prod.sh` + VAP) rejects
-production sandboxes that reference them unless the `azureclaw.azure.com/dev-only`
-label is present.
-
----
-
-## 10. Security Posture
-
-AzureClaw uses a defence-in-depth model with nine distinct enforcement layers.
-Full documentation: [`docs/security.md`](security.md), [`docs/internal/threat-model.md`](threat-model.md).
-
-| Layer | Mechanism | What it stops |
-|-------|-----------|--------------|
-| 1. iptables egress-guard | init container installs UID-1000-scoped OUTPUT rules (lo + DNS + ESTABLISHED only) | Agent reaching external network directly |
-| 2. NetworkPolicy default-deny | Cilium NetworkPolicy per sandbox namespace | Pod-to-pod lateral movement; router reaching unexpected endpoints |
-| 3. Read-only rootfs + drop ALL caps | `readOnlyRootFilesystem: true`, `capabilities: drop: [ALL]`, `allowPrivilegeEscalation: false` | In-container privilege escalation |
-| 4. seccomp `azureclaw-strict` | Localhost profile (~219 allowed syscalls) on `enhanced` isolation | Kernel attack surface reduction |
-| 5. Workload Identity (no API keys) | IMDS token exchange via AKS WI webhook; credentials never in pod spec | Credential exfiltration via pod-spec leak |
-| 6. Content Safety floor | Azure AI Content Safety + Prompt Shields; threshold enforced by router | Prompt injection, jailbreaks, harmful output |
-| 7. AGT governance gate | PolicyDecisionProvider; every tool call evaluated before execution | Excessive agency, policy bypass, rate abuse |
-| 8. Signed OCI egress allowlist | cosign + Fulcio + SAN verification; `SignerPolicy` ConfigMap | Supply-chain attack via egress allowlist tampering |
-| 9. Kata Containers + AMD SEV-SNP (opt-in) | `isolation: confidential`; `kata-vm-isolation` RuntimeClass | VM-level tenant isolation; hardware attestation |
-
-**VAP / MAP admission set** (`deploy/helm/azureclaw/templates/`):
-- **VAP** (Kubernetes ≥ 1.30, GA): deny `exec/attach/portforward` on sandbox
-  namespaces; block posture downgrades (isolation step-down, seccomp removal,
-  `readOnlyRootFilesystem: false`); prevent `dev-only` label removal; require
-  `dev-only` for null/noop/disabled providers.
-- **MAP** (Kubernetes ≥ 1.32, Beta — Helm flag `controller.mutatingAdmissionPolicy.enabled`,
-  default `false`): auto-inject router sidecar; auto-stamp `azureclaw-strict` seccomp.
-  When the flag is `false`, the reconciler performs the same operations
-  deterministically before pod creation.
-
-**Federated-credential reaper** (`controller/src/fedcred_reaper.rs`): 4th arm of
-the main `tokio::select!` loop. Periodically cross-checks live federated
-credentials against active `ClawSandbox` CRs and deletes orphans. Default
-cadence 600 s (`FEDCRED_REAPER_INTERVAL_SECS`). Guards the 20-fedcred-per-MI
-Azure cap.
-
----
-
-## 11. Observability
-
-### Prometheus metrics
-
-| Component | Endpoint | Series prefix |
-|-----------|---------|--------------|
-| Controller | `:9091/metrics` | `azureclaw_controller_*` |
-| Inference Router | `:8443/metrics` (per-pod) | `azureclaw_*` |
-| A2A Gateway | `:9090/metrics` | `azureclaw_a2a_gateway_*` |
-
-### OTel GenAI semantic conventions
-
-Every router span emits OTel GenAI SemConv 1.x attributes:
-`gen_ai.system`, `gen_ai.request.model`,
-`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, and more.
-Export via `OTEL_EXPORTER_OTLP_ENDPOINT`. Source: `inference-router/src/telemetry/`.
-
-### Application Insights
-
-The CLI and controller emit structured JSON traces to Azure Application Insights
-when `APPLICATIONINSIGHTS_CONNECTION_STRING` is set.
-
-### eBPF tracing
-
-`azureclaw trace <name>` attaches eBPF probes to the sandbox pod and streams
-syscall-level traces to the terminal. Requires `CAP_BPF` on the operator's
-kubeconfig identity.
-
----
-
-## 12. Testing Layers
-
-| Layer | Location | What it gates |
-|-------|---------|--------------|
-| **Unit** | `cargo test --all` (inlined `#[cfg(test)]` modules) | Individual functions: `evaluate_lease`, `apply_jitter_factor`, field-manager uniqueness, CEL validation, content-safety parsing, etc. |
-| **Integration** | `cargo test --all` (separate `tests/` modules per crate) | Router middleware stack; controller reconcile logic; policy compile; auth token exchange |
-| **E2E** | `tests/e2e/` via `make test-e2e` | Full cluster lifecycle on Kind: `azureclaw up` → agent running → `azureclaw delete` |
-| **Negative / conformance** | `tests/conformance/` | Protocol edge cases: A2A JWS rejection, MCP OAuth 2.1 BCP gating, policy hot-reload propagation (≤ 5 s), VAP admission rejections |
-| **Chaos / fault injection** | `tests/chaos/` (feature-gated: `--features chaos`) | 22 chaos tests across 4 failure-mode categories: K8s API flakes (8), Foundry 429 storms (6), Entra rotation races (4), AGT relay disconnects (4). Runs as a parallel CI job. |
-| **CNCF AI Conformance v1.35+** | `tests/cncf-conformance/` | CNCF Kubernetes AI Conformance profile; wired into CI as a gating check |
-| **Load** | `tests/k6/router_smoke.js` (nightly) | Router throughput + tail latency regression gate |
-
-**Chaos tier details.** The 22 chaos tests exercise: 500/503/429 K8s API
-storms, stale `resourceVersion` (410 GONE), truncated watch JSON, premature
-EOF; Foundry 429 storms at 80 % and 100 % saturation, mid-stream 503 SSE
-close, slow-backend timeout, blocked-attempt metric accuracy; Workload Identity
-token refresh mid-flight, single-flight invariant, JWKS rotation re-fetch, SA
-token file rotation; AGT relay WS upstream disconnect, handshake timeout (504-
-class), slow-registry deadline, repeated churn with no task leak.
-Source: `tests/chaos/README.md`.
-
----
-
-## 13. Network Architecture Detail
-
-```
-                        ┌─────────────────────────────────┐
-                        │       iptables (per-UID)         │
-                        │                                  │
-  UID 1000 (agent)      │  lo ✓  DNS ✓  ESTABLISHED ✓     │
-                        │  everything else ✗ (DROP)        │
-                        │                                  │
-  UID 1001 (router)     │  no iptables restrictions        │
-                        │  governed by NetworkPolicy only  │
-                        └─────────────────────────────────┘
-                                       │
-                        ┌──────────────┴──────────────┐
-                        │     NetworkPolicy (pod)      │
-                        │                              │
-                        │  Egress: DNS :53, IMDS,      │
-                        │    HTTPS :443, mesh :8443,   │
-                        │    relay :8765/:8080          │
-                        │  Ingress: mesh :8443,         │
-                        │    gateway :18789/:18791      │
-                        │    (AGT-enabled only)         │
-                        └──────────────────────────────┘
-```
-
-**Egress guard iptables rules (UID 1000):**
-
-```
-iptables -A OUTPUT -m owner --uid-owner 1000 -o lo -j ACCEPT
-iptables -A OUTPUT -m owner --uid-owner 1000 -p udp --dport 53 -j ACCEPT
-iptables -A OUTPUT -m owner --uid-owner 1000 -p tcp --dport 53 -j ACCEPT
-iptables -A OUTPUT -m owner --uid-owner 1000 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -m owner --uid-owner 1000 -j DROP
-```
-
-The `ESTABLISHED,RELATED` rule allows inbound-connection reply packets (WebUX,
-channel integrations) without opening any outbound path.
-
----
-
-## 14. API Endpoints
-
-All endpoints served by the inference router on `:8443`.
-
-### Inference (proxied to Azure OpenAI / Foundry)
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/v1/chat/completions` | Chat inference (SSE streaming supported) |
-| POST | `/v1/completions` | Text completions |
-| POST | `/v1/embeddings` | Embedding generation (model-routed) |
-| GET | `/v1/models` | Model catalog |
-
-### Foundry Standalone APIs (18 API groups, IMDS auth)
-
-| Path prefix | Purpose |
-|-------------|---------|
-| `/memory_stores/*` | Memory Store — persistent long-term memory |
-| `/knowledgebases/*` | Foundry IQ — agentic retrieval |
-| `/openai/responses/*` | Responses API (Code Interpreter, Web Search, Memory Search) |
-| `/openai/conversations/*` | Persistent multi-turn conversations |
-| `/openai/evals/*` | Evaluations |
-| `/openai/fine-tuning/*` | Fine-tuning jobs |
-| `/agents/*` | Foundry Agents CRUD |
-| `/evaluators/*`, `/evaluationrules/*`, `/evaluationtaxonomies/*` | Evaluation ecosystem |
-| `/indexes/*`, `/connections/*`, `/deployments/*` | Knowledge indexes, connections, deployments |
-| `/datasets/*`, `/insights/*` | Datasets, monitoring |
-| `/redTeams/runs/*`, `/schedules/*` | Red teams, scheduled jobs |
-
-### MCP 2026
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/mcp` | Streamable HTTP MCP endpoint (OAuth 2.1 BCP-gated in production) |
-
-### Egress Proxy
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/egress/fetch` | Audited HTTP proxy (blocklist → allowlist → pending) |
-| GET | `/egress/allowlist` | List approved domains |
-| GET | `/egress/pending` | List pending approval requests |
-| POST | `/egress/approve` | Approve a domain |
-| POST | `/egress/deny` | Deny a pending domain |
-| GET | `/egress/learned` | Domains observed in learn mode |
-| POST | `/egress/learned/clear` | Clear learned domains |
-| GET | `/egress/learned/blocked` | Domains blocked in enforce mode |
-
-### AGT Governance
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/agt/evaluate` | Policy evaluation |
-| GET | `/agt/trust`, `/agt/trust/{agent_id}` | Trust store queries |
-| GET | `/agt/audit`, `/agt/audit/verify` | Audit log + Merkle-proof verification |
-| GET | `/agt/relay` | WebSocket bridge to agentmesh-relay (E2E encrypted) |
-| GET/POST | `/agt/registry/*` | AgentMesh registry proxy |
-| GET | `/agt/status` | Governance status |
-
-### Sub-Agent Spawning
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/sandbox/spawn` | Create child ClawSandbox CRD |
-| GET | `/sandbox/list` | List child sandboxes |
-| GET | `/sandbox/{name}/status` | Child status |
-| DELETE | `/sandbox/{name}` | Tear down child sandbox |
-
-### A2A 1.0 (outbound)
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| GET | `/.well-known/agent.json` | Serve signed AgentCard (card_server.rs) |
-
-### Health
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| GET | `/healthz` | Liveness probe |
-| GET | `/readyz` | Deep readiness (token + Content Safety) |
-| GET | `/metrics` | Prometheus metrics |
-
----
-
-## 15. Channels and Plugin Auto-Discovery
-
-Messaging channels (Telegram, Slack, Discord, WhatsApp) and third-party search
-plugins (Brave, Tavily, Exa, Firecrawl, Perplexity, OpenAI) follow the same
-discovery flow:
-
-```
-CLI flag  →  K8s Secret (<name>-credentials)  →  envFrom mount
-  →  entrypoint.sh reads env vars  →  plugins.allow + plugins.entries  →  gateway
-```
-
-Source: `sandbox-images/openclaw/entrypoint.sh` (plugin loop at lines 286–301).
-
-Credentials are **namespace-scoped** — each sandbox's secrets are isolated in
-`azureclaw-<name>`. Rotate with `azureclaw credentials update <name>`. The
-controller mounts secrets via `envFrom` with `optional: true` so pods start
-without the secret; it is expected for new sandboxes.
-
-**Node.js 22 proxy.** `proxy-bootstrap.js` is preloaded via
-`NODE_OPTIONS="--require ..."` before any OpenClaw code. It configures undici's
-`EnvHttpProxyAgent` as the global fetch dispatcher so all HTTP/HTTPS requests
-honour `HTTPS_PROXY`/`NO_PROXY`. Node.js 22's built-in `fetch()` ignores these
-env vars without this shim.
-
----
-
-## 16. Identity Provider Seam
-
-`controller/src/providers/identity_*.rs` manages the lifecycle of Microsoft
-Graph agent identities for each sandbox:
-
-- `POST /beta/servicePrincipals/microsoft.graph.agentIdentity` — provision SP
-- `POST /beta/servicePrincipals/{id}/federatedIdentityCredentials` — bind
-  federated credential for the sandbox ServiceAccount
-- `DELETE /beta/servicePrincipals/{id}` — teardown on `ClawSandbox` deletion
-
-`OPENCLAW_GATEWAY_TOKEN` is mounted from a K8s `Secret` via `secretKeyRef`
-(not plain env); a one-shot `warn!` fires on any legacy plain-env path.
-
----
-
-## 17. Policy Hot-Reload
-
-The router subscribes to `ToolPolicy` and `InferencePolicy` ConfigMap changes
-via K8s informers + AGT SSE. New policy takes effect in-process without a
-pod rollout. Flipping `spec.agt.providers.{policy,audit,signing}` between
-`vendored` and `agt` also hot-reloads. Policy-change propagation is asserted
-within 5 s by the conformance corpus.
-
----
-
-## 18. AgentMesh Global Registry (Optional)
-
-For cross-environment handoff (local ↔ cloud), expose the AgentMesh relay and
-registry:
-
-```
-azureclaw up --expose-registry   # AGIC Ingress + NetworkPolicy
-```
-
-This creates Application Gateway Ingress for `registry.<domain>` (HTTPS) and
-`relay.<domain>` (WSS) with Azure-managed TLS and WAF rate limiting.
-
-**4-layer auth chain:**
-
-| Layer | Component | What it stops |
-|-------|-----------|--------------|
-| 1. WAF | Application Gateway | DDoS, connection floods |
-| 2. Ed25519 | Relay `handle_auth()` | Impersonation, replay |
-| 3. Registry check | Relay `RegistryVerifier` | Unregistered / revoked agents |
-| 4. OAuth | Registry `oauth.rs` | Controls registration (GitHub, Entra, Google) |
-
-`azureclaw mesh auth --registry <url> --provider github|entra` generates an
-Ed25519 keypair, runs OAuth, and stores the identity in
-`~/.azureclaw/mesh-identity.json` (AES-256-GCM, machine-bound key).
-
-**Registration gating.** `registrationMode == full` requires both relay and
-registry to be reachable; registry degraded → relay-only mode +
-`Degraded=True` on the affected `ClawSandbox`.
-
----
-
-*For inline diagrams of the full component topology, data flows, and
-multi-runtime dispatch, see [`docs/architecture-diagrams.md`](architecture-diagrams.md).*
+## Where to go next
+
+- **[Architecture diagrams](architecture-diagrams.md)** — the same content, rendered.
+- **[Security model](security.md)** — what each layer enforces.
+- **[Blueprints](blueprints/00-index.md)** — five reference deployment shapes.
+- **[CRD reference](api/crd-reference.md)** — the operator's API.


### PR DESCRIPTION
Wave C of the docs revamp — the architectural canon, rewritten end to end from current code on dev.

**docs/architecture.md** — five design goals in priority order; 4-component table (controller, router, A2A gateway, CLI); explicit dev-vs-prod section naming UID 1000 / UID 1001 / init egress-guard for prod; six-step walkthrough of one model call; mesh / A2A / control-plane sections each one paragraph with links out; "boring parts that matter" section.

**docs/architecture-diagrams.md** — nine fresh Mermaid diagrams replacing 1616 lines of scattered ASCII art:

1. Sandbox pod — dev mode
2. Sandbox pod — prod mode (UID separation, egress-guard, NetworkPolicy)
3. Data path of one model call (sequence)
4. Mesh — X3DH + Double Ratchet + KNOCK + trust score (sequence)
5. A2A gateway — public-ingress peer traffic
6. Control plane — what the controller produces
7. CRD relationships
8. Cluster topology — what `azureclaw up` produces
9. Trust boundaries

Every diagram captioned with what it shows and what it does NOT show. Runtime list, CRD list, UID assignments, pod-shape facts all verified against `controller/src/reconciler/runtime.rs` and helm CRD templates.
