### PR TITLE
fix(refs): drop spurious InferencePolicy.modelPreference.primary.endpoint

### DIFF
--- a/cli/src/commands/up/sandbox_bringup.ts
+++ b/cli/src/commands/up/sandbox_bringup.ts
@@ -340,7 +340,6 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
     namespace: sandboxNamespace,
     model: options.model,
     provider: "azure-openai",
-    endpoint: openAiEndpoint,
     contentSafety: true,
     promptShields: true,
   });

--- a/cli/src/refs.ts
+++ b/cli/src/refs.ts
@@ -27,7 +27,6 @@ export interface InferencePolicyOpts {
   sandboxName: string;
   namespace: string;
   model: string;
-  endpoint?: string;
   provider?: string;
   contentSafety?: boolean;
   promptShields?: boolean;
@@ -48,12 +47,6 @@ export function buildInferencePolicy(opts: InferencePolicyOpts): Record<string, 
       requirePromptShields: opts.promptShields !== false,
     },
   };
-  if (opts.endpoint) {
-    (spec.modelPreference as Record<string, unknown>).primary = {
-      ...(spec.modelPreference as Record<string, { primary: Record<string, unknown> }>).primary,
-      endpoint: opts.endpoint,
-    };
-  }
   const daily = opts.tokenBudgetDaily ?? 0;
   const perReq = opts.tokenBudgetPerRequest ?? 0;
   if (daily > 0 || perReq > 0) {


### PR DESCRIPTION
## Launch-blocker (sibling to #226)

`azureclaw up` failed at step 9/9 with:

```
Error from server (BadRequest): error when creating "STDIN":
InferencePolicy in version "v1alpha1" cannot be handled as a InferencePolicy:
strict decoding error: unknown field "spec.modelPreference.primary.endpoint"
```

## Root cause

`crd-inferencepolicy.yaml` (lines 153–165) defines `modelPreference.primary` with only `{provider, deployment}`. The CRD has strict decoding enabled, so the spurious `endpoint` field rejects the apply rather than silently pruning.

The endpoint URL is conveyed to the inference router via helm values (`inferenceRouter.azure.openai.endpoint`) — the CR field was dead code that never reached the controller.

## Fix

- `cli/src/refs.ts`: drop the `if (opts.endpoint)` injection block + the `endpoint?: string` field from `InferencePolicyOpts`
- `cli/src/commands/up/sandbox_bringup.ts`: drop the `endpoint: openAiEndpoint` argument

## Surfaced by audit

This was BUG #4 from the post-#226 audit ("is the same issue elsewhere?"). The other three audit findings (`from_kagent.ts` missing port, `toolpolicy.ts` missing sandboxMatchLabels guard, `convert.ts` upstreamCompatibility pruning) are NOT on the `azureclaw up` hot path and can wait for post-launch.

## Test

```
cd cli && npx tsc --noEmit && npx vitest run src/migrate/from_kagent.test.ts
✓ 53 tests passed
```