### PR TITLE
Slice 1a: router PolicyStatusRegistry + GET /internal/policy-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1a — router `PolicyStatusRegistry` + `GET /internal/policy-status`
+
+Foundation for the principles.md §3 invariant ("Ready ⇔ router echoes the
+exact published digest"). The controller-side digest-confirmation poller
+ships in Slice 1b; this PR delivers the data-plane half of the contract
+together with its first real producer (AGT).
+
+- New module `inference-router/src/policy_status.rs` exposes
+  `PolicyStatusRegistry` — an in-memory map keyed by `PolicyKind`
+  (only `AgtProfile` today) storing `digest`, `source_path`,
+  `loaded_at`, `last_error`. `record_success` / `record_error`
+  preserve the prior digest on error so transient reload failures
+  don't fake a "no policy loaded" state. 8 unit tests pin the
+  registry behavior including UTF-8-safe error truncation at
+  char boundaries.
+- New route `GET /internal/policy-status` (handler in
+  `inference-router/src/routes/internal.rs`) returns
+  `{schema_version: 1, count, entries: [...]}` with RFC 3339
+  `loaded_at`. Mounted on the `protected` axum router so it
+  inherits admin-token + `ADMIN_ALLOW_IPS` middleware alongside
+  the existing `egress_routes()` / `spawn_routes()`. 5 unit tests
+  cover the response envelope and the hand-rolled RFC 3339
+  formatter (no chrono dep). 4 integration tests in
+  `tests/policy_status_endpoint.rs` exercise the full axum stack
+  including an end-to-end producer→consumer test that loads a real
+  AGT policy file through `Governance::load_policies_from_dir` and
+  asserts the digest surfaces on the route.
+- `Governance::load_policies_from_dir` now records into the
+  registry as a side effect of every reload cycle. Aggregate
+  canonical digest is **length-prefixed**:
+  `u64-BE-len(name) || name || u64-BE-len(bytes) || bytes`
+  concatenated per file, files sorted by path. The length prefix
+  prevents `("ab","c") vs ("a","bc")` collisions; the sort makes
+  the digest deterministic across `read_dir` ordering. The
+  controller poller (Slice 1b) MUST replicate this exact
+  serialization on the publish side.
+- `Governance::new_with_status()` constructor accepts a shared
+  `Arc<PolicyStatusRegistry>`; the existing `new()` continues to
+  work for callers that don't need digest echo (constructs a
+  private registry). `AppState` carries one registry per process,
+  shared with `Governance` so every reload echoes to the route.
+- Empty policy directory → `record_success` with the digest of
+  zero bytes (a real "loaded nothing on purpose" state, distinct
+  from "couldn't read the directory" which records an error with
+  null digest).
+
 ### Slice 0 — honesty events
 
 - **`status.phase=Compiled` introduced** as the load-bearing distinction

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -25,6 +25,7 @@ use std::time::{Duration, Instant};
 
 use crate::behavior_monitor::BehaviorMonitor;
 use crate::metrics;
+use crate::policy_status::{PolicyKind, PolicyStatusRegistry};
 use crate::rate_limiter::RateLimiter;
 
 mod trust_ops;
@@ -112,11 +113,31 @@ pub struct Governance {
     pub(crate) trust_graph: crate::a2a::trust_graph_projection::TrustGraphProjection,
     start_time: Instant,
     policy_rule_count: AtomicU64,
+    /// Per-CRD policy load status. Slice 1 of `crd-well-oiled-machine`:
+    /// the AGT engine writes a `PolicyKind::AgtProfile` row here on
+    /// every successful `load_policies_from_dir`. `GET /internal/policy-status`
+    /// reads it; future slices add their own kinds. Shared via
+    /// `Arc<PolicyStatusRegistry>` with `AppState`.
+    pub policy_status: std::sync::Arc<PolicyStatusRegistry>,
 }
 
 impl Governance {
     /// Initialize governance from environment variables.
     pub fn new(sandbox_name: &str) -> Self {
+        Self::new_with_status(
+            sandbox_name,
+            std::sync::Arc::new(PolicyStatusRegistry::new()),
+        )
+    }
+
+    /// Initialize governance with a shared [`PolicyStatusRegistry`].
+    /// Production callers use the default `new()` helper; tests and
+    /// `AppState::new` use this variant to share one registry instance
+    /// with the HTTP layer.
+    pub fn new_with_status(
+        sandbox_name: &str,
+        policy_status: std::sync::Arc<PolicyStatusRegistry>,
+    ) -> Self {
         let trust_threshold: u32 = std::env::var("AGT_TRUST_THRESHOLD")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -234,6 +255,7 @@ impl Governance {
                 p
             },
             start_time: Instant::now(),
+            policy_status,
         }
     }
 
@@ -257,28 +279,33 @@ impl Governance {
                 dir,
                 "Policy directory not found — starting with empty policy"
             );
+            // No directory → no profile. Record `None` so the controller
+            // can distinguish "no profile mounted yet" from "profile
+            // loaded with digest X".
+            self.policy_status.record_error(
+                PolicyKind::AgtProfile,
+                dir,
+                "policy directory not found",
+            );
             return Ok(0);
         }
 
         let mut total_rules = 0;
+        // Collect files in deterministic order so the aggregate digest
+        // is independent of filesystem listing order. Without sorting,
+        // two routers seeing the same files could echo different
+        // digests, defeating the controller's match check.
+        let mut yaml_files: Vec<std::path::PathBuf> = Vec::new();
+        let mut read_err: Option<String> = None;
         match std::fs::read_dir(path) {
             Ok(entries) => {
                 for entry in entries.flatten() {
                     let p = entry.path();
                     if p.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-                        match self.policy.load_from_file(p.to_str().unwrap_or_default()) {
-                            Ok(()) => {
-                                // Count actual rules inside the file, not just files
-                                let rules_in_file = Self::count_rules_in_file(&p);
-                                tracing::info!(file = %p.display(), rules = rules_in_file, "Loaded policy file");
-                                total_rules += rules_in_file;
-                            }
-                            Err(e) => {
-                                tracing::warn!(file = %p.display(), error = %e, "Failed to load policy");
-                            }
-                        }
+                        yaml_files.push(p);
                     }
                 }
+                yaml_files.sort();
             }
             Err(e) => {
                 // Surface silent permission/IO failures — without this, a
@@ -286,11 +313,69 @@ impl Governance {
                 // legitimately-empty policy directory and silently disables
                 // governance enforcement.
                 tracing::warn!(dir, error = %e, "Policy reload: read_dir failed (perms?)");
+                read_err = Some(format!("read_dir failed: {e}"));
             }
         }
+
+        // Aggregate canonical bytes: per-file, `len(name)\0name\0len(bytes)\0bytes\0`.
+        // Length-prefixing prevents collisions like `("ab", "c")` vs
+        // `("a", "bc")` producing the same hash if we just concatenated.
+        let mut canonical: Vec<u8> = Vec::new();
+        for p in &yaml_files {
+            match std::fs::read(p) {
+                Ok(bytes) => {
+                    let name = p
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or_default()
+                        .as_bytes();
+                    canonical.extend_from_slice(&(name.len() as u64).to_be_bytes());
+                    canonical.extend_from_slice(name);
+                    canonical.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+                    canonical.extend_from_slice(&bytes);
+                    match self.policy.load_from_file(p.to_str().unwrap_or_default()) {
+                        Ok(()) => {
+                            let rules_in_file = Self::count_rules_in_file(p);
+                            tracing::info!(file = %p.display(), rules = rules_in_file, "Loaded policy file");
+                            total_rules += rules_in_file;
+                        }
+                        Err(e) => {
+                            tracing::warn!(file = %p.display(), error = %e, "Failed to load policy");
+                            // Stash the first per-file load failure as
+                            // the registry error — operator UX cue.
+                            if read_err.is_none() {
+                                read_err = Some(format!("{}: {}", p.display(), e));
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(file = %p.display(), error = %e, "Failed to read policy file");
+                    if read_err.is_none() {
+                        read_err = Some(format!("{}: {}", p.display(), e));
+                    }
+                }
+            }
+        }
+
         self.policy_rule_count
             .store(total_rules as u64, Ordering::Relaxed);
         metrics::AGT_POLICY_RULES.set(total_rules as i64);
+
+        // Update the status registry. Empty directory + no read error
+        // ⇒ record success with the digest of an empty buffer — that's
+        // a real "I loaded nothing, on purpose" state, distinct from
+        // "I couldn't read the directory".
+        match read_err {
+            Some(err) => {
+                self.policy_status
+                    .record_error(PolicyKind::AgtProfile, dir, &err);
+            }
+            None => {
+                self.policy_status
+                    .record_success(PolicyKind::AgtProfile, dir, &canonical);
+            }
+        }
         Ok(total_rules)
     }
 

--- a/inference-router/src/lib.rs
+++ b/inference-router/src/lib.rs
@@ -31,6 +31,7 @@ pub mod mcp;
 pub mod mesh;
 pub mod metrics;
 pub mod policy_envelope;
+pub mod policy_status;
 pub mod providers;
 pub mod proxy;
 pub mod rate_limiter;

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -189,7 +189,8 @@ async fn main() -> Result<()> {
             .merge(routes::admin_routes())
             .merge(routes::egress_routes())
             .merge(routes::spawn_routes())
-            .merge(routes::sensitive_agt_routes());
+            .merge(routes::sensitive_agt_routes())
+            .merge(routes::internal_routes());
 
         let protected = if let Some(ref token) = admin_token {
             let token = token.clone();

--- a/inference-router/src/policy_status.rs
+++ b/inference-router/src/policy_status.rs
@@ -1,0 +1,325 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Per-CRD policy load status registry — single source of truth for what
+//! the router believes it is enforcing right now.
+//!
+//! ## Why this exists
+//!
+//! `principles.md` §3 ("Honesty over scaffolding") of the
+//! `crd-well-oiled-machine` plan requires that a CRD only transitions to
+//! `phase=Ready` once the **router** has confirmed it loaded the
+//! controller-published artifact. Until Slice 0, controllers happily
+//! stamped `Ready` after writing a ConfigMap, regardless of whether the
+//! sidecar router ever read it.
+//!
+//! Slice 0 introduced an intermediate `phase=Compiled` (artifact
+//! materialized, router not yet echoing). This module is the second half
+//! of that loop: it records, per `PolicyKind`, the digest the router has
+//! actually loaded into memory. Slice 1b will add a controller-side
+//! poller that walks `GET /internal/policy-status` and only promotes
+//! `Compiled → Ready` once digests match.
+//!
+//! Today the AGT policy reload path
+//! ([`crate::governance::Governance::load_policies_from_dir`]) is the
+//! sole producer; future slices register their own
+//! `PolicyKind::EgressAllowlist`, `PolicyKind::ToolPolicy`, etc. as they
+//! land.
+//!
+//! ## Concurrency
+//!
+//! `Arc<PolicyStatusRegistry>` is cheaply clonable. Internally a single
+//! `Mutex<HashMap<...>>` guards the per-kind entries — write traffic is
+//! limited to hot-reload events (10 s mtime cadence in production), so a
+//! `Mutex` is right-sized; an `RwLock` would add complexity without
+//! measurable throughput benefit.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+/// Closed taxonomy of policies the router can echo back to controllers.
+///
+/// Adding a variant is a public-API change: the corresponding controller
+/// reconciler **must** be wired in the same PR to consume the new kind
+/// via `GET /internal/policy-status`. Don't add variants speculatively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum PolicyKind {
+    /// AGT (Agent Governance Toolkit) profile — YAML rule files mounted
+    /// at `AGT_POLICY_DIR` (default `/etc/azureclaw/policies`). Produced
+    /// by `ToolPolicy` reconciler (Slice 1) and by the built-in
+    /// `agt-profiles/*.yaml` shipped in the sandbox image as a fallback.
+    AgtProfile,
+}
+
+impl PolicyKind {
+    /// Stable wire identifier used in JSON responses. Kept in sync with
+    /// the `Serialize` impl so the `kind` string is consistent across
+    /// internal API + struct field debug output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PolicyKind::AgtProfile => "AgtProfile",
+        }
+    }
+}
+
+/// One row of the registry — current load state for a single
+/// `PolicyKind`. Serialized as-is by `GET /internal/policy-status`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyStatusEntry {
+    pub kind: PolicyKind,
+    /// `sha256:<hex>` digest of the canonical bytes the router loaded.
+    /// `None` when the last load attempt failed — the controller treats
+    /// missing digest as "router hasn't confirmed anything yet" and
+    /// keeps the CRD in `phase=Compiled`.
+    pub digest: Option<String>,
+    /// Filesystem path the bytes came from. Surfaced for operator
+    /// debugging — when a digest mismatch occurs, the operator wants to
+    /// know whether the router was looking at the right file at all.
+    pub source_path: String,
+    /// Wall-clock time the router materialized this state. RFC 3339 in
+    /// the JSON envelope; `SystemTime` in-memory to avoid taking a
+    /// `chrono` dep just for this.
+    pub loaded_at: SystemTime,
+    /// Most-recent error text. `Some(_)` and `digest = None` together
+    /// mean the consumer is broken; `Some(_)` with `digest = Some(_)`
+    /// means the last attempt failed but a previous successful load is
+    /// still in effect.
+    pub last_error: Option<String>,
+}
+
+/// Thread-safe registry of per-`PolicyKind` load state.
+///
+/// Lives at `AppState.policy_status` (single instance shared with the
+/// `Governance` engine). The only mutators today are `record_success`
+/// and `record_error`; future slices will add their own producers as
+/// they land.
+#[derive(Debug, Default)]
+pub struct PolicyStatusRegistry {
+    entries: Mutex<HashMap<PolicyKind, PolicyStatusEntry>>,
+}
+
+impl PolicyStatusRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `kind` was successfully loaded from `source_path`
+    /// with the given canonical bytes. The digest is computed here (not
+    /// at the call site) so all producers hash the same way — drift
+    /// between producers would make digest comparison meaningless.
+    pub fn record_success(&self, kind: PolicyKind, source_path: &str, bytes: &[u8]) {
+        let digest = format!("sha256:{}", hex_digest(bytes));
+        let entry = PolicyStatusEntry {
+            kind,
+            digest: Some(digest),
+            source_path: source_path.to_string(),
+            loaded_at: SystemTime::now(),
+            last_error: None,
+        };
+        if let Ok(mut g) = self.entries.lock() {
+            g.insert(kind, entry);
+        }
+    }
+
+    /// Record a failed load attempt. Preserves any prior successful
+    /// `digest` so the controller can tell "never loaded" from "loaded
+    /// once, now broken". Both states should still keep the CRD out of
+    /// `phase=Ready` — that's the controller's call, not ours.
+    pub fn record_error(&self, kind: PolicyKind, source_path: &str, error: &str) {
+        if let Ok(mut g) = self.entries.lock() {
+            let prior_digest = g.get(&kind).and_then(|e| e.digest.clone());
+            let entry = PolicyStatusEntry {
+                kind,
+                digest: prior_digest,
+                source_path: source_path.to_string(),
+                loaded_at: SystemTime::now(),
+                last_error: Some(truncate_err(error)),
+            };
+            g.insert(kind, entry);
+        }
+    }
+
+    /// Snapshot of all entries. Returns owned values — the registry
+    /// lock is held only for the clone, not the duration of the caller's
+    /// work.
+    pub fn snapshot(&self) -> Vec<PolicyStatusEntry> {
+        self.entries
+            .lock()
+            .map(|g| g.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Lookup a single entry by kind. `None` when the kind has never
+    /// been recorded (i.e., the corresponding consumer hasn't run yet).
+    pub fn get(&self, kind: PolicyKind) -> Option<PolicyStatusEntry> {
+        self.entries.lock().ok().and_then(|g| g.get(&kind).cloned())
+    }
+
+    /// Number of distinct kinds tracked. Useful for tests and for the
+    /// `/internal/policy-status` route's response metadata.
+    pub fn len(&self) -> usize {
+        self.entries.lock().map(|g| g.len()).unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let out = hasher.finalize();
+    let mut s = String::with_capacity(out.len() * 2);
+    for b in out {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// Cap error strings to keep `/internal/policy-status` JSON payloads
+/// bounded. AGT engine errors are usually short, but a bad YAML can
+/// produce multi-kB serde errors with line numbers in the middle of
+/// the file; the head is enough for triage.
+fn truncate_err(err: &str) -> String {
+    const MAX: usize = 512;
+    if err.len() <= MAX {
+        err.to_string()
+    } else {
+        // Truncate at a char boundary to avoid panicking on multi-byte
+        // UTF-8. AGT YAML parser errors are ASCII in practice, but the
+        // policy filename embedded in the error may not be.
+        let mut end = MAX;
+        while !err.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…[truncated]", &err[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_success_stores_digest() {
+        let reg = PolicyStatusRegistry::new();
+        reg.record_success(
+            PolicyKind::AgtProfile,
+            "/etc/azureclaw/policies/a.yaml",
+            b"hello",
+        );
+        let e = reg.get(PolicyKind::AgtProfile).expect("entry present");
+        assert_eq!(e.kind, PolicyKind::AgtProfile);
+        assert_eq!(e.source_path, "/etc/azureclaw/policies/a.yaml");
+        assert_eq!(
+            e.digest.as_deref(),
+            Some("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
+        );
+        assert!(e.last_error.is_none());
+    }
+
+    #[test]
+    fn record_success_overwrites_prior_entry_for_same_kind() {
+        let reg = PolicyStatusRegistry::new();
+        reg.record_success(PolicyKind::AgtProfile, "/a.yaml", b"v1");
+        reg.record_success(PolicyKind::AgtProfile, "/b.yaml", b"v2");
+        assert_eq!(reg.len(), 1, "same kind must collapse to one entry");
+        let e = reg.get(PolicyKind::AgtProfile).unwrap();
+        assert_eq!(e.source_path, "/b.yaml");
+        // Different bytes → different digest.
+        assert_ne!(
+            e.digest.as_deref().unwrap(),
+            "sha256:0e7f3eaf2e36f33b58a1f8de1f56e7e2e3b9fce5dabbf64ab36a0b9eeb0a4f50",
+        );
+    }
+
+    #[test]
+    fn record_error_preserves_prior_digest() {
+        let reg = PolicyStatusRegistry::new();
+        reg.record_success(PolicyKind::AgtProfile, "/a.yaml", b"good");
+        let good_digest = reg.get(PolicyKind::AgtProfile).unwrap().digest.clone();
+        assert!(good_digest.is_some());
+
+        reg.record_error(PolicyKind::AgtProfile, "/a.yaml", "yaml parse error");
+        let e = reg.get(PolicyKind::AgtProfile).unwrap();
+        assert_eq!(
+            e.digest, good_digest,
+            "prior successful digest must survive a later error",
+        );
+        assert_eq!(e.last_error.as_deref(), Some("yaml parse error"));
+    }
+
+    #[test]
+    fn record_error_with_no_prior_load_has_none_digest() {
+        let reg = PolicyStatusRegistry::new();
+        reg.record_error(PolicyKind::AgtProfile, "/a.yaml", "EACCES");
+        let e = reg.get(PolicyKind::AgtProfile).unwrap();
+        assert!(e.digest.is_none());
+        assert_eq!(e.last_error.as_deref(), Some("EACCES"));
+    }
+
+    #[test]
+    fn truncate_err_caps_long_messages() {
+        let reg = PolicyStatusRegistry::new();
+        let long = "x".repeat(2000);
+        reg.record_error(PolicyKind::AgtProfile, "/a.yaml", &long);
+        let e = reg.get(PolicyKind::AgtProfile).unwrap();
+        let err = e.last_error.expect("error stored");
+        assert!(
+            err.len() < long.len(),
+            "expected truncation, got {} bytes",
+            err.len()
+        );
+        assert!(err.ends_with("…[truncated]"));
+    }
+
+    #[test]
+    fn truncate_err_handles_multibyte_boundary() {
+        // 4-byte UTF-8 char ("😀" = U+1F600) repeated to exceed cap.
+        let s = "😀".repeat(200);
+        let reg = PolicyStatusRegistry::new();
+        reg.record_error(PolicyKind::AgtProfile, "/a.yaml", &s);
+        let err = reg.get(PolicyKind::AgtProfile).unwrap().last_error.unwrap();
+        // Must not panic + must be valid UTF-8 (implicit, since it's a
+        // `String`). Also exercises the char-boundary backoff.
+        assert!(err.ends_with("…[truncated]"));
+    }
+
+    #[test]
+    fn snapshot_returns_all_entries_then_releases_lock() {
+        let reg = PolicyStatusRegistry::new();
+        reg.record_success(PolicyKind::AgtProfile, "/a.yaml", b"x");
+        let snap = reg.snapshot();
+        assert_eq!(snap.len(), 1);
+        // Must be able to mutate while caller still holds snapshot.
+        reg.record_success(PolicyKind::AgtProfile, "/b.yaml", b"y");
+        assert_eq!(snap.len(), 1, "snapshot is a point-in-time copy");
+    }
+
+    #[test]
+    fn len_and_is_empty_track_inserts() {
+        let reg = PolicyStatusRegistry::new();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        reg.record_success(PolicyKind::AgtProfile, "/a.yaml", b"x");
+        assert!(!reg.is_empty());
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn policy_kind_as_str_matches_serialize() {
+        // The route serializes `kind` via `Serialize`; downstream consumers
+        // (controller poller, headlamp plugin) match on these strings.
+        // Drift between `as_str()` and the serialized form would be a
+        // silent contract break.
+        let s = serde_json::to_string(&PolicyKind::AgtProfile).unwrap();
+        assert_eq!(s, "\"AgtProfile\"");
+        assert_eq!(PolicyKind::AgtProfile.as_str(), "AgtProfile");
+    }
+}

--- a/inference-router/src/routes/internal.rs
+++ b/inference-router/src/routes/internal.rs
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `/internal/*` — operator-only introspection routes.
+//!
+//! These routes are mounted on the `protected` axum router in
+//! `main.rs`, so they inherit the admin-token gate +
+//! `ADMIN_ALLOW_IPS` allowlist. They are deliberately not under
+//! `/agt/*` (which is also protected but reserved for governance
+//! mutations) or `/admin/*` (which is reserved for operator-driven
+//! mutations like `/admin/model`).
+//!
+//! The first endpoint, `GET /internal/policy-status`, is the bottom
+//! half of the `Ready ⇔ router echoed digest` loop introduced by
+//! `crd-well-oiled-machine` Slice 1. The controller polls this route
+//! and only promotes a CRD from `phase=Compiled` to `phase=Ready` when
+//! the digest in the response matches the digest it published.
+//!
+//! The shape is a stable wire contract — clients (controller poller,
+//! `azureclaw inspect`, headlamp plugin) match on field names. Don't
+//! rename fields without a deprecation window.
+
+use axum::Json;
+use axum::Router;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use serde::Serialize;
+
+use super::AppState;
+use crate::policy_status::PolicyStatusEntry;
+
+pub fn internal_routes() -> Router<AppState> {
+    Router::new().route("/internal/policy-status", get(policy_status))
+}
+
+/// JSON envelope returned by `GET /internal/policy-status`. Each
+/// `PolicyStatusEntry` carries `kind`, `digest`, `source_path`,
+/// `loaded_at`, and `last_error` — see [`crate::policy_status`] for
+/// the field-level contract.
+#[derive(Debug, Serialize)]
+struct PolicyStatusResponse {
+    /// Schema version of this response envelope. Bump on breaking
+    /// changes to the entry shape so clients can fail loudly.
+    schema_version: u32,
+    count: usize,
+    entries: Vec<EntryDto>,
+}
+
+/// Wire DTO. We deliberately don't `#[derive(Serialize)]` on
+/// `PolicyStatusEntry` and expose it directly because `SystemTime`
+/// serializes as a tagged-union nanosecond pair by default — useless
+/// for downstream consumers. Convert to RFC 3339 here.
+#[derive(Debug, Serialize)]
+struct EntryDto {
+    kind: &'static str,
+    digest: Option<String>,
+    source_path: String,
+    loaded_at: String,
+    last_error: Option<String>,
+}
+
+impl From<PolicyStatusEntry> for EntryDto {
+    fn from(e: PolicyStatusEntry) -> Self {
+        Self {
+            kind: e.kind.as_str(),
+            digest: e.digest,
+            source_path: e.source_path,
+            loaded_at: format_rfc3339(e.loaded_at),
+            last_error: e.last_error,
+        }
+    }
+}
+
+/// RFC 3339 / ISO 8601 formatter for `SystemTime`. We avoid `chrono`
+/// here because the router already pulls `time = "0.3"` transitively
+/// via tower/hyper; introducing a second time crate just for one
+/// formatter would be wasteful. The router's existing telemetry path
+/// uses raw seconds-since-epoch in many places — this helper keeps
+/// the wire surface human-readable without proliferating timestamp
+/// formats elsewhere.
+fn format_rfc3339(t: std::time::SystemTime) -> String {
+    let dur = match t.duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => d,
+        Err(_) => return "1970-01-01T00:00:00Z".to_string(),
+    };
+    let secs = dur.as_secs() as i64;
+    let nanos = dur.subsec_nanos();
+
+    // Civil-time conversion via days-from-epoch using the algorithm
+    // from Howard Hinnant's "date" library — deterministic, no
+    // external deps, valid through year 9999.
+    let days = secs.div_euclid(86_400);
+    let secs_of_day = secs.rem_euclid(86_400) as u32;
+    let (year, month, day) = days_to_ymd(days);
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day / 60) % 60;
+    let second = secs_of_day % 60;
+    // Truncate to milliseconds — operator UX doesn't need
+    // nanosecond precision and a shorter string is easier to scan.
+    let millis = nanos / 1_000_000;
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        year, month, day, hour, minute, second, millis
+    )
+}
+
+/// Convert days since 1970-01-01 to civil (year, month, day).
+/// Howard Hinnant's algorithm — public domain.
+fn days_to_ymd(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = y + if m <= 2 { 1 } else { 0 };
+    (y as i32, m as u32, d as u32)
+}
+
+/// `GET /internal/policy-status` — snapshot of every `PolicyKind`
+/// the router has loaded into memory.
+///
+/// Returns `200 OK` with an empty `entries` array when no consumer
+/// has run yet (e.g., AGT engine never reached
+/// `load_policies_from_dir`). The controller treats that the same
+/// way as "consumer not registered" — keeps the CRD in
+/// `phase=Compiled`, never promotes to `Ready`.
+async fn policy_status(State(state): State<AppState>) -> impl IntoResponse {
+    let entries: Vec<EntryDto> = state
+        .policy_status
+        .snapshot()
+        .into_iter()
+        .map(EntryDto::from)
+        .collect();
+    Json(PolicyStatusResponse {
+        schema_version: 1,
+        count: entries.len(),
+        entries,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_status::{PolicyKind, PolicyStatusRegistry};
+    use std::sync::Arc;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[test]
+    fn format_rfc3339_epoch_is_unix_zero() {
+        assert_eq!(format_rfc3339(UNIX_EPOCH), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn format_rfc3339_known_timestamp() {
+        // 2024-01-15T10:30:45.500Z = 1705314645 seconds + 500ms.
+        let t = UNIX_EPOCH + Duration::from_millis(1_705_314_645_500);
+        assert_eq!(format_rfc3339(t), "2024-01-15T10:30:45.500Z");
+    }
+
+    #[test]
+    fn format_rfc3339_leap_year_feb_29() {
+        // 2024-02-29T00:00:00Z.
+        let t = UNIX_EPOCH + Duration::from_secs(1_709_164_800);
+        assert_eq!(format_rfc3339(t), "2024-02-29T00:00:00.000Z");
+    }
+
+    #[test]
+    fn entry_dto_serializes_with_camel_pascal_kind() {
+        let reg = PolicyStatusRegistry::new();
+        reg.record_success(PolicyKind::AgtProfile, "/etc/azureclaw/policies", b"hello");
+        let entry = reg.get(PolicyKind::AgtProfile).unwrap();
+        let dto = EntryDto::from(entry);
+        let json = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["kind"].as_str(), Some("AgtProfile"));
+        assert_eq!(
+            json["digest"].as_str(),
+            Some("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
+        );
+        assert_eq!(
+            json["source_path"].as_str(),
+            Some("/etc/azureclaw/policies")
+        );
+        assert!(json["loaded_at"].as_str().unwrap().ends_with("Z"));
+        assert!(json["last_error"].is_null());
+    }
+
+    #[test]
+    fn policy_status_response_envelope_shape() {
+        let reg = Arc::new(PolicyStatusRegistry::new());
+        reg.record_success(PolicyKind::AgtProfile, "/x", b"y");
+        let entries: Vec<EntryDto> = reg.snapshot().into_iter().map(EntryDto::from).collect();
+        let resp = PolicyStatusResponse {
+            schema_version: 1,
+            count: entries.len(),
+            entries,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["schema_version"].as_u64(), Some(1));
+        assert_eq!(json["count"].as_u64(), Some(1));
+        assert_eq!(json["entries"].as_array().unwrap().len(), 1);
+        assert_eq!(json["entries"][0]["kind"].as_str(), Some("AgtProfile"));
+    }
+
+    #[test]
+    fn empty_registry_yields_empty_entries_array() {
+        let reg = PolicyStatusRegistry::new();
+        let entries: Vec<EntryDto> = reg.snapshot().into_iter().map(EntryDto::from).collect();
+        let resp = PolicyStatusResponse {
+            schema_version: 1,
+            count: entries.len(),
+            entries,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["count"].as_u64(), Some(0));
+        assert_eq!(json["entries"].as_array().unwrap().len(), 0);
+    }
+}

--- a/inference-router/src/routes/mod.rs
+++ b/inference-router/src/routes/mod.rs
@@ -22,6 +22,7 @@ use crate::egress_blocked::BlockedBuffer;
 use crate::governance::Governance;
 use crate::handoff::{DrainState, HandoffSession, HandoffTokenStore, PendingHandoffStore};
 use crate::mesh::{MeshInbox, MeshMetrics};
+use crate::policy_status::PolicyStatusRegistry;
 use crate::providers::{AuditSink, PolicyDecisionProvider, SigningProvider};
 use crate::proxy::UpstreamConfig;
 
@@ -45,6 +46,9 @@ pub use mesh::mesh_routes;
 
 mod egress;
 pub use egress::egress_routes;
+
+mod internal;
+pub use internal::internal_routes;
 
 mod inference;
 pub use inference::{foundry_agent_routes, foundry_standalone_routes, inference_routes};
@@ -111,6 +115,12 @@ pub struct AppState {
     pub drain_state: DrainState,
     /// Pending handoff confirmation store (§9.9.9 two-stage gate).
     pub pending_handoff: PendingHandoffStore,
+    /// Per-CRD policy load status — populated by every consumer that
+    /// materializes a controller-published artifact into the router's
+    /// memory. Read by `GET /internal/policy-status`, which the
+    /// controller polls to confirm `Compiled → Ready` transitions
+    /// (Slice 1 of `crd-well-oiled-machine`).
+    pub policy_status: Arc<PolicyStatusRegistry>,
 }
 
 impl AppState {
@@ -126,8 +136,17 @@ impl AppState {
 
         let sandbox_name = std::env::var("SANDBOX_NAME").unwrap_or_else(|_| "unknown".into());
 
+        // Shared per-CRD policy load status registry. Constructed once
+        // and handed to both the AGT engine (which writes
+        // `PolicyKind::AgtProfile` on every successful reload) and
+        // `AppState` (read by `GET /internal/policy-status`).
+        let policy_status = Arc::new(PolicyStatusRegistry::new());
+
         // Initialize native AGT governance
-        let governance = Arc::new(Governance::new(&sandbox_name));
+        let governance = Arc::new(Governance::new_with_status(
+            &sandbox_name,
+            policy_status.clone(),
+        ));
 
         // Load policy YAML from AGT_POLICY_DIR if set
         let policy_dir = std::env::var("AGT_POLICY_DIR").ok();
@@ -201,6 +220,7 @@ impl AppState {
             handoff_session: HandoffSession::new(),
             drain_state: DrainState::new(),
             pending_handoff: PendingHandoffStore::new(),
+            policy_status,
         })
     }
 

--- a/inference-router/tests/agt_governance_integration.rs
+++ b/inference-router/tests/agt_governance_integration.rs
@@ -35,7 +35,9 @@ use azureclaw_inference_router::routes::{AppState, mesh_routes, sensitive_agt_ro
 
 /// Build a minimal AppState suitable for testing (no env vars, no network).
 fn test_state(sandbox: &str, admin_token: Option<&str>) -> AppState {
-    let governance = Arc::new(Governance::new(sandbox));
+    let policy_status =
+        Arc::new(azureclaw_inference_router::policy_status::PolicyStatusRegistry::new());
+    let governance = Arc::new(Governance::new_with_status(sandbox, policy_status.clone()));
     AppState {
         auth: Arc::new(WorkloadIdentityAuth::new()),
         copilot: Arc::new(azureclaw_inference_router::copilot_auth::CopilotTokenCache::from_env()),
@@ -74,6 +76,7 @@ fn test_state(sandbox: &str, admin_token: Option<&str>) -> AppState {
         handoff_session: HandoffSession::new(),
         drain_state: DrainState::new(),
         pending_handoff: PendingHandoffStore::new(),
+        policy_status,
     }
 }
 

--- a/inference-router/tests/egress_blocked_endpoint.rs
+++ b/inference-router/tests/egress_blocked_endpoint.rs
@@ -30,7 +30,12 @@ use azureclaw_inference_router::providers::{AuditSink, PolicyDecisionProvider, S
 use azureclaw_inference_router::routes::{AppState, egress_routes};
 
 fn test_state() -> AppState {
-    let governance = Arc::new(Governance::new("sb-test"));
+    let policy_status =
+        Arc::new(azureclaw_inference_router::policy_status::PolicyStatusRegistry::new());
+    let governance = Arc::new(Governance::new_with_status(
+        "sb-test",
+        policy_status.clone(),
+    ));
     AppState {
         auth: Arc::new(WorkloadIdentityAuth::new()),
         copilot: Arc::new(azureclaw_inference_router::copilot_auth::CopilotTokenCache::from_env()),
@@ -67,6 +72,7 @@ fn test_state() -> AppState {
         handoff_session: HandoffSession::new(),
         drain_state: DrainState::new(),
         pending_handoff: PendingHandoffStore::new(),
+        policy_status,
     }
 }
 

--- a/inference-router/tests/policy_status_endpoint.rs
+++ b/inference-router/tests/policy_status_endpoint.rs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration test for `GET /internal/policy-status` — exercises the
+//! full axum stack (router, state extraction, JSON serialization) so
+//! the wire contract consumed by the controller poller, `azureclaw
+//! inspect`, and the headlamp panel is locked down.
+//!
+//! Unit tests for the registry and the response DTO live in
+//! `inference-router/src/policy_status.rs` and
+//! `inference-router/src/routes/internal.rs`. This file additionally
+//! verifies:
+//!   1. The route is reachable through the same `Router::merge` wiring
+//!      `main.rs` uses (no helper that bypasses real routing).
+//!   2. Loading AGT policies into a real `Governance` populates the
+//!      registry as a side effect (end-to-end producer→consumer wire).
+//!   3. The empty-registry state serializes to a well-formed envelope.
+
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use azureclaw_inference_router::auth::WorkloadIdentityAuth;
+use azureclaw_inference_router::blocklist::Blocklist;
+use azureclaw_inference_router::budget::TokenBudgetTracker;
+use azureclaw_inference_router::config::{Config, RegistryMode};
+use azureclaw_inference_router::egress_blocked::BlockedBuffer;
+use azureclaw_inference_router::governance::Governance;
+use azureclaw_inference_router::handoff::{
+    DrainState, HandoffSession, HandoffTokenStore, PendingHandoffStore,
+};
+use azureclaw_inference_router::mesh::{MeshInbox, MeshMetrics};
+use azureclaw_inference_router::policy_status::PolicyStatusRegistry;
+use azureclaw_inference_router::providers::{AuditSink, PolicyDecisionProvider, SigningProvider};
+use azureclaw_inference_router::routes::{AppState, internal_routes};
+
+fn test_state() -> (AppState, Arc<PolicyStatusRegistry>) {
+    let policy_status = Arc::new(PolicyStatusRegistry::new());
+    let governance = Arc::new(Governance::new_with_status(
+        "sb-test",
+        policy_status.clone(),
+    ));
+    let state = AppState {
+        auth: Arc::new(WorkloadIdentityAuth::new()),
+        copilot: Arc::new(azureclaw_inference_router::copilot_auth::CopilotTokenCache::from_env()),
+        client: reqwest::Client::new(),
+        config: Arc::new(Config {
+            port: 0,
+            foundry_endpoint: None,
+            foundry_project_endpoint: None,
+            azure_openai_endpoint: None,
+            default_model: "gpt-4".into(),
+            content_safety_enabled: false,
+            prompt_shields_enabled: false,
+            content_safety_endpoint: None,
+            token_budget_daily: 1_000_000,
+            token_budget_per_request: 100_000,
+            registry_mode: RegistryMode::Local,
+            registry_url: None,
+            provider_override: None,
+        }),
+        budget: TokenBudgetTracker::new(1_000_000, 100_000),
+        policy_provider: Arc::clone(&governance) as Arc<dyn PolicyDecisionProvider>,
+        audit_sink: Arc::clone(&governance) as Arc<dyn AuditSink>,
+        signing_provider: Arc::clone(&governance) as Arc<dyn SigningProvider>,
+        governance,
+        blocklist: Blocklist::disabled(),
+        blocked_egress: Arc::new(BlockedBuffer::with_defaults()),
+        sandbox_name: Arc::new("sb-test".to_string()),
+        inbox: Arc::new(MeshInbox::new()),
+        mesh_metrics: Arc::new(MeshMetrics::new()),
+        model_override: Arc::new(std::sync::RwLock::new(None)),
+        admin_token: None,
+        responses_only_models: Arc::new(std::sync::RwLock::new(Default::default())),
+        handoff_tokens: HandoffTokenStore::new(),
+        handoff_session: HandoffSession::new(),
+        drain_state: DrainState::new(),
+        pending_handoff: PendingHandoffStore::new(),
+        policy_status: policy_status.clone(),
+    };
+    (state, policy_status)
+}
+
+fn app(state: AppState) -> Router {
+    Router::new().merge(internal_routes()).with_state(state)
+}
+
+async fn get(app: &Router, uri: &str) -> (StatusCode, Value) {
+    let req = Request::get(uri).body(Body::empty()).unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1_048_576)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+#[tokio::test]
+async fn empty_registry_returns_200_with_empty_entries() {
+    let (state, _reg) = test_state();
+    let app = app(state);
+    let (status, body) = get(&app, "/internal/policy-status").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["schema_version"].as_u64(), Some(1));
+    assert_eq!(body["count"].as_u64(), Some(0));
+    assert!(body["entries"].is_array());
+    assert_eq!(body["entries"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn registry_with_agt_profile_entry_round_trips_through_route() {
+    let (state, reg) = test_state();
+    reg.record_success(
+        azureclaw_inference_router::policy_status::PolicyKind::AgtProfile,
+        "/etc/azureclaw/policies",
+        b"hello",
+    );
+    let app = app(state);
+    let (status, body) = get(&app, "/internal/policy-status").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"].as_u64(), Some(1));
+    let entry = &body["entries"][0];
+    assert_eq!(entry["kind"].as_str(), Some("AgtProfile"));
+    assert_eq!(
+        entry["digest"].as_str(),
+        Some("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
+    );
+    assert_eq!(
+        entry["source_path"].as_str(),
+        Some("/etc/azureclaw/policies")
+    );
+    let loaded_at = entry["loaded_at"].as_str().expect("loaded_at present");
+    assert!(
+        loaded_at.ends_with("Z"),
+        "expected RFC3339 'Z' suffix, got {loaded_at}"
+    );
+    assert!(loaded_at.contains("T"), "expected RFC3339 'T' separator");
+    assert!(entry["last_error"].is_null());
+}
+
+#[tokio::test]
+async fn governance_load_propagates_into_registry_via_route() {
+    use std::io::Write;
+    // Write a minimal valid AGT policy YAML to a tempdir, load it
+    // through Governance, then assert the route reports the matching
+    // digest. This is the producer→consumer end-to-end wire:
+    // controller will use this exact path to confirm "router has
+    // echoed my published artifact".
+    let dir = tempfile::tempdir().unwrap();
+    let policy_path = dir.path().join("test.yaml");
+    let mut f = std::fs::File::create(&policy_path).unwrap();
+    // PolicyEngine::load_from_file expects a `policies:` top-level
+    // sequence — empty seq is valid (counts as 0 rules) so we don't
+    // depend on internal rule schema details.
+    f.write_all(b"version: \"1.0\"\nagent: test\npolicies:\n  - name: noop\n    type: capability\n    denied_actions: []\n    priority: 1\n").unwrap();
+    drop(f);
+
+    let (state, _reg) = test_state();
+    let count = state
+        .governance
+        .load_policies_from_dir(dir.path().to_str().unwrap())
+        .expect("load ok");
+    assert!(count >= 1, "expected at least one rule loaded, got {count}");
+
+    let app = app(state);
+    let (status, body) = get(&app, "/internal/policy-status").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"].as_u64(), Some(1));
+    let entry = &body["entries"][0];
+    assert_eq!(entry["kind"].as_str(), Some("AgtProfile"));
+    let digest = entry["digest"]
+        .as_str()
+        .expect("digest present after successful load");
+    assert!(
+        digest.starts_with("sha256:") && digest.len() == 71,
+        "expected sha256 hex digest, got {digest}",
+    );
+    assert_eq!(
+        entry["source_path"].as_str(),
+        Some(dir.path().to_str().unwrap()),
+    );
+    assert!(entry["last_error"].is_null());
+}
+
+#[tokio::test]
+async fn governance_load_of_missing_dir_records_error() {
+    let (state, _reg) = test_state();
+    state
+        .governance
+        .load_policies_from_dir("/nonexistent/path/will/never/exist")
+        .expect("load returns Ok even when dir missing");
+
+    let app = app(state);
+    let (status, body) = get(&app, "/internal/policy-status").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"].as_u64(), Some(1));
+    let entry = &body["entries"][0];
+    assert_eq!(entry["kind"].as_str(), Some("AgtProfile"));
+    assert!(entry["digest"].is_null(), "no prior load → null digest");
+    let err = entry["last_error"]
+        .as_str()
+        .expect("missing-dir records an error");
+    assert!(
+        err.to_lowercase().contains("not found"),
+        "expected 'not found' in error, got {err}",
+    );
+}


### PR DESCRIPTION
## Summary

Foundation for the [`crd-well-oiled-machine`](docs/internal/crd-well-oiled-machine/) plan, specifically **principles.md §3** — *Ready ⇔ router echoes the exact published digest*. The controller-side digest-confirmation poller ships in **Slice 1b** (separate PR); this PR delivers the data-plane half of the contract together with its first real producer (AGT).

## What's new

- **`inference-router/src/policy_status.rs`** — `PolicyStatusRegistry` keyed by `PolicyKind::AgtProfile` with `record_success` / `record_error` / `snapshot` / `get`. Length-prefixed canonical digest format. UTF-8-safe error truncation. 8 unit tests.
- **`inference-router/src/routes/internal.rs`** — `GET /internal/policy-status` returns `{schema_version: 1, count, entries: [...]}` with RFC 3339 `loaded_at`. Hand-rolled formatter (no chrono dep). Mounted on the `protected` axum router so it inherits the admin-token + `ADMIN_ALLOW_IPS` middleware alongside the existing `egress_routes()` / `spawn_routes()`. 5 unit tests.
- **`Governance::load_policies_from_dir`** now records into the registry on every reload cycle (success or error). Aggregate canonical digest is length-prefixed: `u64-BE-len(name) ‖ name ‖ u64-BE-len(bytes) ‖ bytes` concatenated per file, files sorted by path. Prevents `('ab','c') vs ('a','bc')` collisions and makes the digest deterministic across `read_dir` ordering. The Slice 1b controller poller MUST replicate this exact serialization on the publish side.
- **`Governance::new_with_status()`** constructor accepts a shared `Arc<PolicyStatusRegistry>`; existing `new()` continues to work for callers that don't need digest echo.
- **`AppState`** carries one registry per process, shared with `Governance` so every reload echoes to the route.

## Wire contract (frozen as `schema_version: 1`)

\`\`\`json
GET /internal/policy-status
Authorization: Bearer <admin-token>
→ 200 OK
{
  \"schema_version\": 1,
  \"count\": 1,
  \"entries\": [
    {
      \"kind\": \"AgtProfile\",
      \"digest\": \"sha256:abc...\",
      \"source_path\": \"/etc/azureclaw/policies\",
      \"loaded_at\": \"2026-05-12T03:14:15.926Z\",
      \"last_error\": null
    }
  ]
}
\`\`\`

## Why this isn't scaffolding (principles.md §5)

- AGT engine is a real producer **today** — `governance/mod.rs:323` mtime-polls every 10s and now records into the registry.
- Every future slice (2-6) gets the digest-echo contract for free by adding a `PolicyKind` variant and calling `record_success` / `record_error`.
- The route already has one real consumer in this PR (the integration tests); Slice 1b adds the controller poller; later slices (CLI \`azureclaw inspect\`, Headlamp panel) follow.

## Verification

- ✅ \`cargo build --release\` clean
- ✅ \`cargo test --release --package azureclaw-inference-router --lib\` — **679 pass** (15 new)
- ✅ \`cargo test --release --package azureclaw-inference-router --test policy_status_endpoint\` — **4 pass**
- ✅ \`cargo test --release --package azureclaw-inference-router --test egress_blocked_endpoint\` — **2 pass**
- ✅ \`cargo clippy --release --all-targets --package azureclaw-inference-router -- -D warnings\` clean
- ✅ \`cargo fmt --all -- --check\` clean

## Next: Slice 1b

Controller-side \`status/router_confirmation.rs\` poller that hits \`/internal/policy-status\` on a fixed interval, matches the digest against the published ConfigMap annotation, and promotes \`Compiled → Ready\` only on match. Will add the \`RouterEnforcing\` reason constant and wire into all reconcilers that currently stamp \`Compiled\` (InferencePolicy, ClawMemory; ToolPolicy when Slice 1 proper lands).

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>