### PR TITLE
chore(agt): adopt official @microsoft/agent-governance-sdk 3.6.0

### DIFF
--- a/.github/skills/agt-e2e-encryption/SKILL.md
+++ b/.github/skills/agt-e2e-encryption/SKILL.md
@@ -5,7 +5,9 @@ description: "AzureClaw AGT E2E encryption skill — how the Signal Protocol int
 # AGT E2E Encrypted Inter-Agent Communication
 
 ## Overview
-AzureClaw agents communicate via AgentMesh (amitayks/agentmesh) — a decentralized, E2E encrypted messaging protocol using Signal Protocol (X3DH + Double Ratchet).
+AzureClaw agents communicate via the official Microsoft Agent Governance Toolkit (AGT) — a decentralized, E2E encrypted messaging protocol using Signal Protocol (X3DH + Double Ratchet). Transport is provided through `@microsoft/agent-governance-sdk` (upstream) wrapped by the in-repo `@azureclaw/mesh` provider, selected at runtime via `createMeshTransport()`.
+
+> **History note:** Earlier releases used a vendored fork of `@agentmesh/sdk` with 8+ local patches under `vendor/`. All upstream-relevant fixes have landed in AGT (PRs through the toolkit's 3.x line) and the vendored tree has been removed. The bug table below is preserved as a regression checklist — if any of these symptoms reappear, treat as a regression in the official SDK.
 
 ## Protocol Flow
 ```
@@ -35,8 +37,8 @@ Parent Agent                    Sub-Agent
 - **Session**: KNOCK protocol for policy-gated session establishment
 - **Forward Secrecy**: Per-message key rotation via Double Ratchet
 
-## Vendor Patches (8 bugs fixed)
-All in `vendor/` directory with READMEs explaining each patch:
+## Historical bug catalogue (now-upstream regression checklist)
+All originally fixed via patches in `vendor/` (removed in 2026-05). Listed here as a regression-detection cheatsheet against the current official `@microsoft/agent-governance-sdk`:
 
 | Component | Bug | Fix |
 |-----------|-----|-----|

--- a/mesh-plugin/package-lock.json
+++ b/mesh-plugin/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/agent-governance-sdk": "^3.5.0",
+        "@microsoft/agent-governance-sdk": "^3.6.0",
         "ws": "^8.18"
       },
       "devDependencies": {
@@ -472,9 +472,9 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/agent-governance-sdk": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/agent-governance-sdk/-/agent-governance-sdk-3.5.0.tgz",
-      "integrity": "sha512-CAWqWrWIM6Xlxd/3yi9R1o+sY7bJ0EI8jm4ilMhxCH+bJZJy+ElBfmSfwO6MvKlSkAw67YgoCYiREOSBy0weqA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/agent-governance-sdk/-/agent-governance-sdk-3.6.0.tgz",
+      "integrity": "sha512-O6KVprab0EhTFq7ruuHHpngzWITVkb21s7c3+D0xDWS1s+RS2SHO0etzu6hQxvtob7f3RjoPipRd1hGoZc2wVA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "2.2.0",

--- a/mesh-plugin/package.json
+++ b/mesh-plugin/package.json
@@ -44,7 +44,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@microsoft/agent-governance-sdk": "^3.5.0",
+    "@microsoft/agent-governance-sdk": "^3.6.0",
     "ws": "^8.18"
   },
   "devDependencies": {

--- a/runtimes/openclaw/package-lock.json
+++ b/runtimes/openclaw/package-lock.json
@@ -23,7 +23,7 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@microsoft/agent-governance-sdk": "^3.5.0"
+        "@microsoft/agent-governance-sdk": "^3.6.0"
       }
     },
     "../../mesh-plugin": {
@@ -31,7 +31,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/agent-governance-sdk": "^3.5.0",
+        "@microsoft/agent-governance-sdk": "^3.6.0",
         "ws": "^8.18"
       },
       "devDependencies": {
@@ -498,9 +498,9 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/agent-governance-sdk": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/agent-governance-sdk/-/agent-governance-sdk-3.5.0.tgz",
-      "integrity": "sha512-CAWqWrWIM6Xlxd/3yi9R1o+sY7bJ0EI8jm4ilMhxCH+bJZJy+ElBfmSfwO6MvKlSkAw67YgoCYiREOSBy0weqA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/agent-governance-sdk/-/agent-governance-sdk-3.6.0.tgz",
+      "integrity": "sha512-O6KVprab0EhTFq7ruuHHpngzWITVkb21s7c3+D0xDWS1s+RS2SHO0etzu6hQxvtob7f3RjoPipRd1hGoZc2wVA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/runtimes/openclaw/package.json
+++ b/runtimes/openclaw/package.json
@@ -33,7 +33,7 @@
     "commander": "^13.0.0"
   },
   "optionalDependencies": {
-    "@microsoft/agent-governance-sdk": "^3.5.0"
+    "@microsoft/agent-governance-sdk": "^3.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
Bumps `@microsoft/agent-governance-sdk` pin from `^3.5.0` to `^3.6.0` in mesh-plugin and runtimes/openclaw, and refreshes `.github/skills/agt-e2e-encryption/SKILL.md` to drop the misleading 'vendored fork' framing.

3.6.0 is the latest official AGT TS SDK release (published 2026-05-12). Pre-flight gate before `dev` → `main`, per `docs/internal/agt-official-release-preflight.md`.

**Validated locally:**
- `cargo build --release` ✅
- `cargo test --all` ✅ 1355+ tests
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --all --check` ✅
- `mesh-plugin` build + 63 tests ✅
- `runtimes/openclaw` build + 118 tests ✅
- `cli` typecheck + lint + 639 tests ✅

Pin + lockfile + one doc update only. No code changes.