### PR TITLE
fix(helm): allow operator → agentmesh egress (registry:8080, relay:8765)

### DIFF
--- a/deploy/helm/azureclaw/templates/operator-default-deny-networkpolicy.yaml
+++ b/deploy/helm/azureclaw/templates/operator-default-deny-networkpolicy.yaml
@@ -51,4 +51,20 @@ spec:
           port: 443
         - protocol: TCP
           port: 6443
+    # AGT mesh peer connection — controller registers itself with the
+    # registry (TCP/8080) and connects to the relay (TCP/8765) to act
+    # as a fully-fledged mesh peer for cross-cluster trust propagation
+    # and operator-driven message injection. Without this rule the
+    # controller's `mesh_peer` task logs `Registry registration failed`
+    # forever while sandboxes connect successfully (their NetworkPolicy
+    # is rendered separately by the per-sandbox reconciler).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agentmesh
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8765
 {{- end }}


### PR DESCRIPTION
## Problem

Controller logs spammed with:
```
WARN Registry registration failed — will retry
WARN Registry registration exhausted retries — relay connect will fail until registry recovers
```

The operator's mesh_peer task could never register with the AGT registry → couldn't connect to the relay → operator-driven mesh features (cross-cluster trust, message injection, observability) effectively dead.

## Root cause

`deploy/helm/azureclaw/templates/operator-default-deny-networkpolicy.yaml` allowed egress only to DNS / TCP/443 / TCP/6443. Nothing for the agentmesh namespace. Per-sandbox NetworkPolicies are rendered inline by the controller's Rust code with the correct rules — only the helm-rendered operator policy was missing this.

## Fix

Add an egress rule from the operator namespace to the `agentmesh` namespace on TCP/8080 (registry) + TCP/8765 (relay).

## Verification

```
$ kubectl exec -n azureclaw-system <controller-pod> -- sh -c '
    timeout 3 sh -c "echo > /dev/tcp/agentmesh-registry.agentmesh.svc.cluster.local/8080" && echo OK
    timeout 3 sh -c "echo > /dev/tcp/agentmesh-relay.agentmesh.svc.cluster.local/8765" && echo OK
'
registry:8080 OK
relay:8765 OK
```

Already patched live in the cluster; this PR brings the helm chart in line so the next `azureclaw up` doesn't regress.

## CI gap (same class)

E2E doesn't assert that the operator's mesh_peer reaches Ready / no warning spam. Tracked in #230.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>