### PR TITLE
docs(revamp-E): refresh blueprints — full rewrite of 00+01, surgical updates to 02-05

### DIFF
--- a/docs/blueprints/00-index.md
+++ b/docs/blueprints/00-index.md
@@ -1,42 +1,44 @@
-# AzureClaw Deployment Blueprints
+# Deployment blueprints
 
-Concrete, end-to-end shapes for running AzureClaw. Each blueprint pins down **who runs what**, **where the trust boundary sits**, and **how a single agent task flows from prompt to completion** — including which CRDs, controllers, network paths, and identity surfaces are in play.
+Five concrete shapes for running AzureClaw. Each blueprint pins down **who runs what**, **where the trust boundary sits**, and **the main flow** end to end.
 
-The four [use cases in `docs/use-cases.md`](../use-cases.md) describe *what* AzureClaw does. The blueprints below describe *how you run it for a given audience*. They are not mutually exclusive — a single AzureClaw cluster can serve multiple blueprints simultaneously (e.g. Blueprint 02 for internal employees + Blueprint 03 for external partners).
+These are not mutually exclusive — one AzureClaw cluster can serve several of them simultaneously (e.g. Blueprint 02 for internal employees + Blueprint 03 for external partners on the same cluster).
 
-## Blueprint catalogue
+## Catalogue
 
-| # | Blueprint | Audience | Where AzureClaw runs | Today's status |
+| # | Blueprint | Audience | Where AzureClaw runs | Status |
 |---|---|---|---|---|
-| **01** | [Developer inner-loop](01-developer-inner-loop.md) | Individual contributor on a laptop | Local Docker / kind, single-node | ✅ Shipping |
-| **02** | [Enterprise self-hosted cluster](02-enterprise-self-hosted.md) | Platform team inside a single org | Customer-owned AKS, single tenant | ✅ Shipping |
-| **03** | [Managed public offload service](03-managed-public-offload.md) | SaaS provider serving many external tenants | Provider-owned AKS, multi-tenant, Kata + AMD SEV-SNP | ✅ Runtime shipping · 🚧 SaaS productization in progress |
-| **04** | [Cross-org federation](04-cross-org-federation.md) | Two or more orgs collaborating | Two AKS clusters meshed E2E | ✅ Shipping |
-| **05** | [Sovereign / air-gapped](05-sovereign-airgapped.md) | Regulated, classified, disconnected, or sovereign-cloud workloads | Customer-owned AKS in an isolated network island | 🚧 Patterns documented; reproducible bundle on roadmap |
+| **[01](01-developer-inner-loop.md)** | Developer inner loop | Individual contributor | Laptop (`azureclaw dev` — single Docker container) | ✅ |
+| **[02](02-enterprise-self-hosted.md)** | Enterprise self-hosted | Platform team, single org | Customer-owned AKS, single tenant | ✅ |
+| **[03](03-managed-public-offload.md)** | Managed public offload | SaaS provider, many tenants | Provider-owned AKS, multi-tenant, optional Kata + AMD SEV-SNP | ✅ runtime · 🚧 productization |
+| **[04](04-cross-org-federation.md)** | Cross-org federation | Two or more orgs collaborating | Two AKS clusters, mesh + A2A across | ✅ |
+| **[05](05-sovereign-airgapped.md)** | Sovereign / air-gapped | Regulated / classified / disconnected | Isolated AKS, no public egress | 🚧 patterns documented |
 
-## Reading guide
+## How to read each blueprint
 
-Each blueprint has the same shape:
+Every blueprint follows the same shape:
 
-1. **Persona & intent** — who you are, what you want.
-2. **Topology** — Mermaid diagram of who-runs-what.
+1. **Persona & intent** — who, what, why.
+2. **Topology** — Mermaid diagram of who runs what.
 3. **Trust boundary** — where the credential / control boundary sits.
 4. **Primary flow** — sequence diagram of the main happy-path interaction.
-5. **What you provision** — concrete CLI / kubectl invocations.
-6. **What's unique to this blueprint** — the property that makes it not just a sub-case of another blueprint.
-7. **References** — code, CRDs, ADRs.
+5. **What you provision** — concrete CLI / Helm / `kubectl` invocations.
+6. **What is unique** — the property that makes this blueprint not just a sub-case of another.
+7. **References** — code, CRDs, related docs.
 
-## Cross-cutting properties
+## What every blueprint inherits
 
-Regardless of blueprint, every AzureClaw deployment ships:
+These properties are not blueprint-specific; they come from running AzureClaw at all. If your environment cannot satisfy them, you are outside the threat model — open an issue before deploying.
 
-- **Egress isolation** — agent UID 1000 can only reach `localhost` + DNS. The router (UID 1001) is the sole external path.
-- **Foundry-side Content Safety** — `Microsoft.DefaultV2` Prompt Shields on every inference.
-- **AGT-native governance** — `PolicyEngine`, `TrustManager`, `AuditLogger`, `RateLimiter`, `BehaviorMonitor` evaluated in-process on every tool call, every inference, every mesh message.
-- **Tamper-evident audit chain** — hash-chained log persisted via `AuditSink`.
-- **Signal-Protocol mesh** — X3DH + Double Ratchet. Relay sees only ciphertext. No plaintext fallback; failed-decrypt is a `security_event`, never a delivered cleartext message.
-- **CRD-driven control plane** — eight namespaced CRDs under `azureclaw.azure.com/v1alpha1`: `ClawSandbox`, `ClawPairing`, `McpServer`, `ToolPolicy`, `InferencePolicy`, `A2AAgent`, `ClawMemory`, `ClawEval`. All eight reconcilers shipped in Phase 2. Full reference: [`docs/api/crd-reference.md`](../api/crd-reference.md).
-- **Multi-runtime hosting** — `spec.runtime.kind` selects the agent runtime variant: `OpenClaw` (default, Tier-1), `OpenAIAgents`, `MicrosoftAgentFramework` (Tier-1), `SemanticKernel`, `LangGraph`, `Anthropic` (Tier-2, schema shipped), or `BYO`. The inference-router, governance, and audit chain are runtime-agnostic.
-- **`spec.inferenceRef.name` (ref form)** — sandboxes reference an `InferencePolicy` CR by name rather than inlining model/budget config. Inline inference fields were removed in S13; all example YAMLs in these blueprints use the ref form.
+- **Egress isolation.** Agent runs as UID 1000 with no path to the network. The router (UID 1001) is the only egress. Enforced by the `egress-guard` initContainer (iptables) and a Kubernetes NetworkPolicy.
+- **Foundry-side Content Safety.** `Microsoft.DefaultV2` Prompt Shields on every inference, both directions.
+- **AGT governance.** `PolicyEngine`, `TrustManager`, `AuditLogger`, `RateLimiter`, `BehaviorMonitor` evaluated in-process on every tool call, every inference, every mesh message.
+- **Tamper-evident audit.** Hash-chained log via `AuditSink`. Each record is signed.
+- **Signal-Protocol mesh.** X3DH + Double Ratchet. Relay sees only ciphertext. Failed decrypt is a `security_event`; there is no plaintext fallback.
+- **CRD-driven control plane.** Eight CRDs in `azureclaw.azure.com/v1alpha1`: `ClawSandbox`, `A2AAgent`, `McpServer`, `ToolPolicy`, `InferencePolicy`, `ClawMemory`, `ClawEval`, `TrustGraph`. Full schema in [`docs/api/crd-reference.md`](../api/crd-reference.md).
+- **Multi-runtime hosting.** `ClawSandbox.spec.runtime.kind` selects the runtime: `OpenClaw` (default), `OpenAIAgents`, `MicrosoftAgentFramework` (Python — .NET deferred), `LangGraph` (Python or TypeScript), `Anthropic`, `PydanticAi`, or `BYO`. `SemanticKernel` is reserved but not yet wired. See [Runtime catalog](../runtimes.md).
+- **InferencePolicy reference.** Sandboxes bind to an `InferencePolicy` by name; model and budget configuration is no longer inline.
 
-If your environment can't support one of those, you're outside the AzureClaw threat model — open an issue before deploying.
+---
+
+The blueprints reuse the diagrams in [Architecture diagrams](../architecture-diagrams.md) where possible — go there for the canonical view of any given component.

--- a/docs/blueprints/01-developer-inner-loop.md
+++ b/docs/blueprints/01-developer-inner-loop.md
@@ -1,166 +1,116 @@
-# Blueprint 01 — Developer inner-loop
+# Blueprint 01 — Developer inner loop
 
-> "I'm on my laptop. I want to iterate on AzureClaw — controller, router, sandbox image, plugin — without provisioning AKS, without paying for Azure, and without weakening the security model so much that what I test locally diverges from what runs in production."
+> *"I am on my laptop. I want to write an agent, change a tool policy, fix a router bug, and see the effect in seconds — without provisioning AKS, without paying for Azure, and without a different code path that 'will be replaced in production'."*
 
 ## Persona & intent
 
-- **You are:** an individual contributor or maintainer.
-- **You want:** sub-minute reload of controller / router / CLI / plugin / sandbox image. Real Foundry calls *optional* (`stub-foundry` mode for offline). Real K8s reconciliation. Real seccomp + NetworkPolicy enforcement so a green local run means something.
-- **You do not want:** to provision AKS for every PR; to share Azure credentials with experimental builds; to maintain a parallel "dev mock" code path that drifts from prod.
+- **You are:** an agent author or AzureClaw maintainer.
+- **You want:** seconds of feedback. Real router code. Real policy decisions. Real audit format. Optionally real Foundry calls (you have an Azure OpenAI key on your laptop). No Kubernetes.
+- **You do not want:** to operate a kind cluster for every PR; to stand up Workload Identity locally; to maintain a parallel "dev mock" that drifts from production.
 
 ## Topology
 
+One Docker container. Same image as the sandbox, just with the router co-located inside instead of a separate pod.
+
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#f1f5f9','primaryBorderColor':'#475569','primaryTextColor':'#0f172a','lineColor':'#475569','clusterBkg':'#f8fafc','clusterBorder':'#94a3b8','fontFamily':'-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif'}}}%%
 flowchart LR
-  subgraph Laptop["💻 Laptop (your machine)"]
-    direction TB
-    KIND[("🔵 kind cluster<br/>1 node")]
-    REG[("📦 local registry<br/>:5001")]
-
-    subgraph KINDCONTENT[" "]
-      direction TB
-      CTRL["azureclaw-controller<br/>(operator)"]
-      SBX["ClawSandbox 'dev'<br/>📦 openclaw + 🛡 router"]
-    end
-
-    KIND --- KINDCONTENT
-    DOCKER["docker engine<br/>(builds + kind nodes)"]
+  subgraph Laptop["💻 Your laptop"]
     CLI["azureclaw CLI"]
+    subgraph Container["one Docker container"]
+      Agent["agent runtime"]
+      Router["inference-router (Rust)"]
+      Agent --> Router
+    end
+    Secret["mounted secret<br/>(Foundry key)"]
+    Secret -.-> Router
+    CLI -->|azureclaw dev / connect| Container
   end
-
-  CLI -->|"azureclaw up<br/>--mode local"| KIND
-  DOCKER -->|"docker push :5001"| REG
-  REG -->|"image pull"| KIND
-
-  CLI -.->|"azureclaw connect dev<br/>(port-forward 18789)"| SBX
-
-  subgraph Foundry["☁️ Azure AI Foundry (optional)"]
-    FND["gpt-4.1, gpt-5-mini, …"]
-  end
-
-  SBX -.->|"only if AZURE_OPENAI_*<br/>env vars set"| FND
-
-  classDef opt stroke-dasharray:5 5;
-  class Foundry,FND opt;
+  Foundry["☁️ Azure AI Foundry<br/>(optional)"]
+  Router -.->|"only if you set<br/>endpoint + key"| Foundry
+  classDef opt stroke-dasharray:5 5
+  class Foundry opt
 ```
 
 ## Trust boundary
 
-The trust boundary is **identical to production**:
+The trust boundary is **deliberately weaker than production**, because there is one process sharing one network namespace inside one Docker container. There is no UID separation, no egress guard, no NetworkPolicy. Treat dev mode as a development surface, not a security surface.
 
-- Agent UID 1000 inside the sandbox pod can reach only `localhost` + DNS. The router on UID 1001 is the sole external path.
-- The custom strict seccomp profile is loaded by kind (annotation: `localhostProfile: azureclaw-strict.json`).
-- NetworkPolicy default-deny is enforced by Cilium-on-kind.
-- Foundry calls go to the real Foundry endpoint via Workload Identity *only if* the user has configured one; otherwise the router runs in `--stub-foundry` mode and returns deterministic canned responses.
+| Property | Dev mode | Prod mode |
+|---|---|---|
+| Pod shape | one container | multi-container (agent + router + egress-guard) |
+| UID separation | no | UID 1000 (agent) / UID 1001 (router) |
+| Egress guard | no | iptables initContainer + NetworkPolicy |
+| Identity | resource-level Foundry key | Workload Identity (federated) |
+| Content Safety | yes | yes |
+| Governance + audit | yes | yes |
+| Mesh available | yes (against a real relay if you point at one) | yes |
 
-The only thing that's *not* like production is the host: `kind` instead of AKS, no Application Gateway, no Confidential Containers (kata + SEV-SNP) — Confidential mode silently degrades to standard mode in local-dev.
+Everything yes/yes is the same code path in both modes. That is what makes a green dev-mode test meaningful.
 
 ## Primary flow
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#f1f5f9','primaryBorderColor':'#475569','primaryTextColor':'#0f172a','lineColor':'#475569','clusterBkg':'#f8fafc','clusterBorder':'#94a3b8','fontFamily':'-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif'}}}%%
 sequenceDiagram
-    autonumber
-    participant Dev as 👤 You
-    participant CLI as azureclaw CLI
-    participant Docker as docker
-    participant Reg as local registry
-    participant Kind as kind
-    participant Ctrl as controller pod
-    participant SBX as ClawSandbox 'dev'
+  autonumber
+  participant Dev as You
+  participant CLI as azureclaw CLI
+  participant Docker as Docker
+  participant Img as Sandbox image
+  participant Router as Router (in-image)
 
-    Dev->>CLI: azureclaw up --mode local
-    CLI->>Docker: docker compose up (registry)
-    CLI->>Kind: kind create cluster
-    CLI->>CLI: helm install azureclaw …
-    Kind->>Ctrl: schedule controller
-    Dev->>Docker: cargo build && docker build sandbox
-    Docker->>Reg: docker push :5001/sandbox:latest
-    Dev->>CLI: azureclaw add dev --model stub-foundry
-    CLI->>Kind: kubectl apply ClawSandbox
-    Ctrl->>Kind: reconcile → Deployment + NP + ConfigMap
-    Kind->>SBX: pull from :5001 → start
-    Dev->>CLI: azureclaw connect dev
-    CLI->>SBX: kubectl port-forward 18789
-    Dev->>SBX: chat over WebUI
-    SBX-->>Dev: deterministic response (stub-foundry)
+  Dev->>CLI: azureclaw dev --name hello
+  CLI->>Docker: build image (cached)
+  CLI->>Docker: run container
+  Docker->>Img: ENTRYPOINT
+  Img->>Router: start on 127.0.0.1:8443
+  Img->>Img: start agent runtime
+  Dev->>CLI: azureclaw connect hello
+  CLI->>Img: TUI / WebSocket
+  Note over Dev,Router: every prompt goes through<br/>the same policy / audit / safety<br/>code path as in production
 ```
 
 ## What you provision
 
 ```bash
-# One-time
-git clone https://github.com/Azure/azureclaw && cd azureclaw
-make dev-prereqs                  # installs kind, helm, kubectl, cargo, node 22
+# clone + build (Node 22+, Rust 1.88+)
+git clone https://github.com/Azure/azureclaw.git
+cd azureclaw/cli && npm ci && npm run build && npm link
 
-# Every-loop
-make build                        # cargo build + cli npm run build
-make images                       # docker build for controller, router, sandbox
-azureclaw up --mode local         # spins kind + local registry + helm install
-azureclaw add dev --model stub-foundry --governance
-azureclaw connect dev             # port-forward to WebUI on :18789
+# run a sandbox locally — Docker only, no Azure, no Kubernetes
+azureclaw dev --name hello
 
-# When you change Rust code:
-make build images && azureclaw push --only sandbox --apply
+# talk to it
+azureclaw connect hello
 
-# Tear down:
-azureclaw down --mode local       # kind delete + docker compose down
+# tail logs (router + agent)
+azureclaw logs hello -f
+
+# inspect / change policy
+azureclaw policy show hello
+azureclaw policy apply ./my-tool-policy.yaml --sandbox hello
+
+# tear down
+azureclaw destroy hello
 ```
 
-### Runtime selection and the ref form
+On the first run you are prompted for an Azure OpenAI endpoint, deployment name, and resource-level key. **That credential is the only one dev mode ever sees, and it never leaves your laptop.** If you skip the prompt, the sandbox starts with a stub model — useful for offline plugin / policy work.
 
-Blueprint 01 defaults to `runtime.kind: OpenClaw`. To test a different runtime adapter locally, set `spec.runtime.kind` in the `ClawSandbox` manifest. The `spec.inferenceRef.name` field (S13 ref form) is **mandatory** on every sandbox — it points to an `InferencePolicy` CR in the same namespace instead of inlining model/budget config:
+## What is unique to this blueprint
 
-```yaml
-# azureclaw-dev namespace is created by the controller on reconcile
-apiVersion: azureclaw.azure.com/v1alpha1
-kind: InferencePolicy
-metadata:
-  name: dev-policy
-  namespace: azureclaw-dev
-spec:
-  tokenBudget:
-    dailyTokens: 500000
----
-apiVersion: azureclaw.azure.com/v1alpha1
-kind: ClawSandbox
-metadata:
-  name: dev
-  namespace: azureclaw-dev
-spec:
-  runtime:
-    kind: OpenClaw   # swap to OpenAIAgents / MicrosoftAgentFramework / BYO to test adapters
-  inferenceRef:
-    name: dev-policy # ref form — never inline; missing CR → Degraded/InferencePolicyNotFound
-  governance:
-    enabled: true
-```
+- **One image, two sides.** The router and the agent share an image so the inner loop is `docker run` rather than `kubectl apply`. This is the only difference in deployment shape between dev and the rest of the blueprints.
+- **Production-equal control logic.** The router is the same Rust crate. The policy engine is the same. The audit format is the same. A policy that allows a tool call locally allows it in prod; a policy that denies it locally denies it in prod.
+- **No Azure subscription required to start.** You can write plugins and iterate on `ToolPolicy` against the stub model. You only need an Azure OpenAI key the moment you want to talk to a real model.
 
-`azureclaw add dev --model stub-foundry --governance` emits the above CRs automatically; the YAML above is for direct `kubectl apply` iteration.
+## When this is the wrong blueprint
 
-For the cross-runtime mesh path (Blueprint 04 reduced to one machine), the same stack supports:
-
-```bash
-azureclaw mesh promote --port-forward      # exposes registry+relay on :18080/:18765
-azureclaw pair generate --name laptop-self # mints a token you can paste back into a NemoClaw also running locally
-```
-
-## What's unique to this blueprint
-
-- **Real reconciliation, fake cloud.** The controller does real K8s API calls against a real apiserver; only Foundry is optionally stubbed. No mock controllers, no in-memory K8s clients.
-- **Same image, same seccomp, same NP.** What you test locally is what gets pushed to AKS — modulo Confidential mode and Application Gateway.
-- **No Azure credentials anywhere on the laptop** in stub-foundry mode. Safe to run on shared / personal machines, in CI, in dependabot autoruns.
-
-## What this blueprint is NOT
-
-- Not a production deployment. `kind` is a single-node cluster on your laptop; if your laptop dies, your sandbox dies.
-- Not a security-audited environment. Local-dev disables some isolation features that require real AKS (Confidential Containers, Application Gateway WAF, Foundry-side Prompt Shields when in stub-foundry).
-- Not a substitute for the [conformance + compat suites](../conformance-suite.md) — those need a real cluster.
+- You want **multi-tenant isolation** — go to Blueprint 02.
+- You want **hardware-isolated execution** for customer prompts — go to Blueprint 03.
+- You want **two organisations to talk** — go to Blueprint 04.
+- You want **air-gapped deployment** — go to Blueprint 05.
 
 ## References
 
-- `cli/src/commands/up.ts` (`--mode local` branch)
-- `docker-compose.dev.yml` (local registry + helm-install harness)
-- `Makefile` (`dev-prereqs`, `build`, `images`, `images-load`)
-- `tests/e2e/` (kind-based e2e harness, same shape as this blueprint)
+- [`cli/src/commands/dev.ts`](../../cli/src/commands/dev.ts) — the implementation of `azureclaw dev`.
+- [`sandbox-images/`](../../sandbox-images/) — the per-runtime images dev mode uses.
+- [Architecture — Two modes](../architecture.md#two-modes) — the canonical write-up of dev vs prod.
+- [Getting started — Step 1](../getting-started.md#step-1--local-five-minutes) — the user-facing walkthrough.

--- a/docs/blueprints/02-enterprise-self-hosted.md
+++ b/docs/blueprints/02-enterprise-self-hosted.md
@@ -132,7 +132,7 @@ sequenceDiagram
 
 ### CRDs in use
 
-Blueprint 02 uses the full Phase 2 CRD stack. Apply these in the sandbox namespace (`azureclaw-<name>`) before creating the `ClawSandbox`:
+Blueprint 02 uses the full v1.0 CRD stack. Apply these in the sandbox namespace (`azureclaw-<name>`) before creating the `ClawSandbox`:
 
 | CRD | Role in this blueprint |
 |---|---|
@@ -147,13 +147,16 @@ Blueprint 02 uses the full Phase 2 CRD stack. Apply these in the sandbox namespa
 
 Enterprise teams often have existing agent code in Python or .NET. `spec.runtime.kind` selects the adapter without changing the router, governance, or audit chain:
 
-| `kind` | Use case | Tier |
+| `kind` | Use case | Status |
 |---|---|---|
-| `OpenClaw` | Default. AzureClaw plugin + OpenClaw framework. | Tier-1 |
-| `OpenAIAgents` | Python teams using the OpenAI Agents SDK. Bring OCI image or git URL. | Tier-1 |
-| `MicrosoftAgentFramework` | Python or .NET teams on the Microsoft Agent Framework. | Tier-1 |
-| `SemanticKernel`, `LangGraph`, `Anthropic` | Schema shipped; adapters landing in a future phase (`RuntimeReady=False/AdapterMissing` until then). | Tier-2 |
-| `BYO` | Any container declaring the `org.azureclaw.runtime.contract` OCI label. | Tier-1 |
+| `OpenClaw` | Default. AzureClaw plugin + OpenClaw framework. | ✅ |
+| `OpenAIAgents` | Python teams on the OpenAI Agents SDK. | ✅ |
+| `MicrosoftAgentFramework` | Microsoft Agent Framework (Python). `.NET` is `ShapeInvalid` until the .NET AgentMesh SDK ships. | ✅ Python |
+| `LangGraph` | LangChain's stateful agent framework — Python or TypeScript via `language`. | ✅ |
+| `Anthropic` | Claude Agent SDK. | ✅ |
+| `PydanticAi` | Pydantic-AI (provider-agnostic). | ✅ |
+| `SemanticKernel` | Reserved in the CRD enum; adapter image not yet built — emits `AdapterMissing`. | 🚧 |
+| `BYO` | Any container that satisfies the [BYO contract](../runtimes.md#the-contract-your-image-must-satisfy). | ✅ |
 
 ```yaml
 # Example: enterprise team migrating from Python OpenAI Agents SDK
@@ -182,7 +185,7 @@ spec:
         oci:
           image: myacr.azurecr.io/research-agent:latest
   inferenceRef:
-    name: research-bot-policy   # ref form (S13); never inline
+    name: research-bot-policy   # InferencePolicy ref (inline model config was removed)
   governance:
     enabled: true
     toolPolicyRef:
@@ -286,7 +289,7 @@ azureclaw trace research-bot --network
 
 ## Operator polish
 
-The Phase 2 controller ships production-grade operator hygiene relevant to enterprise deployments:
+The v1.0 controller ships production-grade operator hygiene relevant to enterprise deployments:
 
 - **Leader election.** The controller Deployment runs two replicas (`replicas: 2`) with a `coordination.k8s.io/v1` Lease (`azureclaw-leader-election`). Exactly one pod reconciles at a time; leadership loss triggers a pod restart and immediate re-election. Opt out with `LEADER_ELECTION_ENABLED=false` for single-replica dev clusters.
 - **Jittered requeue.** Every error-requeue duration carries ±20% multiplicative jitter (module `controller::backoff`). This prevents thundering-herd API-server bursts when many CRs fail simultaneously (e.g., after a Foundry outage).

--- a/docs/blueprints/04-cross-org-federation.md
+++ b/docs/blueprints/04-cross-org-federation.md
@@ -163,7 +163,7 @@ azureclaw mesh peer add \
 
 ## A2A gateway — cross-org public A2A path
 
-The AgentMesh relay handles authenticated cross-org traffic between AzureClaw clusters. For interoperability with non-AzureClaw agents that speak only **A2A 1.2 HTTP**, Phase 2 ships the `azureclaw-a2a-gateway` — a Rust axum binary with distroless static image that sits in front of your sandboxes.
+The AgentMesh relay handles authenticated cross-org traffic between AzureClaw clusters. For interoperability with non-AzureClaw agents that speak only **A2A 1.2 HTTP**, the `azureclaw-a2a-gateway` is a Rust axum binary (distroless static image) that sits in front of your sandboxes.
 
 ### Architecture
 

--- a/docs/blueprints/05-sovereign-airgapped.md
+++ b/docs/blueprints/05-sovereign-airgapped.md
@@ -9,7 +9,7 @@
 - **You are:** a defence, intelligence, regulator, financial-services, or sovereign-cloud operator. Or an enterprise that has chosen to self-host LLMs.
 - **You want:** AzureClaw's threat model, but with the model running on private hardware (e.g. Foundry-Edge, vLLM, llama.cpp, ONNX Runtime, an on-prem Triton) and zero traffic crossing the network island.
 - **You do not want:** any default outbound destination — every domain in the blocklist, the Foundry SDK, Application Insights, and the audit sink — to be assumed reachable.
-- **Runtime:** choose `spec.runtime.kind: OpenClaw` (default, Tier-1) for zero agent-code changes, or `BYO` for a custom container image that declares the `org.azureclaw.runtime.contract` OCI label. Python teams using the OpenAI Agents SDK or Microsoft Agent Framework can set `OpenAIAgents` or `MicrosoftAgentFramework` (Tier-1) — the same isolation and governance apply. Tier-2 runtimes (`SemanticKernel`, `LangGraph`, `Anthropic`) carry `RuntimeReady=False/AdapterMissing` until adapters ship.
+- **Runtime:** choose `spec.runtime.kind: OpenClaw` (default) for zero agent-code changes, or `BYO` for a custom container that satisfies the [BYO contract](../runtimes.md#the-contract-your-image-must-satisfy). Python teams using the OpenAI Agents SDK, Microsoft Agent Framework (Python), LangGraph (Python or TypeScript), Anthropic Claude SDK, or Pydantic-AI can use the matching first-class adapter — same isolation and governance apply. `SemanticKernel` is reserved in the CRD enum but the adapter image is not yet built (emits `AdapterMissing`).
 
 ## Topology
 
@@ -119,7 +119,7 @@ All eight CRDs work offline. The runtime adapter and model connection are config
 
 | CRD | Air-gap role |
 |---|---|
-| `InferencePolicy` | Token budget (daily/monthly) + content safety against the local model. Referenced by `ClawSandbox.spec.inferenceRef.name` (S13 ref form; omitting it → `Degraded/InferencePolicyNotFound`). |
+| `InferencePolicy` | Token budget (daily/monthly) + content safety against the local model. Referenced by `ClawSandbox.spec.inferenceRef.name` (omitting it → `Degraded/InferencePolicyNotFound`). |
 | `ToolPolicy` | Per-tool rate limits and spend caps for local tool servers (e.g., code search over cluster-local MCP). |
 | `McpServer` | Declare cluster-local private MCP servers. No OAuth unless you run an on-prem IdP. |
 | `ClawMemory` | Bind to an on-prem Foundry-Edge or compatible memory-store endpoint. |
@@ -147,7 +147,7 @@ spec:
   runtime:
     kind: OpenClaw               # or BYO if you supply your own container
   inferenceRef:
-    name: analyst-policy         # S13 ref form; required
+    name: analyst-policy         # InferencePolicy ref
   networkPolicy:
     allowlistRef:                # signed OCI artifact bundled offline (see below)
       registry: private-registry.local


### PR DESCRIPTION
Wave E of the docs revamp — the blueprint catalogue.

**`00-index.md`** — clean 5-blueprint table; "what every blueprint inherits" lists the correct 8 CRDs (with `TrustGraph`, no `ClawPairing`) and 7 first-class runtimes + BYO with deferred items honestly flagged.

**`01-developer-inner-loop.md`** rewritten — aligns with the new `azureclaw dev` story (single Docker container, router co-located) and drops the prior `azureclaw up --mode local` + kind story. Dev-vs-prod table reinforces the "two modes" narrative.

**`02–05.md`** — surgical edits: drop "Phase 2" / "S13" jargon for plain English; correct runtime tables (7 first-class shipping + BYO, MAF .NET / SemanticKernel correctly deferred). Substance left intact.
