### PR TITLE
fix(sandbox-images): rename cbl-mariner base images → azurelinux (+ nodejs 22 → 24)

### DIFF
--- a/sandbox-images/anthropic/Dockerfile
+++ b/sandbox-images/anthropic/Dockerfile
@@ -29,7 +29,7 @@
 # `runtimes/wheels/*.whl`. This keeps the image hermetic without
 # publishing private wheels to PyPI.
 
-FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS base
 
 LABEL org.azureclaw.runtime.contract="v1"
 LABEL org.azureclaw.runtime.kind="Anthropic"

--- a/sandbox-images/langgraph-ts/Dockerfile
+++ b/sandbox-images/langgraph-ts/Dockerfile
@@ -29,7 +29,7 @@
 # Build context MUST be the repo root (the COPY paths are anchored at
 # `runtimes/langgraph-ts/` and `sandbox-images/langgraph-ts/`).
 
-FROM mcr.microsoft.com/cbl-mariner/base/nodejs:22 AS builder
+FROM mcr.microsoft.com/azurelinux/base/nodejs:24 AS builder
 
 WORKDIR /build/runtime
 
@@ -40,7 +40,7 @@ COPY runtimes/langgraph-ts/src ./src
 RUN ./node_modules/.bin/tsc -p .
 
 # ---- Production stage ----------------------------------------------------
-FROM mcr.microsoft.com/cbl-mariner/base/nodejs:22
+FROM mcr.microsoft.com/azurelinux/base/nodejs:24
 
 LABEL org.azureclaw.runtime.contract="v1"
 LABEL org.azureclaw.runtime.kind="LangGraph"

--- a/sandbox-images/langgraph/Dockerfile
+++ b/sandbox-images/langgraph/Dockerfile
@@ -31,7 +31,7 @@
 # `runtimes/wheels/*.whl`. This keeps the image hermetic without
 # publishing private wheels to PyPI.
 
-FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS base
 
 LABEL org.azureclaw.runtime.contract="v1"
 LABEL org.azureclaw.runtime.kind="LangGraph"

--- a/sandbox-images/maf-python/Dockerfile
+++ b/sandbox-images/maf-python/Dockerfile
@@ -23,7 +23,7 @@
 #   - Honors `AZURECLAW_*` env wiring (router URL, AGT relay URL, identity SAN).
 #   - Does not bind privileged ports; default `securityContext` only.
 
-FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS base
 
 LABEL org.azureclaw.runtime.contract="v1"
 LABEL org.azureclaw.runtime.kind="MicrosoftAgentFramework"

--- a/sandbox-images/openai-agents/Dockerfile
+++ b/sandbox-images/openai-agents/Dockerfile
@@ -24,7 +24,7 @@
 # `runtimes/wheels/*.whl`. This keeps the image hermetic without
 # publishing private wheels to PyPI.
 
-FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS base
 
 LABEL org.azureclaw.runtime.contract="v1"
 LABEL org.azureclaw.runtime.kind="OpenAIAgents"

--- a/sandbox-images/pydantic-ai/Dockerfile
+++ b/sandbox-images/pydantic-ai/Dockerfile
@@ -31,7 +31,7 @@
 # `runtimes/wheels/*.whl`. This keeps the image hermetic without
 # publishing private wheels to PyPI.
 
-FROM mcr.microsoft.com/cbl-mariner/base/python:3.12 AS base
+FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS base
 
 LABEL org.azureclaw.runtime.contract="v1"
 LABEL org.azureclaw.runtime.kind="PydanticAi"


### PR DESCRIPTION
## What
Six runtime Dockerfiles referenced `mcr.microsoft.com/cbl-mariner/base/{python,nodejs}` which 404s today. Microsoft renamed the namespace to `azurelinux` when Mariner was rebranded. Same Azure Linux 3 user-space, just at the new path.

## Failure this unblocks
`azureclaw up` step 5 / `azureclaw push` for any non-OpenClaw runtime:
```
ERROR: failed to solve: mcr.microsoft.com/cbl-mariner/base/python:3.12: not found
```

## Changes
| File | Was | Is |
|---|---|---|
| openai-agents, maf-python, langgraph, anthropic, pydantic-ai | `cbl-mariner/base/python:3.12` | `azurelinux/base/python:3.12` |
| langgraph-ts (builder + runtime) | `cbl-mariner/base/nodejs:22` | `azurelinux/base/nodejs:24` |

`azurelinux/base/nodejs` only publishes `20` and `24` tags (no 22) — verified via the MCR `/v2/.../tags/list` endpoint. 24 is the current LTS, forward-compatible with LangGraph.js (`>=20`).

## Verification
`docker build -f sandbox-images/openai-agents/Dockerfile .` — completes successfully (was the exact failing command in the user's `azureclaw up`).

## Out of scope
- Pinning the new bases to digests (recommended follow-up; OpenClaw's base already does this).
- Actually pushing the 6 runtime images to ACR (separate operator action; this PR only fixes the build).