### PR TITLE
fix(controller): use '.' not '/' in mirrored-from label value

### DIFF
--- a/controller/src/reconciler/governance_mounts.rs
+++ b/controller/src/reconciler/governance_mounts.rs
@@ -48,7 +48,9 @@ use serde_json::{Value, json};
 use std::collections::BTreeMap;
 
 /// Owned-resource label key, attached to every mirror by the reconciler
-/// so cleanup/observability can find them.
+/// so cleanup/observability can find them. Value format is
+/// `<kind>.<name>` (lowercased) — note `.` not `/`: K8s label *values*
+/// cannot contain `/` (only label *keys* may use the `prefix/name` form).
 pub(crate) const MIRROR_OWNER_LABEL: &str = "azureclaw.azure.com/mirrored-from";
 /// Sandbox name label, links the mirror back to its `ClawSandbox`.
 pub(crate) const MIRROR_SANDBOX_LABEL: &str = "azureclaw.azure.com/sandbox";
@@ -108,7 +110,7 @@ pub async fn mirror_configmap(
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert(
         MIRROR_OWNER_LABEL.into(),
-        format!("{source_kind}/{name}").to_lowercase(),
+        format!("{source_kind}.{name}").to_lowercase(),
     );
     labels.insert(MIRROR_SANDBOX_LABEL.into(), sandbox_name.into());
     labels.insert(
@@ -179,7 +181,7 @@ pub async fn mirror_secret(
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert(
         MIRROR_OWNER_LABEL.into(),
-        format!("{source_kind}/{name}").to_lowercase(),
+        format!("{source_kind}.{name}").to_lowercase(),
     );
     labels.insert(MIRROR_SANDBOX_LABEL.into(), sandbox_name.into());
     labels.insert(


### PR DESCRIPTION
## Problem

`azureclaw up` on a fresh sandbox failed with the controller stuck reconciling, no sandbox pod created, WebUI port-forward target absent. Controller log:

```
ConfigMap "toolpolicy-<sandbox>-<ref>-profile" is invalid:
  metadata.labels: Invalid value: "toolpolicy/toolpolicy-<sandbox>-<ref>-profile":
  a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.'
```

## Root cause

`mirror_configmap` / `mirror_secret` in `reconciler/governance_mounts.rs` built the `azureclaw.azure.com/mirrored-from` label *value* as `<kind>/<name>`. K8s allows `/` only in label *keys* (as a prefix), never in values.

## Fix

Switch separator to `.` (allowed in label values). Doc-comment `MIRROR_OWNER_LABEL` so this stays put.

## Test

`cargo test --package azureclaw-controller governance_mounts` — all 5 mount tests still pass. No test asserted the `/` format (no consumer parses this label value).

## CI gap

Same class as #226 / #227: no integration test runs the patch against a real or fake apiserver, so K8s validation rules never fire on builders. Tracked for post-launch (CRD/object schema validation in `npm test` + Rust integration test for ConfigMap mirror).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>