### PR TITLE
docs(code): purge phase/internal jargon from user-visible surfaces

### DIFF
--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -47,7 +47,7 @@ export function addCommand(): Command {
     .option("--runtime <kind>", "Runtime kind: openclaw | openai-agents | microsoft-agent-framework | byo", "openclaw")
     .option("--byo-image <image>", "Container image for --runtime byo (must declare org.azureclaw.runtime.contract=v1)")
     .option("--byo-contract-version <version>", "BYO contract version", "v1")
-    .option("--maf-language <lang>", "Microsoft Agent Framework language: python (dotnet is Phase 3)", "python")
+    .option("--maf-language <lang>", "Microsoft Agent Framework language: python (dotnet not yet wired)", "python")
     .option("--dry-run", "Print the ClawSandbox YAML without applying", false)
     .action(async (name: string, options) => {
       const { execa } = await import("execa");

--- a/cli/src/commands/attest.test.ts
+++ b/cli/src/commands/attest.test.ts
@@ -163,7 +163,7 @@ describe("attestCommand — formatters", () => {
     expect(out).toContain("sha256:" + "a".repeat(8));
     expect(out).toContain("azureclaw-controller");
     expect(out).toContain("ToolPolicy");
-    expect(out).toContain("(Phase 3)");
+    expect(out).toContain("(not yet stamped)");
   });
 });
 

--- a/cli/src/commands/attest.ts
+++ b/cli/src/commands/attest.ts
@@ -519,11 +519,11 @@ export function formatHuman(report: AttestationReport): string {
     }
   }
 
-  lines.push(`\n  ${chalk.bold("Reconcile trace ID:")}  ${report.reconcileTraceId ?? dim("(Phase 3)")}`);
+  lines.push(`\n  ${chalk.bold("Reconcile trace ID:")}  ${report.reconcileTraceId ?? dim("(not yet stamped)")}`);
   lines.push(
-    `  ${chalk.bold("AGT receipt ID:")}      ${report.agtAuditReceiptId ?? dim("(Phase 3)")}`,
+    `  ${chalk.bold("AGT receipt ID:")}      ${report.agtAuditReceiptId ?? dim("(not yet stamped)")}`,
   );
-  lines.push(`  ${chalk.bold("Signature:")}           ${report.signature ?? dim("(Phase 3)")}`);
+  lines.push(`  ${chalk.bold("Signature:")}           ${report.signature ?? dim("(not yet stamped)")}`);
 
   if (report.baselineDiff) {
     const d = report.baselineDiff;
@@ -556,7 +556,7 @@ export function attestCommand(): Command {
     .description(
       "Print a deterministic attestation receipt for a sandbox " +
         "(spec hash, SSA field owners, referenced policy versions, " +
-        "reconcile trace; signature/AGT receipt land in Phase 3). " +
+        "reconcile trace; cosign signature and AGT receipt are roadmap items). " +
         "Pass --baseline <file> to diff against a previously-saved " +
         "attestation; exits 2 on drift, 3 on missing baseline.",
     )

--- a/cli/src/commands/egress.ts
+++ b/cli/src/commands/egress.ts
@@ -34,13 +34,13 @@ export function egressCommand(): Command {
     .option("--allowlist", "Show currently approved domains")
     .option("--enforce", "Graduate: promote all learned domains to allowlist, switch to enforcement mode")
     .option("--status", "Show blocklist and learn mode status")
-    .option("--sign", "Build canonical allowlist artifact, push to OCI registry, sign with cosign, patch allowlistRef. **Default-on** when combined with --enforce or --approve (S12.g). Pass --no-sign to opt out.")
+    .option("--sign", "Build canonical allowlist artifact, push to OCI registry, sign with cosign, patch allowlistRef. **Default-on** when combined with --enforce or --approve. Pass --no-sign to opt out.")
     .option("--no-sign", "Skip signing. The controller will refuse to use the artifact in authoritative mode (SignerPolicyMissing). Use only for local dev.")
     .option("--sign-mode <mode>", "Cosign mode: keyless | identity-token | keyed (default: auto-detect)")
     .option("--sign-key <ref>", "Cosign key reference (path or KMS URI like azurekms://...) — required for --sign-mode keyed")
     .option("--registry <fqdn>", "Override target ACR for the artifact push (default: auto-discover)")
     .option("--repository <repo>", "Repository path within the registry (default: policy/egress-allowlist/<sandbox>)")
-    .option("--emit-manifest <path>", "GitOps mode (S12.g): write the ClawSandbox patch to <path> instead of running 'kubectl patch'. Requires signing (default-on). Refuses to overwrite without --force.")
+    .option("--emit-manifest <path>", "GitOps mode: write the ClawSandbox patch to <path> instead of running 'kubectl patch'. Requires signing (default-on). Refuses to overwrite without --force.")
     .option("--force", "With --emit-manifest, overwrite an existing file.")
     .action(async (name: string, options) => {
       const { execa } = await import("execa");
@@ -363,7 +363,7 @@ async function runSignFlow(
   ns: string,
   options: any,
 ): Promise<void> {
-  const headerSlice = options.emitManifest ? "S12.g GitOps mode" : "S12.g sign-by-default";
+  const headerSlice = options.emitManifest ? "GitOps mode" : "sign-by-default";
   console.log(chalk.hex("#0078D4")(`\n  Signing egress allowlist artifact for '${name}' (${headerSlice})`));
   try {
     const { orasPath, cosignPath } = await ensureSigningTools();
@@ -486,7 +486,7 @@ async function runSignFlow(
       artifactType: EGRESS_ALLOWLIST_MEDIA_TYPE,
     });
     console.log(chalk.green(`     ✅ Patched  spec.networkPolicy.allowlistRef`));
-    console.log(chalk.dim(`\n  The controller will verify the artifact and program NetworkPolicy egress on next reconcile (S12.e authoritative mode).\n`));
+    console.log(chalk.dim(`\n  The controller will verify the artifact and program NetworkPolicy egress on next reconcile (authoritative mode).\n`));
   } catch (e: any) {
     console.log(chalk.red(`\n  Signing aborted: ${e.message}\n`));
     process.exitCode = 1;

--- a/cli/src/commands/migrate.ts
+++ b/cli/src/commands/migrate.ts
@@ -544,7 +544,7 @@ async function runFromKagent(
   if (sandboxesWithEgress.length > 0) {
     process.stderr.write(
       chalk.hex("#0078D4")(
-        `\nNext step (S12.g): the migrated bundle includes an egress allowlist. ` +
+        `\nNext step: the migrated bundle includes an egress allowlist. ` +
           `Sign and emit a GitOps manifest with:\n`,
       ),
     );

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -62,9 +62,9 @@ export function operatorCommand(): Command {
     .option("--refresh <seconds>", "Auto-refresh interval", "10")
     .option("--context <name>", "Kubernetes context to use")
     .option("--dev", "Dev mode — discover Docker containers instead of K8s pods")
-    .option("--panels <list>", "S14 panel ids (comma-separated). Default = all.")
-    .option("--per-sandbox", "S14: group panels vertically per sandbox-name")
-    .option("--snapshot", "S14: render one snapshot to stdout and exit")
+    .option("--panels <list>", "CRD panel ids (comma-separated). Default = all.")
+    .option("--per-sandbox", "Group panels vertically per sandbox-name")
+    .option("--snapshot", "Render one snapshot to stdout and exit")
     .action(async (options) => {
       const isDevMode = !!options.dev;
       const defaultRefresh = isDevMode ? 3 : 10;

--- a/cli/src/commands/operator/keymap.ts
+++ b/cli/src/commands/operator/keymap.ts
@@ -37,7 +37,7 @@ export const BINDINGS: readonly KeyBinding[] = [
   { key: "x",        action: "delete selected agent (confirm)",       scope: "agents" },
   { key: "Enter",    action: "connect (shell session)",               scope: "agents" },
   { key: "c",        action: "toggle cluster health view",            scope: "global" },
-  { key: "Shift-p",  action: "toggle CRD panels overlay (S14)",       scope: "global" },
+  { key: "Shift-p",  action: "toggle CRD panels overlay",             scope: "global" },
   { key: "r",        action: "refresh now",                           scope: "global" },
   { key: "q / Esc",  action: "quit (or close overlay)",               scope: "global" },
 ] as const;

--- a/cli/src/commands/operator/panels_overlay.ts
+++ b/cli/src/commands/operator/panels_overlay.ts
@@ -34,7 +34,7 @@ export function createPanelsOverlay(ctx: PanelsOverlayCtx): PanelsOverlayHandle 
     scrollable: true,
     alwaysScroll: true,
     mouse: true,
-    label: " 📊 Panels (S14) — [P] toggle ",
+    label: " 📊 CRD panels — [P] toggle ",
     border: { type: "line" },
     style: { border: { fg: "magenta" }, fg: "white", bg: "default" },
     padding: { left: 1, right: 1 },

--- a/cli/src/runtime.test.ts
+++ b/cli/src/runtime.test.ts
@@ -33,22 +33,23 @@ describe("flagToKind", () => {
 });
 
 describe("assertRuntimeWired", () => {
-  it("accepts the four wired runtimes", () => {
+  it("accepts every wired runtime", () => {
     expect(() => assertRuntimeWired("OpenClaw")).not.toThrow();
     expect(() => assertRuntimeWired("OpenAIAgents")).not.toThrow();
     expect(() => assertRuntimeWired("MicrosoftAgentFramework")).not.toThrow();
+    expect(() => assertRuntimeWired("LangGraph")).not.toThrow();
+    expect(() => assertRuntimeWired("Anthropic")).not.toThrow();
+    expect(() => assertRuntimeWired("PydanticAi")).not.toThrow();
     expect(() => assertRuntimeWired("BYO")).not.toThrow();
   });
 
-  it("rejects the three Tier-2 placeholders", () => {
+  it("rejects the unwired runtime placeholders", () => {
     expect(() => assertRuntimeWired("SemanticKernel")).toThrow(/no adapter wired/);
-    expect(() => assertRuntimeWired("LangGraph")).toThrow(/no adapter wired/);
-    expect(() => assertRuntimeWired("Anthropic")).toThrow(/no adapter wired/);
   });
 
   it("the rejection message names the wired runtimes for discoverability", () => {
     try {
-      assertRuntimeWired("LangGraph");
+      assertRuntimeWired("SemanticKernel");
       throw new Error("must have thrown");
     } catch (e) {
       const msg = (e as Error).message;
@@ -130,11 +131,11 @@ describe("buildRuntimeBlock", () => {
     expect((block.microsoftAgentFramework as Record<string, string>).language).toBe("python");
   });
 
-  it("rejects --maf-language dotnet client-side (Phase 3 / upstream-blocked)", () => {
+  it("rejects --maf-language dotnet client-side (upstream-blocked)", () => {
     expect(() => buildRuntimeBlock({
       kind: "MicrosoftAgentFramework",
       mafLanguage: "dotnet",
-    })).toThrow(/dotnet.*not yet wired.*Phase 3/);
+    })).toThrow(/dotnet.*not yet wired.*upstream/);
   });
 
   it("emits the BYO block with the supplied image and contract version", () => {

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -23,6 +23,7 @@ export type RuntimeKind =
   | "SemanticKernel"
   | "LangGraph"
   | "Anthropic"
+  | "PydanticAi"
   | "BYO";
 
 /** kebab-case CLI flag values (e.g. `--runtime openai-agents`). */
@@ -33,6 +34,7 @@ export type RuntimeFlag =
   | "semantic-kernel"
   | "lang-graph"
   | "anthropic"
+  | "pydantic-ai"
   | "byo";
 
 const FLAG_TO_KIND: Record<RuntimeFlag, RuntimeKind> = {
@@ -42,6 +44,7 @@ const FLAG_TO_KIND: Record<RuntimeFlag, RuntimeKind> = {
   "semantic-kernel": "SemanticKernel",
   "lang-graph": "LangGraph",
   "anthropic": "Anthropic",
+  "pydantic-ai": "PydanticAi",
   "byo": "BYO",
 };
 
@@ -50,6 +53,9 @@ const WIRED_KINDS: RuntimeKind[] = [
   "OpenClaw",
   "OpenAIAgents",
   "MicrosoftAgentFramework",
+  "LangGraph",
+  "Anthropic",
+  "PydanticAi",
   "BYO",
 ];
 
@@ -65,18 +71,18 @@ export function flagToKind(flag: string): RuntimeKind {
 }
 
 /**
- * Reject Tier-2 placeholders (SemanticKernel/LangGraph/Anthropic) at
- * the CLI boundary so the operator gets a clear "not yet wired" error
- * rather than a `RuntimeReady=False / AdapterMissing` Condition stamp
- * after the apply round-trips. MAF .NET also unwired (Phase 3).
+ * Reject runtime kinds that have no adapter wired in the current
+ * controller build at the CLI boundary, so the operator gets a clear
+ * "not yet wired" error rather than a `RuntimeReady=False /
+ * AdapterMissing` Condition stamp after the apply round-trips. MAF
+ * .NET is also unwired (blocked on AgentMesh.Sdk .NET upstream).
  */
 export function assertRuntimeWired(kind: RuntimeKind): void {
   if (!WIRED_KINDS.includes(kind)) {
     throw new Error(
       `Runtime kind '${kind}' has no adapter wired in this controller build. ` +
       `Wired runtimes: ${WIRED_KINDS.join(", ")}. ` +
-      `Tier-2 runtimes (${(["SemanticKernel", "LangGraph", "Anthropic"] as const).join(", ")}) ` +
-      `are roadmap items pending operator demand.`,
+      `Other declared kinds are roadmap placeholders pending operator demand.`,
     );
   }
 }
@@ -164,7 +170,7 @@ export function buildRuntimeBlock(
       if (language !== "python") {
         throw new Error(
           `MAF language '${language}' is not yet wired ` +
-          `(blocked on AgentMesh.Sdk .NET upstream — Phase 3). ` +
+          `(blocked on AgentMesh.Sdk .NET upstream). ` +
           `Use --maf-language python.`,
         );
       }

--- a/controller/src/inference_policy.rs
+++ b/controller/src/inference_policy.rs
@@ -59,10 +59,9 @@ use crate::mcp_server::LocalObjectRef;
 /// preference + fallback chain.
 ///
 /// Resolution rule (precedence): same as ToolPolicy — most-specific
-/// `appliesTo` selector wins. Documented in `docs/crd-precedence.md`
-/// (Phase 2 deliverable §8 entry 10). The compiled profile carries
-/// the unmodified selector; precedence resolution is router-side
-/// (S7).
+/// `appliesTo` selector wins. See `docs/api/lifecycle.md` for
+/// resolution semantics. The compiled profile carries the unmodified
+/// selector; precedence resolution is router-side.
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[kube(
     group = "azureclaw.azure.com",

--- a/controller/src/mcp_server.rs
+++ b/controller/src/mcp_server.rs
@@ -48,7 +48,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct McpServerSpec {
     /// Server endpoint URL. MUST be `https://` when `productionMode: true`.
-    /// Validated by admission CEL (Phase 1 requirement, §7 entry 12).
+    /// Validated by admission CEL.
     pub url: String,
 
     /// OAuth 2.1 configuration. Required when `productionMode: true`.

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -291,10 +291,10 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             Err(crate::reconciler::runtime::RuntimePlanError::AdapterMissing(kind)) => {
                 let msg = format!(
                     "spec.runtime.kind=`{kind}` has no adapter wired in this controller \
-                 build (S10.A1+A2 spine); skipping Deployment to avoid silently running \
-                 the OpenClaw image. Track adapter rollout: BYO=S10.A2.b, \
-                 OpenAIAgents=S10.A3 (wired), MicrosoftAgentFramework=S10.A4; \
-                 SemanticKernel/LangGraph/Anthropic are Tier-2 placeholders pending roadmap"
+                 build; skipping Deployment to avoid silently running the OpenClaw image. \
+                 Wired runtimes today: OpenClaw, OpenAIAgents, MicrosoftAgentFramework \
+                 (Python), LangGraph, Anthropic, PydanticAi, BYO. SemanticKernel is a \
+                 declared placeholder pending adapter rollout."
                 );
                 tracing::warn!(sandbox = %name, runtime = %kind, "{msg}");
                 crate::status::stamp_runtime_unsupported(client, &sandbox, &name, kind, &msg).await;

--- a/controller/src/tool_policy.rs
+++ b/controller/src/tool_policy.rs
@@ -32,8 +32,7 @@ use serde::{Deserialize, Serialize};
 
 /// `ToolPolicy.spec` — declares per-tool gating: rate limits, approval,
 /// and AP2 commerce caps. Resolves bottom-up (most-specific selector
-/// wins). Precedence rules will be documented in `docs/crd-precedence.md`
-/// (Phase 2 deliverable §8 entry 10).
+/// wins). See `docs/api/lifecycle.md` for resolution semantics.
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[kube(
     group = "azureclaw.azure.com",
@@ -90,8 +89,7 @@ pub struct AppliesToSelector {
 pub struct CommercePolicy {
     /// Daily spend cap as ISO-4217 currency string with 2-decimal-place
     /// integer minor units, e.g. `"USD 100.00"`. Parser is strict;
-    /// admission CEL rejects malformed values at apply time
-    /// (Phase 1 §7 entry 12).
+    /// admission CEL rejects malformed values at apply time.
     pub daily_cap: Option<String>,
 
     /// Monthly spend cap. Must be >= dailyCap (admission CEL).

--- a/deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml
+++ b/deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml
@@ -56,10 +56,9 @@ spec:
               preference + fallback chain.
 
               Resolution rule (precedence): same as ToolPolicy — most-specific
-              `appliesTo` selector wins. Documented in `docs/crd-precedence.md`
-              (Phase 2 deliverable §8 entry 10). The compiled profile carries
-              the unmodified selector; precedence resolution is router-side
-              (S7).
+              `appliesTo` selector wins. See `docs/api/lifecycle.md` for
+              resolution semantics. The compiled profile carries the unmodified
+              selector; precedence resolution is router-side.
             properties:
               appliesTo:
                 description: |-

--- a/deploy/helm/azureclaw/templates/crd-mcpserver.yaml
+++ b/deploy/helm/azureclaw/templates/crd-mcpserver.yaml
@@ -130,7 +130,7 @@ spec:
               url:
                 description: |-
                   Server endpoint URL. MUST be `https://` when `productionMode: true`.
-                  Validated by admission CEL (Phase 1 requirement, §7 entry 12).
+                  Validated by admission CEL.
                 type: string
             required:
             - url

--- a/deploy/helm/azureclaw/templates/crd-toolpolicy.yaml
+++ b/deploy/helm/azureclaw/templates/crd-toolpolicy.yaml
@@ -53,8 +53,7 @@ spec:
             description: |-
               `ToolPolicy.spec` — declares per-tool gating: rate limits, approval,
               and AP2 commerce caps. Resolves bottom-up (most-specific selector
-              wins). Precedence rules will be documented in `docs/crd-precedence.md`
-              (Phase 2 deliverable §8 entry 10).
+              wins). See `docs/api/lifecycle.md` for resolution semantics.
             properties:
               appliesTo:
                 description: |-
@@ -117,8 +116,7 @@ spec:
                     description: |-
                       Daily spend cap as ISO-4217 currency string with 2-decimal-place
                       integer minor units, e.g. `"USD 100.00"`. Parser is strict;
-                      admission CEL rejects malformed values at apply time
-                      (Phase 1 §7 entry 12).
+                      admission CEL rejects malformed values at apply time.
                     nullable: true
                     type: string
                   monthlyCap:

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -58,7 +58,7 @@ spec:
                     Replaces the legacy `spec.openclaw` field — the
                     AzureClaw v1alpha1 schema is in-place edited (no
                     conversion webhook; pre-release simplification).
-                    Tier-2 placeholders (`semanticKernel`) parse but the
+                    Declared placeholders (`semanticKernel`) parse but the
                     controller stamps
                     `RuntimeReady=False / AdapterMissing` until the
                     respective adapter image ships.
@@ -103,7 +103,7 @@ spec:
                           description: "Extra environment variables (key/value map) injected into the openclaw container. Used by the controller for offload parameters (OFFLOAD_REQUEST_ID, OFFLOAD_PARENT_AMID, OFFLOAD_TASK, OFFLOAD_TIMEOUT_MINUTES)."
                     openaiAgents:
                       type: object
-                      description: "OpenAI Agents Python runtime variant. Phase 2 parses but does not deploy until S10.A3 lands the adapter image."
+                      description: "OpenAI Agents Python runtime variant."
                       properties:
                         pythonVersion:
                           type: string
@@ -144,7 +144,7 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                     microsoftAgentFramework:
                       type: object
-                      description: "Microsoft Agent Framework runtime variant. Python is wired (S10.A4). .NET is `[GAP-V1]`: blocked upstream on a `Microsoft.AgentGovernance` .NET package that exposes an `AgentMesh` relay client (the package today ships trust/identity/policy/audit only). Re-introduced in v1.1 once upstream lands."
+                      description: "Microsoft Agent Framework runtime variant. Python is wired. .NET is blocked upstream on a `Microsoft.AgentGovernance` .NET package that exposes an `AgentMesh` relay client (the package today ships trust/identity/policy/audit only); it will be re-introduced once upstream lands."
                       properties:
                         language:
                           type: string
@@ -181,7 +181,7 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                     semanticKernel:
                       type: object
-                      description: "Semantic Kernel runtime variant (Tier-2 placeholder). Schema is locked but the controller stamps `RuntimeReady=False / AdapterMissing` until the SK adapter image ships."
+                      description: "Semantic Kernel runtime variant (declared placeholder). Schema is locked but the controller stamps `RuntimeReady=False / AdapterMissing` until the SK adapter image ships."
                       properties:
                         language:
                           type: string
@@ -328,7 +328,7 @@ spec:
                     byo:
                       type: object
                       required: ["image", "contractVersion"]
-                      description: "Bring-your-own runtime. The image must honor the BYO contract. Phase 2 enforcement is warn-only via `RuntimeReady` Condition."
+                      description: "Bring-your-own runtime. The image must honor the BYO contract. Enforcement is warn-only via `RuntimeReady` Condition unless the cluster operator opts in to strict mode."
                       properties:
                         image:
                           type: string
@@ -526,15 +526,13 @@ spec:
                       description: |
                         Reference to a signed OCI artifact containing the
                         canonical egress allowlist. Populated by
-                        `azureclaw egress … --sign` (S12.c). Audit-only
-                        in S12.a — controller still derives NetworkPolicy
-                        from `allowedEndpoints`. **Authoritative in
-                        S12.e** (always-on, no feature gate): when set,
-                        the verified canonical artifact is the source
-                        of truth for NetworkPolicy egress; on verify
-                        failure the controller fails closed (last-known
-                        good cache fallback, then no-broad-egress).
-                        See docs/internal/policy-canonical-format.md.
+                        `azureclaw egress … --sign`. **Authoritative**:
+                        when set, the verified canonical artifact is the
+                        source of truth for NetworkPolicy egress; on
+                        verify failure the controller fails closed
+                        (last-known-good cache fallback, then
+                        no-broad-egress).
+                        See docs/egress-proxy.md for the canonical format.
                       required:
                         - registry
                         - repository
@@ -652,7 +650,7 @@ spec:
           jsonPath: .spec.sandbox.isolation
         - name: Allowlist
           type: string
-          description: "Authoritative-allowlist condition status (S12.e)"
+          description: "Authoritative-allowlist condition status"
           jsonPath: .status.conditions[?(@.type=="AllowlistAuthoritative")].status
           priority: 1
         - name: Age

--- a/deploy/helm/azureclaw/values.yaml
+++ b/deploy/helm/azureclaw/values.yaml
@@ -9,11 +9,11 @@ controller:
     tag: "latest"  # Pin to digest in production
     pullPolicy: Always
   replicas: 2
-  # Phase 3 S8: when true, BYO sandboxes whose
+  # When true, BYO sandboxes whose
   # spec.runtime.byo.contractVersion is missing or unknown, OR whose
   # byo.image is shape-invalid, are rejected with Degraded=True
   # (Reason=BYOContractInvalid) instead of reconciling. Default
-  # `false` keeps the Phase 2 warn-only behaviour. Recommended `true`
+  # `false` keeps the warn-only behaviour. Recommended `true`
   # in production to fail-closed against operator typos.
   byoStrict: false
   # Optional list of additional env vars merged into the controller
@@ -144,7 +144,6 @@ monitoring:
       traceMount: true      # Detect mount attempts (should be blocked)
 
 # Admission policies shipped with the chart.
-# See internal Phase 1 plan §6 item 6 and §0.2 principle 9.
 admission:
   nullProviderBlock:
     # Deploy the ValidatingAdmissionPolicy that rejects
@@ -229,11 +228,11 @@ azure:
 cilium:
   enabled: false
 
-# S12.d — Cluster-scoped SignerPolicy ConfigMap.
+# Cluster-scoped SignerPolicy ConfigMap.
 #
 # Watched by the controller (filtered to the `azureclaw-signer-policy`
 # ConfigMap in this namespace). Defines who is permitted to sign egress
-# allowlist OCI artifacts (see `docs/internal/policy-canonical-format.md`).
+# allowlist OCI artifacts (see `docs/egress-proxy.md`).
 #
 # Both lists are required when `enabled: true`. Either list empty → the
 # controller surfaces `SignerPolicyMalformed` on affected ClawSandbox
@@ -259,7 +258,7 @@ signerPolicy:
     - https://github.com/Azure/azureclaw/.github/workflows/*.yml@*
 
 
-# A2A public-ingress gateway (Phase 2 S3.5 — ADR-0001 #4).
+# A2A public-ingress gateway (ADR-0001 #4).
 #
 # Opt-in. When `enabled: false` (default), the inference router is
 # reachable only on the cluster-internal mesh (port 8443) — current
@@ -303,8 +302,8 @@ a2aGateway:
     # Subject map cap. Beyond this, the most-stale subject is evicted
     # (RAM-only — replicas do NOT share state in v1).
     maxSubjects: 50000
-    # Cross-replica synchronisation entry-point. **Not implemented in
-    # S3.5** — the field is locked here so future opt-in is
+    # Cross-replica synchronisation entry-point. **Not yet
+    # implemented** — the field is locked here so future opt-in is
     # backward-compatible. Setting this value today has no effect.
     sharedRedisUrl: ""
   resources:


### PR DESCRIPTION
## What

Removes phase/internal jargon (`S14`, `S12.x`, `S10.A*`, `S7.x`, `Tier-1/Tier-2`, `Phase N`) from strings the user actually sees:

- CLI `--help` descriptions (operator, add, egress, attest, migrate)
- Operator TUI labels and keymap
- Helm CRD `description:` fields (ClawSandbox, McpServer, ToolPolicy, InferencePolicy)
- `values.yaml` operator-visible comments


## Bonus fix

`cli/src/runtime.ts` only listed **4** wired runtime kinds, but the controller actually wires **7** (only `SemanticKernel` remains a declared placeholder). Synced `WIRED_KINDS`, `RuntimeKind`, `RuntimeFlag`, `FLAG_TO_KIND` with `controller/src/reconciler/runtime.rs`, and `azureclaw add --runtime pydantic-ai` is now a real, accepted flag value (was missing entirely).

## Verification

| Gate | Result |
|---|---|
| `cargo test -p azureclaw-controller --release` | **483 / 0** |
| 7 helm_drift CRD-vs-Rust schema tests | **all green** (Rust doc-comments updated in lockstep) |
| `cli` vitest | **537 passed, 2 skipped** |
| `cli` typecheck | **clean** |

## Why this matters for OSS launch

First impression of the project comes through `azureclaw --help`, `kubectl explain clawsandbox.spec`, the operator TUI, and `values.yaml`. None of those should be reading like internal sprint shorthand.