### PR TITLE
docs: fix 27 broken intra-docs links

### DIFF
--- a/docs/architecture/agt-boundary.md
+++ b/docs/architecture/agt-boundary.md
@@ -74,4 +74,4 @@ Per-tenant override via `ClawSandbox.spec.agt.outageMode`.
 
 - This file is shared with the AGT team for confirmation as a living seam document.
 - Disagreements are resolved by: (a) AGT's ownership wins if they commit to shipping; (b) AzureClaw picks it up temporarily if they cannot commit; (c) the scope is documented here and in the relevant security-audit doc.
-- AGT Rust SDK releases trigger `ci/vendored-patch-audit.sh` re-runs (see [`docs/internal/agt-vendored-patch-audit.md`](../agt-vendored-patch-audit.md)).
+- AGT Rust SDK releases trigger `ci/vendored-patch-audit.sh` re-runs.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -250,7 +250,7 @@ azureclaw add my-agent --runtime byo --byo-image myacr.azurecr.io/my-agent:lates
 azureclaw add reviewer --dry-run
 ```
 
-**See also:** [docs/api/crd-reference.md](api/crd-reference.md), [docs/runtime-contract.md](runtime-contract.md), [docs/channels-plugins.md](channels-plugins.md)
+**See also:** [docs/api/crd-reference.md](api/crd-reference.md), [docs/runtimes.md](runtimes.md), [docs/channels-plugins.md](channels-plugins.md)
 
 ---
 
@@ -340,7 +340,7 @@ azureclaw push --only controller
 Translates manifests between `ClawSandbox` and the upstream
 `agents.x-k8s.io/v1alpha1 Sandbox` format (and the `overlay` variant). Hard-fails
 on lossy translations by default; pass `--allow-lossy` to proceed with
-warnings. See [docs/internal/sigs-agent-sandbox-compat.md](sigs-agent-sandbox-compat.md)
+warnings. See `docs/internal/sigs-agent-sandbox-compat.md` (internal)
 for the normative field mapping.
 
 **Usage:**
@@ -369,7 +369,7 @@ azureclaw convert -f clawsandbox.yaml --to upstream-sandbox --allow-lossy
 azureclaw convert -f sandbox.yaml --to overlay --sandbox-ref=prod/web
 ```
 
-**See also:** [docs/internal/sigs-agent-sandbox-compat.md](sigs-agent-sandbox-compat.md)
+**See also:** `docs/internal/sigs-agent-sandbox-compat.md` (internal)
 
 ---
 
@@ -436,7 +436,7 @@ azureclaw migrate from-kagent agent.yaml --isolation enhanced --out-dir ./manife
 cat kagent-agent.yaml | azureclaw migrate from-kagent -
 ```
 
-**See also:** [docs/internal/sigs-agent-sandbox-compat.md](sigs-agent-sandbox-compat.md)
+**See also:** `docs/internal/sigs-agent-sandbox-compat.md` (internal)
 
 ---
 
@@ -565,7 +565,7 @@ azureclaw handoff my-agent --status
 azureclaw handoff my-agent --abort
 ```
 
-**See also:** [docs/architecture.md](architecture.md), [docs/internal/e2e-encryption-proof.md](e2e-encryption-proof.md)
+**See also:** [docs/architecture.md](architecture.md), `docs/internal/e2e-encryption-proof.md` (internal)
 
 ---
 
@@ -937,7 +937,7 @@ azureclaw egress my-agent --enforce --emit-manifest ./patches/egress-my-agent.ya
 azureclaw egress my-agent --approve api.github.com --sign-mode keyed --sign-key azurekms://myvault.vault.azure.net/keys/cosign
 ```
 
-**See also:** [docs/egress-proxy.md](egress-proxy.md), [docs/internal/policy-canonical-format.md](policy-canonical-format.md)
+**See also:** [docs/egress-proxy.md](egress-proxy.md), `docs/internal/policy-canonical-format.md` (internal)
 
 ---
 
@@ -1107,7 +1107,7 @@ azureclaw mesh demote
 azureclaw mesh unpair --name my-peer
 ```
 
-**See also:** [docs/internal/e2e-encryption-proof.md](e2e-encryption-proof.md)
+**See also:** `docs/internal/e2e-encryption-proof.md` (internal)
 
 ---
 
@@ -1164,7 +1164,7 @@ azureclaw pair inspect my-peer
 azureclaw pair revoke my-peer
 ```
 
-**See also:** [docs/internal/e2e-encryption-proof.md](e2e-encryption-proof.md)
+**See also:** `docs/internal/e2e-encryption-proof.md` (internal)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,7 +90,7 @@ az login
 az account set --subscription <your-subscription-id>
 ```
 
-You need permission to create resource groups, AKS clusters, ACRs, Foundry resources, and federated credentials in your subscription. (`Contributor` + `User Access Administrator` is sufficient; tighter scoping is documented in [`docs/operations/least-privilege.md`](operations/least-privilege.md) when present.)
+You need permission to create resource groups, AKS clusters, ACRs, Foundry resources, and federated credentials in your subscription.. `Contributor` + `User Access Administrator` is sufficient.
 
 ### 2.2 Bring it up
 

--- a/docs/operations/byo-strict.md
+++ b/docs/operations/byo-strict.md
@@ -87,6 +87,6 @@ If you have existing BYO sandboxes:
 
 ## Related
 
-- [`docs/byo-runtime-contract.md`](../byo-runtime-contract.md) — the contract itself
+- [`docs/runtimes.md`](../runtimes.md) — the BYO runtime contract
 - [`examples/byo-quickstart/`](../../examples/byo-quickstart/) — minimal working sandbox
 - [`controller/src/reconciler/byo_contract.rs`](../../controller/src/reconciler/byo_contract.rs) — implementation

--- a/docs/operations/gitops.md
+++ b/docs/operations/gitops.md
@@ -3,7 +3,7 @@
 This walkthrough covers the **sign-by-default** + **`--emit-manifest`**
 GitOps workflow shipped in slice S12.g (the close-out for S12). It
 assumes you have already followed
-[`docs/internal/policy-canonical-format.md`](../policy-canonical-format.md) for
+`docs/internal/policy-canonical-format.md` (internal) for
 the v1 canonical egress allowlist format and that your cluster has a
 `SignerPolicy` ConfigMap installed (S12.d).
 
@@ -195,4 +195,4 @@ flow needed in CI.
 `azureclaw migrate from-kagent` now emits a one-line "Next step" hint
 when the translated bundle includes an egress allowlist, pointing
 operators directly at the GitOps `--emit-manifest` flow. See
-[`docs/internal/policy-canonical-format.md`](../policy-canonical-format.md).
+`docs/internal/policy-canonical-format.md` (internal).

--- a/docs/security-validation.md
+++ b/docs/security-validation.md
@@ -252,7 +252,7 @@ Different session UUIDs confirm independent cryptographic sessions.
 | Router (WebSocket bridge) | Same as relay — opaque forwarding | ❌ No |
 | Gateway (endpoint) | Decrypted plaintext: "16" | ✅ Yes |
 
-Full hex-dump analysis: [`docs/internal/e2e-encryption-proof.md`](e2e-encryption-proof.md)
+Full hex-dump analysis: `docs/internal/e2e-encryption-proof.md` (internal companion).
 
 ---
 

--- a/docs/security/red-team.md
+++ b/docs/security/red-team.md
@@ -27,7 +27,7 @@ Each finding records: ID, date, surface, severity, summary, status, fix commit /
 
 ### Phase 0 + Phase 1 baseline
 
-The Phase 0 + 1 surface was exercised against the threat model in [`docs/internal/threat-model.md`](../threat-model.md) and [`security/stride.md`](../security/stride.md) before v1.0 cut. Findings closed during that window are not enumerated here individually — the per-capability sign-off lives under [`docs/internal/security-audits/`](../security-audits/).
+The Phase 0 + 1 surface was exercised against the threat model in `docs/internal/threat-model.md` (internal) and [`security/stride.md`](../security/stride.md) before v1.0 cut. Findings closed during that window are not enumerated here individually — the per-capability sign-off lives under `docs/internal/security-audits/` (internal).
 
 ### Phase 2
 

--- a/docs/security/stride.md
+++ b/docs/security/stride.md
@@ -1,6 +1,6 @@
 # STRIDE Threat Model — AzureClaw
 
-> Companion to [`docs/internal/threat-model.md`](../threat-model.md) (per-route inference-router model) and [`docs/security.md`](../security.md) (defense-in-depth layers). This document classifies the threats AzureClaw mitigates using STRIDE (Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege) across the four primary trust boundaries.
+> Companion to `docs/internal/threat-model.md` (internal) (per-route inference-router model) and [`docs/security.md`](../security.md) (defense-in-depth layers). This document classifies the threats AzureClaw mitigates using STRIDE (Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege) across the four primary trust boundaries.
 
 ## Trust boundaries
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -7,11 +7,11 @@ Six fully-shipped use cases covering every deployment pattern from laptop inner-
 | # | Scenario | Where the user runs | Network shape | Status | Reference |
 |---|---|---|---|---|---|
 | 1 | **AzureClaw-native agents (OpenClaw)** | AKS (operator owns the cluster) | Cluster-internal | ✅ Shipping | [`docs/architecture.md`](architecture.md) |
-| 2 | **Any-OpenClaw → AzureClaw cloud offload** | Laptop / NemoClaw / any OpenClaw host (no AzureClaw CLI required) | Host ↔ AKS via AgentMesh relay (E2E-encrypted) | ✅ Shipping | [`docs/internal/any-openclaw-cloud-offload.md`](any-openclaw-cloud-offload.md) |
-| 3 | **AzureClaw ↔ AzureClaw mesh** | Two AKS-hosted agents, single or multiple clusters | Cluster ↔ cluster via AgentMesh relay (E2E-encrypted) | ✅ Shipping | [`docs/internal/e2e-encryption-proof.md`](e2e-encryption-proof.md) |
+| 2 | **Any-OpenClaw → AzureClaw cloud offload** | Laptop / NemoClaw / any OpenClaw host (no AzureClaw CLI required) | Host ↔ AKS via AgentMesh relay (E2E-encrypted) | ✅ Shipping | `docs/internal/any-openclaw-cloud-offload.md` (internal) |
+| 3 | **AzureClaw ↔ AzureClaw mesh** | Two AKS-hosted agents, single or multiple clusters | Cluster ↔ cluster via AgentMesh relay (E2E-encrypted) | ✅ Shipping | `docs/internal/e2e-encryption-proof.md` (internal) |
 | 4 | **Multi-runtime hosting** | AKS (same operator, different agent stacks) | Cluster-internal per sandbox | ✅ Shipping (OpenClaw, OpenAIAgents, MAF Python, LangGraph Py+TS, Anthropic, PydanticAi, BYO) | [`docs/runtimes.md`](runtimes.md) |
 | 5 | **A2A federation across organisations** | Foreign agent anywhere; inbound via public a2a-gateway | Internet → A2A gateway → per-sandbox router (mTLS-pinned) | ✅ Shipping | [`docs/adr/0001-a2a-ingress-front-edge.md`](adr/0001-a2a-ingress-front-edge.md) |
-| 6 | **Migration from kagent or `sigs/agent-sandbox`** | Source cluster (any) → AzureClaw cluster | Translate + apply | ✅ Shipping | [`docs/internal/sigs-agent-sandbox-compat.md`](sigs-agent-sandbox-compat.md) |
+| 6 | **Migration from kagent or `sigs/agent-sandbox`** | Source cluster (any) → AzureClaw cluster | Translate + apply | ✅ Shipping | `docs/internal/sigs-agent-sandbox-compat.md` (internal) |
 
 All use cases share the same trust boundary:
 
@@ -168,7 +168,7 @@ spec:
 
 ### What the operator wants
 
-The defining property of this scenario is that **the plugin user does not install AzureClaw**. They install the `azureclaw-mesh` plugin into their existing OpenClaw host. An AzureClaw operator runs the AKS cluster, mints a one-time pairing token, and sends it to the user over any secure channel. See [`docs/internal/any-openclaw-cloud-offload.md`](any-openclaw-cloud-offload.md) for the full walkthrough.
+The defining property of this scenario is that **the plugin user does not install AzureClaw**. They install the `azureclaw-mesh` plugin into their existing OpenClaw host. An AzureClaw operator runs the AKS cluster, mints a one-time pairing token, and sends it to the user over any secure channel. See `docs/internal/any-openclaw-cloud-offload.md` (internal) for the full walkthrough.
 
 ### Topology
 
@@ -267,10 +267,10 @@ spec:
 | Resource | Reference |
 |---|---|
 | Blueprint | [Blueprint 03 — Managed public offload](blueprints/03-managed-public-offload.md) |
-| Full walkthrough | [`docs/internal/any-openclaw-cloud-offload.md`](any-openclaw-cloud-offload.md) |
+| Full walkthrough | `docs/internal/any-openclaw-cloud-offload.md` (internal) |
 | CLI commands | [`azureclaw mesh`](cli-reference.md#azureclaw-mesh), [`azureclaw pair`](cli-reference.md#azureclaw-pair) |
 | CRD fields | [`ClawPairing`](api/crd-reference.md#clawpairing), [`spec.governance`](api/crd-reference.md#spec-fields--specgovernance) |
-| E2E proof | [`docs/internal/e2e-encryption-proof.md`](e2e-encryption-proof.md) |
+| E2E proof | `docs/internal/e2e-encryption-proof.md` (internal) |
 
 ---
 
@@ -383,7 +383,7 @@ spec:
 | Blueprint | [Blueprint 04 — Cross-org federation](blueprints/04-cross-org-federation.md) |
 | CLI commands | [`azureclaw mesh`](cli-reference.md#azureclaw-mesh), [`azureclaw pair`](cli-reference.md#azureclaw-pair), [`azureclaw up --expose-registry`](cli-reference.md#azureclaw-up) |
 | CRD fields | [`ClawPairing`](api/crd-reference.md#clawpairing), [`spec.governance.registryMode`](api/crd-reference.md#spec-fields--specgovernance) |
-| E2E proof | [`docs/internal/e2e-encryption-proof.md`](e2e-encryption-proof.md) |
+| E2E proof | `docs/internal/e2e-encryption-proof.md` (internal) |
 | ADR | [`docs/adr/0001-a2a-ingress-front-edge.md`](adr/0001-a2a-ingress-front-edge.md) |
 
 ---
@@ -559,7 +559,7 @@ spec:
     defaultDeny: true
 ```
 
-> **BYO contract requirement:** the image label `org.azureclaw.runtime.contract=v1` must be present. Images without this label are rejected at admission. See [`docs/runtime-contract.md`](runtime-contract.md) for the full contract specification.
+> **BYO contract requirement:** the image label `org.azureclaw.runtime.contract=v1` must be present. Images without this label are rejected at admission. See [`docs/runtimes.md`](runtimes.md) for the full contract specification.
 
 ### What you get regardless of runtime
 
@@ -576,7 +576,7 @@ spec:
 |---|---|
 | CRD fields | [`spec.runtime`](api/crd-reference.md#spec-fields--specruntime), [`InferencePolicy`](api/crd-reference.md#inferencepolicy), [`ToolPolicy`](api/crd-reference.md#toolpolicy), [`ClawMemory`](api/crd-reference.md#clawmemory), [`ClawEval`](api/crd-reference.md#claweval) |
 | CLI commands | [`azureclaw add --runtime`](cli-reference.md#azureclaw-add), [`azureclaw add --byo-image`](cli-reference.md#azureclaw-add) |
-| BYO contract | [`docs/runtime-contract.md`](runtime-contract.md) |
+| BYO contract | [`docs/runtimes.md`](runtimes.md) |
 | Conditions | [`RuntimeReady`, `AdapterMissing`](api/crd-reference.md#conditions-emitted) |
 
 ---
@@ -742,7 +742,7 @@ spec:
 
 ### What the operator wants
 
-A translator that converts existing agent manifests into AzureClaw resource bundles, with explicit warnings for lossy fields and a dry-run path. See [`docs/internal/sigs-agent-sandbox-compat.md`](sigs-agent-sandbox-compat.md) for the full field-mapping table and the three compatibility modes (`Native`, `Translate`, `Overlay`).
+A translator that converts existing agent manifests into AzureClaw resource bundles, with explicit warnings for lossy fields and a dry-run path. See `docs/internal/sigs-agent-sandbox-compat.md` (internal) for the full field-mapping table and the three compatibility modes (`Native`, `Translate`, `Overlay`).
 
 ### Topology — migration flow
 
@@ -874,7 +874,7 @@ All dropped fields default to `disabled` (dev-only label applied automatically) 
 
 | Resource | Reference |
 |---|---|
-| Compat design | [`docs/internal/sigs-agent-sandbox-compat.md`](sigs-agent-sandbox-compat.md) |
+| Compat design | `docs/internal/sigs-agent-sandbox-compat.md` (internal) |
 | CLI commands | [`azureclaw migrate from-kagent`](cli-reference.md#azureclaw-migrate), [`azureclaw migrate to-overlay`](cli-reference.md#azureclaw-migrate), [`azureclaw convert`](cli-reference.md#azureclaw-convert) |
 | CRD fields | [`spec.upstreamCompatibility`](api/crd-reference.md#spec-fields--specupstreamcompatibility) |
 | Blueprint | [Blueprint 02 — Enterprise self-hosted](blueprints/02-enterprise-self-hosted.md) |


### PR DESCRIPTION
Sweep + fix of 27 dangling links left by earlier waves that demoted internal-only files to docs/internal/ (which is gitignored). Zero broken intra-docs links remaining; mdbook clean.