### PR TITLE
fix(up): pass --force-conflicts to helm upgrade

### DIFF
--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -766,6 +766,12 @@ Auto-resume:
           "--set", `azure.keyVaultCsi.keyVaultName=${kvName}`,
           "--wait",
           "--timeout", "5m",
+          // Take ownership of fields previously written by `kubectl apply`
+          // or `kubectl patch` (e.g. CRDs / ClusterRoles touched out-of-band
+          // during prior debugging). Without this, Helm's server-side apply
+          // refuses with "conflict with kubectl-client-side-apply" and the
+          // whole `azureclaw up` flow fails after the 18-min image build.
+          "--force-conflicts",
         ];
         if (foundryEndpoint) {
           helmArgs.push("--set", `foundry.endpoint=${foundryEndpoint}`);


### PR DESCRIPTION
## Why

`azureclaw up` was failing at the helm step with:

```
conflict with "kubectl-client-side-apply" using apiextensions.k8s.io/v1: .spec.versions
conflict with "kubectl-patch" using rbac.authorization.k8s.io/v1: .rules
```

…**after** the 18-minute image build phase, which is rough.

## Root cause

Helm 3.14+ uses server-side apply by default. If a CRD or ClusterRole has been touched out-of-band by a plain `kubectl apply` or `kubectl patch` (during debugging, manual fixes, prior versions of the chart), SSA registers those field managers and refuses to let Helm overwrite them on the next `helm upgrade`.

## Fix

Pass `--force-conflicts` to `helm upgrade --install`. Helm 3.14+ supports this flag natively — it's the same semantic as `kubectl apply --server-side --force-conflicts` and is the standard fix for this class of error.

## Workaround for users on builds without this patch

```bash
kubectl get crd clawsandboxes.azureclaw.azure.com -o yaml \
  | kubectl apply --server-side --force-conflicts --field-manager=helm -f -
kubectl get clusterrole azureclaw-controller -o yaml \
  | kubectl apply --server-side --force-conflicts --field-manager=helm -f -
azureclaw up    # auto-resume (PR #219) picks up at the helm phase
```

## Risk

`--force-conflicts` only changes behavior when there is an existing field manager other than helm. In a clean install (no external kubectl apply), it's a no-op. The chart's own object set is unchanged.

## Validation

- `npx tsc --noEmit` clean
- `helm upgrade --help | grep force-conflicts` confirms the flag is supported

Hit during my own `azureclaw up` retry today (5 May 2026).