### PR TITLE
feat(cli,helm): ship all 7 runtime images + parallel SKU preflight

### DIFF
--- a/cli/src/commands/push.ts
+++ b/cli/src/commands/push.ts
@@ -70,6 +70,20 @@ export function pushCommand(): Command {
           buildArgs: ["--build-arg", `CACHE_BUST=${Date.now()}`] },
         { name: "registry", tag: "agentmesh-registry:latest", dockerfile: "vendor/agentmesh-registry/Dockerfile", context: "vendor/agentmesh-registry",
           buildArgs: ["--build-arg", `CACHE_BUST=${Date.now()}`] },
+        // Multi-runtime adapter images — must match controller defaults in
+        // `controller/src/reconciler/runtime.rs` (DEFAULT_*_IMAGE constants).
+        { name: "runtime-openai-agents", tag: "azureclaw-runtime-openai-agents:latest",
+          dockerfile: "sandbox-images/openai-agents/Dockerfile" },
+        { name: "runtime-maf-python", tag: "azureclaw-runtime-maf-python:latest",
+          dockerfile: "sandbox-images/maf-python/Dockerfile" },
+        { name: "runtime-anthropic", tag: "azureclaw-runtime-anthropic:latest",
+          dockerfile: "sandbox-images/anthropic/Dockerfile" },
+        { name: "runtime-langgraph", tag: "azureclaw-runtime-langgraph:latest",
+          dockerfile: "sandbox-images/langgraph/Dockerfile" },
+        { name: "runtime-langgraph-ts", tag: "azureclaw-runtime-langgraph-ts:latest",
+          dockerfile: "sandbox-images/langgraph-ts/Dockerfile" },
+        { name: "runtime-pydantic-ai", tag: "azureclaw-runtime-pydantic-ai:latest",
+          dockerfile: "sandbox-images/pydantic-ai/Dockerfile" },
       ];
 
       // Filter if --only specified; skip sandbox-base unless explicitly requested

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -33,6 +33,7 @@ export function upCommand(): Command {
     .option("--force-infra", "Force Bicep deployment even if AKS cluster exists", false)
     .option("--source-acr <server>", "Source ACR for pre-built images (customers)", "azureclawacr.azurecr.io")
     .option("--build", "Build images locally and push to ACR (developer mode)", false)
+    .option("--skip-runtime-images", "Skip building/importing the 6 multi-runtime adapter images (faster first deploy; only OpenClaw + BYO will be runnable)", false)
     .option("--foundry-endpoint <url>", "Existing Azure AI Foundry project endpoint (services.ai.azure.com)")
     .option("--openai-endpoint <url>", "Existing Azure OpenAI endpoint (openai.azure.com, derived from Foundry if omitted)")
     .option("--dry-run", "Show what would be done without executing", false)
@@ -464,6 +465,22 @@ export function upCommand(): Command {
           await buildPush("vendor/agentmesh-relay/Dockerfile", "agentmesh-relay:latest", [], "vendor/agentmesh-relay");
           await buildPush("vendor/agentmesh-registry/Dockerfile", "agentmesh-registry:latest", [], "vendor/agentmesh-registry");
 
+          // Multi-runtime adapter images. Tags must match the controller's
+          // DEFAULT_*_IMAGE constants in `reconciler/runtime.rs`. Skipped
+          // when --skip-runtime-images is passed (faster first deploy).
+          if (!options.skipRuntimeImages) {
+            for (const rt of [
+              { dir: "openai-agents", tag: "azureclaw-runtime-openai-agents:latest" },
+              { dir: "maf-python", tag: "azureclaw-runtime-maf-python:latest" },
+              { dir: "anthropic", tag: "azureclaw-runtime-anthropic:latest" },
+              { dir: "langgraph", tag: "azureclaw-runtime-langgraph:latest" },
+              { dir: "langgraph-ts", tag: "azureclaw-runtime-langgraph-ts:latest" },
+              { dir: "pydantic-ai", tag: "azureclaw-runtime-pydantic-ai:latest" },
+            ]) {
+              await buildPush(`sandbox-images/${rt.dir}/Dockerfile`, rt.tag);
+            }
+          }
+
           stepper.done("Images built and pushed to ACR");
         } else {
           // Customer mode: import pre-built images from source ACR
@@ -475,6 +492,14 @@ export function upCommand(): Command {
             { source: `${sourceAcr}/openclaw-sandbox:latest`, target: "openclaw-sandbox:latest" },
             { source: `${sourceAcr}/agentmesh-relay:latest`, target: "agentmesh-relay:latest" },
             { source: `${sourceAcr}/agentmesh-registry:latest`, target: "agentmesh-registry:latest" },
+            // Multi-runtime adapter images. Failures here are non-fatal —
+            // some source ACRs may not host every runtime.
+            { source: `${sourceAcr}/azureclaw-runtime-openai-agents:latest`, target: "azureclaw-runtime-openai-agents:latest" },
+            { source: `${sourceAcr}/azureclaw-runtime-maf-python:latest`, target: "azureclaw-runtime-maf-python:latest" },
+            { source: `${sourceAcr}/azureclaw-runtime-anthropic:latest`, target: "azureclaw-runtime-anthropic:latest" },
+            { source: `${sourceAcr}/azureclaw-runtime-langgraph:latest`, target: "azureclaw-runtime-langgraph:latest" },
+            { source: `${sourceAcr}/azureclaw-runtime-langgraph-ts:latest`, target: "azureclaw-runtime-langgraph-ts:latest" },
+            { source: `${sourceAcr}/azureclaw-runtime-pydantic-ai:latest`, target: "azureclaw-runtime-pydantic-ai:latest" },
           ];
 
           for (const img of images) {
@@ -631,6 +656,14 @@ export function upCommand(): Command {
           "--set", `inferenceRouter.azure.openai.endpoint=${openAiEndpoint}`,
           "--set", `sandbox.image.repository=${acrLoginServer}/openclaw-sandbox`,
           "--set", `sandbox.image.tag=latest`,
+          // Multi-runtime adapter image overrides (consumed by controller via
+          // *_RUNTIME_IMAGE env vars; see helm controller-deployment.yaml).
+          "--set", `runtimes.openaiAgents.image=${acrLoginServer}/azureclaw-runtime-openai-agents:latest`,
+          "--set", `runtimes.mafPython.image=${acrLoginServer}/azureclaw-runtime-maf-python:latest`,
+          "--set", `runtimes.anthropic.image=${acrLoginServer}/azureclaw-runtime-anthropic:latest`,
+          "--set", `runtimes.langgraph.image=${acrLoginServer}/azureclaw-runtime-langgraph:latest`,
+          "--set", `runtimes.langgraphTs.image=${acrLoginServer}/azureclaw-runtime-langgraph-ts:latest`,
+          "--set", `runtimes.pydanticAi.image=${acrLoginServer}/azureclaw-runtime-pydantic-ai:latest`,
           "--set", `azure.workloadIdentity.clientId=${wiClientId}`,
           "--set", `azure.keyVaultCsi.keyVaultName=${kvName}`,
           "--wait",

--- a/cli/src/commands/up/preflight.ts
+++ b/cli/src/commands/up/preflight.ts
@@ -348,8 +348,7 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
       { sku: "Standard_D4s_v5", label: "AKS system pool (D4s_v5)" },
       { sku: agentSku, label: agentLabel },
     ];
-    let skuOk = true;
-    for (const check of skuChecks) {
+    const checkOne = async (check: { sku: string; label: string }): Promise<{ ok: boolean; line: string; available: boolean }> => {
       try {
         const { stdout: skuJson } = await execa("az", [
           "vm", "list-skus",
@@ -357,18 +356,22 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
           "--size", check.sku,
           "--query", "[0].restrictions",
           "--output", "json",
-        ], { stdio: "pipe", timeout: 15000 });
+        ], { stdio: "pipe", timeout: 10000 });
         const restrictions = JSON.parse(skuJson || "[]");
         const blocked = restrictions.some((r: { type: string }) => r.type === "Location");
-        if (blocked) {
-          checkLine(false, `${check.label} — ${chalk.red("not available")} in ${options.region}`);
-          skuOk = false;
-        } else {
-          checkLine(true, `${check.label} — available`);
-        }
+        return blocked
+          ? { ok: false, available: false, line: `${check.label} — ${chalk.red("not available")} in ${options.region}` }
+          : { ok: true, available: true, line: `${check.label} — available` };
       } catch {
-        checkLine(false, `${check.label} — ${chalk.yellow("could not verify")} (continuing)`);
+        // Network/CLI failure is non-fatal — surface as "could not verify" but don't fail preflight
+        return { ok: true, available: true, line: `${check.label} — ${chalk.yellow("could not verify")} (continuing)` };
       }
+    };
+    const results = await Promise.all(skuChecks.map(checkOne));
+    let skuOk = true;
+    for (const r of results) {
+      checkLine(r.ok, r.line);
+      if (!r.available) skuOk = false;
     }
     if (!skuOk) {
       console.log(chalk.yellow(`\n  Some VM SKUs are not available in ${options.region}.`));

--- a/deploy/helm/azureclaw/templates/controller-deployment.yaml
+++ b/deploy/helm/azureclaw/templates/controller-deployment.yaml
@@ -55,6 +55,21 @@ spec:
               value: "{{ .Values.inferenceRouter.image.repository }}:{{ .Values.inferenceRouter.image.tag }}"
             - name: SANDBOX_IMAGE
               value: "{{ .Values.sandbox.image.repository }}:{{ .Values.sandbox.image.tag }}"
+            # Multi-runtime adapter image overrides (consumed by
+            # controller/src/reconciler/runtime.rs::*_default_image()).
+            # Empty string keeps the controller's compiled-in default.
+            - name: OPENAI_AGENTS_RUNTIME_IMAGE
+              value: {{ .Values.runtimes.openaiAgents.image | default "" | quote }}
+            - name: MAF_RUNTIME_IMAGE
+              value: {{ .Values.runtimes.mafPython.image | default "" | quote }}
+            - name: ANTHROPIC_RUNTIME_IMAGE
+              value: {{ .Values.runtimes.anthropic.image | default "" | quote }}
+            - name: LANGGRAPH_RUNTIME_IMAGE
+              value: {{ .Values.runtimes.langgraph.image | default "" | quote }}
+            - name: LANGGRAPH_TS_RUNTIME_IMAGE
+              value: {{ .Values.runtimes.langgraphTs.image | default "" | quote }}
+            - name: PYDANTIC_AI_RUNTIME_IMAGE
+              value: {{ .Values.runtimes.pydanticAi.image | default "" | quote }}
             - name: AZURE_OPENAI_ENDPOINT
               value: {{ .Values.inferenceRouter.azure.openai.endpoint | quote }}
             - name: FOUNDRY_ENDPOINT

--- a/deploy/helm/azureclaw/values.yaml
+++ b/deploy/helm/azureclaw/values.yaml
@@ -78,6 +78,25 @@ sandbox:
       cpu: "2"
       memory: "4Gi"
 
+# Multi-runtime adapter images. Each value is a fully-qualified
+# `<repo>:<tag>` string consumed by controller/src/reconciler/runtime.rs
+# via the `*_RUNTIME_IMAGE` env vars on the controller Deployment.
+# Empty string falls back to the controller's compiled-in default.
+# `azureclaw up` populates these with `<your-acr>/azureclaw-runtime-*:latest`.
+runtimes:
+  openaiAgents:
+    image: ""
+  mafPython:
+    image: ""
+  anthropic:
+    image: ""
+  langgraph:
+    image: ""
+  langgraphTs:
+    image: ""
+  pydanticAi:
+    image: ""
+
 # Network policy defaults
 networkPolicy:
   defaultDenyEgress: true


### PR DESCRIPTION
## What

### 1. Ship all multi-runtime adapter images via `up` / `push`

Before: only `openclaw-sandbox` was built/imported. Any non-OpenClaw runtime would ImagePullBackOff because the controller's compiled-in defaults point at `azureclawacr.azurecr.io` (internal dev ACR).

After: `azureclaw push` and `azureclaw up` now build (or import in customer mode) all 6 runtime adapter images — `openai-agents`, `maf-python`, `anthropic`, `langgraph`, `langgraph-ts`, `pydantic-ai` — and Helm `--set`s the controller's `*_RUNTIME_IMAGE` env vars at `<user-acr>/azureclaw-runtime-*:latest`.

New flag: `azureclaw up --skip-runtime-images` (faster first deploy when you only intend to use OpenClaw or BYO).

### 2. Parallel SKU availability check

The `Checking VM SKU availability in <region>` step ran two sequential `az vm list-skus` calls (15s timeout each → up to 30s wall-clock). Now `Promise.all` with 10s timeouts → ~10s wall-clock max.

## Files

| File | Change |
|---|---|
| `cli/src/commands/up/preflight.ts` | parallelise SKU check |
| `cli/src/commands/up.ts` | build/import 6 runtime images, `--set` 6 helm runtime image keys, new `--skip-runtime-images` flag |
| `cli/src/commands/push.ts` | add 6 runtime image entries to default images list |
| `deploy/helm/azureclaw/templates/controller-deployment.yaml` | 6 new `*_RUNTIME_IMAGE` env vars |
| `deploy/helm/azureclaw/values.yaml` | new `runtimes.*` block |

## Verification

- `cargo test -p azureclaw-controller --release helm_drift`: **14/0** (no CRD schema drift)
- `cli` vitest: **537 passed, 2 skipped**
- `cli` typecheck: **clean**