### PR TITLE
docs: Wave I — CRD lifecycle doc + diagram redistribution

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -50,6 +50,7 @@
 # API & policy
 
 - [CRD reference](api/crd-reference.md)
+- [Lifecycle & reconciliation](api/lifecycle.md)
 - [Conditions](api/conditions.md)
 - [Backwards compatibility](api/backwards-compatibility.md)
 

--- a/docs/api/lifecycle.md
+++ b/docs/api/lifecycle.md
@@ -1,0 +1,347 @@
+# Lifecycle — what happens when you apply a CRD
+
+This page is the end-to-end story for every AzureClaw CRD: which CLI command writes it, what the controller does when it lands, what cluster artifacts get produced, and which component consumes those artifacts at runtime.
+
+If you only read one document about how AzureClaw fits together, read this one.
+
+> Source of truth: `controller/src/*_reconciler.rs` and `inference-router/src/routes/*.rs`. Every diagram and table here is grounded in those files.
+
+## Table of contents
+
+- [The big picture](#the-big-picture)
+- [Two reconcile patterns](#two-reconcile-patterns)
+- [CLI ↔ CRD ↔ artifact map](#cli--crd--artifact-map)
+- [`ClawSandbox` — the heavyweight reconcile](#clawsandbox--the-heavyweight-reconcile)
+- [`InferencePolicy` — the policy compile pattern](#inferencepolicy--the-policy-compile-pattern)
+- [`McpServer` — declared MCP backend](#mcpserver--declared-mcp-backend)
+- [`A2AAgent` — public-ingress endpoint](#a2aagent--public-ingress-endpoint)
+- [`ToolPolicy` / `ClawMemory` / `ClawEval` / `TrustGraph`](#toolpolicy--clawmemory--clawevaluation--trustgraph)
+- [Status, conditions, requeue](#status-conditions-requeue)
+- [Deletion & finalizers](#deletion--finalizers)
+
+---
+
+## The big picture
+
+```mermaid
+flowchart LR
+  CLI["`azureclaw` CLI<br/>or GitOps / kubectl"]
+  CRD[("CRD<br/>(8 kinds)")]
+  Ctrl["azureclaw-controller<br/>(kube-rs)"]
+  Art[("Cluster artifacts<br/>Namespace · ServiceAccount · NetworkPolicy<br/>Deployment · Service · ConfigMap · Secret<br/>FederatedIdentityCredential")]
+  Runtime["Runtime data plane<br/>inference-router · A2A gateway · sandbox pod"]
+
+  CLI -->|writes| CRD
+  CRD -->|watch + reconcile| Ctrl
+  Ctrl -->|server-side apply| Art
+  Art -->|mounted into| Runtime
+  Ctrl -->|patch_status| CRD
+```
+
+Three things happen in order:
+
+1. **A CRD lands in etcd.** Either you ran an `azureclaw <verb>` command (which is just sugar over `kubectl apply`), or your GitOps tool synced one, or you ran `kubectl apply -f` directly. They are all equivalent.
+2. **The controller reconciles it.** It reads the spec, compiles it into Kubernetes-native objects, and server-side-applies them. Then it patches `status.conditions` so observers can see what happened.
+3. **The data plane consumes the artifacts.** The inference router reads governance / inference / tool / trust profiles from mounted `ConfigMap`s. The A2A gateway reads `AgentCard`s from a `ConfigMap`. The sandbox pod runs the runtime image the controller chose for `spec.runtime.kind`.
+
+This is the whole loop. Everything else on this page is detail.
+
+---
+
+## Two reconcile patterns
+
+AzureClaw's eight CRDs split into two operational shapes:
+
+| Pattern | CRDs | What gets produced |
+|---|---|---|
+| **Compile-to-artifact** | `InferencePolicy`, `ToolPolicy`, `A2AAgent`, `McpServer`, `ClawMemory`, `ClawEval`, `TrustGraph` | A deterministic `ConfigMap` (and sometimes a `Secret`) that the router or gateway mounts. The CRD spec is hashed; the hash is stored in `status.versionHash`. |
+| **Heavyweight namespace** | `ClawSandbox` | A whole tenant namespace: `Namespace` + `ServiceAccount` + Workload-Identity federated credential + `NetworkPolicy` + governance `ConfigMap` + `Deployment` + `Service`. |
+
+### The reconciler map
+
+All eight reconcilers run in the same controller pod under one leader-election lease, with a separate lease for the mesh-peer reconciler so it can fail independently.
+
+```mermaid
+graph TD
+  subgraph operator["controller pod (replicas: 2, ns: azureclaw-system)"]
+    direction TB
+    LE["Leader election<br/>coordination.k8s.io/v1 Lease<br/>(env: LEADER_ELECTION_ENABLED, default true)"]
+    subgraph reconcilers["Reconciler tasks (spawn after leader gate)"]
+      direction LR
+      R1["ClawSandbox<br/>fm: clawsandbox"]
+      R2["McpServer<br/>fm: mcp"]
+      R3["ToolPolicy<br/>fm: toolpolicy"]
+      R4["InferencePolicy<br/>fm: inferencepolicy"]
+      R5["A2AAgent<br/>fm: a2aagent"]
+      R6["ClawMemory<br/>fm: clawmemory"]
+      R7["ClawEval<br/>fm: claweval"]
+      R8["TrustGraph<br/>fm: trustgraph"]
+    end
+    R9["ClawPairing reconciler<br/>(internal — bound by ClawSandbox)"]
+    MESH["mesh-peer reconciler<br/>(own lease — agentmesh-mesh-peer-leader)"]
+    METR["Metrics + health server<br/>:9091 — /metrics /healthz /readyz"]
+  end
+  LE --> reconcilers
+  LE --> R9
+  LE -.->|independent| MESH
+```
+
+The `fm:` labels are the SSA field manager suffixes — every reconciler owns its own subtree of the CR via server-side apply. Out-of-band edits (e.g., a manual `kubectl edit`) show up as field-manager conflicts in controller logs and trigger a re-reconcile.
+
+### The compile pattern
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User / CLI
+  participant K as Kubernetes API
+  participant C as Controller
+  participant CM as ConfigMap
+  participant R as Inference router (running pod)
+
+  U->>K: kubectl apply <Policy>
+  K-->>C: watch event (Added / Modified)
+  C->>C: validate + compile spec → profile JSON
+  C->>C: hash = sha256(profile)
+  C->>K: patch finalizer (first time only)
+  C->>CM: server-side apply ConfigMap (data: profile.json)
+  C->>K: patch_status (phase=Ready, versionHash=…, conditions[])
+  Note over R: kubelet propagates ConfigMap mount<br/>(eventually consistent, no router restart)
+  R->>R: reload profile from disk on next request
+```
+
+The heavyweight pattern adds many more steps and a finalizer that owns the whole tenant namespace — see the dedicated section below.
+
+---
+
+## CLI ↔ CRD ↔ artifact map
+
+Every CLI command is a thin wrapper around `kubectl apply`. The CLI does no orchestration the controller wouldn't do — it just produces well-formed CR YAML and submits it.
+
+| CLI command | CRD written | Cluster artifact produced | Consumed by |
+|---|---|---|---|
+| `azureclaw up` | `ClawSandbox` (one or more) | Tenant namespace + everything inside it | The agent pod itself |
+| `azureclaw add <name>` | `ClawSandbox` | Same as above | Same |
+| `azureclaw destroy <name>` | Deletes `ClawSandbox` | Cascades via finalizer to delete the namespace + federated credential | — |
+| `azureclaw inferencepolicy apply` | `InferencePolicy` | `ConfigMap` `inferencepolicy-<name>-profile` | Inference router (`/v1/chat`, `/v1/responses`) |
+| `azureclaw toolpolicy apply` | `ToolPolicy` | `ConfigMap` `toolpolicy-<name>-profile` | Inference router (every tool dispatch) |
+| `azureclaw mcp add` | `McpServer` | `Secret` `mcp-<name>-signing` (Ed25519 keypair) <br/> `ConfigMap` `mcp-<name>-jwks` (when `productionMode=true`) | Inference router (`/v1/mcp/*` proxy) |
+| `azureclaw a2a-agent apply` | `A2AAgent` | `ConfigMap` `a2aagent-<name>-card` (signed AgentCard) | A2A gateway (inbound JWS verification) |
+| `azureclaw eval` | `ClawEval` | `ConfigMap` `claweval-<name>-spec` <br/> `Job` (when run-now) | Eval harness |
+| `azureclaw mesh ...` | `TrustGraph` | `ConfigMap` `trustgraph-<name>-graph` | Inference router (KNOCK accept/deny + AGT trust score) |
+
+> The CLI's `apply` and `get` verbs round-trip through `kubectl` for parity with GitOps. There is no hidden CLI-only state.
+
+---
+
+## `ClawSandbox` — the heavyweight reconcile
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User / CLI
+  participant K as Kube API
+  participant C as Controller
+  participant AAD as Microsoft Graph<br/>(Workload Identity)
+  participant Pod as Sandbox pod
+
+  U->>K: kubectl apply ClawSandbox
+  K-->>C: watch event
+  C->>C: validate name (lowercase / hyphens / ≤63)
+  C->>K: add finalizer<br/>azureclaw.azure.com/namespace-cleanup
+  C->>C: dispatch on spec.runtime.kind<br/>(runtime.rs → image + cmd + args)
+  alt unsupported runtime
+    C->>K: patch_status (Degraded, AdapterMissing)
+    Note over C: requeue 5 min
+  end
+  C->>K: ensure Namespace azureclaw-&lt;name&gt;
+  C->>K: ensure ServiceAccount<br/>(annotated for Workload Identity)
+  C->>AAD: ensure federated credential<br/>(maps SA token → AAD)
+  C->>K: ensure ClusterRoleBinding<br/>(spawner role for sub-agents)
+  C->>K: ensure NetworkPolicy<br/>(default-deny + DNS + IMDS + Foundry + relay)
+  C->>K: ensure governance ConfigMap<br/>(AGT profile, sandbox identity)
+  C->>K: ensure ConfigMap mounts<br/>(ToolPolicy, InferencePolicy, TrustGraph)
+  C->>K: ensure Deployment<br/>(init: egress-guard ; agent UID 1000 ; router UID 1001)
+  C->>K: ensure Service (ClusterIP, port 8443)
+  C->>K: patch_status (phase=Ready, conditions[])
+  Note over Pod: kubelet schedules pod
+  Pod->>Pod: init: iptables — block UID 1000 egress
+  Pod->>Pod: agent + router start
+  Pod->>K: SA token projected
+```
+
+**What happens for each step in code** (file references):
+
+| Step | Code |
+|---|---|
+| Name validation | `controller/src/reconciler/mod.rs:138-151` |
+| Finalizer add / cascade delete | `controller/src/reconciler/mod.rs:159-264` |
+| Runtime dispatch | `controller/src/reconciler/runtime.rs` (8 match arms) |
+| Federated credential | `controller/src/fedcred.rs` |
+| NetworkPolicy template | `controller/src/reconciler/mod.rs:807-890` |
+| Governance mount | `controller/src/reconciler/governance_mounts.rs` |
+| TrustGraph mount | `controller/src/reconciler/trustgraph_mount.rs` |
+| BYO contract validation | `controller/src/reconciler/byo_contract.rs` |
+| Status patching | `controller/src/status/` |
+
+---
+
+## `InferencePolicy` — the policy compile pattern
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User / CLI
+  participant K as Kube API
+  participant C as Controller
+  participant CM as ConfigMap<br/>inferencepolicy-&lt;name&gt;-profile
+  participant R as Inference router
+
+  U->>K: kubectl apply InferencePolicy
+  K-->>C: watch event
+  C->>C: compile_to_profile(spec) → JSON
+  C->>C: version_hash = sha256(profile)
+  C->>K: ensure finalizer
+  C->>CM: SSA: { profile.json, label.versionHash }
+  C->>K: patch_status:<br/>phase, observedGeneration,<br/>profileConfigMapRef, versionHash, conditions[]
+  Note over R: ConfigMap mount in sandbox pod<br/>updates within ~minute (kubelet sync)
+  R->>R: on next request: re-read profile if hash changed
+```
+
+**Verified against**: `controller/src/inference_policy_reconciler.rs:100-200` (entry point), `inference_policy_compile.rs` (deterministic compile).
+
+The router reads `model_preference`, `token_budget`, and `content_safety` blocks from the profile. Token-budget enforcement happens **before** the Foundry call (`inference-router/src/routes/chat_completions.rs:75-89`).
+
+---
+
+## `McpServer` — declared MCP backend
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User / CLI
+  participant K as Kube API
+  participant C as Controller
+  participant Iss as OAuth issuer<br/>(remote, optional)
+  participant S as Secret<br/>mcp-&lt;name&gt;-signing
+  participant J as ConfigMap<br/>mcp-&lt;name&gt;-jwks
+  participant R as Inference router
+
+  U->>K: kubectl apply McpServer
+  K-->>C: watch event
+  C->>K: ensure finalizer
+  C->>S: ensure Ed25519 signing keypair<br/>(generated once; kid stable)
+  alt productionMode == true
+    C->>Iss: GET .well-known/openid-configuration<br/>then jwks_uri
+    Iss-->>C: JWKS JSON
+    C->>J: SSA: { jwks.json }
+  else productionMode == false
+    Note over C: skip JWKS — dev / local servers
+  end
+  C->>K: patch_status:<br/>phase, signingKeyRef, jwksConfigMapRef, lastProbedAt
+  Note over R: At inference time the router resolves<br/>spec.endpoint, signs requests with the<br/>Secret keypair, verifies inbound JWTs<br/>against the JWKS ConfigMap.
+```
+
+**Verified against**: `controller/src/mcp_server_reconciler.rs:246-377`.
+
+Two artifacts, two purposes:
+
+- **The `Secret`** (`mcp-<name>-signing`) is the local Ed25519 keypair used by the router to sign outbound MCP requests. The `kid` is stable across reconciles; the keypair is created once and persists.
+- **The `ConfigMap`** (`mcp-<name>-jwks`) contains the remote OAuth issuer's JWKS, fetched by the controller and refreshed on each reconcile. Only present when `productionMode=true` and `spec.oauth.issuer` is set. Used by the router to verify JWTs the MCP server returns.
+
+If JWKS fetch fails the CR is stamped `Degraded / JwksFetchFailed` and the controller requeues with backoff. The router's tool dispatch path treats this as fail-closed for that MCP server.
+
+---
+
+## `A2AAgent` — public-ingress endpoint
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User / CLI
+  participant K as Kube API
+  participant C as Controller
+  participant CM as ConfigMap<br/>a2aagent-&lt;name&gt;-card
+  participant GW as A2A gateway
+
+  U->>K: kubectl apply A2AAgent
+  K-->>C: watch event
+  C->>K: ensure finalizer
+  C->>C: compile signed AgentCard from spec<br/>(name, endpoints, capabilities, JWS)
+  C->>C: version_hash = sha256(card)
+  C->>CM: SSA: { agentcard.json }
+  C->>K: patch_status (phase, cardConfigMapRef, versionHash)
+  Note over GW: gateway watches the<br/>a2aagent-*-card ConfigMaps and<br/>uses them to route inbound traffic<br/>to the matching ClawSandbox.
+```
+
+**Verified against**: `controller/src/a2a_agent_reconciler.rs:96-200` and `controller/src/a2a_agent_compile.rs`.
+
+When an external peer hits the A2A gateway with a JWS-signed envelope, the gateway looks up the target agent in this `ConfigMap` set, verifies the signature against the trust anchor, and forwards over mTLS to the router on port 8445. See [A2A gateway architecture](../architecture/a2a-gateway.md) for the full data flow.
+
+---
+
+## `ToolPolicy` / `ClawMemory` / `ClawEval` / `TrustGraph`
+
+Each follows the compile-to-ConfigMap pattern with one added wrinkle:
+
+| CRD | Adds | Where the artifact is consumed |
+|---|---|---|
+| `ToolPolicy` | Compiles allow / deny / approval rules into a flat decision profile | Inference router on every tool dispatch (`/v1/mcp/*`, `/v1/spawn`, `/v1/handoff`) |
+| `ClawMemory` | Resolves storage backend (Cosmos / blob / in-memory) and stamps a binding token | Inference router on `/v1/memory/*` proxy |
+| `ClawEval` | Compiles spec into a `Job` template; spawns one `Job` per `run-now` request | Eval harness pod; results PVC-mounted |
+| `TrustGraph` | Snapshots peer identities + trust scores into a ConfigMap | Inference router on KNOCK accept/deny path (mesh ingress) |
+
+**Code references**:
+
+- `controller/src/tool_policy_reconciler.rs` + `tool_policy_compile.rs`
+- `controller/src/claw_memory_reconciler.rs` + `claw_memory_compile.rs`
+- `controller/src/claw_eval_reconciler.rs` + `claw_eval_compile.rs`
+- `controller/src/trust_graph_reconciler.rs` + `trust_graph_compile.rs`
+
+All four follow the same `compile → version_hash → SSA ConfigMap → patch_status` shape as `InferencePolicy`. The reconcile loops are intentionally near-identical so the failure modes and observability are uniform.
+
+---
+
+## Status, conditions, requeue
+
+Every reconcile ends with a `patch_status` call. The status block always carries:
+
+- `phase` — `Ready` / `Degraded` / (heavyweight CRDs add `Progressing`).
+- `observedGeneration` — `metadata.generation` of the spec the reconciler saw.
+- `conditions[]` — at least `Ready`, `Progressing`, `Degraded`. Reasons are taxonomy-controlled — see [Conditions reference](conditions.md).
+- For compile pattern: `versionHash`, the `*-Ref` pointing at the produced `ConfigMap`/`Secret`, and `lastCompiledAt` / `lastProbedAt`.
+
+Requeue cadence is per-reconciler:
+
+| Outcome | Requeue interval (default) |
+|---|---|
+| Reconcile success | `REQUEUE_OK` (typically 5 min) |
+| Reconcile failure (`Degraded`) | `REQUEUE_FAIL` (typically 30 s with jitter) |
+| Spec validation rejection | 5 min (waits for user to edit the CR) |
+| Federated-credential transient error | 30 s with jitter (`controller/src/backoff.rs`) |
+
+`status.conditions[].lastTransitionTime` is preserved when the status doesn't flip — this matters for downstream automation that triggers on transitions.
+
+---
+
+## Deletion & finalizers
+
+Every reconciler installs a finalizer on first reconcile. This blocks Kubernetes from completing the `DELETE` until the controller has run cleanup. Cleanup is **synchronous**: a transient failure (e.g., AAD Graph 5xx during federated credential delete) requeues the finalizer rather than removing it.
+
+| CRD | Finalizer | Cleanup work |
+|---|---|---|
+| `ClawSandbox` | `azureclaw.azure.com/namespace-cleanup` | Delete the tenant namespace (cascades to all resources), delete spawner ClusterRoleBinding, **delete federated credential**, release pairing slot, then remove finalizer. |
+| Compile-pattern CRDs | `azureclaw.azure.com/<kind>-cleanup` | Delete the produced `ConfigMap` (and `Secret`, where present), then remove finalizer. |
+
+The federated-credential delete is the one cleanup that crosses the cluster boundary into Microsoft Graph. See `controller/src/fedcred_reaper.rs` for the orphan-collector that backstops force-delete and pre-finalizer CRs.
+
+---
+
+## See also
+
+- [CRD reference](crd-reference.md) — exhaustive field-by-field schema.
+- [Conditions reference](conditions.md) — every status condition the controller emits and why.
+- [Architecture](../architecture.md) — the prose walkthrough of one model call.
+- [Architecture diagrams](../architecture-diagrams.md) — high-level visual index.
+- [Runtimes](../runtimes.md) — how `spec.runtime.kind` maps to images.
+- [BYO contract](../blueprints/01-developer-inner-loop.md) — for `spec.runtime.kind: BYO`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,14 +61,50 @@ Whichever mode you run in, the CRDs are the same, the audit chain is the same, a
 
 Walk through what happens when an agent in prod mode says *"call the model"*:
 
-1. The agent SDK is configured (by the runtime adapter) to point at `http://127.0.0.1:8443`. There is no way for it to reach Foundry directly — egress-guard would drop the packet.
-2. The router receives the request. It runs **content safety** (Foundry guardrails on the way in), checks the **token budget** for the tenant, and asks the **governance** layer (`InferencePolicy` + AGT) whether this call is allowed.
-3. If allowed, the router attaches a **Workload Identity** AAD token (which it minted from the projected service-account token) and forwards to Foundry.
-4. The response comes back. Content safety runs on the way out.
-5. The router **audits** the call: prompt-fingerprint, model, tokens-in, tokens-out, decision, latency. The audit record is hash-chained to the previous record so tampering is detectable.
-6. The router returns to the agent. Done.
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Agent as Agent (UID 1000)
+  participant Router as Router (UID 1001)
+  participant Gov as Governance<br/>(InferencePolicy + AGT)
+  participant Budget as Token budget
+  participant WI as Workload Identity<br/>(IMDS / federated)
+  participant Foundry as Foundry model<br/>(DefaultV2 guardrails inline)
 
-Every other external call (web fetch, MCP tool, sub-agent spawn, A2A peer message) goes through the same path with a different policy module. The router is a small Rust crate; its surface is small enough to audit.
+  Agent->>Router: POST /v1/chat (prompt)
+  Router->>Gov: allow? (model + sandbox + action)
+  alt deny
+    Gov-->>Router: deny + reason
+    Router-->>Agent: 403 policy_violation
+  else allow
+    Gov-->>Router: allow
+    Router->>Budget: check tenant budget
+    alt over budget
+      Budget-->>Router: exceeded
+      Router-->>Agent: 429 budget_exceeded
+    else within budget
+      Router->>WI: exchange SA token → AAD bearer
+      WI-->>Router: bearer (cached, ~5 min)
+      Router->>Foundry: POST /openai/... + bearer
+      Foundry-->>Router: completion + prompt_filter_results
+      Router->>Router: parse content flags<br/>report to AGT BehaviorMonitor
+      Router->>Router: append audit record (hash-chained)
+      Router-->>Agent: completion
+    end
+  end
+```
+
+In prose:
+
+1. The agent SDK is configured (by the runtime adapter) to point at `http://127.0.0.1:8443`. There is no way for it to reach Foundry directly — `egress-guard` would drop the packet.
+2. The router receives the request. It asks the **governance** layer (`InferencePolicy` + AGT `PolicyDecisionProvider`) whether this call is allowed. Deny → 403.
+3. It checks the **token budget** for the tenant. Over → 429.
+4. It mints a **Workload Identity** AAD token (from the projected service-account token, cached for the token TTL) and forwards to Foundry.
+5. **Content safety is enforced by Foundry's DefaultV2 guardrails inline** — the router does not make a separate Content Safety call. The Foundry response carries `prompt_filter_results` annotations; the router parses them and reports flags to AGT's `BehaviorMonitor`.
+6. The router appends an **audit record** — prompt-fingerprint, model, tokens-in / tokens-out, decision, latency — hash-chained to the previous record so tampering is detectable.
+7. The router returns to the agent.
+
+Every other external call (web fetch, MCP tool, sub-agent spawn, A2A peer message) goes through the same shape with a different policy module. Code: `inference-router/src/routes/chat_completions.rs:27-100`.
 
 ---
 

--- a/docs/architecture/a2a-gateway.md
+++ b/docs/architecture/a2a-gateway.md
@@ -20,83 +20,77 @@ reaching ours) terminate at a single, narrow surface that:
 
 ## Data flow
 
-```text
-                      external A2A 1.0.0 caller
-                                │
-                       TLS (rotating leaf)
-                                │
-                                ▼
-              ┌──────────────────────────────────────┐
-              │  Application Gateway for Containers   │
-              │  (Gateway API resource — Helm)        │
-              └─────────────────┬────────────────────┘
-                                │
-                                ▼
-              ┌──────────────────────────────────────┐
-              │      azureclaw-a2a-gateway            │
-              │                                       │
-              │  • TLS termination (rustls + ring)    │
-              │  • JWS verify (azureclaw-a2a-core)    │
-              │  • Replay nonce cache (5 min TTL)     │
-              │  • Subject token-bucket (60 burst /   │
-              │    5 rps refill, RAM-only in v1)      │
-              │  • Drop privs to UID 1002             │
-              │  • Distroless static + read-only FS   │
-              └─────────────────┬────────────────────┘
-                                │
-                            mTLS (8445)
-                                │
-                                ▼
-              ┌──────────────────────────────────────┐
-              │      azureclaw-inference-router       │
-              │      :8445 (mTLS) — gateway path      │
-              │      :8443 (mesh) — unchanged         │
-              └─────────────────┬────────────────────┘
-                                │
-                                ▼
-                          sandbox pod
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Peer as External A2A 1.2 caller<br/>(other org)
+  participant Ing as App Gateway for Containers<br/>(public TLS)
+  participant GW as a2a-gateway<br/>(UID 1002, distroless)
+  participant Cache as Replay nonce cache<br/>(5 min TTL)
+  participant Bucket as Token bucket<br/>(60 burst / 5 rps refill)
+  participant Router as Inference router<br/>(:8445 mTLS)
+  participant Pod as Sandbox pod
+
+  Peer->>Ing: HTTPS + signed AgentCard envelope
+  Ing->>GW: forward (TLS terminated at ingress)
+  GW->>GW: rustls TLS termination (leaf cert rotates)
+  GW->>GW: JWS verify (azureclaw-a2a-core)
+  alt invalid signature / no trust anchor
+    GW-->>Peer: 401 untrusted_card
+  end
+  GW->>Cache: check replay nonce
+  alt nonce seen within 5 min
+    GW-->>Peer: 409 replay
+  end
+  GW->>Bucket: per-subject limit (sub claim)
+  alt over rate
+    GW-->>Peer: 429 rate_limited
+  end
+  GW->>Router: mTLS on :8445<br/>(gateway path; mesh :8443 unchanged)
+  Router->>Pod: localhost dispatch
+  Pod-->>Router: response
+  Router-->>GW: response
+  GW->>GW: emit audit (peer subject, target sandbox, outcome)
+  GW-->>Peer: response
 ```
+
+The gateway runs as **UID 1002**, distroless static, read-only filesystem. Privileges drop on first request. The replay cache and rate-limit token bucket are RAM-only in `v1` (state survives a single pod, not a restart) — see [the operations runbook](../operations/a2a-gateway.md) for how this is monitored and what to consider when scaling out.
 
 ## Threat model
 
-### In scope (mitigated in S3.5)
+### What we mitigate
 
 | Threat | Mitigation |
 |---|---|
 | Eavesdropping on the public path | TLS 1.2/1.3 via rustls. |
 | Stolen TLS leaf | `notify::Watcher` triggers `Arc<ServerConfig>` swap on cert rotation; old sessions drain. |
-| Forged AgentCard | JWS Ed25519 verify in `azureclaw_a2a_core::verify_inbound_card` (library complete & tested) against a pinned trust store; `alg` allow-list is hard-coded to `EdDSA`. **`[GAP-V1]`** the gateway *binary* does not yet run this verifier in its proxy hot path — see "Out of scope in S3.5" below. |
+| Forged AgentCard | JWS Ed25519 verify in `azureclaw_a2a_core::verify_inbound_card` against a pinned trust store; `alg` allow-list is hard-coded to `EdDSA`. The gateway today consumes the verified subject from the `X-A2A-Agent-Subject` header populated by the upstream Gateway API mTLS handshake; wiring the verifier directly as an axum layer is a v1.1 task. |
 | Replay of a valid envelope | Nonce cache with 5 min TTL and 100k entry cap. |
 | Untrusted gateway impersonating router | Router :8445 verifies client cert against the gateway-only CA bundle at `/etc/azureclaw/a2a-gateway-ca.pem`. |
 | Burst flood from one subject | Per-subject token bucket (60 burst / 5 rps); over-budget calls return 429. |
 | Container escape from the gateway | Distroless static base, read-only root FS, drop ALL caps, UID 1002, seccomp `azureclaw-strict.json`. |
 
-### Out of scope in S3.5
+### Known limitations (v1)
 
-| Concern | Resolution path |
+| Limitation | Notes |
 |---|---|
-| **`[GAP-V1]` JWS verifier wired as an axum layer** | The verifier is implemented and tested in `azureclaw-a2a-core`; the gateway binary today consumes the verified subject from the `X-A2A-Agent-Subject` header populated by the upstream Gateway API mTLS handshake. Wiring `verify_inbound_card` directly inside the gateway as an opt-in axum layer is a v1.1 task. The unused `azureclaw-a2a-core` workspace dependency in `a2a-gateway/Cargo.toml` is the placeholder. |
-| Cross-replica rate-limit sync | Helm value `a2aGateway.rateLimits.sharedRedisUrl` is reserved; impl is `unimplemented!()`. Replicas in v1 enforce in-memory only — the router's downstream limiter is the second line of defence. |
+| Cross-replica rate-limit sync | Helm value `a2aGateway.rateLimits.sharedRedisUrl` is reserved; impl is `unimplemented!()`. Replicas enforce in-memory only — the router's downstream limiter is the second line of defence. |
 | SAN pinning beyond CA chain on :8445 | The gateway CA is single-purpose (issued only to gateway pods) so chain-of-trust is sufficient for v1. |
-| Mandatory mTLS on :8443 | Out of scope — :8443 stays exactly as it is in the dev branch. |
+| Mandatory mTLS on :8443 | Out of scope — :8443 stays exactly as it is on the dev branch. |
 
-## Surveyed-existing-implementation — what was lifted vs. what is new
+## Code layout
 
-The slice deliberately did *not* fork the JWS verifier. Instead:
+The JWS verifier and agent-card schema live in a shared workspace crate so the router and the gateway use the same byte-for-byte implementation:
 
-| Component | Pre-S3.5 location | Post-S3.5 location |
+| Module | Crate | Purpose |
 |---|---|---|
-| `signature.rs` (RFC 7515 signing-input) | `inference-router/src/a2a/` | `azureclaw-a2a-core/src/` |
-| `agent_card.rs` (A2A §5.5 schema) | `inference-router/src/a2a/` | `azureclaw-a2a-core/src/` |
-| `card_signing.rs` (Ed25519 sign + verify) | `inference-router/src/a2a/` | `azureclaw-a2a-core/src/` |
-| `card_verifier.rs` (inbound caller pin) | `inference-router/src/a2a/` | `azureclaw-a2a-core/src/` |
-| `error.rs` (A2A §3.3.2 codes) | `inference-router/src/a2a/` | `azureclaw-a2a-core/src/` |
+| `signature.rs` | `azureclaw-a2a-core` | RFC 7515 signing-input construction. |
+| `agent_card.rs` | `azureclaw-a2a-core` | A2A §5.5 schema. |
+| `card_signing.rs` | `azureclaw-a2a-core` | Ed25519 sign + verify. |
+| `card_verifier.rs` | `azureclaw-a2a-core` | Inbound caller pin against the trust store. |
+| `error.rs` | `azureclaw-a2a-core` | A2A §3.3.2 error codes. |
 
-The router re-exports each module under its original path
-(`crate::a2a::signature::*`, etc.) so every existing call site
-keeps compiling unchanged. The gateway depends on the new core
-crate directly. Both binaries therefore use the same byte-for-byte
-verifier.
+The router re-exports each module under its original path (`crate::a2a::signature::*`, etc.) so existing call sites keep compiling unchanged.
 
 ## Deployment sizing
 

--- a/docs/egress-proxy.md
+++ b/docs/egress-proxy.md
@@ -50,25 +50,49 @@ then checks the request through the egress decision pipeline:
 
 ### Decision Flow
 
+```mermaid
+flowchart TD
+  REQ["Agent (UID 1000)<br/>HTTPS request"] --> IPT["iptables NAT REDIRECT<br/>TCP 443 → 127.0.0.1:8444"]
+  IPT --> FP["Forward proxy<br/>inference-router :8444"]
+  FP --> EXT["Extract domain<br/>from CONNECT or Host header"]
+  EXT --> BL{"Domain in<br/>blocklist?<br/>(seed + OISD + URLhaus)"}
+  BL -->|yes| BLOCK["403 Forbidden<br/>+ audit reason"]
+  BL -->|no| TLD{"High-risk TLD?<br/>.tk · .ml · .ga · .cf · .gq"}
+  TLD -->|yes| BLOCK
+  TLD -->|no| PRIV{"Private IP after<br/>DNS resolve?"}
+  PRIV -->|yes| BLOCK
+  PRIV -->|no| MODE{"Egress mode"}
+  MODE -->|learn| LOG["Log domain to learned set<br/>→ operator review queue"]
+  LOG --> TUNNEL
+  MODE -->|enforce| AL{"Domain in<br/>allowlist?<br/>(parent-domain match)"}
+  AL -->|yes| TUNNEL["Open TCP tunnel<br/>agent ↔ destination"]
+  AL -->|no| PEND["Create PendingApproval<br/>(deduped by domain)<br/>→ 403 'pending operator approval'"]
+
+  classDef block fill:#fde2e1,stroke:#c0392b
+  classDef ok fill:#dff5e1,stroke:#27ae60
+  classDef wait fill:#fff3cd,stroke:#d68910
+  class BLOCK,PEND block
+  class TUNNEL,LOG ok
+  class MODE,BL,TLD,PRIV,AL wait
 ```
-Request arrives at /egress/fetch
-    │
-    ▼
-Blocklist check (seed + OISD + URLhaus + high-risk TLDs + bare IPs)
-    │── Match ──→ BLOCKED (403 Forbidden)
-    │
-    ▼
-Allowlist check (operator-approved domains, parent domain matching)
-    │── Match ──→ ALLOWED (proxied to destination)
-    │
-    ▼
-Learn mode enabled?
-    │── Yes ──→ ALLOWED + domain logged to learned set
-    │
-    ▼
-Create pending approval request (dedup by domain)
-    └──────→ DENIED (403 — "pending operator approval")
+
+Verified against `inference-router/src/forward_proxy.rs` (handler) and `inference-router/src/blocklist.rs` (`check_egress`, the high-risk TLD list, the parent-domain allowlist match, `PendingApproval` deduplication).
+
+### Learn → Enforce lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Learn: azureclaw add &lt;name&gt;<br/>(default; blocklist still enforced)
+  Learn: 🔍 Learn mode\nAll domains logged\nBlocklist still enforced
+  Review: 📋 Operator review\nazureclaw egress &lt;name&gt; --learned
+  Enforce: 🔒 Enforce mode\nOnly approved domains pass\nNew domains → PendingApproval
+
+  Learn --> Review: operator inspects learned set
+  Review --> Review: approve / deny per domain
+  Review --> Enforce: azureclaw egress --enforce
+  Enforce --> Learn: azureclaw egress --learn (rare)
 ```
+
 
 ## Operator Workflow
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -23,6 +23,32 @@ The same router, the same governance profile, the same audit chain, the same Net
 
 The CRD enum is the source of truth for which kinds exist; `controller/src/reconciler/runtime.rs` is the source of truth for which kinds resolve to a working pod.
 
+### How dispatch works
+
+When you `kubectl apply` a `ClawSandbox`, the reconciler reads `spec.runtime.kind` and calls a single `dispatch()` function that fans out to one producer per kind. Each producer returns a fully-formed pod plan; everything *outside* the runtime container — the inference router sidecar, the egress-guard init container, the `NetworkPolicy`, the WI federated credential — is identical across all kinds.
+
+```mermaid
+flowchart LR
+  CR["ClawSandbox<br/>spec.runtime.kind"] --> D{dispatch}
+  D -->|OpenClaw| P1["openclaw producer<br/>image: sandbox-images/openclaw"]
+  D -->|OpenAIAgents| P2["openai-agents producer"]
+  D -->|MicrosoftAgentFramework<br/>language: python| P3["maf-python producer"]
+  D -->|MicrosoftAgentFramework<br/>language: dotnet| P3X[("ShapeInvalid<br/>🚧 deferred")]
+  D -->|LangGraph<br/>language: python| P4["langgraph producer"]
+  D -->|LangGraph<br/>language: typescript| P4T["langgraph-ts producer"]
+  D -->|Anthropic| P5["anthropic producer"]
+  D -->|PydanticAi| P6["pydantic-ai producer"]
+  D -->|SemanticKernel| P7X[("AdapterMissing<br/>🚧 deferred")]
+  D -->|BYO| P8["BYO contract validation<br/>(image + ports + env)"]
+  P1 & P2 & P3 & P4 & P4T & P5 & P6 & P8 --> COMMON["Common shell:<br/>· inference-router sidecar<br/>· egress-guard init<br/>· NetworkPolicy<br/>· WI federated credential<br/>· governance ConfigMap"]
+  COMMON --> POD[("Sandbox Pod")]
+
+  classDef deferred fill:#f0f0f0,stroke:#999,stroke-dasharray:4 3,color:#666
+  class P3X,P7X deferred
+```
+
+Verified against `controller/src/reconciler/runtime.rs:249-400` (`kind_str`, the dispatch match, and the producers for each kind). `SemanticKernel` returns `AdapterMissing` and `MicrosoftAgentFramework` with `language: dotnet` returns `ShapeInvalid` — both surface as `Degraded` conditions on the CR.
+
 ---
 
 ## Why each first-class adapter exists

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,6 +100,29 @@ Sub-µs evaluation latency. Plugin-side AGT only handles E2E-encrypted mesh tran
 
 The router exposes four provider seams (`PolicyDecisionProvider`, `AuditSink`, `SigningProvider`, `MeshProvider`), three with in-tree implementations and one (`MeshProvider`) by-design plugin-side. See **[Architecture — provider seams](architecture.md)** if you need to plug in a custom backend.
 
+#### Per-request gate order
+
+The governance modules don't fire as one giant blob — they run in a fixed order on every action that reaches the router (model inference, tool invocation, mesh send). Reading `Governance::evaluate_with_context` in `inference-router/src/governance/mod.rs`:
+
+```mermaid
+flowchart LR
+  ACT["Action arrives<br/>(inference / tool / mesh)"] --> RL{"RateLimiter<br/>token bucket"}
+  RL -->|over budget| D1[("429 + audit 'denied'")]
+  RL -->|allowed| PE{"PolicyEngine<br/>YAML rules"}
+  PE -->|deny| D2[("403 + audit 'denied'")]
+  PE -->|allow| AU["AuditLogger<br/>append hash-chained entry"]
+  AU --> BM["BehaviorMonitor<br/>record + score"]
+  BM -->|anomaly| AL[("emit alert<br/>(does not block)")]
+  BM -->|normal| OK[("→ proceed")]
+
+  classDef deny fill:#fde2e1,stroke:#c0392b
+  classDef ok fill:#dff5e1,stroke:#27ae60
+  class D1,D2 deny
+  class OK ok
+```
+
+`TrustManager` is **not** on the per-request hot path — it is consulted at session establishment time on the mesh (see Layer 8) to decide whether to accept a KNOCK from a peer.
+
 ### Layer 8 — End-to-end encrypted mesh
 
 Inter-agent communication uses [Signal Protocol](https://signal.org/docs/) (X3DH + Double Ratchet) over a small relay/registry that AzureClaw operates. The relay sees only ciphertext and routing metadata. KNOCK-gated session establishment evaluates per-peer trust score against `AGT_TRUST_THRESHOLD`.


### PR DESCRIPTION
## Summary

Wave I of the docs revamp adds the missing "end-to-end CRD coherence" story and redistributes the most useful diagrams from the old monolithic `architecture-diagrams.md` (and the richer version on `main`) to their natural homes.

The user feedback driving this wave: *"CRDs are supposed to be our bread and butter but no-one really knows what happens if an MCP CRD is written"* and *"the diagrams are gold but they don't all have to be in the same document"*.

## What's new

| File | Change |
|---|---|
| `docs/api/lifecycle.md` | **New.** Two reconcile patterns, reconciler map for all 8 CRDs, per-CRD sequence diagrams (ClawSandbox heavyweight, InferencePolicy compile pattern, McpServer with JWKS, A2AAgent), status/conditions/requeue, deletion/finalizers. Every section cites code paths. |
| `docs/architecture.md` | Data-path Mermaid diagram added; corrected to reflect Foundry-inline DefaultV2 (no separate Content Safety service call). |
| `docs/runtimes.md` | Multi-runtime dispatch Mermaid; verified against `controller/src/reconciler/runtime.rs`. SemanticKernel and MAF .NET shown as 🚧 deferred. |
| `docs/security.md` | Per-request governance gate-order diagram (rate → policy → audit → behavior) under Layer 7, verified against `governance/mod.rs::evaluate_with_context`. |
| `docs/egress-proxy.md` | Mermaid flowchart for the egress decision pipeline + Learn → Enforce state machine. Verified against `forward_proxy.rs` + `blocklist.rs`. |
| `docs/architecture/a2a-gateway.md` | ASCII art → Mermaid sequence; threat-model and code-layout sections polished (stale "S3.5 / [GAP-V1] / Phase 2" framing removed). |
| `docs/SUMMARY.md` | Adds Lifecycle entry under API & policy. |

## What was deliberately *not* imported

Per the user's "don't blindly add everything, accuracy and Swiss precision matter" guidance:

- **Handoff sub-diagrams (§15, §16 on main)** — the feature is real (`inference-router/src/routes/handoff/`) but the main-branch state machine is dense and partially stale; deserves its own dedicated doc, not a copy-paste.
- **A2A exposure state machine** — the reconciler doesn't model an explicit state machine in code; importing one would be fabrication.
- **§3.3 "Operator Polish (S7.A/B/C/D/E)"** — useful content (leader election, jittered requeue, Progressing condition) is already covered as prose in lifecycle.md without the phase-ID labels.
- **§5 trust-gate decision flow** — referenced numeric thresholds that have drifted; left to a future security pass after re-reading `governance/trust_ops.rs` end-to-end.

## Verification

Every diagram added in this PR cites the file it was verified against:

- `controller/src/reconciler/runtime.rs:249-400` (runtime dispatch)
- `controller/src/{mcp_server,inference_policy,a2a_agent,...}_reconciler.rs` (reconcile patterns)
- `controller/src/reconciler/mod.rs` (ClawSandbox heavyweight flow)
- `inference-router/src/routes/chat_completions.rs:27-100` (data-path order)
- `inference-router/src/governance/mod.rs:359-414` (per-request gate order)
- `inference-router/src/forward_proxy.rs` + `blocklist.rs` (egress flow)
- `inference-router/src/safety.rs` (DefaultV2 inline; no separate CS call)

`mdbook build` is clean — no missing files, no warnings.
