### PR TITLE
chore(privacy): make docs/internal/ folder fully invisible on the public repo

### DIFF
--- a/docs/internal/.gitignore
+++ b/docs/internal/.gitignore
@@ -1,6 +1,0 @@
-# Internal planning documents — not for public repo
-*
-!.gitignore
-!global-agentmesh-plan.md
-!2026-04-28-Azure-azureclaw.md
-!phase3-manual-verification.md


### PR DESCRIPTION
Follow-up to #249. The previous PR untracked all 198 internal docs but left `docs/internal/.gitignore` tracked — which kept the folder visible on the GitHub web UI even though it was empty otherwise.

This removes that last file from version control. Folder disappears entirely from the public tree.

The repo-root `.gitignore` line 454 (`docs/internal/`) still keeps everything ignored locally, so the redundant inner .gitignore is preserved on disk for contributors but no longer tracked.