### PR TITLE
Slice 0: honesty events — introduce `Compiled` phase + Warning Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to AzureClaw will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — `crd-well-oiled-machine`
+
+### Slice 0 — honesty events
+
+- **`status.phase=Compiled` introduced** as the load-bearing distinction
+  between "controller wrote the artifact" and "data plane is enforcing the
+  artifact". `InferencePolicy` and `ClawMemory` now stamp `Compiled` on the
+  success path (instead of `Ready`) and the `Ready` condition is `False` with
+  reason `AwaitingRouterEnforcement`. Each reconciler also emits a `Warning`
+  Event (`reason=PolicyNotEnforced`) so operators see the gap in
+  `kubectl describe` and `kubectl get events`. `kubectl wait
+  --for=condition=Ready` no longer returns immediately for policies that the
+  router is not yet consuming.
+- **`McpServer` emits a `LimitedSupport` Warning Event** on every successful
+  reconcile pointing at the upcoming Slice 4 plural-MCP migration. The
+  singular `spec.mcp` binding continues to work; the event is purely
+  informational.
+- **`ToolPolicy`** keeps `phase=Ready` (its enforcement is runtime-side, not
+  router-side) but now uses the shared `PHASE_READY`/`PHASE_DEGRADED`
+  constants from `controller/src/status/phase.rs` instead of string literals.
+- New module `controller/src/status/phase.rs` carries the closed phase
+  vocabulary (`Pending`/`Compiled`/`Ready`/`Degraded`/`Failed`) and a
+  `PhaseEventReporter` wrapping `kube::runtime::events::Recorder` for
+  `Warning` Event publishing. 7 unit tests pin the vocabulary, reason
+  constants, and `ObjectReference` shape.
+- New condition reason `AwaitingRouterEnforcement` registered in
+  `controller/src/status/conditions.rs::reason`.
+- Headlamp plugin `phaseToStatus()` now branches explicitly on `Compiled` →
+  amber/warning (previously fell through to the default warning branch).
+- New phase vocabulary table in `docs/api/lifecycle.md`.
+
 ## [Unreleased] — Phase 5 (AGT default + local-k8s mesh)
 
 ### Changed

--- a/controller/src/a2a_agent_reconciler.rs
+++ b/controller/src/a2a_agent_reconciler.rs
@@ -55,6 +55,7 @@ use crate::a2a_agent::{A2AAgent, A2AAgentStatus};
 use crate::a2a_agent_compile::{compile_agent_card, version_hash};
 use crate::mcp_server::LocalObjectRef;
 use crate::status::conditions::{self, reason, status as cond_status};
+use crate::status::phase::{PHASE_DEGRADED, PHASE_READY};
 
 /// Field manager for SSA patches emitted by this reconciler. Distinct
 /// from S1 `…/mcp` and S2 `…/toolpolicy` per §10.4 #1 — surfaces
@@ -173,9 +174,9 @@ async fn reconcile(agent: Arc<A2AAgent>, ctx: Arc<Ctx>) -> Result<Action, Reconc
             .map(|(reason, msg)| (*reason, msg.as_str())),
     );
     let phase = if degraded.is_some() {
-        "Degraded"
+        PHASE_DEGRADED
     } else {
-        "Ready"
+        PHASE_READY
     };
 
     // SSA requires apiVersion + kind in the patch body — without

--- a/controller/src/claw_eval_reconciler.rs
+++ b/controller/src/claw_eval_reconciler.rs
@@ -45,6 +45,7 @@ use crate::claw_eval::{ClawEval, ClawEvalStatus};
 use crate::claw_eval_compile::{compile_to_binding, version_hash};
 use crate::mcp_server::LocalObjectRef;
 use crate::status::conditions::{self, reason, status as cond_status};
+use crate::status::phase::{PHASE_DEGRADED, PHASE_READY};
 
 const FIELD_MANAGER: &str = crate::field_managers::CLAW_EVAL;
 const FINALIZER: &str = "azureclaw.azure.com/claweval-cleanup";
@@ -142,9 +143,9 @@ async fn reconcile(eval: Arc<ClawEval>, ctx: Arc<Ctx>) -> Result<Action, Reconci
         degraded.as_ref().map(|(r, m)| (*r, m.as_str())),
     );
     let phase = if degraded.is_some() {
-        "Degraded"
+        PHASE_DEGRADED
     } else {
-        "Ready"
+        PHASE_READY
     };
 
     // SSA requires apiVersion + kind in the patch body — without

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -17,18 +17,26 @@
 //!
 //! The controller does **not** create the upstream Azure AI Foundry
 //! Memory Store — that happens runtime-side via the CLI plugin and
-//! the router's `/memory_stores/*` proxy on first use (S7+ wiring).
-//! Therefore, on a successful binding compile, the controller reports:
+//! the router's `/memory_stores/*` proxy on first use (Slice 3
+//! wiring). Therefore, on a successful binding compile, the
+//! controller reports:
 //!
-//! - `phase = "Pending"` (not `"Ready"`)
+//! - `phase = "Compiled"` (not `"Ready"`)
 //! - `Ready = False` / reason `AwaitingFoundryProvisioning`
 //! - `Progressing = True` / reason `AwaitingFoundryProvisioning`
+//! - A `Warning` Event with reason `PolicyNotEnforced` pointing at
+//!   the Slice 3 tracking issue (see
+//!   `crate::status::phase::PhaseEventReporter::warn_policy_not_enforced`).
 //!
 //! Reporting `Ready=True` after only writing the binding ConfigMap is
 //! a lie: the router will still 404 on `/memory_stores/<name>` until
 //! the runtime path provisions the store. `kubectl wait
 //! --for=condition=Ready` must block here — flipping it `True`
-//! prematurely was the bug this module guards against.
+//! prematurely was the bug this module guards against. The new
+//! `Compiled` phase (introduced by Slice 0 of
+//! `crd-well-oiled-machine`) is the canonical signal for "spec parsed
+//! but data plane not yet enforcing" and replaces the previous
+//! `Pending`-forever apology.
 //!
 //! When binding write itself fails, phase is `Failed` (not
 //! `Degraded`), `Ready=False`, `Degraded=True`.
@@ -62,6 +70,7 @@ use crate::claw_memory::{ClawMemory, ClawMemoryStatus};
 use crate::claw_memory_compile::{compile_to_binding, version_hash};
 use crate::mcp_server::LocalObjectRef;
 use crate::status::conditions::{self, reason, status as cond_status};
+use crate::status::phase::{PHASE_COMPILED, PHASE_FAILED, PhaseEventReporter};
 
 const FIELD_MANAGER: &str = crate::field_managers::CLAW_MEMORY;
 const FINALIZER: &str = "azureclaw.azure.com/clawmemory-cleanup";
@@ -88,6 +97,7 @@ impl ReconcileError {
 
 struct Ctx {
     client: Client,
+    phase_reporter: PhaseEventReporter,
 }
 
 async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
@@ -159,22 +169,46 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
         observed_generation,
         degraded.as_ref().map(|(r, m)| (*r, m.as_str())),
     );
-    // Honesty rule (see module docstring + claw_memory.rs §"Scope (S5)"):
+    // Honesty rule (principles.md §3, slice-0-honesty-events):
     // The controller only compiles a binding ConfigMap. Creating the
     // upstream Azure AI Foundry Memory Store is the runtime path's job
     // (CLI plugin → router `/memory_stores/*` proxy), and is not wired
-    // in this slice. Until S7 lands a sandbox-side informer that
+    // in this slice. Until Slice 3 lands a sandbox-side informer that
     // confirms the upstream store exists and stamps `foundryStoreId`,
     // we MUST NOT report `phase=Ready` / `Ready=True` — doing so makes
     // operators believe the store is provisioned when the router will
-    // still 404 on `/memory_stores/<name>`. Report `Pending` instead so
-    // `kubectl wait --for=condition=Ready` blocks until the upstream
-    // store is real.
+    // still 404 on `/memory_stores/<name>`. Report `Compiled` instead
+    // and publish a `PolicyNotEnforced` Warning Event so the user sees
+    // *why* in `kubectl describe`. `kubectl wait
+    // --for=condition=Ready` continues to block.
     let phase = if degraded.is_some() {
-        "Failed"
+        PHASE_FAILED
     } else {
-        "Pending"
+        PHASE_COMPILED
     };
+
+    if degraded.is_none() {
+        // Slice 0: surface the gap loudly. Slice 3 will delete this
+        // call site when ClawMemory becomes router-echoed.
+        if let Err(e) = ctx
+            .phase_reporter
+            .warn_policy_not_enforced(
+                memory.as_ref(),
+                "CompileBinding",
+                "ClawMemory binding ConfigMap is compiled but the upstream Azure AI Foundry \
+                 Memory Store has not been provisioned yet. The router will 404 on \
+                 /memory_stores/<name> until the runtime path (Slice 3) creates the store. \
+                 Tracking: crd-well-oiled-machine slice-3-claw-memory.",
+            )
+            .await
+        {
+            tracing::warn!(
+                clawmemory = %name,
+                error = %e,
+                "ClawMemoryEventPublishFailed",
+            );
+        }
+    }
 
     // SSA requires apiVersion + kind in the patch body — without
     // them, the API server returns "invalid object type: /, Kind=".
@@ -390,7 +424,10 @@ pub async fn run(client: Client) -> Result<()> {
             return Ok(());
         }
     }
-    let ctx = Arc::new(Ctx { client });
+    let ctx = Arc::new(Ctx {
+        client: client.clone(),
+        phase_reporter: PhaseEventReporter::new(client, "ClawMemory"),
+    });
     Controller::new(memories, kube::runtime::watcher::Config::default())
         .run(
             |x, ctx| async move {

--- a/controller/src/inference_policy_reconciler.rs
+++ b/controller/src/inference_policy_reconciler.rs
@@ -59,6 +59,7 @@ use crate::inference_policy::{InferencePolicy, InferencePolicyStatus};
 use crate::inference_policy_compile::{compile_to_profile, version_hash};
 use crate::mcp_server::LocalObjectRef;
 use crate::status::conditions::{self, reason, status as cond_status};
+use crate::status::phase::{PHASE_COMPILED, PHASE_DEGRADED, PhaseEventReporter};
 
 /// Field manager for SSA patches emitted by this reconciler. Distinct
 /// from S1 `…/mcp`, S2 `…/toolpolicy`, S3 `…/a2aagent` per §10.4 #1
@@ -95,6 +96,7 @@ impl ReconcileError {
 
 struct Ctx {
     client: Client,
+    phase_reporter: PhaseEventReporter,
 }
 
 async fn reconcile(policy: Arc<InferencePolicy>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
@@ -167,11 +169,39 @@ async fn reconcile(policy: Arc<InferencePolicy>, ctx: Arc<Ctx>) -> Result<Action
         observed_generation,
         degraded.as_ref().map(|(r, m)| (*r, m.as_str())),
     );
+    // Honesty rule (principles.md §3, slice-0-honesty-events):
+    // The InferencePolicy spec body (`tokenBudget`, `contentSafety`,
+    // `modelPreference`) is parsed and a profile ConfigMap is
+    // written, but the router does not yet consume it — Slice 2
+    // wires the router-side enforcement. Stamping `Ready` here lies
+    // to `kubectl wait --for=condition=Ready`; stamp `Compiled`
+    // instead and publish a `PolicyNotEnforced` Warning Event so the
+    // user can grep `kubectl describe` for the explanation.
     let phase = if degraded.is_some() {
-        "Degraded"
+        PHASE_DEGRADED
     } else {
-        "Ready"
+        PHASE_COMPILED
     };
+
+    if degraded.is_none()
+        && let Err(e) = ctx
+            .phase_reporter
+            .warn_policy_not_enforced(
+                policy.as_ref(),
+                "CompileProfile",
+                "InferencePolicy spec is parsed and the profile ConfigMap is written, but the \
+                 router does not yet consume it. Token budget, content safety, and model \
+                 preference are not enforced on model calls until the Slice 2 router-side \
+                 informer lands. Tracking: crd-well-oiled-machine slice-2-inference-policy.",
+            )
+            .await
+    {
+        tracing::warn!(
+            inferencepolicy = %name,
+            error = %e,
+            "InferencePolicyEventPublishFailed",
+        );
+    }
 
     // SSA requires apiVersion + kind in the patch body — without
     // them, the API server returns "invalid object type: /, Kind=".
@@ -246,20 +276,32 @@ fn build_conditions(
             ));
         }
         None => {
+            // Honesty rule (crd-well-oiled-machine principles.md §3,
+            // slice-0-honesty-events): the profile ConfigMap is
+            // written but the router does not yet consume it. We
+            // CANNOT report `Ready=True` here — `kubectl wait
+            // --for=condition=Ready` would return immediately for a
+            // policy that is doing nothing. Stamp
+            // `Ready=False` / `AwaitingRouterEnforcement` and keep
+            // `Progressing=True` until Slice 2 wires the router-side
+            // informer; at that point delete this branch's
+            // `AwaitingRouterEnforcement` reason and flip back to
+            // `Ready=True` / `Reconciled` after the router echoes the
+            // loaded digest.
             out.push(conditions::preserve_transition_time(
                 prior_ready,
                 conditions::TYPE_READY,
-                cond_status::TRUE,
-                reason::RECONCILED,
-                "InferencePolicy compiled and published",
+                cond_status::FALSE,
+                reason::AWAITING_ROUTER_ENFORCEMENT,
+                "profile ConfigMap published; router-side enforcement lands in Slice 2",
                 observed_generation,
             ));
             out.push(conditions::preserve_transition_time(
                 prior_progressing,
                 conditions::TYPE_PROGRESSING,
-                cond_status::FALSE,
-                reason::RECONCILED,
-                "compile complete",
+                cond_status::TRUE,
+                reason::AWAITING_ROUTER_ENFORCEMENT,
+                "awaiting router-side enforcement",
                 observed_generation,
             ));
             out.push(conditions::preserve_transition_time(
@@ -384,7 +426,10 @@ pub async fn run(client: Client) -> Result<()> {
             return Ok(());
         }
     }
-    let ctx = Arc::new(Ctx { client });
+    let ctx = Arc::new(Ctx {
+        client: client.clone(),
+        phase_reporter: PhaseEventReporter::new(client, "InferencePolicy"),
+    });
     Controller::new(policies, kube::runtime::watcher::Config::default())
         .run(
             |x, ctx| async move {
@@ -429,6 +474,10 @@ mod tests {
 
     #[test]
     fn build_conditions_emits_all_three_types_on_success() {
+        // Slice 0 honesty rule: until Slice 2 wires the router-side
+        // informer, success means `Ready=False` /
+        // `AwaitingRouterEnforcement` because the profile ConfigMap
+        // is written but the router does not yet consume it.
         let conds = build_conditions(&[], Some(1), None);
         assert_eq!(conds.len(), 3);
         let types: Vec<&str> = conds.iter().map(|c| c.type_.as_str()).collect();
@@ -439,7 +488,13 @@ mod tests {
             .iter()
             .find(|c| c.type_ == conditions::TYPE_READY)
             .unwrap();
-        assert_eq!(ready.status, cond_status::TRUE);
+        assert_eq!(ready.status, cond_status::FALSE);
+        assert_eq!(ready.reason, reason::AWAITING_ROUTER_ENFORCEMENT);
+        let progressing = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_PROGRESSING)
+            .unwrap();
+        assert_eq!(progressing.status, cond_status::TRUE);
         let degraded = conds
             .iter()
             .find(|c| c.type_ == conditions::TYPE_DEGRADED)

--- a/controller/src/mcp_server_reconciler.rs
+++ b/controller/src/mcp_server_reconciler.rs
@@ -52,6 +52,7 @@ use std::time::Duration;
 
 use crate::mcp_server::{LocalObjectRef, McpServer, McpServerStatus};
 use crate::status::conditions::{self, reason, status as cond_status};
+use crate::status::phase::{PHASE_DEGRADED, PHASE_READY, PhaseEventReporter};
 
 /// Field manager for SSA patches emitted by this reconciler. A unique
 /// suffix per reconciler is the §10.4 #1 craftsmanship requirement —
@@ -100,6 +101,10 @@ struct Ctx {
     client: Client,
     /// Override hook for tests — swap the JWKS fetcher with a mock.
     jwks_fetcher: Arc<dyn JwksFetcher>,
+    /// Publisher for `LimitedSupport` Warning Events. Optional so
+    /// unit tests can construct a `Ctx` without a real `Client` —
+    /// production builds always wire it via `run()`.
+    phase_reporter: Option<PhaseEventReporter>,
 }
 
 /// Pluggable JWKS fetcher — production uses [`HttpJwksFetcher`], tests
@@ -341,9 +346,18 @@ async fn reconcile(mcp: Arc<McpServer>, ctx: Arc<Ctx>) -> Result<Action, Reconci
             .map(|(reason, msg)| (*reason, msg.as_str())),
     );
     let phase = if degraded.is_some() {
-        "Degraded"
+        PHASE_DEGRADED
     } else {
-        "Ready"
+        // Slice 0 honesty: McpServer reconciler today binds exactly
+        // one server per ClawSandbox via `spec.mcp:` (singular).
+        // Slice 4 of crd-well-oiled-machine introduces a plural
+        // multi-server model + per-server enable/disable. We keep
+        // `Ready` here (the singular path *does* work end-to-end and
+        // the router consumes it), but publish a `LimitedSupport`
+        // Warning Event so operators reading `kubectl describe` see
+        // the upcoming change before they ship CRs that assume
+        // multi-MCP today.
+        PHASE_READY
     };
 
     // SSA requires apiVersion + kind in the patch body — without
@@ -372,6 +386,23 @@ async fn reconcile(mcp: Arc<McpServer>, ctx: Arc<Ctx>) -> Result<Action, Reconci
     if degraded.is_some() {
         Ok(Action::requeue(REQUEUE_FAIL))
     } else {
+        // Slice 0 honesty event: tell operators the singular
+        // `spec.mcp:` model is intentional-today / migrating in
+        // Slice 4. Best-effort — never fail reconcile on Event
+        // publish.
+        if let Some(reporter) = &ctx.phase_reporter
+            && let Err(e) = reporter
+                .warn_limited_support(
+                    &*mcp,
+                    "BindMcpServer",
+                    "McpServer is reconciled via a singular `spec.mcp` binding today; \
+                     a plural multi-server model lands in crd-well-oiled-machine Slice 4. \
+                     CRs assuming a list of MCP servers will be migrated automatically.",
+                )
+                .await
+        {
+            tracing::warn!(error = %e, "failed to publish LimitedSupport event");
+        }
         Ok(Action::requeue(REQUEUE_OK))
     }
 }
@@ -654,8 +685,9 @@ pub async fn run(client: Client) -> Result<()> {
         }
     }
     let ctx = Arc::new(Ctx {
-        client,
+        client: client.clone(),
         jwks_fetcher: Arc::new(HttpJwksFetcher::new()),
+        phase_reporter: Some(PhaseEventReporter::new(client, "McpServer")),
     });
     Controller::new(mcps, kube::runtime::watcher::Config::default())
         .run(

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -194,6 +194,18 @@ pub mod reason {
     /// the controller. Until the runtime confirms the upstream store
     /// exists, we cannot honestly report `Ready=True`.
     pub const AWAITING_FOUNDRY_PROVISIONING: &str = "AwaitingFoundryProvisioning";
+    /// `crd-well-oiled-machine` Slice 0 — `AwaitingRouterEnforcement`:
+    /// the controller has compiled the spec and published the
+    /// artifact ConfigMap, but the router has not yet echoed back the
+    /// loaded digest (or, for today, the router does not yet consume
+    /// this CRD kind at all — InferencePolicy in Slice 0, McpServer
+    /// plural in Slice 4, etc.). Until the data-plane confirmation
+    /// closure of principles.md §3 is wired, the controller emits
+    /// `Ready=False` / reason=`AwaitingRouterEnforcement` and stamps
+    /// `phase=Compiled`. Each slice that wires its router-side
+    /// informer deletes the corresponding call site (§5 "delete on
+    /// contact").
+    pub const AWAITING_ROUTER_ENFORCEMENT: &str = "AwaitingRouterEnforcement";
 }
 
 /// Build a condition with a freshly-stamped `lastTransitionTime`.

--- a/controller/src/status/mod.rs
+++ b/controller/src/status/mod.rs
@@ -10,6 +10,7 @@
 //! everything we write into `.status`.
 
 pub mod conditions;
+pub mod phase;
 
 use crate::crd::ClawSandbox;
 use kube::ResourceExt;

--- a/controller/src/status/phase.rs
+++ b/controller/src/status/phase.rs
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Canonical `.status.phase` strings + helpers to emit the matching
+//! Warning Event when a reconciler stamps a decorative phase.
+//!
+//! ## Why this module exists
+//!
+//! Per `docs/internal/crd-well-oiled-machine/principles.md` §3 the
+//! contract is:
+//!
+//! - **`Ready`** — the data plane (router or sandbox-side informer) has
+//!   confirmed it is enforcing the spec.
+//! - **`Compiled`** — the controller parsed the spec and wrote a
+//!   ConfigMap, but the router has not echoed the digest yet (or, for
+//!   today, the router does not yet consume this CRD kind at all).
+//!
+//! Three reconcilers historically stamped `Ready` while the data plane
+//! ignored the body (`InferencePolicy`'s `tokenBudget` /
+//! `contentSafety` / `modelPreference`, `ClawMemory`'s binding) or
+//! stamped `Pending` forever with a TODO comment. Each was a lie to the
+//! user: `kubectl wait --for=condition=Ready` returned green for a
+//! policy that was doing nothing.
+//!
+//! This module is the single place that owns:
+//!
+//! 1. The phase-string vocabulary the rest of the operator must use.
+//! 2. The `PolicyNotEnforced` Warning Event format. Whenever a
+//!    reconciler stamps `Compiled` because the router does not yet
+//!    consume the spec, it also publishes a Warning Event so the
+//!    explanation is visible in `kubectl describe`.
+//!
+//! ## Why a `Reporter` wrapper, not raw `kube::runtime::events`
+//!
+//! Three reasons:
+//!
+//! - Reconcilers already take a `Ctx { client }`; threading a
+//!   `Recorder` per reconciler avoids constructing one per reconcile
+//!   call (which would mean a new HTTP client + UUID each time).
+//! - Tests can pass a no-op reporter without faking the K8s API.
+//! - The `controller` / `instance` fields are uniform across every
+//!   reconciler — Phase 2 §10.4 #1 (field-manager-per-reconciler)
+//!   gives us provenance, but the Event reporter must still identify
+//!   the operator pod as the source.
+
+use k8s_openapi::api::core::v1::ObjectReference;
+use kube::runtime::events::{Event, EventType, Recorder, Reporter};
+use kube::{Client, Resource};
+
+/// `.status.phase = "Pending"` — controller has accepted the CR but
+/// has not yet produced a compiled artifact (e.g. waiting on an admit
+/// step, or finalizer cleanup in progress).
+///
+/// No reconciler in Slice 0 stamps this value (every CR goes
+/// straight from "no status" → `Compiled` or `Failed`), but the
+/// constant is part of the public phase vocabulary documented in
+/// `docs/api/lifecycle.md` and consumed by the Headlamp plugin's
+/// `phaseToStatus()`. Future reconcilers (e.g. async finalizer flows)
+/// will need to emit it.
+#[allow(dead_code)]
+pub const PHASE_PENDING: &str = "Pending";
+
+/// `.status.phase = "Compiled"` — the controller parsed the spec,
+/// wrote the ConfigMap, but the router has not yet confirmed it is
+/// enforcing the compiled artifact. The user's `kubectl wait
+/// --for=condition=Ready` must block here.
+///
+/// Introduced in Slice 0 of `crd-well-oiled-machine`. Replaces the
+/// historical practice of stamping `Ready` for unwired CRDs and the
+/// `Pending`-forever apology in `ClawMemory`.
+pub const PHASE_COMPILED: &str = "Compiled";
+
+/// `.status.phase = "Ready"` — the data plane has confirmed it is
+/// enforcing the compiled artifact. For Slice 0 only `ToolPolicy` and
+/// `McpServer` (singular) and `A2AAgent` may stamp this. The remaining
+/// reconcilers stamp `Compiled` until their slice lands.
+pub const PHASE_READY: &str = "Ready";
+
+/// `.status.phase = "Degraded"` — the spec is valid but some
+/// dependency is failing. Reconciler should still attempt progress on
+/// the next requeue.
+pub const PHASE_DEGRADED: &str = "Degraded";
+
+/// `.status.phase = "Failed"` — the spec itself or a hard prerequisite
+/// is wrong; reconciler will not converge without a spec change.
+pub const PHASE_FAILED: &str = "Failed";
+
+/// Canonical Warning Event reason for "controller compiled the spec
+/// but the router does not yet consume it." Whatever slice eventually
+/// wires the consumer must delete the corresponding
+/// [`PhaseEventReporter::warn_policy_not_enforced`] call site as part
+/// of its PR (principles.md §5: delete on contact).
+pub const REASON_POLICY_NOT_ENFORCED: &str = "PolicyNotEnforced";
+
+/// Canonical Warning Event reason for "this CRD kind ships as singular
+/// today; plural support arrives in a later slice." Distinct from
+/// `PolicyNotEnforced` because `McpServer` *is* enforced — there is
+/// just a sandbox-side capacity cap of one.
+pub const REASON_LIMITED_SUPPORT: &str = "LimitedSupport";
+
+/// Default reporter identity. The pod name is filled from
+/// `CONTROLLER_POD_NAME` (set in the controller Deployment) when
+/// available; otherwise we fall back to a static identifier so events
+/// still publish during local `cargo test` runs.
+const REPORTER_CONTROLLER: &str = "azureclaw-controller";
+
+/// Thin wrapper around [`kube::runtime::events::Recorder`].
+///
+/// Constructed once per reconciler at start-up (placed in each
+/// reconciler's `Ctx`) and cloned cheaply per reconcile call.
+#[derive(Clone)]
+pub struct PhaseEventReporter {
+    recorder: Recorder,
+}
+
+impl PhaseEventReporter {
+    /// Build a reporter for a named reconciler. The `reconciler_name`
+    /// shows up in the Event's `reportingController` so operators can
+    /// disambiguate which reconciler stamped the event.
+    pub fn new(client: Client, reconciler_name: &str) -> Self {
+        let instance = std::env::var("CONTROLLER_POD_NAME").ok();
+        let reporter = Reporter {
+            controller: format!("{REPORTER_CONTROLLER}/{reconciler_name}"),
+            instance,
+        };
+        Self {
+            recorder: Recorder::new(client, reporter),
+        }
+    }
+
+    /// Publish a `Warning` Event explaining that the CR is in the
+    /// `Compiled` phase because the router does not yet consume the
+    /// spec.
+    ///
+    /// `note` is the human-readable message — keep it ≤1 KiB; we
+    /// truncate defensively below the kube-runtime limit. `action`
+    /// shows up in event JSON (not `kubectl describe`) and identifies
+    /// the operation that produced the outcome.
+    ///
+    /// Returns the underlying `kube::Error` on publish failure;
+    /// reconcilers should `tracing::warn!` and continue rather than
+    /// fail the reconcile — the status is the source of truth, the
+    /// event is just user-visible context.
+    pub async fn warn_policy_not_enforced<R>(
+        &self,
+        cr: &R,
+        action: &str,
+        note: impl Into<String>,
+    ) -> Result<(), kube::Error>
+    where
+        R: Resource<DynamicType = ()>,
+    {
+        self.publish_warning(cr, REASON_POLICY_NOT_ENFORCED, action, note.into())
+            .await
+    }
+
+    /// Publish a `Warning` Event explaining that the CR is supported
+    /// only in a limited fashion today (e.g. singular `McpServer`
+    /// where the user might expect plural support). Distinct from
+    /// `warn_policy_not_enforced` so operators can grep events by
+    /// reason.
+    pub async fn warn_limited_support<R>(
+        &self,
+        cr: &R,
+        action: &str,
+        note: impl Into<String>,
+    ) -> Result<(), kube::Error>
+    where
+        R: Resource<DynamicType = ()>,
+    {
+        self.publish_warning(cr, REASON_LIMITED_SUPPORT, action, note.into())
+            .await
+    }
+
+    async fn publish_warning<R>(
+        &self,
+        cr: &R,
+        reason: &str,
+        action: &str,
+        mut note: String,
+    ) -> Result<(), kube::Error>
+    where
+        R: Resource<DynamicType = ()>,
+    {
+        // kube-runtime caps `note` at 1 KiB; truncate defensively so
+        // we never emit a stricter-than-doc'd error.
+        if note.len() > 1024 {
+            note.truncate(1024);
+        }
+        let event = Event {
+            type_: EventType::Warning,
+            reason: reason.to_string(),
+            note: Some(note),
+            action: action.to_string(),
+            secondary: None,
+        };
+        let reference = object_ref_for(cr);
+        self.recorder.publish(&event, &reference).await
+    }
+}
+
+/// Build the [`ObjectReference`] consumed by
+/// [`kube::runtime::events::Recorder::publish`].
+///
+/// Pulled out as a free function so unit tests can verify the shape
+/// without a live Recorder.
+pub fn object_ref_for<R>(cr: &R) -> ObjectReference
+where
+    R: Resource<DynamicType = ()>,
+{
+    use kube::ResourceExt;
+    ObjectReference {
+        api_version: Some(R::api_version(&()).into_owned()),
+        kind: Some(R::kind(&()).into_owned()),
+        name: Some(cr.name_any()),
+        namespace: cr.namespace(),
+        uid: cr.meta().uid.clone(),
+        resource_version: cr.meta().resource_version.clone(),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claw_memory::ClawMemory;
+    use crate::inference_policy::InferencePolicy;
+    use crate::mcp_server::McpServer;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    #[test]
+    fn phase_constants_are_pascal_case() {
+        for s in [
+            PHASE_PENDING,
+            PHASE_COMPILED,
+            PHASE_READY,
+            PHASE_DEGRADED,
+            PHASE_FAILED,
+        ] {
+            assert!(
+                s.chars().next().is_some_and(|c| c.is_uppercase()),
+                "phase {s} must be PascalCase"
+            );
+            assert!(
+                !s.contains('_') && !s.contains('-') && !s.contains(' '),
+                "phase {s} must be one PascalCase word"
+            );
+        }
+    }
+
+    #[test]
+    fn compiled_phase_is_distinct_from_ready_and_pending() {
+        // Regression guard: a refactor that aliases these constants
+        // would silently re-introduce the "Ready means nothing" bug.
+        assert_ne!(PHASE_COMPILED, PHASE_READY);
+        assert_ne!(PHASE_COMPILED, PHASE_PENDING);
+    }
+
+    #[test]
+    fn reason_constants_match_documented_format() {
+        // Reasons must be PascalCase per K8s Events convention.
+        for s in [REASON_POLICY_NOT_ENFORCED, REASON_LIMITED_SUPPORT] {
+            assert!(s.chars().next().is_some_and(|c| c.is_uppercase()));
+            assert!(s.chars().all(|c| c.is_ascii_alphabetic()));
+        }
+    }
+
+    fn cm_fixture() -> ClawMemory {
+        ClawMemory {
+            metadata: ObjectMeta {
+                name: Some("mem-1".into()),
+                namespace: Some("azureclaw-test".into()),
+                uid: Some("00000000-0000-0000-0000-000000000001".into()),
+                resource_version: Some("42".into()),
+                ..Default::default()
+            },
+            spec: Default::default(),
+            status: None,
+        }
+    }
+
+    #[test]
+    fn object_ref_for_clawmemory_carries_identifiers() {
+        let r = object_ref_for(&cm_fixture());
+        assert_eq!(r.kind.as_deref(), Some("ClawMemory"));
+        assert_eq!(r.name.as_deref(), Some("mem-1"));
+        assert_eq!(r.namespace.as_deref(), Some("azureclaw-test"));
+        assert_eq!(
+            r.uid.as_deref(),
+            Some("00000000-0000-0000-0000-000000000001")
+        );
+        assert_eq!(r.resource_version.as_deref(), Some("42"));
+        let av = r.api_version.unwrap();
+        assert!(av.starts_with("azureclaw.azure.com/"), "got {av}");
+    }
+
+    #[test]
+    fn object_ref_for_inferencepolicy_uses_correct_kind() {
+        let p = InferencePolicy {
+            metadata: ObjectMeta {
+                name: Some("p-1".into()),
+                namespace: Some("ns".into()),
+                ..Default::default()
+            },
+            spec: Default::default(),
+            status: None,
+        };
+        let r = object_ref_for(&p);
+        assert_eq!(r.kind.as_deref(), Some("InferencePolicy"));
+        assert_eq!(r.name.as_deref(), Some("p-1"));
+        assert_eq!(r.namespace.as_deref(), Some("ns"));
+    }
+
+    #[test]
+    fn object_ref_for_mcpserver_uses_correct_kind() {
+        let m = McpServer {
+            metadata: ObjectMeta {
+                name: Some("m-1".into()),
+                namespace: Some("ns".into()),
+                ..Default::default()
+            },
+            spec: Default::default(),
+            status: None,
+        };
+        let r = object_ref_for(&m);
+        assert_eq!(r.kind.as_deref(), Some("McpServer"));
+    }
+}

--- a/controller/src/tool_policy_reconciler.rs
+++ b/controller/src/tool_policy_reconciler.rs
@@ -45,6 +45,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::status::conditions::{self, reason, status as cond_status};
+use crate::status::phase::{PHASE_DEGRADED, PHASE_READY};
 use crate::tool_policy::{ToolPolicy, ToolPolicyStatus};
 use crate::tool_policy_compile::{compile_to_profile, version_hash};
 
@@ -163,9 +164,17 @@ async fn reconcile(tp: Arc<ToolPolicy>, ctx: Arc<Ctx>) -> Result<Action, Reconci
             .map(|(reason, msg)| (*reason, msg.as_str())),
     );
     let phase = if degraded.is_some() {
-        "Degraded"
+        PHASE_DEGRADED
     } else {
-        "Ready"
+        // Slice 0 honesty rule: ToolPolicy keeps `Ready` today
+        // because its enforcement is **runtime-side** (openclaw
+        // plugin allow/deny via AGT profile); the controller is the
+        // SoT for the profile bytes and the runtime consumes them
+        // directly. No router-side data plane is in the loop, so
+        // there is nothing to await. If/when Slice 4 introduces a
+        // controller→router push for tool policies, flip to
+        // `PHASE_COMPILED` + emit a `PolicyNotEnforced` event.
+        PHASE_READY
     };
 
     // SSA requires apiVersion + kind in the patch body — without

--- a/controller/src/trust_graph_reconciler.rs
+++ b/controller/src/trust_graph_reconciler.rs
@@ -44,6 +44,7 @@ use std::time::Duration;
 
 use crate::mcp_server::LocalObjectRef;
 use crate::status::conditions::{self, reason, status as cond_status};
+use crate::status::phase::{PHASE_DEGRADED, PHASE_READY};
 use crate::trust_graph::{TrustGraph, TrustGraphStatus};
 use crate::trust_graph_compile::{CompileResult, compile_trust_graph};
 
@@ -173,9 +174,9 @@ async fn reconcile(tg: Arc<TrustGraph>, ctx: Arc<Ctx>) -> Result<Action, Reconci
     let new_conditions =
         build_conditions(&prior_conditions, observed_generation, degraded_for_cond);
     let phase = if degraded.is_some() {
-        "Degraded"
+        PHASE_DEGRADED
     } else {
-        "Ready"
+        PHASE_READY
     };
 
     let status_patch = json!({

--- a/controller/tests/phase_taxonomy_guard.rs
+++ b/controller/tests/phase_taxonomy_guard.rs
@@ -1,0 +1,129 @@
+//! Regression-guard test for `crd-well-oiled-machine` Slice 0
+//! "honesty events".
+//!
+//! ## What this enforces
+//!
+//! All `*_reconciler.rs` files must stamp `status.phase` from the
+//! closed taxonomy in `controller/src/status/phase.rs`
+//! (`PHASE_PENDING` / `PHASE_COMPILED` / `PHASE_READY` /
+//! `PHASE_DEGRADED` / `PHASE_FAILED`) and **must not** hand-roll
+//! string literals like `"Pending"` / `"Ready"` / `"Degraded"` /
+//! `"Failed"` / `"Compiled"`.
+//!
+//! Without this guard a future drive-by `phase: Some("Ready".into())`
+//! would silently break the principles.md §3 invariant that
+//! `Ready` ⇔ router echoed digest.
+//!
+//! ## Why a test instead of clippy
+//!
+//! Clippy can't distinguish "phase string literal" from "any string
+//! literal". This test reads each reconciler file and greps for
+//! suspect literals in non-comment, non-test contexts.
+//!
+//! ## How to update
+//!
+//! If you genuinely need a new phase, add the constant to
+//! `controller/src/status/phase.rs` and use it. Do not add to
+//! `LITERAL_DENYLIST` and a new exception — the whole point is that
+//! exceptions don't get added.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// String literals that must never appear in reconciler source.
+const LITERAL_DENYLIST: &[&str] = &[
+    "\"Pending\"",
+    "\"Compiled\"",
+    "\"Ready\"",
+    "\"Degraded\"",
+    "\"Failed\"",
+];
+
+/// Reconcilers under audit. Adding a new `*_reconciler.rs` file
+/// without listing it here is fine — the directory walker picks it
+/// up — but the explicit list documents the contract.
+fn reconciler_files() -> Vec<PathBuf> {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    fs::read_dir(&src)
+        .expect("controller/src directory must exist")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.ends_with("_reconciler.rs"))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Crude classifier: skip lines that are clearly comments.
+/// We bias to false-negatives over false-positives because the cost
+/// of a missed grep is a controller bug, while the cost of a
+/// false-positive is developer friction.
+fn is_excluded_line(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("//")
+        || t.starts_with("/*")
+        || t.starts_with("*")
+        || t.starts_with("#[doc")
+        || t.starts_with("#![doc")
+}
+
+#[test]
+fn reconcilers_must_use_phase_constants_not_string_literals() {
+    let files = reconciler_files();
+    assert!(
+        !files.is_empty(),
+        "no *_reconciler.rs files discovered — broken test harness, not real pass"
+    );
+
+    let mut violations: Vec<String> = Vec::new();
+
+    for path in &files {
+        let body =
+            fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+
+        let mut in_test_module = false;
+        let mut brace_depth_at_test_entry = 0i32;
+        let mut current_depth = 0i32;
+
+        for (idx, line) in body.lines().enumerate() {
+            current_depth += line.matches('{').count() as i32;
+            current_depth -= line.matches('}').count() as i32;
+
+            if !in_test_module && line.contains("#[cfg(test)]") {
+                in_test_module = true;
+                brace_depth_at_test_entry = current_depth;
+                continue;
+            }
+            if in_test_module && current_depth <= brace_depth_at_test_entry {
+                in_test_module = false;
+            }
+            if in_test_module {
+                continue;
+            }
+            if is_excluded_line(line) {
+                continue;
+            }
+
+            for needle in LITERAL_DENYLIST {
+                if line.contains(needle) {
+                    violations.push(format!(
+                        "{}:{}: forbidden phase literal `{}` — use the constant from \
+                         controller/src/status/phase.rs",
+                        path.file_name().unwrap().to_string_lossy(),
+                        idx + 1,
+                        needle
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "phase taxonomy violations (crd-well-oiled-machine principles.md §3 / Slice 0):\n  {}",
+        violations.join("\n  ")
+    );
+}

--- a/docs/api/lifecycle.md
+++ b/docs/api/lifecycle.md
@@ -306,10 +306,24 @@ All four follow the same `compile → version_hash → SSA ConfigMap → patch_s
 
 Every reconcile ends with a `patch_status` call. The status block always carries:
 
-- `phase` — `Ready` / `Degraded` / (heavyweight CRDs add `Progressing`).
+- `phase` — see vocabulary table below.
 - `observedGeneration` — `metadata.generation` of the spec the reconciler saw.
 - `conditions[]` — at least `Ready`, `Progressing`, `Degraded`. Reasons are taxonomy-controlled — see [Conditions reference](conditions.md).
 - For compile pattern: `versionHash`, the `*-Ref` pointing at the produced `ConfigMap`/`Secret`, and `lastCompiledAt` / `lastProbedAt`.
+
+### Phase vocabulary
+
+The `status.phase` string is part of the public contract: `azureclaw connect`, `kubectl wait`, GitOps tooling and the Headlamp plugin all branch on it. The taxonomy is closed — reconcilers must use one of these values (constants live in `controller/src/status/phase.rs`):
+
+| Phase | Meaning | `Ready` condition | When the controller stamps it |
+|---|---|---|---|
+| `Pending` | Controller accepted the CR but has not yet produced a compiled artifact (waiting on an admit step or finalizer cleanup). | `False` | Reserved for async admission flows; not stamped by Slice 0 reconcilers. |
+| `Compiled` | Spec parsed, `ConfigMap` written, but the **router has not yet echoed back the loaded digest**. The artifact exists; the data plane is not yet enforcing it. | `False` (reason `AwaitingRouterEnforcement`) | Slice 0 — `InferencePolicy`, `ClawMemory`. Each reconciler also emits a `Warning` Event with reason `PolicyNotEnforced` so operators see the gap in `kubectl describe`. |
+| `Ready` | Spec compiled **and** the consuming component (router, runtime, etc.) has confirmed it is enforcing the artifact. `kubectl wait --for=condition=Ready` must only return at this point. | `True` | `ToolPolicy` (runtime-side enforcement is co-located), `McpServer` (singular today; see Slice 4), `A2AAgent`, `ClawSandbox`, `TrustGraph`. |
+| `Degraded` | Spec is valid but a dependency is failing (Foundry 5xx, JWKS fetch timeout, etc.). Retry will help — the reconciler requeues at `REQUEUE_FAIL`. | `False` (reason describes the dependency) | Any reconciler on transient failure. |
+| `Failed` | Spec is invalid and will not converge without user editing the CR (validation, signature mismatch, malformed reference). | `False` | Any reconciler on permanent failure. |
+
+The `Compiled` state is the load-bearing honesty value introduced in `docs/internal/crd-well-oiled-machine/slice-0-honesty-events.md`. Each subsequent slice (2 = `InferencePolicy`, 3 = `ClawMemory`, …) deletes its `Compiled`/`AwaitingRouterEnforcement` call site once the router-side informer or runtime echo is wired, flipping the success path back to `Ready=True`.
 
 Requeue cadence is per-reconciler:
 

--- a/tools/headlamp-plugin/src/index.tsx
+++ b/tools/headlamp-plugin/src/index.tsx
@@ -147,6 +147,12 @@ function phaseToStatus(phase: string | undefined): StatusKind {
   if (!phase) return "";
   if (phase === "Ready" || phase === "Provisioned" || phase === "Active") return "success";
   if (phase === "Degraded" || phase === "Failed" || phase === "Error") return "error";
+  // `Compiled` is the crd-well-oiled-machine Slice 0 honesty value:
+  // controller wrote the artifact ConfigMap but the router has not
+  // echoed a loaded digest yet. Render amber/warning so operators
+  // see at a glance that the policy is parsed but NOT live. Falls
+  // back to "warning" for any unknown phase (defensive default).
+  if (phase === "Compiled" || phase === "Pending") return "warning";
   return "warning";
 }
 


### PR DESCRIPTION
Implements `docs/internal/crd-well-oiled-machine/slice-0-honesty-events.md`. Introduces `status.phase=Compiled` as the load-bearing distinction between "controller wrote the artifact" and "data plane is enforcing the artifact" (principles.md §3).

## Highlights

- `InferencePolicy` and `ClawMemory`: success path now `phase=Compiled` + `Ready=False` / `AwaitingRouterEnforcement` + Warning Event `PolicyNotEnforced`. `kubectl wait --for=condition=Ready` no longer returns prematurely.
- `McpServer`: emits `LimitedSupport` Warning Event flagging upcoming Slice 4 plural-MCP migration.
- `ToolPolicy` / `A2AAgent` / `ClawEval` / `TrustGraph`: hygiene-only swap to shared phase constants.
- New regression-guard integration test scans reconcilers for forbidden phase string literals.
- New `docs/api/lifecycle.md` phase vocabulary table.

## Tests

- `cargo build --release` clean.
- `cargo test --package azureclaw-controller` — 493 unit + 1 guard = **494 pass**.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.

Pre-existing flaky test `governance_content_flag_applies_penalty` in inference-router fails on `origin/dev` too — out of scope for this slice.