### PR TITLE
fix(refs,migrate): ToolPolicy.appliesTo uses sandboxMatchLabels, not sandboxName

### DIFF
--- a/cli/src/migrate/from_kagent.ts
+++ b/cli/src/migrate/from_kagent.ts
@@ -730,7 +730,8 @@ export function translate(
         },
       },
       spec: {
-        appliesTo: { sandboxName },
+        // ToolPolicy.appliesTo has no sandboxName field — scope via sandbox label.
+        appliesTo: { sandboxMatchLabels: { [SANDBOX_LABEL_KEY]: sandboxName } },
       },
     });
     toolPolicies.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));

--- a/cli/src/refs.ts
+++ b/cli/src/refs.ts
@@ -93,7 +93,10 @@ export function buildToolPolicy(opts: ToolPolicyOpts): Record<string, unknown> {
         : undefined,
     },
     spec: {
-      appliesTo: { sandboxName: opts.sandboxName },
+      // ToolPolicy.appliesTo has no sandboxName field — scope via sandbox label.
+      appliesTo: {
+        sandboxMatchLabels: { "azureclaw.azure.com/sandbox": opts.sandboxName },
+      },
     },
   };
 }


### PR DESCRIPTION
## Launch-blocker

`azureclaw up` failed at step 8/9 with:

```
error validating data: ValidationError(ToolPolicy.spec.appliesTo): unknown field "sandboxName"
```

## Root cause

`ToolPolicy.spec.appliesTo` schema (`deploy/helm/azureclaw/templates/crd-toolpolicy.yaml`) has only `{tool, mcpServer, sandboxMatchLabels}` — **no `sandboxName` field**. Two CLI builders were emitting the invalid field:

- `cli/src/refs.ts` — `buildToolPolicy()` (called from `up`, `add`)
- `cli/src/migrate/from_kagent.ts` — synthetic `<sandbox>-toolpolicy` aggregator (called from `migrate` with `--governance`)

Note: `InferencePolicy.appliesTo` legitimately has `sandboxName` (per `crd-inferencepolicy.yaml`) — that path is unchanged.

## Fix

Scope the aggregator ToolPolicy via the `azureclaw.azure.com/sandbox=<name>` label that is already set on `metadata.labels`. Matches what canonical `examples/demo-clawshield/*.yaml` already use.

## Why CI missed it

- No CRD-schema validation in unit tests (asserted JS object shape only)
- `buildToolPolicy` in `refs.ts` had no dedicated test
- `buildToolPolicySpecFromFlags` in `commands/toolpolicy.ts` is well-tested and *correct* — divergent code paths
- E2E doesn't exercise CLI-emitted YAML against the live CRD

Follow-up issue worth filing post-launch: validate emitted CRs against the CRD OpenAPI schema in `npm test` (cheap ajv pass).

## Test

```
$ cd cli && npm run build && npx vitest run src/migrate/from_kagent.test.ts
✓ 53 tests passed
```

User hit this on launch-eve during `azureclaw up`. Verified locally; will re-run end-to-end after merge + global reinstall.