### PR TITLE
fix(sandbox): scope node-host plugin allowlist to skip bundled-runtime-deps install

### DIFF
--- a/sandbox-images/openclaw/entrypoint.sh
+++ b/sandbox-images/openclaw/entrypoint.sh
@@ -975,10 +975,27 @@ mkdir -p /tmp/node-host-home/.openclaw
 [ "$IS_ROOT" = "true" ] && chown -R sandbox:sandbox /tmp/node-host-home
 # Create a minimal config for the node-host — it only needs gateway connectivity,
 # NOT our plugins. Using the main config causes "plugin not found: azureclaw" crash loops.
+#
+# IMPORTANT: `plugins.allow: []` (empty) is interpreted by OpenClaw's loader as
+# "no allowlist applied" — so every bundled plugin with `enabledByDefault: true`
+# (e.g. `acpx` with `activation.onStartup: true`) loads and triggers
+# `ensureBundledPluginRuntimeDeps`, which kicks off a 42-spec npm install at
+# runtime under the egress-guarded UID 1000. That blocks the node-host's event
+# loop indefinitely behind the forward proxy and wedges the gateway path the
+# WebUI talks to. Pre-staging at /opt/openclaw-stage doesn't help because
+# OpenClaw's materialization check reads `installRoot/package.json` and
+# `installRoot` is the LAST entry of OPENCLAW_PLUGIN_STAGE_DIR (the writable
+# `/tmp/openclaw-cache`, which is empty).
+#
+# Fix: pass a non-empty allowlist with a single lightweight bundled plugin
+# (`openai`). The loader's allow-list logic then disables every other bundled
+# plugin (`enableState.enabled = false`) and skips the runtime-deps install
+# path entirely (loader.js gates on `enableState.enabled` before calling
+# `prepareBundledPluginRuntimeLoadRoot`).
 cat > /tmp/node-host-home/.openclaw/openclaw.json << 'NODECONF'
 {
   "gateway": { "port": 18789 },
-  "plugins": { "allow": [] }
+  "plugins": { "allow": ["openai"] }
 }
 NODECONF
 [ "$IS_ROOT" = "true" ] && chown sandbox:sandbox /tmp/node-host-home/.openclaw/openclaw.json


### PR DESCRIPTION
## Problem

WebUI chat hangs / first-impression failure: messages never reach the model
provider on a fresh sandbox. Diagnosed via direct probes:

- `POST /v1/chat/completions` directly to inference router from inside the
  pod returns 200 in ~1.6 s. Router → Foundry path is healthy.
- `openclaw agent --agent default -m "say hi"` from the openclaw container
  hangs > 3 min on first invocation.
- Forward-proxy CONNECT to `registry.npmjs.org:443` returns
  `HTTP/1.1 200 Connection Established`. Network path is healthy.
- `/tmp/node-host.log` shows the wedge:
  ```
  [plugins] acpx staging bundled runtime deps (42 specs):
    @agentclientprotocol/claude-agent-acp@0.31.1, ... (full 42-package list)
  [plugins] acpx: Low disk space near /tmp/openclaw-cache/...: 1024 MiB
  ```
  → the `openclaw node run` sub-process is doing a runtime npm install of the
  ACP runtime stack via the forward proxy under UID 1000 with egress-guard,
  which blocks the shared event loop.

## Root cause

The node-host config (`/tmp/node-host-home/.openclaw/openclaw.json`) had
`plugins.allow: []`. OpenClaw's loader interprets an **empty** allowlist as
"no allowlist applied" (not "allow nothing"), so every bundled plugin with
`enabledByDefault: true` loads on startup. `acpx` additionally has
`activation.onStartup: true`, so it runs `ensureBundledPluginRuntimeDeps`
during boot.

Pre-staging at `/opt/openclaw-stage` is correct — `package.json` has
`name: "openclaw-runtime-deps-install"` with all 102 deps (the 42 acpx wants
are a subset) and 2.5 GiB of populated `node_modules/`. But OpenClaw's
materialization gate reads `installRoot/package.json`, where `installRoot`
is the **last** entry of `OPENCLAW_PLUGIN_STAGE_DIR`
(`bundled-runtime-deps-Dj2QXhNg.js:1101: externalRoots.at(-1)`) =
`/tmp/openclaw-cache/openclaw-<ver>` — an empty tmpfs. So the gate fails
and the install runs anyway.

The entrypoint comment about "missingSpecs = [] → install never executes"
no longer holds in current OpenClaw — `ensureBundledPluginRuntimeDeps` uses
`plan.installSpecs` (full per-plugin list) for the materialization check via
`sameRuntimeDepSpecs`, which requires equality, not "all satisfied in any
search root".

## Fix

Give the node-host a non-empty allowlist with one lightweight bundled
plugin (`openai`). The loader's allow-list logic then sets
`enableState.enabled = false` for `acpx` (and every other bundled plugin)
and skips the staging path entirely
(`loader-CLyHx60E.js:4076` gates the call to
`prepareBundledPluginRuntimeLoadRoot` on `enableState.enabled`).

`azureclaw` is intentionally NOT in the node-host's allowlist (it's an
in-tree extension and triggers "plugin not found" crash loops there).
The main gateway already has `plugins.allow: ["azureclaw", "openai"]` and
is unaffected.

## Verification

- `bash -n sandbox-images/openclaw/entrypoint.sh` clean.
- Pre/post-fix log inspection in pod confirms the 42-spec line originates
  in `/tmp/node-host.log` (node-host process), not the gateway log.
- The main gateway config (`entrypoint.sh:374, 977`) is unchanged and still
  uses `plugins.allow: ["azureclaw", "openai"]`.

## Deploy

After merge:
```
azureclaw push --only sandbox --apply
```
to rebuild the sandbox image and roll the running pod.