### PR TITLE
docs(revamp-G): operations index, conditions TrustGraph, CLI count

### DIFF
--- a/docs/api/conditions.md
+++ b/docs/api/conditions.md
@@ -88,6 +88,14 @@ that means the object **is** degraded; for `Ready`, that means it
 | `Progressing` | `Indexing`, `Backfilling`                                       |
 | `Degraded`    | `StoreUnreachable`, `EmbeddingFailed`                           |
 
+## TrustGraph
+
+| Type          | Reason values                                                  |
+|---------------|----------------------------------------------------------------|
+| `Ready`       | `GraphActive`, `GraphEmpty`                                     |
+| `Progressing` | `Resolving`, `RollupComputing`                                  |
+| `Degraded`    | `PeerUnverified`, `RegistryUnreachable`                         |
+
 ## Adding a new reason
 
 1. Pick the smallest noun phrase in PascalCase that names the failure.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,13 +1,14 @@
 # AzureClaw CLI Reference
 
-AzureClaw ships 23 top-level commands organised by purpose: **Lifecycle**,
+AzureClaw ships **26 top-level commands** organised by purpose: **Lifecycle**,
 **Operations**, **Configuration**, **Observability**, and **Multi-Agent /
 Federation**. Everything you need to go from zero to a production-hardened,
 E2E-encrypted agent sandbox is expressed through these commands.
 
-See [README.md](../README.md) for the quick-start (< 5 minutes with
-`azureclaw up`). Architecture details live in
-[docs/architecture.md](architecture.md). CRD field reference is in
+See [README.md](../README.md) for the five-minute quick-start with
+`azureclaw dev`, and [getting-started.md](getting-started.md) for the
+full walkthrough including `azureclaw up` against AKS. Architecture details
+live in [docs/architecture.md](architecture.md). CRD field reference is in
 [docs/api/crd-reference.md](api/crd-reference.md).
 
 ---

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,38 @@
+# Operations
+
+How to operate AzureClaw in production. Each page is one operational concern, with the full runbook for that concern.
+
+| Topic | Read |
+|---|---|
+| **GitOps** — managing AzureClaw with Flux / Argo CD instead of the CLI. | [`gitops.md`](gitops.md) |
+| **Secret rotation** — rotating Foundry keys, ACR credentials, federated identities. | [`secret-rotation.md`](secret-rotation.md) |
+| **Image versioning** — `:latest` tag policy, pinning by digest, supply-chain considerations. | [`image-versioning.md`](image-versioning.md) |
+| **Helm packaging** — packaging the chart for offline / sovereign deployments. | [`helm-packaging.md`](helm-packaging.md) |
+| **Branch protection** — repository hygiene for forks and downstream consumers. | [`branch-protection.md`](branch-protection.md) |
+| **Supply chain** — Cosign signing, SBOM, SLSA provenance. | [`supply-chain.md`](supply-chain.md) |
+| **Chaos tier** — fault-injection harness used in CI and on demand against staging. | [`chaos-tier.md`](chaos-tier.md) |
+| **A2A gateway** — operating the public-ingress A2A endpoint. | [`a2a-gateway.md`](a2a-gateway.md) |
+| **BYO strict** — running the strict-validation BYO contract. | [`byo-strict.md`](byo-strict.md) |
+
+## Day-to-day reference
+
+For day-to-day work the most useful surfaces are:
+
+- **`azureclaw operator`** — the live fleet TUI. See [`docs/operator-tui.md`](../operator-tui.md).
+- **`azureclaw status <name>`** — quick health snapshot of one sandbox.
+- **`azureclaw logs <name> -f`** — tail router + agent logs.
+- **`azureclaw policy show <name>`** — what is allowed / denied / approval-gated for a sandbox.
+- **`kubectl describe clawsandbox <name>`** — full condition chain (every status condition is documented in [`../api/conditions.md`](../api/conditions.md)).
+- **`azureclaw eval`** — reproducible evaluation against a pinned sandbox spec.
+
+## What is not here
+
+- **Cluster provisioning** — see [Getting started](../getting-started.md). `azureclaw up` provisions AKS, ACR, Foundry, federated identity, and Helm install in one go.
+- **Architecture and CRDs** — see [Architecture](../architecture.md) and [CRD reference](../api/crd-reference.md).
+- **Security guarantees** — see [Security model](../security.md).
+
+## See also
+
+- [CLI reference](../cli-reference.md)
+- [Backwards compatibility](../api/backwards-compatibility.md)
+- [Conditions reference](../api/conditions.md)


### PR DESCRIPTION
Wave G of the docs revamp — operations + API hygiene.

- **`docs/operations/README.md`** (new) — the operations index page was missing. Adds a single-table landing page routing to all nine existing ops runbooks, plus the day-to-day operator commands (`status`, `logs`, `policy show`, `operator` TUI).
- **`docs/api/conditions.md`** — added the missing `TrustGraph` CRD section (`GraphActive` / `GraphEmpty` / `RollupComputing` / `PeerUnverified` / `RegistryUnreachable`).
- **`docs/cli-reference.md`** — command count corrected (23 → 26, matches `cli/src/commands/`); quick-start link re-pointed from `azureclaw up` to `azureclaw dev` to match the post-revamp Getting Started narrative.

The other ops runbooks (`a2a-gateway.md`, `branch-protection.md`, `byo-strict.md`, `chaos-tier.md`, `gitops.md`, `helm-packaging.md`, `image-versioning.md`, `secret-rotation.md`, `supply-chain.md`) are accurate as-is and untouched. `backwards-compatibility.md` is also accurate as-is.
