### PR TITLE
cli(add): list all 7 wired runtimes in --runtime help text

### DIFF
--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -44,7 +44,7 @@ export function addCommand(): Command {
     .option("--perplexity-api-key <key>", "Perplexity API key")
     .option("--openai-api-key <key>", "OpenAI API key (for dual-provider setups)")
     .option("--learn-egress", "Enable egress learn mode: observe all domains (blocklist still enforced), then review with 'azureclaw policy learn'", false)
-    .option("--runtime <kind>", "Runtime kind: openclaw | openai-agents | microsoft-agent-framework | byo", "openclaw")
+    .option("--runtime <kind>", "Runtime kind: openclaw | openai-agents | microsoft-agent-framework | langgraph | anthropic | pydantic-ai | byo", "openclaw")
     .option("--byo-image <image>", "Container image for --runtime byo (must declare org.azureclaw.runtime.contract=v1)")
     .option("--byo-contract-version <version>", "BYO contract version", "v1")
     .option("--maf-language <lang>", "Microsoft Agent Framework language: python (dotnet not yet wired)", "python")


### PR DESCRIPTION
Followup to #208 — the --runtime help string in `azureclaw add` was still advertising only 4 kinds (openclaw, openai-agents, microsoft-agent-framework, byo) even though `cli/src/runtime.ts` now accepts all 7 wired kinds. Adds langgraph, anthropic, pydantic-ai to the visible `--help` list.