### PR TITLE
cli: r3 polish — top-level command groups + tight descriptions

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -74,13 +74,33 @@ export function createCli(): Command {
   program.addCommand(a2aAgentCommand());
   program.addCommand(migrateCommand());
 
-  // Governance CRDs (Slice S6)
+  // Governance CRDs
   program.addCommand(toolPolicyCommand());
   program.addCommand(inferencePolicyCommand());
   program.addCommand(mcpCommand());
 
-  // Attestation (Phase 2 read surface; signing lands in Phase 3)
+  // Attestation
   program.addCommand(attestCommand());
+
+  program.addHelpText("after", `
+Command groups:
+  Lifecycle       up, dev, add, push, destroy
+  Operations      connect, status, list, logs
+  Configuration   credentials, model, policy, egress
+  Observability   trace, eval, operator
+  Agent mobility  handoff, mesh, pair
+  Interop         convert, a2a, a2a-agent, migrate
+  Governance      toolpolicy, inferencepolicy, mcp
+  Attestation     attest
+
+Quick start:
+  azureclaw up                    # Provision Azure + deploy controller + first sandbox
+  azureclaw add my-bot            # Add a sandbox to an existing cluster
+  azureclaw operator              # Live TUI dashboard for all sandboxes
+  azureclaw <cmd> --help          # Detailed help for any subcommand
+
+Docs: https://github.com/Azure/azureclaw#readme
+`);
 
   return program;
 }

--- a/cli/src/commands/a2a.ts
+++ b/cli/src/commands/a2a.ts
@@ -38,7 +38,7 @@ import { runApply, runDelete, runGet, runList } from "./toolpolicy.js";
  */
 export function a2aCommand(): Command {
   const cmd = new Command("a2a")
-    .description("Inspect A2A (Agent-to-Agent) ingress surfaces.");
+    .description("Inspect A2A (Agent-to-Agent) ingress surfaces");
 
   cmd
     .command("list-exposed")

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -26,10 +26,13 @@ export function devCommand(): Command {
 
   cmd
     .description(
-      "Run a sandbox locally via Docker for development. Same policies, same model routing, on your laptop.\n" +
-      "Requires an existing Azure OpenAI resource with at least one model deployment (e.g. gpt-4.1).\n" +
-      "On first run, you will be prompted for your endpoint, model deployment name, and resource-level API key."
+      "Run a sandbox locally via Docker for development. Same policies, same model routing, on your laptop."
     )
+    .addHelpText("before", `
+Requires an existing Azure OpenAI resource with at least one model deployment
+(e.g. gpt-4.1). On first run, you will be prompted for your endpoint, model
+deployment name, and resource-level API key.
+`)
     // ── Identity ───────────────────────────────────────────────────────
     .option("--name <name>", "Sandbox name", "dev-agent")
     .option("--model <model>", "Existing model deployment name in your Azure OpenAI resource", "gpt-4.1")

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -12,7 +12,7 @@ export function upCommand(): Command {
 
   cmd
     .description(
-      "One command to go from zero to running agent. Provisions Azure resources, builds images, deploys controller, creates sandbox."
+      "One command to go from zero to running agent — provisions Azure resources, builds images, deploys controller, creates sandbox"
     )
     // ── Identity ───────────────────────────────────────────────────────
     .option("--name <name>", "Sandbox name", "my-assistant")


### PR DESCRIPTION
Splendid-pass for the top-level CLI surface.

## What's new

**`azureclaw --help` now has structure.**

Added an `.addHelpText('after', …)` block listing all 25 commands grouped under: Lifecycle, Operations, Configuration, Observability, Agent mobility, Interop, Governance, Attestation. Plus a 4-line quick-start and a docs link. First-time users now see structure instead of an alphabetical wall.

**Description polish:**
- `dev` description was 3 lines and wrapped ugly in the top-level listing — collapsed to one sentence; the prompt-detail paragraph moved into `addHelpText('before', …)` so it shows before Usage when running `dev --help`.
- `up` joined two clauses with an em-dash (matches `connect`/`trace`/`operator` style); trailing period removed.
- `a2a` trailing period removed for consistency.

**Internal jargon scrub:** the last two `//` comments in `cli.ts` ("Slice S6", "Phase 2 read surface") cleaned.

## Verification

```
cd cli && npm run build && npm test       # 537 passed, 2 skipped
azureclaw --help                          # groups + quick-start + docs link
azureclaw dev --help                      # detail block before Usage
```