### PR TITLE
cli: wide polish — runtime-aware eval + drop ADR/version jargon + agent-neutral connect

### DIFF
--- a/cli/src/commands/a2a.ts
+++ b/cli/src/commands/a2a.ts
@@ -38,7 +38,7 @@ import { runApply, runDelete, runGet, runList } from "./toolpolicy.js";
  */
 export function a2aCommand(): Command {
   const cmd = new Command("a2a")
-    .description("A2A 1.0.0 ingress surfacing (per ADR-0001 D6).");
+    .description("Inspect A2A (Agent-to-Agent) ingress surfaces.");
 
   cmd
     .command("list-exposed")
@@ -71,7 +71,7 @@ export function a2aCommand(): Command {
   cmd
     .command("schema")
     .description(
-      "Print the AgentCard JSON shape this cluster will publish per A2A 1.0.0 §4.4. Useful for tenants writing CR specs."
+      "Print the AgentCard JSON shape this cluster publishes per the A2A spec. Useful for tenants writing CR specs."
     )
     .action(async () => {
       // Mirrors inference-router/src/a2a/agent_card.rs serialization.

--- a/cli/src/commands/connect.ts
+++ b/cli/src/commands/connect.ts
@@ -98,7 +98,7 @@ export function connectCommand(): Command {
           return;
         }
         if (!options.web) {
-          console.log(chalk.hex("#0078D4")(`\n  Connected to ${chalk.bold(name)} (local). OpenClaw is ready.\n`));
+          console.log(chalk.hex("#0078D4")(`\n  Connected to ${chalk.bold(name)} (local). Agent is ready.\n`));
           console.log(chalk.dim(`  Chat:    openclaw tui`));
           console.log(chalk.dim(`  Message: openclaw agent --agent main --local -m "hello" --session-id test`));
           console.log(chalk.dim(`  Exit:    type "exit"\n`));
@@ -225,7 +225,7 @@ export function connectCommand(): Command {
         }
       } else {
         // Shell mode
-        console.log(chalk.hex("#0078D4")(`\n  Connected to ${chalk.bold(name)}. OpenClaw is ready.\n`));
+        console.log(chalk.hex("#0078D4")(`\n  Connected to ${chalk.bold(name)}. Agent is ready.\n`));
         console.log(chalk.dim(`  Chat:    openclaw tui`));
         console.log(chalk.dim(`  Exit:    type "exit"\n`));
         await execa("kubectl", [

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -3,6 +3,7 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
+import { agentContainerName, runtimeKindFromCr } from "../runtime.js";
 
 export function evalCommand(): Command {
   const cmd = new Command("eval");
@@ -39,10 +40,21 @@ export function evalCommand(): Command {
 
         const V = "api-version=2025-11-15-preview";
 
+        // Resolve the agent container name from the ClawSandbox CR's
+        // runtime kind — `openclaw` for OpenClaw, `agent` for every
+        // other adapter image. Falls back to `openclaw` if lookup fails.
+        let agentContainer = "openclaw";
+        try {
+          const { stdout: crJson } = await execa("kubectl", [
+            "get", "clawsandbox", name, "-n", "azureclaw-system", "-o", "json",
+          ], { stdio: "pipe" });
+          agentContainer = agentContainerName(runtimeKindFromCr(JSON.parse(crJson)));
+        } catch { /* fall back to openclaw default */ }
+
         // Helper: exec curl inside the pod via the inference router
         async function foundryGet(path: string): Promise<unknown> {
           const { stdout } = await execa("kubectl", [
-            "exec", "-n", namespace, podName, "-c", "openclaw", "--",
+            "exec", "-n", namespace, podName, "-c", agentContainer, "--",
             "curl", "-s", `http://localhost:8443/${path}?${V}`,
           ], { stdio: "pipe" });
           return JSON.parse(stdout);
@@ -50,7 +62,7 @@ export function evalCommand(): Command {
 
         async function foundryPost(path: string, body: unknown): Promise<unknown> {
           const { stdout } = await execa("kubectl", [
-            "exec", "-n", namespace, podName, "-c", "openclaw", "--",
+            "exec", "-n", namespace, podName, "-c", agentContainer, "--",
             "curl", "-s", "-X", "POST",
             `http://localhost:8443/${path}?${V}`,
             "-H", "Content-Type: application/json",


### PR DESCRIPTION
## Summary

Polish pass across the CLI surface flagged by a code-review audit.

### P0 — `azureclaw eval` broken on non-OpenClaw runtimes

`eval.ts` hardcoded \`-c openclaw\` in two \`kubectl exec\` calls. For OpenAIAgents / MicrosoftAgentFramework / LangGraph / Anthropic / PydanticAi / BYO sandboxes the agent container is named \`agent\` (see \`runtime.ts → agentContainerName\`), so the command would fail with *container openclaw not found*. Now resolves the container name from the ClawSandbox CR's runtime kind, with a fallback to \`openclaw\` if the lookup fails.

### P1 — Visible jargon

- \`a2a.ts\` command description said \`A2A 1.0.0 (per ADR-0001 D6)\`. We ship 1.2 and ADR numbering is internal — rephrased to plain English.
- \`connect.ts\` printed *OpenClaw is ready* on success — wrong for non-OpenClaw runtimes. Now prints *Agent is ready*.

## Verification

\`\`\`
cd cli && npm run build && npm test
# → 537 passed, 2 skipped
\`\`\`

## Out of scope (followups)

- \`up.ts\` / \`dev.ts\` lack \`addHelpText('after', …)\` grouping
- \`mcp.ts\` \`--allowed-tool\` (singular) inconsistent with \`--agent-tools\` (plural) — breaking change for any user scripts, deferred
- \`policy learn\` deprecated subcommand (kept as-is; alias for \`azureclaw egress --learned\`)
- Internal \`//\` doc-comments referencing Phase/Slice numbers — not user-visible, left untouched per Wave M policy