### PR TITLE
feat(up): auto-resume after failed runs

### DIFF
--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -49,6 +49,7 @@ export function upCommand(): Command {
     // ── Output / lifecycle ────────────────────────────────────────────
     .option("--dry-run", "Show what would be done without executing", false)
     .option("--upgrade", "Fast upgrade: skip prompts, reuse cached context, just re-run Helm + RBAC", false)
+    .option("--from-scratch", "Ignore any partial state from a prior failed run and start over", false)
     .addHelpText("after", `
 Flag groups:
   Identity:           --name, --model, --policy
@@ -57,13 +58,22 @@ Flag groups:
   Images:             --source-acr, --build, --skip-runtime-images
   Foundry:            --foundry-endpoint, --openai-endpoint
   Mesh federation:    --mesh-peer / --no-mesh-peer, --global-registry, --expose-registry
-  Output / lifecycle: --dry-run, --upgrade
+  Output / lifecycle: --dry-run, --upgrade, --from-scratch
 
 Examples:
   azureclaw up                                       # Full provision with defaults
   azureclaw up --name myagent --region westus3       # Pick a name + region
   azureclaw up --skip-infra                          # Reuse existing AKS cluster
   azureclaw up --upgrade                             # Fast Helm-only redeploy
+  azureclaw up --from-scratch                        # Discard any partial state from a previous failed run
+
+Auto-resume:
+  If a previous \`azureclaw up\` failed mid-flight, the next invocation
+  automatically resumes by skipping phases that already completed
+  (network firewall config, image push). State lives in
+  ~/.azureclaw/context.json and is invalidated on topology change
+  (region / resource-group / cluster / sandbox name) or after 7 days.
+  Use --from-scratch to discard it explicitly.
 `)
     .action(async (options) => {
       // Up-front validation: reject obviously-wrong values before any Azure work.
@@ -108,6 +118,35 @@ Examples:
       const clusterName = options.clusterName ?? "azureclaw";
       const baseName = clusterName.replace(/-aks$/, "");
       let acrName = ""; // resolved from Bicep output after deployment
+
+      // ── Auto-resume from prior partial run ──────────────────────────
+      // Inspects ~/.azureclaw/context.json. Returns null when there's no
+      // partial state, when topology (region / RG / cluster / sandbox /
+      // source-acr) changed, when the saved state is stale, or when the
+      // user passed --from-scratch.
+      const { loadResumeState, isPhaseSkippable, markPhaseDone, formatAge } =
+        await import("./up/resume.js");
+      const resumeTopology = {
+        region: options.region,
+        resourceGroup: rg,
+        aksCluster: `${baseName}-aks`,
+        sandboxName: options.name,
+        sourceAcr: options.sourceAcr,
+      };
+      const resumeState = loadResumeState(
+        { fromScratch: options.fromScratch },
+        resumeTopology,
+      );
+      if (resumeState) {
+        console.log(
+          chalk.cyan(
+            `  ↻ Resuming previous run (last completed: ${resumeState.resumeFromPhase}, ${formatAge(resumeState.ageMs)} ago). Use --from-scratch to start over.\n`,
+          ),
+        );
+      } else if (options.fromScratch) {
+        console.log(chalk.dim(`  --from-scratch: any cached partial state will be ignored.\n`));
+      }
+      const resumeFromPhase = resumeState?.resumeFromPhase ?? null;
       // Stepper counts the 9 runtime phases below (10 with --expose-registry).
       // Preflight runs before the stepper (see runPreflightChecks above).
       //   1. Resource group + preview features
@@ -213,6 +252,7 @@ Examples:
         await execa("az", ["provider", "register", "-n", "Microsoft.ContainerService", "--output", "none"], { stdio: "pipe" }).catch(() => {});
 
         stepper.done(`Resource group '${rg}' ready${callerIp ? ` (IP: ${callerIp})` : ""}`);
+        markPhaseDone("rg", {}, resumeTopology);
 
         // ── Step 3: Deploy Bicep (AKS + ACR + KV + AOAI + Monitor + WI) ─
         let acrLoginServer: string;
@@ -297,6 +337,11 @@ Examples:
             }
 
             stepper.done("Azure resources provisioned");
+            markPhaseDone(
+              "infra",
+              { acrLoginServer, acrName, foundryEndpoint: options.foundryEndpoint, wiClientId, keyVaultName: kvName },
+              resumeTopology,
+            );
           } catch (bicepErr: any) {
             clearInterval(ticker);
             throw bicepErr;
@@ -339,9 +384,19 @@ Examples:
           stepper.detail("ok", `Workload Identity — ${wiClientId.slice(0, 8)}...`);
 
           stepper.done("Infrastructure verified (Bicep skipped)");
+          markPhaseDone(
+            "infra",
+            { acrLoginServer, acrName, foundryEndpoint: options.foundryEndpoint, wiClientId, keyVaultName: kvName },
+            resumeTopology,
+          );
         }
 
         // ── Step 3a: Ensure caller IP is in AKS API server authorized ranges ──
+        if (isPhaseSkippable("network", resumeFromPhase)) {
+          stepper.step("Configuring network access & firewalls...");
+          stepper.detail("ok", "Already configured in previous run — skipping");
+          stepper.done("Network access (skipped — resumed from prior run)");
+        } else {
         stepper.step("Configuring network access & firewalls...");
         if (callerIp) {
           stepper.update("Updating AKS API server authorized IPs...");
@@ -425,6 +480,8 @@ Examples:
         });
 
         stepper.done("Network access configured");
+        }
+        markPhaseDone("network", {}, resumeTopology);
 
         // ── Step 5: Get AKS credentials ──────────────────────────────
         stepper.step("Configuring kubectl...");
@@ -436,11 +493,16 @@ Examples:
           "--output", "none",
         ], { stdio: "pipe" });
         stepper.done("kubectl configured");
+        markPhaseDone("kubectl", {}, resumeTopology);
 
         // ── Step 6: Get images into ACR ──────────────────────────────
         const acr = acrLoginServer.replace(".azurecr.io", "");
 
-        if (options.build) {
+        if (isPhaseSkippable("images", resumeFromPhase)) {
+          stepper.step(options.build ? "Building and pushing images..." : "Importing images from source ACR...");
+          stepper.detail("ok", "Already pushed/imported in previous run — skipping");
+          stepper.done("Images (skipped — resumed from prior run)");
+        } else if (options.build) {
           // Developer mode: build locally and push
           stepper.step("Building and pushing images...");
           stepper.update("Logging into ACR...");
@@ -554,6 +616,7 @@ Examples:
 
           stepper.done("Images available in ACR");
         }
+        markPhaseDone("images", {}, resumeTopology);
 
         // ── Step 6: Install / upgrade Helm chart ─────────────────────
         stepper.step("Deploying Helm chart (controller + CRD + RBAC)...");
@@ -787,6 +850,7 @@ Examples:
         ], { stdio: "pipe" }).catch(() => {});
 
         stepper.done(`Controller ${helmExists ? "upgraded" : "deployed"}`);
+        markPhaseDone("helm", {}, resumeTopology);
 
         // ── Step 6b/6c: Inspektor Gadget + AgentMesh deploy ──────────
         // (S15.d.3: extracted to ./up/agentmesh_deploy.ts)
@@ -798,6 +862,7 @@ Examples:
         const registryMode = meshResult.registryMode;
         const globalRegistryUrl = meshResult.globalRegistryUrl;
         const globalRelayUrl = meshResult.globalRelayUrl;
+        markPhaseDone("mesh", { registryMode, globalRegistryUrl, globalRelayUrl }, resumeTopology);
 
         // ── Step 7+8: Sandbox bring-up (S15.d.4: extracted to ./up/sandbox_bringup.ts) ──
         // Federated credentials, MI Contributor, Foundry RBAC, ClawSandbox CR,

--- a/cli/src/commands/up/resume.test.ts
+++ b/cli/src/commands/up/resume.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Redirect homedir() to a per-test tmp dir so context.json writes are
+// isolated from the user's real ~/.azureclaw.
+let tmpHome: string = mkdtempSync(join(tmpdir(), "azureclaw-resume-test-"));
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return { ...actual, homedir: () => tmpHome };
+});
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "azureclaw-resume-test-"));
+  mkdirSync(join(tmpHome, ".azureclaw"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+const CONTEXT_PATH = () => join(tmpHome, ".azureclaw", "context.json");
+
+function writeContext(ctx: Record<string, unknown>): void {
+  writeFileSync(CONTEXT_PATH(), JSON.stringify(ctx, null, 2), "utf-8");
+}
+
+describe("up/resume", () => {
+  async function loadModules() {
+    // Reset module cache so config.ts re-captures CONFIG_DIR from the
+    // per-test tmpHome via the mocked homedir().
+    vi.resetModules();
+    const mod = await import("./resume.js");
+    return mod;
+  }
+
+  it("returns null when no context.json exists", async () => {
+    const { loadResumeState } = await loadModules();
+    expect(loadResumeState({}, { region: "eastus2" })).toBeNull();
+  });
+
+  it("returns null when phase is missing", async () => {
+    writeContext({ region: "eastus2", savedAt: new Date().toISOString() });
+    const { loadResumeState } = await loadModules();
+    expect(loadResumeState({}, { region: "eastus2" })).toBeNull();
+  });
+
+  it("returns null when phase is 'complete' (last run finished)", async () => {
+    writeContext({ phase: "complete", region: "eastus2", savedAt: new Date().toISOString() });
+    const { loadResumeState } = await loadModules();
+    expect(loadResumeState({}, { region: "eastus2" })).toBeNull();
+  });
+
+  it("returns null when --from-scratch is passed", async () => {
+    writeContext({ phase: "network", region: "eastus2", savedAt: new Date().toISOString() });
+    const { loadResumeState } = await loadModules();
+    expect(loadResumeState({ fromScratch: true }, { region: "eastus2" })).toBeNull();
+  });
+
+  it("returns null when topology mismatches (region change)", async () => {
+    writeContext({ phase: "network", region: "eastus2", savedAt: new Date().toISOString() });
+    const { loadResumeState } = await loadModules();
+    expect(loadResumeState({}, { region: "westus3" })).toBeNull();
+  });
+
+  it("returns null when context is older than 7 days", async () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    writeContext({ phase: "network", region: "eastus2", savedAt: tenDaysAgo });
+    const { loadResumeState } = await loadModules();
+    expect(loadResumeState({}, { region: "eastus2" })).toBeNull();
+  });
+
+  it("returns resume state when phase is partial and topology matches", async () => {
+    writeContext({
+      phase: "network",
+      region: "eastus2",
+      resourceGroup: "azureclaw-eastus2",
+      aksCluster: "azureclaw-aks",
+      sandboxName: "my-assistant",
+      savedAt: new Date().toISOString(),
+    });
+    const { loadResumeState } = await loadModules();
+    const state = loadResumeState(
+      {},
+      { region: "eastus2", resourceGroup: "azureclaw-eastus2", aksCluster: "azureclaw-aks", sandboxName: "my-assistant" },
+    );
+    expect(state).not.toBeNull();
+    expect(state?.resumeFromPhase).toBe("network");
+    expect(state?.ageMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("isPhaseSkippable returns true only for SKIPPABLE phases at-or-before resumeFromPhase", async () => {
+    const { isPhaseSkippable } = await loadModules();
+    // network is skippable
+    expect(isPhaseSkippable("network", "network")).toBe(true);
+    expect(isPhaseSkippable("network", "images")).toBe(true);
+    expect(isPhaseSkippable("network", "rg")).toBe(false); // not done yet
+    // images is skippable
+    expect(isPhaseSkippable("images", "images")).toBe(true);
+    expect(isPhaseSkippable("images", "network")).toBe(false);
+    // rg is NOT in SKIPPABLE
+    expect(isPhaseSkippable("rg", "complete")).toBe(false);
+    // helm is NOT in SKIPPABLE
+    expect(isPhaseSkippable("helm", "helm")).toBe(false);
+    // null resumeFromPhase: never skip
+    expect(isPhaseSkippable("network", null)).toBe(false);
+    expect(isPhaseSkippable("images", undefined)).toBe(false);
+  });
+
+  it("markPhaseDone writes phase + topology to context.json and merges with prior state", async () => {
+    writeContext({ acrLoginServer: "test.azurecr.io" });
+    const { markPhaseDone } = await loadModules();
+    markPhaseDone(
+      "infra",
+      { keyVaultName: "kv-foo" },
+      { region: "eastus2", resourceGroup: "rg-foo", aksCluster: "aks-foo", sandboxName: "s" },
+    );
+    const written = JSON.parse(readFileSync(CONTEXT_PATH(), "utf-8"));
+    expect(written.phase).toBe("infra");
+    expect(written.acrLoginServer).toBe("test.azurecr.io"); // preserved
+    expect(written.keyVaultName).toBe("kv-foo");            // new
+    expect(written.region).toBe("eastus2");                  // topology
+    expect(written.resourceGroup).toBe("rg-foo");
+    expect(written.savedAt).toBeTypeOf("string");
+    expect(written.phaseStartedAt).toBeTypeOf("string");
+  });
+
+  it("markPhaseDone('complete') stamps complete and clears the resumable state", async () => {
+    writeContext({ phase: "mesh", region: "eastus2", savedAt: new Date().toISOString() });
+    const { markPhaseDone, loadResumeState } = await loadModules();
+    markPhaseDone("complete", {}, { region: "eastus2" });
+    expect(loadResumeState({}, { region: "eastus2" })).toBeNull();
+    const written = JSON.parse(readFileSync(CONTEXT_PATH(), "utf-8"));
+    expect(written.phase).toBe("complete");
+  });
+
+  it("formatAge produces compact strings", async () => {
+    const { formatAge } = await loadModules();
+    expect(formatAge(0)).toBe("<1m");
+    expect(formatAge(30_000)).toBe("<1m");
+    expect(formatAge(60_000)).toBe("1m");
+    expect(formatAge(12 * 60_000)).toBe("12m");
+    expect(formatAge(2 * 60 * 60_000)).toBe("2h");
+    expect(formatAge(3 * 24 * 60 * 60_000)).toBe("3d");
+    expect(formatAge(-1)).toBe("?");
+  });
+
+  it("file is created with expected location under $HOME", async () => {
+    const { markPhaseDone } = await loadModules();
+    markPhaseDone("rg", {}, { region: "eastus2" });
+    expect(existsSync(CONTEXT_PATH())).toBe(true);
+  });
+});

--- a/cli/src/commands/up/resume.ts
+++ b/cli/src/commands/up/resume.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Auto-resume support for `azureclaw up`.
+ *
+ * Strategy: every successful phase in up.ts calls `markPhaseDone(phase, ...)`
+ * which merges into the existing `~/.azureclaw/context.json`. On a subsequent
+ * run, `loadResumeState()` returns the last completed phase (subject to
+ * topology-match + TTL checks), and `isPhaseSkippable()` is consulted before
+ * each expensive phase. On full success, `markPhaseDone("complete", ...)` is
+ * called from sandbox_bringup so the next `up` starts fresh.
+ *
+ * Why only some phases skip:
+ *   - rg, infra, kubectl, helm, mesh, sandbox already self-probe and finish
+ *     in seconds; running them again is harmless.
+ *   - network and images are the expensive ones (network: ~6 min, images:
+ *     ~minutes per image with --build, or ~30s/image with --source-acr).
+ *     These are the high-value skips on resume.
+ */
+
+import { loadContext, saveContext, type DeploymentContext, type UpPhase } from "../../config.js";
+
+/** Linear order of phases; index() comparison drives skip-logic. */
+const PHASE_ORDER: UpPhase[] = [
+  "rg",
+  "infra",
+  "network",
+  "kubectl",
+  "images",
+  "helm",
+  "mesh",
+  "sandbox",
+  "complete",
+];
+
+/** Phases we actually skip on resume (others are cheap or self-idempotent). */
+const SKIPPABLE: ReadonlySet<UpPhase> = new Set<UpPhase>(["network", "images"]);
+
+/** Hard TTL — older partial state is ignored (subscription/quota may have changed). */
+const RESUME_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * Topology fields that, if changed between runs, should invalidate a
+ * partial resume (the saved context is for a different deployment).
+ */
+export interface ResumeTopology {
+  subscription?: string;
+  region?: string;
+  resourceGroup?: string;
+  aksCluster?: string;
+  sandboxName?: string;
+  sourceAcr?: string;
+}
+
+export interface ResumeState {
+  /** Last completed phase from the previous run (never "complete"). */
+  resumeFromPhase: UpPhase;
+  /** The cached context from disk, including all values from prior phases. */
+  ctx: DeploymentContext;
+  /** Age of the saved context, milliseconds. */
+  ageMs: number;
+  /** If non-null, a human-readable note why we re-ran a phase even though it might be skippable. */
+  warning?: string;
+}
+
+/**
+ * Returns true if the saved context's topology matches the current run.
+ * If a saved field is unset, it is treated as "compatible" (older context).
+ */
+function topologyMatches(saved: DeploymentContext, current: ResumeTopology): boolean {
+  const cmp = (a?: string, b?: string): boolean => !a || !b || a === b;
+  return (
+    cmp(saved.subscription, current.subscription) &&
+    cmp(saved.region, current.region) &&
+    cmp(saved.resourceGroup, current.resourceGroup) &&
+    cmp(saved.aksCluster, current.aksCluster) &&
+    cmp(saved.sandboxName, current.sandboxName) &&
+    cmp(saved.sourceAcr, current.sourceAcr)
+  );
+}
+
+/**
+ * Decide whether to resume from a partial previous run. Returns null if any of:
+ *   - no context.json on disk
+ *   - context.phase is missing or "complete"
+ *   - topology mismatches the current invocation
+ *   - context is older than RESUME_TTL_MS
+ *   - caller passed `fromScratch: true`
+ */
+export function loadResumeState(
+  options: { fromScratch?: boolean },
+  topology: ResumeTopology,
+): ResumeState | null {
+  if (options.fromScratch) return null;
+  const ctx = loadContext();
+  if (!ctx || !ctx.phase || ctx.phase === "complete") return null;
+  if (!topologyMatches(ctx, topology)) return null;
+  const ageMs = ctx.savedAt ? Date.now() - new Date(ctx.savedAt).getTime() : Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(ageMs) || ageMs < 0 || ageMs > RESUME_TTL_MS) return null;
+  return { resumeFromPhase: ctx.phase, ctx, ageMs };
+}
+
+/**
+ * Returns true if `phase` was already completed in the previous run AND is
+ * one of the phases we choose to skip on resume.
+ */
+export function isPhaseSkippable(phase: UpPhase, resumeFromPhase: UpPhase | null | undefined): boolean {
+  if (!resumeFromPhase) return false;
+  if (!SKIPPABLE.has(phase)) return false;
+  const cur = PHASE_ORDER.indexOf(phase);
+  const last = PHASE_ORDER.indexOf(resumeFromPhase);
+  return cur >= 0 && last >= 0 && cur <= last;
+}
+
+/**
+ * Persist that `phase` just completed. Merges any newly-resolved values
+ * (e.g. acrLoginServer after Bicep) into the on-disk context. Topology
+ * fields are stamped on every call so the resume guard has fresh values.
+ */
+export function markPhaseDone(
+  phase: UpPhase,
+  partial: Partial<DeploymentContext> = {},
+  topology: ResumeTopology = {},
+): void {
+  const existing = loadContext() ?? {};
+  const merged: DeploymentContext = {
+    ...existing,
+    ...partial,
+    phase,
+    subscription: topology.subscription ?? partial.subscription ?? existing.subscription,
+    region: topology.region ?? partial.region ?? existing.region,
+    resourceGroup: topology.resourceGroup ?? partial.resourceGroup ?? existing.resourceGroup,
+    aksCluster: topology.aksCluster ?? partial.aksCluster ?? existing.aksCluster,
+    sandboxName: topology.sandboxName ?? existing.sandboxName,
+    sourceAcr: topology.sourceAcr ?? existing.sourceAcr,
+  };
+  if (phase !== "complete" && !merged.phaseStartedAt) {
+    merged.phaseStartedAt = new Date().toISOString();
+  }
+  saveContext(merged);
+}
+
+/** Format a millisecond age compactly: "<1m", "12m", "3h", "2d". */
+export function formatAge(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "?";
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return "<1m";
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  return `${Math.floor(hr / 24)}d`;
+}
+
+export const _internal = { PHASE_ORDER, SKIPPABLE, RESUME_TTL_MS };

--- a/cli/src/commands/up/sandbox_bringup.ts
+++ b/cli/src/commands/up/sandbox_bringup.ts
@@ -481,7 +481,9 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
     console.log(`  ${chalk.green("→")} ${chalk.cyan.underline(webUiUrl)}`);
   }
 
-  // Cache deployment context for subsequent commands (add, status, list, push, etc.)
+  // Cache deployment context for subsequent commands (add, status, list, push,
+  // etc.). Setting phase: "complete" also marks the auto-resume state as fully
+  // consumed so the next `azureclaw up` starts fresh.
   try {
     saveContext({
       region: options.region,
@@ -500,6 +502,9 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
       registryMode,
       globalRegistryUrl,
       globalRelayUrl,
+      phase: "complete",
+      sandboxName: options.name,
+      sourceAcr: typeof options.sourceAcr === "string" ? options.sourceAcr : undefined,
     });
   } catch { /* non-critical */ }
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -54,7 +54,22 @@ export interface AzureClawConfig {
   foundryProjectEndpoint?: string;
 }
 
-/** Cached deployment context — saved after successful `azureclaw up` */
+/**
+ * Up phases tracked for auto-resume. Persisted in DeploymentContext.phase
+ * after each completed phase; cleared (set to "complete") after a successful run.
+ */
+export type UpPhase =
+  | "rg"
+  | "infra"
+  | "network"
+  | "kubectl"
+  | "images"
+  | "helm"
+  | "mesh"
+  | "sandbox"
+  | "complete";
+
+/** Cached deployment context — saved incrementally during `azureclaw up` */
 export interface DeploymentContext {
   subscription?: string;
   region?: string;
@@ -79,6 +94,24 @@ export interface DeploymentContext {
   globalRelayUrl?: string;
   /** How the registry was promoted: "port-forward" | "loadbalancer" */
   promoteMode?: string;
+  /**
+   * Last completed phase of `azureclaw up`. Used by auto-resume to skip
+   * already-done phases on a re-run after a failure. Set to "complete"
+   * after a fully successful run.
+   */
+  phase?: UpPhase;
+  /** ISO-8601 timestamp when the current run started (for resume staleness). */
+  phaseStartedAt?: string;
+  /**
+   * Sandbox name from --name. Used to detect topology mismatches that
+   * should invalidate a partial-run resume.
+   */
+  sandboxName?: string;
+  /**
+   * Source ACR (--source-acr) used for the run. Used to detect topology
+   * changes that should invalidate a partial-run resume.
+   */
+  sourceAcr?: string;
 }
 
 const CONTEXT_FILE = join(CONFIG_DIR, "context.json");

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -114,6 +114,7 @@ azureclaw up [options]
 | `--openai-endpoint <url>` | — | Existing Azure OpenAI endpoint (`openai.azure.com`; derived from Foundry if omitted) |
 | `--dry-run` | `false` | Show what would be done without executing |
 | `--upgrade` | `false` | Fast upgrade: skip prompts, reuse cached context, re-run Helm + RBAC only |
+| `--from-scratch` | `false` | Ignore any partial state from a prior failed run and start over |
 | `--mesh-peer` | `true` | Enable mesh federation peer (`--no-mesh-peer` to disable) |
 | `--global-registry <url>` | — | Use an external AgentMesh registry (skip local registry deployment) |
 | `--expose-registry` | `false` | Deploy AGIC Ingress to expose this cluster's registry publicly |
@@ -135,7 +136,22 @@ azureclaw up --dry-run
 
 # Developer — build images locally, connect to Foundry
 azureclaw up --build --foundry-endpoint https://my-project.services.ai.azure.com
+
+# Force a clean run (discard any auto-resume state)
+azureclaw up --from-scratch
 ```
+
+**Auto-resume:** If `azureclaw up` fails mid-flight (e.g. a transient quota
+error during image push), the next run automatically picks up where the
+previous one left off. State lives in `~/.azureclaw/context.json` and tracks
+which phases (`rg`, `infra`, `network`, `kubectl`, `images`, `helm`, `mesh`,
+`sandbox`) succeeded. On resume, the slow `network` and `images` phases are
+skipped if they already completed; everything else is re-run idempotently.
+The state is invalidated automatically when:
+- Topology changes (`--region`, `--resource-group`, `--cluster-name`, `--name`, `--source-acr`)
+- The saved state is older than 7 days
+- The previous run completed successfully (`phase: complete`)
+- You pass `--from-scratch`
 
 **See also:** [README quick-start](../README.md), [docs/architecture.md](architecture.md)
 


### PR DESCRIPTION
## Why

Today, when \`azureclaw up\` fails mid-flight (transient quota error during image push, network blip, az CLI glitch), the next run starts from scratch. The 6-minute network-firewall step and the image push/import phase re-run every time.

## What changes

Persist the last-completed phase to \`~/.azureclaw/context.json\` after each successful step. On the next run, skip the expensive phases that already succeeded (\`network\` and \`images\`); re-run everything else idempotently.

State is invalidated automatically when:
- Topology changes (\`--region\`, \`--resource-group\`, \`--cluster-name\`, \`--name\`, \`--source-acr\`)
- Saved state is older than 7 days
- Previous run completed successfully (\`phase: complete\`)
- User passes new \`--from-scratch\` flag

## How it works

\`\`\`
$ azureclaw up
... fails during image push ...

$ azureclaw up
↻ Resuming previous run (last completed: network, 12m ago). Use --from-scratch to start over.

  1/9 ✔ Resource group ready
  2/9 ✔ Infrastructure verified (Bicep skipped)  [1s]
  3/9 ✔ Network access (skipped — resumed from prior run)  [<1s]
  4/9 ✔ kubectl configured
  5/9 → Importing images from source ACR...
  ...
\`\`\`

## Files

- \`cli/src/config.ts\` — \`UpPhase\` type, \`phase\` / \`sandboxName\` / \`sourceAcr\` / \`phaseStartedAt\` fields on \`DeploymentContext\`
- \`cli/src/commands/up/resume.ts\` (new) — \`loadResumeState\`, \`isPhaseSkippable\`, \`markPhaseDone\`, \`formatAge\`
- \`cli/src/commands/up/resume.test.ts\` (new) — 12 tests covering topology mismatch, TTL, skip logic, from-scratch
- \`cli/src/commands/up.ts\` — \`--from-scratch\` flag, resume banner, phase markers after each \`stepper.done\`, skip-guards on network + images
- \`cli/src/commands/up/sandbox_bringup.ts\` — sets \`phase: "complete"\` in final \`saveContext\`
- \`docs/cli-reference.md\` — new flag + auto-resume section

## Tests

- New: 12 tests in \`resume.test.ts\` (all pass)
- Existing CLI suite: 551 pass, 2 skipped (no regressions)

## Notes

- We keep \`rg\`, \`infra\`, \`kubectl\`, \`helm\`, \`mesh\`, \`sandbox\` as re-runnable on resume (they self-probe and complete in seconds). \`network\` and \`images\` are the high-value skips.
- This complements the existing \`--upgrade\` mode (which intentionally skips infra entirely for fast Helm-only redeploys); \`--upgrade\` is unaffected by auto-resume.