### PR TITLE
feat(dev): GitHub Models as a first-class persistent provider for `azureclaw dev`

### DIFF
--- a/cli/src/commands/credentials.ts
+++ b/cli/src/commands/credentials.ts
@@ -14,7 +14,7 @@ export function credentialsCommand(): Command {
 
   cmd
     .description(
-      "Manage AzureClaw credentials (Azure OpenAI, channel tokens, API keys)"
+      "Manage AzureClaw credentials (inference provider, channel tokens, API keys)"
     )
     .action(async () => {
       const { default: inquirer } = await import("inquirer");
@@ -37,7 +37,7 @@ export function credentialsCommand(): Command {
 
       // Main menu
       const categories = [
-        { name: "Azure OpenAI  — endpoint, model, API key", value: "aoai" },
+        { name: "Inference     — Azure AI Foundry / Azure OpenAI or GitHub Models", value: "inference" },
         { name: "Telegram      — bot token, allowed users", value: "telegram" },
         { name: "Slack         — bot OAuth token", value: "slack" },
         { name: "Discord       — bot token", value: "discord" },
@@ -57,8 +57,8 @@ export function credentialsCommand(): Command {
 
         if (category === "done") break;
 
-        if (category === "aoai") {
-          await promptAndSaveCredentials({ heading: "Azure OpenAI" });
+        if (category === "inference") {
+          await promptAndSaveCredentials({ heading: "Inference provider" });
         } else {
           const promptMap: Record<string, Array<{ key: string; label: string; allowSuffix?: boolean }>> = {
             telegram: [

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -29,9 +29,17 @@ export function devCommand(): Command {
       "Run a sandbox locally via Docker for development. Same policies, same model routing, on your laptop."
     )
     .addHelpText("before", `
-Requires an existing Azure OpenAI resource with at least one model deployment
-(e.g. gpt-4.1). On first run, you will be prompted for your endpoint, model
-deployment name, and resource-level API key.
+Requires either:
+  • An existing Azure AI Foundry / Azure OpenAI deployment, OR
+  • A GitHub PAT with \`models:read\` scope, which routes inference through
+    GitHub Models — no Azure subscription needed.
+
+On first run, you'll be prompted to choose between the two providers and
+your choice (and credentials) will be saved to ~/.azureclaw/. Subsequent
+runs reuse the saved provider — no flags required.
+
+Use --github-token for a one-off, ephemeral GitHub Models run that does
+NOT overwrite your saved credentials.
 `)
     // ── Identity ───────────────────────────────────────────────────────
     .option("--name <name>", "Sandbox name", "dev-agent")
@@ -40,6 +48,11 @@ deployment name, and resource-level API key.
       "--policy <preset>",
       "Policy preset: minimal | developer | web | azure",
       "developer"
+    )
+    // ── Provider override ─────────────────────────────────────────────
+    .option(
+      "--github-token <pat>",
+      "One-off GitHub Models override (does NOT save). Requires a PAT with `models:read`. To save GitHub Models as your default provider, run without this flag and pick GitHub Models at the prompt."
     )
     // ── Image build ────────────────────────────────────────────────────
     .option(
@@ -121,18 +134,46 @@ Notes:
 
         // ── Credentials (first — prompt before potentially long build) ──
         stepper.step("Checking credentials...");
+        const githubToken = typeof options.githubToken === "string" ? options.githubToken.trim() : undefined;
         let creds = loadConfig();
-        if (!creds) {
+        let mountedSecretPath = CREDENTIALS_FILE;
+
+        if (githubToken) {
+          // Ephemeral GitHub Models override: don't touch saved creds. Build
+          // an inline config and write the PAT to a per-run tempfile that
+          // gets mounted instead of the saved credentials file.
+          const ghModelsEndpoint = "https://models.github.ai/inference";
+          const ghDefaultModel = options.model !== "gpt-4.1" ? options.model : "gpt-4o-mini";
+          creds = {
+            endpoint: ghModelsEndpoint,
+            model: ghDefaultModel,
+            apiKey: githubToken,
+            foundryProjectEndpoint: undefined,
+            provider: "github-models",
+          };
+          const { mkdtempSync, writeFileSync, chmodSync } = await import("node:fs");
+          const ghTmpDir = mkdtempSync(path.join(os.tmpdir(), "azureclaw-ghmodels-"));
+          mountedSecretPath = path.join(ghTmpDir, "azure-openai-key");
+          writeFileSync(mountedSecretPath, githubToken, "utf-8");
+          chmodSync(mountedSecretPath, 0o600);
+          stepper.done("Credentials loaded (GitHub Models — ephemeral, not saved)");
+        } else if (!creds) {
           // Stop spinner so inquirer interactive prompts display correctly
           stepper.stop();
-          console.log(chalk.yellow("\n  No Azure OpenAI credentials found. Let's set them up."));
-          console.log(chalk.yellow("  You need an existing Azure OpenAI resource with a deployed model (e.g. gpt-4.1).\n"));
+          console.log(chalk.yellow("\n  No inference credentials found. Let's set them up."));
+          console.log(chalk.dim("  Choose between Azure AI Foundry / Azure OpenAI (full feature set) or GitHub Models (free, GitHub PAT).\n"));
           creds = await promptAndSaveCredentials();
-          stepper.done("Credentials configured");
+          const providerLabel = creds.provider === "github-models" ? "GitHub Models" : "Azure AI Foundry";
+          stepper.done(`Credentials configured (${providerLabel})`);
         } else {
-          stepper.done("Credentials loaded");
+          const providerLabel = creds.provider === "github-models" ? "GitHub Models" : "Azure AI Foundry";
+          stepper.done(`Credentials loaded (${providerLabel})`);
         }
-        const model = options.model !== "gpt-4.1" ? options.model : creds.model;
+        const isGithubModelsMode = creds.provider === "github-models";
+        const model = isGithubModelsMode
+          ? creds.model
+          : (options.model !== "gpt-4.1" ? options.model : creds.model);
+
 
         // ── Image resolution ─────────────────────────────────────────
         stepper.step("Resolving sandbox image...");
@@ -277,7 +318,8 @@ Notes:
         let discoveredDeployments = "";
         // Discover deployed models via Azure CLI (ARM management API — only reliable way).
         // Data-plane /openai/deployments always returns 404; skip it.
-        try {
+        // GitHub Models mode: skip entirely (the endpoint isn't an Azure resource).
+        if (!isGithubModelsMode) try {
           const accountName = new URL(creds.endpoint).hostname.split(".")[0];
           const { stdout: rgOut } = await execa("az", [
             "cognitiveservices", "account", "list",
@@ -598,7 +640,7 @@ Notes:
           "--tmpfs", "/tmp:rw,noexec,nosuid,size=1g",
           "-v", `${containerName}-data:/sandbox`,
           // Mount API key as read-only secret (never as env var)
-          "-v", `${CREDENTIALS_FILE}:/run/secrets/azure-openai-key:ro`,
+          "-v", `${mountedSecretPath}:/run/secrets/azure-openai-key:ro`,
           ...dockerSockArgs,
           ...kubeArgs,
           // Hide unnecessary filesystem paths
@@ -614,6 +656,7 @@ Notes:
           "-e", `AZURE_OPENAI_ENDPOINT=${creds.endpoint}`,
           "-e", `SANDBOX_NAME=${options.name}`,
           "-e", "AZURECLAW_DEV_MODE=true",
+          ...(isGithubModelsMode ? ["-e", "AZURECLAW_PROVIDER=github-models"] : []),
           "-e", `DOCKER_NETWORK=${AGT_NETWORK}`,
           // Phase 2/F8 mitigations — env-gated suppression of false-positive
           // governance findings. Default-on in dev so research/citation

--- a/cli/src/config.test.ts
+++ b/cli/src/config.test.ts
@@ -75,6 +75,7 @@ describe("loadConfig", () => {
       model: "gpt-4.1",
       apiKey: "sk-test-key-1234567890",
       foundryProjectEndpoint: undefined,
+      provider: "foundry",
     });
   });
 
@@ -90,6 +91,43 @@ describe("loadConfig", () => {
 
     const config = loadConfig();
     expect(config?.model).toBe("gpt-4.1");
+  });
+
+  it("loads GitHub Models provider with sane defaults", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation((p) => {
+      const path = String(p);
+      if (path.endsWith("config.json"))
+        return JSON.stringify({
+          endpoint: "https://models.github.ai/inference",
+          provider: "github-models",
+        });
+      if (path.endsWith("credentials")) return "ghp_testpat_1234567890";
+      return "";
+    });
+
+    const config = loadConfig();
+    expect(config?.provider).toBe("github-models");
+    expect(config?.endpoint).toBe("https://models.github.ai/inference");
+    // Default model for GitHub Models is gpt-4o-mini, not gpt-4.1
+    expect(config?.model).toBe("gpt-4o-mini");
+    expect(config?.apiKey).toBe("ghp_testpat_1234567890");
+  });
+
+  it("treats unknown provider strings as foundry", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation((p) => {
+      const path = String(p);
+      if (path.endsWith("config.json"))
+        return JSON.stringify({
+          endpoint: "https://test.openai.azure.com",
+          provider: "bogus-provider",
+        });
+      if (path.endsWith("credentials")) return "sk-test-key";
+      return "";
+    });
+
+    expect(loadConfig()?.provider).toBe("foundry");
   });
 
   it("returns null when endpoint is missing", () => {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -52,6 +52,15 @@ export interface AzureClawConfig {
   model: string;
   apiKey: string;
   foundryProjectEndpoint?: string;
+  /**
+   * Inference provider. "foundry" (default) routes inference at an Azure AI
+   * Foundry / Azure OpenAI resource via api-key or Workload Identity.
+   * "github-models" routes at https://models.github.ai/inference using a
+   * GitHub PAT — no Azure subscription needed; Foundry-only features
+   * (Memory Store, agents, evaluations, indexes, Content Safety inline)
+   * are unavailable in this mode.
+   */
+  provider?: "foundry" | "github-models";
 }
 
 /** Cached deployment context — saved after successful `azureclaw up` */
@@ -114,14 +123,24 @@ export function loadConfig(): AzureClawConfig | null {
     const apiKey = secrets["azure-openai-key"]
       || (existsSync(CREDENTIALS_FILE) ? readFileSync(CREDENTIALS_FILE, "utf-8").trim() : "");
     if (!config.endpoint || !apiKey) return null;
-    return { endpoint: config.endpoint, model: config.model || "gpt-4.1", apiKey, foundryProjectEndpoint: config.foundryProjectEndpoint };
+    const provider: AzureClawConfig["provider"] =
+      config.provider === "github-models" ? "github-models" : "foundry";
+    return {
+      endpoint: config.endpoint,
+      model: config.model || (provider === "github-models" ? "gpt-4o-mini" : "gpt-4.1"),
+      apiKey,
+      foundryProjectEndpoint: config.foundryProjectEndpoint,
+      provider,
+    };
   } catch {
     return null;
   }
 }
 
 /**
- * Interactively prompt for Azure OpenAI credentials, verify them, and save.
+ * Interactively prompt for inference credentials, verify them, and save.
+ * Leads with a provider choice (Azure AI Foundry / Azure OpenAI vs GitHub
+ * Models); the GitHub Models branch only needs a PAT.
  * If existing config is found, shows it as defaults.
  */
 export async function promptAndSaveCredentials(options?: {
@@ -129,6 +148,8 @@ export async function promptAndSaveCredentials(options?: {
   skipVerify?: boolean;
   /** Heading to show before prompts */
   heading?: string;
+  /** Force a specific provider (skip the choice prompt) */
+  provider?: "foundry" | "github-models";
 }): Promise<AzureClawConfig> {
   const existing = loadConfig();
 
@@ -137,9 +158,135 @@ export async function promptAndSaveCredentials(options?: {
   }
 
   if (existing) {
-    console.log(chalk.dim(`  Existing config found (${existing.endpoint}). Press Enter to keep.\n`));
+    const label = existing.provider === "github-models" ? "GitHub Models" : existing.endpoint;
+    console.log(chalk.dim(`  Existing config found (${label}). Press Enter to keep.\n`));
   }
 
+  // ── Step 1: provider choice ────────────────────────────────────────
+  let provider: "foundry" | "github-models";
+  if (options?.provider) {
+    provider = options.provider;
+  } else {
+    const providerAnswer = await inquirer.prompt([
+      {
+        type: "list",
+        name: "provider",
+        message: "Which inference provider do you want to use?",
+        default: existing?.provider ?? "foundry",
+        choices: [
+          {
+            name: "Azure AI Foundry / Azure OpenAI  (full feature set: Memory Store, agents, Content Safety, etc.)",
+            value: "foundry",
+          },
+          {
+            name: "GitHub Models                     (free; just need a GitHub PAT — Foundry-only features disabled)",
+            value: "github-models",
+          },
+        ],
+      },
+    ]);
+    provider = providerAnswer.provider;
+  }
+
+  if (provider === "github-models") {
+    return promptGithubModels(existing, options?.skipVerify);
+  }
+  return promptFoundry(existing, options?.skipVerify);
+}
+
+/**
+ * Prompt + verify + save the GitHub Models provider. The PAT lives in the
+ * same `azure-openai-key` slot the router reads at /run/secrets/, so no
+ * downstream wiring needs to change — only the URL and Bearer-vs-api-key
+ * decision (handled in the router based on the endpoint hostname).
+ */
+async function promptGithubModels(
+  existing: AzureClawConfig | null,
+  skipVerify?: boolean,
+): Promise<AzureClawConfig> {
+  console.log(chalk.dim(
+    "\n  GitHub Models docs: https://docs.github.com/github-models — create a PAT with 'models:read' scope.\n",
+  ));
+
+  const answers = await inquirer.prompt([
+    {
+      type: "input",
+      name: "model",
+      message: "Model to use (e.g. gpt-4o-mini, gpt-4o, Phi-3.5-mini-instruct):",
+      default: existing?.provider === "github-models" ? existing.model : "gpt-4o-mini",
+    },
+    {
+      type: "password",
+      name: "apiKey",
+      message: "GitHub PAT (must have 'models:read' scope):",
+      mask: "•",
+      validate: (input: string) => {
+        if (!input || input.length < 20) return "PAT is required";
+        return true;
+      },
+    },
+  ]);
+
+  const endpoint = "https://models.github.ai/inference";
+
+  // Verify by calling /catalog/models (a GET that just authenticates the PAT;
+  // doesn't consume the rate-limited inference budget).
+  if (!skipVerify) {
+    const spinner = ora({ color: "cyan" }).start("Verifying PAT against GitHub Models...");
+    try {
+      const response = await fetch("https://models.github.ai/catalog/models", {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${answers.apiKey}`,
+          "Accept": "application/vnd.github+json",
+          "User-Agent": "azureclaw-cli",
+        },
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        spinner.fail("GitHub PAT verification failed");
+        console.log(chalk.red(`\n  ${response.status}: ${body.slice(0, 400)}\n`));
+        if (response.status === 401 || response.status === 403) {
+          console.log(chalk.yellow("  The PAT is missing the 'models:read' scope, or has been revoked."));
+          console.log(chalk.yellow("  Create a new fine-grained token: https://github.com/settings/personal-access-tokens/new\n"));
+        }
+        process.exit(1);
+      }
+      spinner.succeed("GitHub PAT verified (GitHub Models)");
+    } catch (error) {
+      spinner.fail("Could not reach GitHub Models");
+      console.log(chalk.red(`\n  ${error instanceof Error ? error.message : String(error)}\n`));
+      process.exit(1);
+    }
+  }
+
+  // Persist
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  const configObj: Record<string, string> = {
+    endpoint,
+    model: answers.model,
+    provider: "github-models",
+    version: "0.1.0-alpha.1",
+  };
+  writeFileSync(CONFIG_FILE, JSON.stringify(configObj, null, 2), "utf-8");
+  chmodSync(CONFIG_FILE, 0o600);
+  setSecret("azure-openai-key", answers.apiKey);
+  writeFileSync(CREDENTIALS_FILE, answers.apiKey, "utf-8");
+  chmodSync(CREDENTIALS_FILE, 0o600);
+
+  return {
+    endpoint,
+    model: answers.model,
+    apiKey: answers.apiKey,
+    provider: "github-models",
+  };
+}
+
+/** Prompt + verify + save the Azure AI Foundry / Azure OpenAI provider. */
+async function promptFoundry(
+  existing: AzureClawConfig | null,
+  skipVerify?: boolean,
+): Promise<AzureClawConfig> {
   const answers = await inquirer.prompt([
     {
       type: "input",
@@ -172,7 +319,7 @@ export async function promptAndSaveCredentials(options?: {
   ]);
 
   // Verify
-  if (!options?.skipVerify) {
+  if (!skipVerify) {
     const spinner = ora({ color: "cyan" }).start("Verifying credentials...");
     try {
       const response = await fetch(
@@ -221,7 +368,12 @@ export async function promptAndSaveCredentials(options?: {
 
   // Save
   mkdirSync(CONFIG_DIR, { recursive: true });
-  const configObj: Record<string, string> = { endpoint: answers.endpoint, model: answers.model, version: "0.1.0-alpha.1" };
+  const configObj: Record<string, string> = {
+    endpoint: answers.endpoint,
+    model: answers.model,
+    provider: "foundry",
+    version: "0.1.0-alpha.1",
+  };
   if (foundryProjectEndpoint) configObj.foundryProjectEndpoint = foundryProjectEndpoint;
   writeFileSync(CONFIG_FILE, JSON.stringify(configObj, null, 2), "utf-8");
   chmodSync(CONFIG_FILE, 0o600);
@@ -230,7 +382,13 @@ export async function promptAndSaveCredentials(options?: {
   writeFileSync(CREDENTIALS_FILE, answers.apiKey, "utf-8");
   chmodSync(CREDENTIALS_FILE, 0o600);
 
-  return { endpoint: answers.endpoint, model: answers.model, apiKey: answers.apiKey, foundryProjectEndpoint: foundryProjectEndpoint || undefined };
+  return {
+    endpoint: answers.endpoint,
+    model: answers.model,
+    apiKey: answers.apiKey,
+    foundryProjectEndpoint: foundryProjectEndpoint || undefined,
+    provider: "foundry",
+  };
 }
 
 /**
@@ -241,7 +399,7 @@ export async function ensureCredentials(): Promise<AzureClawConfig> {
   const existing = loadConfig();
   if (existing) return existing;
 
-  console.log(chalk.yellow("\n  No Azure OpenAI credentials found. Let's set them up:\n"));
+  console.log(chalk.yellow("\n  No inference credentials found. Let's set them up:\n"));
   return promptAndSaveCredentials();
 }
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -20,7 +20,7 @@ const SECRETS_FILE = join(CONFIG_DIR, "secrets.json");
 
 /** Well-known secret keys and their descriptions */
 export const KNOWN_SECRETS: Record<string, { env: string; label: string }> = {
-  "azure-openai-key":  { env: "AZURE_OPENAI_API_KEY", label: "Azure OpenAI API key" },
+  "azure-openai-key":  { env: "AZURE_OPENAI_API_KEY", label: "Inference API key (Azure OpenAI key OR GitHub PAT)" },
   "telegram-token":    { env: "TELEGRAM_BOT_TOKEN",   label: "Telegram bot token" },
   "telegram-allow-from": { env: "TELEGRAM_ALLOW_FROM", label: "Telegram allowed user IDs" },
   "slack-token":       { env: "SLACK_BOT_TOKEN",      label: "Slack bot OAuth token" },

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -145,9 +145,16 @@ azureclaw up --build --foundry-endpoint https://my-project.services.ai.azure.com
 
 Runs a fully-policy-enforced sandbox locally via Docker for inner-loop
 development. Same model routing, same egress policies, and the same
-AGT governance layer as AKS — but on your laptop. Requires an existing
-Azure OpenAI resource with at least one model deployment. On first run,
-prompts for your endpoint, deployment name, and API key.
+AGT governance layer as AKS — but on your laptop.
+
+**Two inference providers** are supported. On first run you'll be asked
+to pick one; your choice is saved to `~/.azureclaw/config.json` and
+reused on subsequent runs:
+
+| Provider | Requires | Saved as | Trade-offs |
+|---|---|---|---|
+| **Azure AI Foundry / Azure OpenAI** | Existing Foundry or Azure OpenAI resource + API key | `provider: "foundry"` | Full feature set: Memory Store, agents, evaluations, Content Safety inline, indexes |
+| **GitHub Models** | A GitHub PAT with `models:read` scope | `provider: "github-models"` | Free, no Azure subscription needed. Foundry-only routes (Memory Store, agents, evaluations, indexes, Content Safety inline) return `501`. Subject to GitHub Models rate limits. |
 
 **Usage:**
 ```
@@ -158,8 +165,9 @@ azureclaw dev [options]
 | Flag | Default | Description |
 |---|---|---|
 | `--name <name>` | `dev-agent` | Sandbox name |
-| `--model <model>` | `gpt-4.1` | Azure OpenAI model deployment name |
+| `--model <model>` | `gpt-4.1` (Foundry) / `gpt-4o-mini` (GitHub Models) | Model deployment name |
 | `--policy <preset>` | `developer` | Policy preset: `minimal`, `developer`, `web`, `azure` |
+| `--github-token <pat>` | — | One-off GitHub Models override (does NOT save). Use this for ephemeral runs that shouldn't overwrite your saved provider. To make GitHub Models your default, run `azureclaw dev` without this flag and pick GitHub Models at the prompt. |
 | `--image <image>` | `azureclaw-sandbox:dev` | Sandbox container image |
 | `--build` | `false` | Build sandbox image locally from Dockerfile |
 | `--build-base` | `false` | Rebuild the sandbox base image (heavy deps; only needed when upgrading OpenClaw/Python/Go) |
@@ -182,6 +190,9 @@ azureclaw dev [options]
 ```bash
 # Start a local sandbox with default settings (prompts for credentials on first run)
 azureclaw dev
+
+# Ephemeral GitHub Models run — does not change your saved Foundry creds
+azureclaw dev --github-token $GITHUB_PAT
 
 # Named sandbox with Telegram channel
 azureclaw dev --name my-bot --channels telegram --telegram-token 123456:ABC-DEF

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -727,11 +727,20 @@ echo $?  # 0=match 2=drift 3=missing baseline
 
 ### `azureclaw credentials`
 
-Manages AzureClaw credentials (Azure OpenAI endpoint/key, channel tokens,
+Manages AzureClaw credentials (inference provider, channel tokens,
 third-party API keys). Invoking without a subcommand opens an interactive
-guided prompt. Use `credentials set` / `list` / `remove` for scripting.
-Use `credentials update` to patch a running AKS sandbox's K8s Secret without
-restarting the pod (unless you want a restart).
+guided prompt that lets you pick between **Azure AI Foundry / Azure OpenAI**
+and **GitHub Models** for inference, save channel tokens (Telegram, Slack,
+Discord), and configure third-party API keys (Brave, Tavily, Exa,
+Firecrawl, Perplexity, OpenAI). Use `credentials set` / `list` / `remove`
+for scripting. Use `credentials update` to patch a running AKS sandbox's
+K8s Secret without restarting the pod (unless you want a restart).
+
+The inference provider you pick is saved to `~/.azureclaw/config.json`
+(field `provider: "foundry" | "github-models"`); the API key / GitHub PAT
+is saved alongside in `~/.azureclaw/secrets.json` under the key
+`azure-openai-key`. Switch providers any time by re-running this command
+and picking the other option.
 
 **Usage:**
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,10 +13,23 @@ The sandbox YAML you wrote in step 1 runs unchanged in step 2. That is the whole
 
 | For | You need |
 |---|---|
-| Local mode | Docker Desktop (or any OCI runtime), Node.js 22+, Rust 1.88+, an Azure AI Foundry (or Azure OpenAI) endpoint + deployment + key. |
+| Local mode (Foundry) | Docker Desktop (or any OCI runtime), Node.js 22+, Rust 1.88+, an Azure AI Foundry (or Azure OpenAI) endpoint + deployment + key. |
+| Local mode (GitHub Models) | Docker Desktop, Node.js 22+, Rust 1.88+, a GitHub PAT with `models:read` scope. **No Azure account needed.** |
 | AKS mode | The above, plus the [Azure CLI](https://learn.microsoft.com/cli/azure/) (`az`), [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [Helm 3.14+](https://helm.sh/), and an Azure subscription where you can create resource groups. |
 
 The CLI bootstraps everything else (Helm chart install, Foundry resource creation, ACR build/push, federated identity wiring). You do not need to provision any of it by hand.
+
+### Quickest path: GitHub Models (no Azure account)
+
+If you just want to play with `azureclaw dev` and don't care about the Foundry-only features (Memory Store, agents, evaluations, indexes, inline Content Safety), you can run inference through **GitHub Models** with nothing but a GitHub PAT:
+
+1. Create a fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with the **`models:read`** scope.
+2. Run `azureclaw dev` and pick **GitHub Models** at the first prompt.
+3. Paste your PAT. The CLI verifies it against `https://models.github.ai/catalog/models` and saves it to `~/.azureclaw/`.
+
+Subsequent runs reuse the saved provider — no flag required. To override for one run only (without overwriting your saved provider), pass `--github-token <pat>`.
+
+> ⚠️ **Trade-offs in GitHub Models mode.** Foundry-only routes return `501 Not Implemented` (Memory Store, agents, evaluations, indexes, knowledge bases, datasets, deployments, connections). Inline Content Safety prompt-shield filtering is **not enforced** server-side — the router can only act on `prompt_filter_results` returned by the model, and GitHub Models doesn't return them. Subject to GitHub Models rate limits (free-tier; see [GitHub Models docs](https://docs.github.com/github-models)).
 
 ### Don't have an Azure AI Foundry deployment yet?
 
@@ -70,11 +83,12 @@ The CLI is a Node 22 ESM build with a small Rust dependency for the local router
 azureclaw dev --name hello
 ```
 
-On the first run you are prompted for:
+On the first run you are prompted to pick a provider:
 
-- **Endpoint** — your Azure OpenAI / Foundry endpoint, e.g. `https://my-resource.openai.azure.com`.
-- **Deployment name** — the model deployment you want the agent to use, e.g. `gpt-4.1`.
-- **API key** — a resource-level key. **This is the only credential local mode ever sees, and it is mounted from a local secret file — it never leaves your machine.**
+- **Azure AI Foundry / Azure OpenAI** — full feature set. Asks for your endpoint, model deployment name, and resource-level API key. **The API key is the only credential local mode ever sees, and it is mounted from a local secret file — it never leaves your machine.**
+- **GitHub Models** — free, no Azure account needed. Asks only for your GitHub PAT (`models:read` scope). Endpoint is hardcoded to `https://models.github.ai/inference`. Default model is `gpt-4o-mini`. Foundry-only routes return `501`.
+
+Your choice is saved to `~/.azureclaw/config.json` and reused on subsequent runs.
 
 The CLI then builds (or pulls cached) the local sandbox image and starts a single container. In dev mode the agent runtime and the inference router are co-located in that one image — there is no separate router pod, no init container, no NetworkPolicy. You get the same router code path, the same governance profile, the same audit format.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,6 +90,8 @@ On the first run you are prompted to pick a provider:
 
 Your choice is saved to `~/.azureclaw/config.json` and reused on subsequent runs.
 
+To switch providers later (or rotate keys), run **`azureclaw credentials`** — the same interactive prompt is exposed there too. The same command also handles channel tokens (Telegram, Slack, Discord) and third-party API keys (Brave, Tavily, Exa, Firecrawl, Perplexity, OpenAI). Or scriptable: `azureclaw credentials set <key> <value>` / `list` / `remove`.
+
 The CLI then builds (or pulls cached) the local sandbox image and starts a single container. In dev mode the agent runtime and the inference router are co-located in that one image — there is no separate router pod, no init container, no NetworkPolicy. You get the same router code path, the same governance profile, the same audit format.
 
 ### 1.3 Talk to the agent

--- a/docs/security.md
+++ b/docs/security.md
@@ -221,6 +221,7 @@ Honesty matters. AzureClaw does not — and cannot — protect against:
 - **A compromised cluster operator who controls Kata-less nodes.** Without Kata + AMD SEV-SNP, a cluster operator can read pod memory. Move to confidential isolation if your threat model includes the cluster operator.
 - **A compromised CI / supply chain.** We add gates and pinning, but ultimately you trust your builders. See **[`docs/internal/threat-model.md`](../docs/internal/threat-model.md)** for the per-route walkthrough.
 - **The model knowing your API surface.** Prompt injection is real. Treat any output from the model as untrusted; the router enforces this assumption, but you must too in your tools and plugins.
+- **Inline prompt-shield filtering on GitHub Models (`azureclaw dev --github-token` / `provider: "github-models"`).** GitHub Models does not return Foundry's `prompt_filter_results` in responses, so the router cannot enforce inline Content Safety actions. Use Foundry / Azure OpenAI in any environment where inline prompt-shield is part of your threat model. The CLI logs and `~/.azureclaw/config.json` make the chosen provider explicit so this is auditable.
 
 ---
 

--- a/inference-router/src/config.rs
+++ b/inference-router/src/config.rs
@@ -146,9 +146,10 @@ impl Config {
             self.foundry_endpoint.as_deref(),
             self.foundry_project_endpoint.as_deref(),
         ];
-        candidates.iter().flatten().any(|e| {
-            e.contains("models.github.ai") || e.contains("models.inference.ai.azure.com")
-        })
+        candidates
+            .iter()
+            .flatten()
+            .any(|e| e.contains("models.github.ai") || e.contains("models.inference.ai.azure.com"))
     }
 }
 

--- a/inference-router/src/config.rs
+++ b/inference-router/src/config.rs
@@ -134,4 +134,67 @@ impl Config {
                 .filter(|s| !s.is_empty()),
         })
     }
+
+    /// Returns true if any configured endpoint points at GitHub Models
+    /// (a free, public, OpenAI-compatible inference service backed by a
+    /// GitHub PAT). When this is true, the router skips Azure-specific
+    /// URL rewriting (`/openai/v1/`) and Foundry-only routes return 501
+    /// instead of failing with a confusing upstream error.
+    pub fn is_github_models(&self) -> bool {
+        let candidates = [
+            self.azure_openai_endpoint.as_deref(),
+            self.foundry_endpoint.as_deref(),
+            self.foundry_project_endpoint.as_deref(),
+        ];
+        candidates.iter().flatten().any(|e| {
+            e.contains("models.github.ai") || e.contains("models.inference.ai.azure.com")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(endpoint: Option<&str>) -> Config {
+        Config {
+            port: 8443,
+            foundry_endpoint: None,
+            foundry_project_endpoint: None,
+            azure_openai_endpoint: endpoint.map(String::from),
+            default_model: "gpt-4o-mini".into(),
+            content_safety_enabled: false,
+            prompt_shields_enabled: false,
+            content_safety_endpoint: None,
+            token_budget_daily: 0,
+            token_budget_per_request: 0,
+            registry_mode: RegistryMode::Local,
+            registry_url: None,
+        }
+    }
+
+    #[test]
+    fn detects_github_models_marketplace_endpoint() {
+        assert!(cfg(Some("https://models.github.ai/inference")).is_github_models());
+    }
+
+    #[test]
+    fn detects_legacy_github_models_endpoint() {
+        assert!(cfg(Some("https://models.inference.ai.azure.com")).is_github_models());
+    }
+
+    #[test]
+    fn does_not_match_foundry_endpoint() {
+        assert!(!cfg(Some("https://contoso.services.ai.azure.com")).is_github_models());
+    }
+
+    #[test]
+    fn does_not_match_legacy_aoai_endpoint() {
+        assert!(!cfg(Some("https://contoso.openai.azure.com")).is_github_models());
+    }
+
+    #[test]
+    fn returns_false_when_no_endpoint_set() {
+        assert!(!cfg(None).is_github_models());
+    }
 }

--- a/inference-router/src/proxy.rs
+++ b/inference-router/src/proxy.rs
@@ -462,6 +462,14 @@ fn inject_stream_usage(body: Bytes) -> Bytes {
     body
 }
 
+/// Returns true if the endpoint is a GitHub Models endpoint
+/// (https://models.github.ai/inference or the legacy
+/// https://models.inference.ai.azure.com URL). GitHub Models is OpenAI-API
+/// compatible but does NOT use the Azure `/openai/v1/` URL prefix.
+fn is_github_models_endpoint(endpoint: &str) -> bool {
+    endpoint.contains("models.github.ai") || endpoint.contains("models.inference.ai.azure.com")
+}
+
 /// Build the upstream URL and optionally inject model into request body.
 /// Uses the unified /openai/v1/ format — works with both API-key and Entra auth.
 fn build_upstream_url(
@@ -470,14 +478,24 @@ fn build_upstream_url(
     path: &str,
     request_body: Bytes,
 ) -> Result<(String, Bytes)> {
-    // Use the unified /openai/v1/ format for all modes.
-    // Both API-key (dev) and Entra (AKS) work with Bearer auth on this endpoint.
-    // This supports all models including Responses-only models like gpt-5.4-pro.
-    let url = format!(
-        "{}/openai/v1/{}",
-        upstream.endpoint.trim_end_matches('/'),
-        path.trim_start_matches('/'),
-    );
+    // GitHub Models exposes OpenAI-compatible routes directly under the
+    // endpoint (no Azure-style `/openai/v1/` prefix). Detect and skip the
+    // rewrite for those endpoints; everything else goes via the unified
+    // `/openai/v1/` format that works for both Azure OpenAI (api-key) and
+    // Foundry project (Entra) endpoints.
+    let url = if is_github_models_endpoint(&upstream.endpoint) {
+        format!(
+            "{}/{}",
+            upstream.endpoint.trim_end_matches('/'),
+            path.trim_start_matches('/'),
+        )
+    } else {
+        format!(
+            "{}/openai/v1/{}",
+            upstream.endpoint.trim_end_matches('/'),
+            path.trim_start_matches('/'),
+        )
+    };
     let body = if let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_body)
     {
         if body_json.get("model").is_none() {

--- a/inference-router/src/routes/inference.rs
+++ b/inference-router/src/routes/inference.rs
@@ -573,6 +573,32 @@ async fn foundry_proxy(
         .or_else(|| state.config.azure_openai_endpoint.clone())
         .unwrap_or_default();
 
+    // GitHub Models mode does not provide Foundry-only APIs (Memory Store,
+    // agents, evaluations, indexes, knowledge bases, datasets, deployments,
+    // connections, etc.). Return a clear 501 instead of letting the call
+    // hit GitHub Models with a path it doesn't understand.
+    if state.config.is_github_models() {
+        tracing::info!(
+            sandbox = %sandbox_name,
+            path = %uri.path(),
+            "Rejected Foundry-only route under GitHub Models mode"
+        );
+        return (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(serde_json::json!({
+                "error": {
+                    "message": format!(
+                        "GitHub Models mode does not support `{}`. This endpoint requires Azure AI Foundry. Re-run `azureclaw dev` without --github-token (or set up Foundry) to enable Memory Stores, agents, evaluations, indexes, and other Foundry-only features.",
+                        uri.path()
+                    ),
+                    "type": "unsupported_for_provider",
+                    "provider": "github-models"
+                }
+            })),
+        )
+            .into_response();
+    }
+
     // Blocklist check — block requests to known-malicious Foundry project endpoints
     if let crate::blocklist::BlockResult::Blocked { reason, domain } =
         state.blocklist.is_blocked(&endpoint).await


### PR DESCRIPTION
## What

Adds **GitHub Models** as a first-class inference provider for `azureclaw dev`, sitting alongside the existing **Azure AI Foundry / Azure OpenAI** provider. Picked interactively at first run and saved to `~/.azureclaw/config.json` — same persistence pattern as Foundry.

## Why

OSS launch readiness. Today `azureclaw dev` requires an Azure subscription. With this PR, anyone with a GitHub account can run a fully-policy-enforced sandbox locally with nothing but a GitHub PAT (`models:read` scope). Foundry remains the default and is required for any of the Foundry-only features (Memory Store, agents, evaluations, indexes, inline Content Safety).

## How it feels

```
$ azureclaw dev
? Which inference provider do you want to use?
> Azure AI Foundry / Azure OpenAI  (full feature set)
  GitHub Models                     (free; just need a GitHub PAT)
```

Pick GitHub Models → paste PAT → CLI verifies it against `https://models.github.ai/catalog/models` (read-only, doesn't burn rate limit) → saved. Subsequent `azureclaw dev` runs auto-load it. No flag required.

`--github-token <pat>` is preserved as a non-saving, ephemeral override (for CI, scripted runs, or trying GitHub Models without losing saved Foundry creds).

## Trade-offs (documented in security.md)

In GH Models mode:
- Foundry-only routes return clean `501` (Memory Store, agents, evaluations, indexes, knowledge bases, datasets, deployments, connections — all hit `foundry_proxy()` which now early-returns)
- Inline Content Safety prompt-shield is **not enforced** server-side because GitHub Models doesn't return `prompt_filter_results` — explicitly called out under 'What we do *not* defend against'
- Subject to GitHub Models rate limits

## Tests

- 541 CLI tests pass (2 new in `config.test.ts`: GH Models round-trip + unknown-provider fallback)
- Router unit tests: 5 new in `config.rs` covering `is_github_models()`
- Router `cargo build -p azureclaw-inference-router` clean

## Files

- `cli/src/config.ts` — `AzureClawConfig.provider`, provider list-prompt, GH Models branch with PAT verification
- `cli/src/commands/dev.ts` — `isGithubModelsMode` derived from `creds.provider`; `--github-token` becomes ephemeral override
- `inference-router/src/config.rs` — `is_github_models()` + tests
- `inference-router/src/proxy.rs` — endpoint-aware URL formation
- `inference-router/src/routes/inference.rs` — 501 guard in `foundry_proxy`
- `docs/cli-reference.md`, `docs/getting-started.md`, `docs/security.md` — docs updates

## Companion

Stacks on top of #219 (auto-resume for `azureclaw up`). No conflicts expected — different files.