### PR TITLE
cli: r2 polish — group up/dev help, validate enums, drop policy-learn deprecation banner

### DIFF
--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -30,13 +30,15 @@ export function devCommand(): Command {
       "Requires an existing Azure OpenAI resource with at least one model deployment (e.g. gpt-4.1).\n" +
       "On first run, you will be prompted for your endpoint, model deployment name, and resource-level API key."
     )
+    // ── Identity ───────────────────────────────────────────────────────
     .option("--name <name>", "Sandbox name", "dev-agent")
     .option("--model <model>", "Existing model deployment name in your Azure OpenAI resource", "gpt-4.1")
     .option(
       "--policy <preset>",
-      "Policy preset: minimal, developer, web, azure",
+      "Policy preset: minimal | developer | web | azure",
       "developer"
     )
+    // ── Image build ────────────────────────────────────────────────────
     .option(
       "--image <image>",
       "Sandbox container image",
@@ -53,28 +55,52 @@ export function devCommand(): Command {
       false
     )
     .option(
+      "--base-image <image>",
+      "Azure Linux base image for building sandbox (override for custom registries)",
+      AZURELINUX_BASE
+    )
+    // ── Mesh federation ───────────────────────────────────────────────
+    .option(
       "--global-registry <url>",
       "Use a shared external registry (enables handoff). Skips local relay/registry/postgres."
     )
+    // ── Channels (OpenClaw only) ──────────────────────────────────────
     .option("--channels <channels>", "Channels to enable: telegram,slack,discord,whatsapp (comma-separated)")
     .option("--telegram-token <token>", "Telegram bot token (from BotFather)")
     .option("--telegram-allow-from <ids>", "Telegram user IDs allowed to DM (comma-separated numeric IDs)")
     .option("--slack-token <token>", "Slack bot OAuth token")
     .option("--discord-token <token>", "Discord bot token")
+    // ── Skills + plugins (OpenClaw only) ──────────────────────────────
     .option("--skills <skills>", "Skills to activate: browser,github,summarize,weather (comma-separated)")
-    // Third-party plugin API keys (search, scraping, LLM providers)
     .option("--brave-api-key <key>", "Brave Search API key")
     .option("--tavily-api-key <key>", "Tavily search API key")
     .option("--exa-api-key <key>", "Exa search API key")
     .option("--firecrawl-api-key <key>", "Firecrawl web scraping API key")
     .option("--perplexity-api-key <key>", "Perplexity API key")
     .option("--openai-api-key <key>", "OpenAI API key (for dual-provider setups)")
-    .option(
-      "--base-image <image>",
-      "Azure Linux base image for building sandbox (override for custom registries)",
-      AZURELINUX_BASE
-    )
+    .addHelpText("after", `
+Flag groups:
+  Identity:           --name, --model, --policy
+  Image build:        --image, --build, --build-base, --base-image
+  Mesh federation:    --global-registry
+  Channels:           --channels, --telegram-*, --slack-token, --discord-token
+  Skills + plugins:   --skills, --brave-api-key, --tavily-api-key,
+                      --exa-api-key, --firecrawl-api-key,
+                      --perplexity-api-key, --openai-api-key
+
+Notes:
+  - Channels, skills, and plugin API keys are OpenClaw-specific. For
+    other runtimes, configure equivalents inside the agent's own code.
+  - Router-side guardrails (Content Safety, rate limits, audit, egress
+    allowlist) are always enforced — same in dev as in production.
+`)
     .action(async (options) => {
+      const policyPresets = ["minimal", "developer", "web", "azure"];
+      if (options.policy && !policyPresets.includes(options.policy)) {
+        console.error(chalk.red(`\n  Error: --policy must be one of: ${policyPresets.join(" | ")} (got "${options.policy}").\n`));
+        process.exit(1);
+      }
+
       banner("AzureClaw · Local Sandbox", "Secure AI Agent Runtime on Azure");
 
       const stepper = new Stepper({ totalSteps: 4 });

--- a/cli/src/commands/policy.ts
+++ b/cli/src/commands/policy.ts
@@ -128,17 +128,13 @@ export function policyCommand(): Command {
 
   cmd
     .command("learn")
-    .description("[DEPRECATED] Use 'azureclaw egress <name> --learned' instead")
+    .description("Alias for 'azureclaw egress <name> --learned' (kept for backward compatibility)")
     .argument("<name>", "Sandbox name")
     .option("--apply", "Apply learned domains as the sandbox allowlist", false)
     .option("--clear", "Clear learned domains after export", false)
     .action(async (name: string, options) => {
-      console.log(chalk.yellow("\n  ⚠ 'policy learn' is deprecated. Use these instead:"));
-      console.log(chalk.dim("    View learned domains:  azureclaw egress " + name + " --learned"));
-      console.log(chalk.dim("    Apply as allowlist:    azureclaw egress " + name + " --enforce"));
-      console.log(chalk.dim("    Approve a domain:      azureclaw egress " + name + " --approve <domain>\n"));
-
-      // Still execute for backward compat
+      // Quiet hint — full functionality preserved below for backward compat.
+      console.log(chalk.dim(`\n  Tip: 'azureclaw egress ${name} --learned' is the documented path for this workflow.\n`));
       const { execa } = await import("execa");
       const namespace = `azureclaw-${name}`;
       const spinner = ora(`Fetching learned domains from '${name}'...`).start();

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -14,35 +14,70 @@ export function upCommand(): Command {
     .description(
       "One command to go from zero to running agent. Provisions Azure resources, builds images, deploys controller, creates sandbox."
     )
+    // ── Identity ───────────────────────────────────────────────────────
     .option("--name <name>", "Sandbox name", "my-assistant")
     .option("--model <model>", "AI model", "gpt-4.1")
     .option(
       "--policy <preset>",
-      "Policy preset: minimal, developer, web, azure",
+      "Policy preset: minimal | developer | web | azure",
       "developer"
     )
+    // ── Cluster / region ───────────────────────────────────────────────
     .option("--region <region>", "Azure region", "eastus2")
     .option("--cluster-name <name>", "AKS cluster name", "azureclaw")
     .option(
       "--isolation <level>",
-      "Pod isolation level: standard (runc), enhanced (runc + strict seccomp), confidential (Kata VM)",
+      "Pod isolation level: standard (runc) | enhanced (runc + strict seccomp) | confidential (Kata VM)",
       "enhanced"
     )
     .option("-g, --resource-group <name>", "Resource group name")
+    // ── Infrastructure ────────────────────────────────────────────────
     .option("--skip-infra", "Skip infrastructure provisioning (reuse existing cluster)", false)
     .option("--force-infra", "Force Bicep deployment even if AKS cluster exists", false)
+    .option("--skip-preflight", "Skip upfront RBAC & provider checks (advanced; you know what you're doing)", false)
+    // ── Images ─────────────────────────────────────────────────────────
     .option("--source-acr <server>", "Source ACR for pre-built images (customers)", "azureclawacr.azurecr.io")
     .option("--build", "Build images locally and push to ACR (developer mode)", false)
     .option("--skip-runtime-images", "Skip building/importing the 6 multi-runtime adapter images (faster first deploy; only OpenClaw + BYO will be runnable)", false)
+    // ── Foundry / Azure OpenAI ────────────────────────────────────────
     .option("--foundry-endpoint <url>", "Existing Azure AI Foundry project endpoint (services.ai.azure.com)")
     .option("--openai-endpoint <url>", "Existing Azure OpenAI endpoint (openai.azure.com, derived from Foundry if omitted)")
-    .option("--dry-run", "Show what would be done without executing", false)
-    .option("--upgrade", "Fast upgrade: skip prompts, reuse cached context, just re-run Helm + RBAC", false)
+    // ── Mesh federation ───────────────────────────────────────────────
     .option("--mesh-peer", "Enable mesh federation peer (default: on; use --no-mesh-peer to disable)", true)
     .option("--global-registry <url>", "Use an external AgentMesh registry (skip local registry deployment)")
     .option("--expose-registry", "Deploy AGIC Ingress to expose this cluster's registry publicly", false)
-    .option("--skip-preflight", "Skip upfront RBAC & provider checks (advanced; you know what you're doing)", false)
+    // ── Output / lifecycle ────────────────────────────────────────────
+    .option("--dry-run", "Show what would be done without executing", false)
+    .option("--upgrade", "Fast upgrade: skip prompts, reuse cached context, just re-run Helm + RBAC", false)
+    .addHelpText("after", `
+Flag groups:
+  Identity:           --name, --model, --policy
+  Cluster / region:   --region, --cluster-name, --isolation, --resource-group
+  Infrastructure:     --skip-infra, --force-infra, --skip-preflight
+  Images:             --source-acr, --build, --skip-runtime-images
+  Foundry:            --foundry-endpoint, --openai-endpoint
+  Mesh federation:    --mesh-peer / --no-mesh-peer, --global-registry, --expose-registry
+  Output / lifecycle: --dry-run, --upgrade
+
+Examples:
+  azureclaw up                                       # Full provision with defaults
+  azureclaw up --name myagent --region westus3       # Pick a name + region
+  azureclaw up --skip-infra                          # Reuse existing AKS cluster
+  azureclaw up --upgrade                             # Fast Helm-only redeploy
+`)
     .action(async (options) => {
+      // Up-front validation: reject obviously-wrong values before any Azure work.
+      const isolationLevels = ["standard", "enhanced", "confidential"];
+      if (options.isolation && !isolationLevels.includes(options.isolation)) {
+        console.error(chalk.red(`\n  Error: --isolation must be one of: ${isolationLevels.join(" | ")} (got "${options.isolation}").\n`));
+        process.exit(1);
+      }
+      const policyPresets = ["minimal", "developer", "web", "azure"];
+      if (options.policy && !policyPresets.includes(options.policy)) {
+        console.error(chalk.red(`\n  Error: --policy must be one of: ${policyPresets.join(" | ")} (got "${options.policy}").\n`));
+        process.exit(1);
+      }
+
       const { execa } = await import("execa");
 
       // ── FAST UPGRADE PATH (S15.d.1: extracted to ./up/fast_upgrade.ts) ──

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -98,6 +98,7 @@ azureclaw up [options]
 | `--force-infra` | `false` | Force Bicep deployment even if AKS cluster already exists |
 | `--source-acr <server>` | `azureclawacr.azurecr.io` | Source ACR for pre-built images (customer deployments) |
 | `--build` | `false` | Build images locally and push to ACR (developer mode) |
+| `--skip-runtime-images` | `false` | Skip building/importing the 6 multi-runtime adapter images (faster first deploy; only OpenClaw + BYO will be runnable) |
 | `--foundry-endpoint <url>` | — | Existing Azure AI Foundry project endpoint (`services.ai.azure.com`) |
 | `--openai-endpoint <url>` | — | Existing Azure OpenAI endpoint (`openai.azure.com`; derived from Foundry if omitted) |
 | `--dry-run` | `false` | Show what would be done without executing |
@@ -823,8 +824,8 @@ azureclaw model list my-agent
 ### `azureclaw policy`
 
 Manages sandbox network and security policies. Hot-reload capable: `allow`
-and `deny` take effect without a pod restart. `learn` is deprecated in favour
-of `azureclaw egress <name> --learned`.
+and `deny` take effect without a pod restart. `learn` is kept as a
+backward-compatible alias for `azureclaw egress <name> --learned`.
 
 **Usage:**
 ```
@@ -837,7 +838,7 @@ azureclaw policy <subcommand> [arguments] [options]
 | `allow <name> <host>` | Add an allowed egress endpoint (hot-reload) |
 | `get <name>` | Show the active policy for a sandbox |
 | `deny <name> <host>` | Remove an allowed endpoint from a running sandbox |
-| `learn <name>` | *(Deprecated)* Use `azureclaw egress <name> --learned` instead |
+| `learn <name>` | Alias for `azureclaw egress <name> --learned` (kept for backward compatibility) |
 
 **Arguments for `allow` / `deny`:**
 | Name | Required | Description |
@@ -850,7 +851,7 @@ azureclaw policy <subcommand> [arguments] [options]
 |---|---|---|
 | `--port <port>` | `443` | Port |
 
-**Options for `learn` (deprecated):**
+**Options for `learn`:**
 | Flag | Default | Description |
 |---|---|---|
 | `--apply` | `false` | Apply learned domains as the sandbox allowlist |


### PR DESCRIPTION
## Summary

Continues the OSS-launch CLI polish — two largest commands (\`up\`, \`dev\`) and one noisy deprecation banner.

### Changes

**\`up.ts\` (24 flags)**
- Grouped \`.option\` calls under named sections via \`// ── ── \` comments
- Added \`.addHelpText('after', …)\` listing flag groups + 4 examples
- Up-front validation for \`--isolation\` (standard|enhanced|confidential) and \`--policy\` (minimal|developer|web|azure) — bogus values fail fast before any Azure work

**\`dev.ts\` (20 flags)**
- Same grouping pattern
- \`addHelpText\` notes channels/skills are OpenClaw-specific and that router-side guardrails are always on
- Validates \`--policy\` enum

**\`policy.ts\`**
- \`policy learn\` keeps full functionality but is no longer presented as deprecated
- Removed the \`[DEPRECATED]\` tag from the description
- Replaced the loud yellow banner + 3 alternative commands with a single dim hint at the canonical path

### Docs

- \`cli-reference.md\`: added missing \`--skip-runtime-images\` row in the \`up\` table
- \`cli-reference.md\`: rewrote the policy section blurb and \`learn\` row to match the alias framing

### Verification

\`\`\`
cd cli && npm run build && npm test           # 537 passed, 2 skipped
azureclaw up --policy bogus                   # fails with clear enum error
azureclaw up --isolation bogus                # fails with clear enum error
azureclaw dev --policy bogus                  # fails with clear enum error
\`\`\`