### PR TITLE
Slice 2 prep: extract shared router-confirmation I/O helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 2 prep — shared router-confirmation helper extracted
+
+Pre-refactor to unblock Slice 2 (InferencePolicy) and later
+consumers (ClawMemory, McpServer fleet). The k8s I/O helpers
+that drive the "Ready ⇔ router echo" loop were inlined in
+`controller/src/tool_policy_reconciler.rs` after Slice 1c; they
+now live in a shared module so the next reconciler doesn't
+have to duplicate them.
+
+- New `controller/src/status/router_confirmation_io.rs` module:
+  - `list_sandboxes_matching(client, ns, |cs| …)` — generic
+    discovery helper; the caller supplies the
+    `FnMut(&ClawSandbox) -> bool` predicate so each CRD can
+    bind to its own ref field (`spec.governance.toolPolicyRef`,
+    `spec.inferenceRef`, etc.) without baking a CRD-kind enum
+    into the helper. Replaces the ToolPolicy-only
+    `list_referencing_sandboxes` from Slice 1c.
+  - `read_admin_token(client, sandbox)` — verbatim move; reads
+    `Secret azureclaw-<sandbox>/router-admin-token` key
+    `token`. Now reusable from any reconciler.
+  - `poll_referencing_sandboxes(client, http, sandboxes)` —
+    verbatim move; same `Err(ConfirmError::HttpStatus(0))`
+    sentinel for "token Secret not yet present".
+- `PolicyStatusResponse` gains generic
+  `find_digest(&self, kind: &str)` and
+  `find_last_error(&self, kind: &str)` methods. The existing
+  `agt_profile_digest()` / `agt_profile_last_error()` are now
+  one-line wrappers — back-compat preserved, but new
+  reconcilers (InferencePolicy etc.) call `find_digest("…")`
+  with their own `PolicyKind` string. Cross-checked with a
+  belt-and-braces "wrappers must agree with generic method"
+  test so a future refactor that touches one branch but not
+  the other is caught immediately.
+- `tool_policy_reconciler.rs` now imports from the shared
+  module; the three inline functions (~80 LOC) are deleted,
+  not duplicated.
+- Net effect: one production callsite swap, four net-new
+  unit tests, zero behavior change. 522 controller tests
+  pass (+4 from the previous 518), clippy `-D warnings`
+  clean, helm_drift green.
+
 ### Slice 1c — ToolPolicy router-confirmation poller (closes the loop)
 
 Closes the consumer half of the principles.md §3 invariant for

--- a/controller/src/status/mod.rs
+++ b/controller/src/status/mod.rs
@@ -12,6 +12,7 @@
 pub mod conditions;
 pub mod phase;
 pub mod router_confirmation;
+pub mod router_confirmation_io;
 
 use crate::crd::ClawSandbox;
 use kube::ResourceExt;

--- a/controller/src/status/router_confirmation.rs
+++ b/controller/src/status/router_confirmation.rs
@@ -77,27 +77,57 @@ pub struct PolicyStatusEntry {
 }
 
 impl PolicyStatusResponse {
+    /// Return the `digest` from the entry whose `kind` matches
+    /// `kind`, if present. Returns `None` when:
+    /// * the response has no entry of that kind (router has not
+    ///   loaded a policy of this kind yet);
+    /// * the entry has `digest: None` (load failed mid-flight, error
+    ///   in `last_error`).
+    ///
+    /// Each `PolicyKind` variant on the router side has a fixed
+    /// string name (`"AgtProfile"`, `"InferencePolicy"`,
+    /// `"ClawMemory"`, …); see `inference-router/src/policy_status.rs`
+    /// for the canonical list. Reconcilers should pass that exact
+    /// string.
+    pub fn find_digest(&self, kind: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|e| e.kind == kind)
+            .and_then(|e| e.digest.as_deref())
+    }
+
+    /// Return the `last_error` from the entry whose `kind` matches
+    /// `kind`, if any. Used by reconcilers to surface a router-side
+    /// parse failure as the Ready=False message instead of a generic
+    /// timeout.
+    pub fn find_last_error(&self, kind: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|e| e.kind == kind)
+            .and_then(|e| e.last_error.as_deref())
+    }
+
     /// Return the `digest` from the `AgtProfile` entry, if present.
     /// Returns `None` when:
     /// * the response has no `AgtProfile` entry (router has not loaded
     ///   any policy yet);
     /// * the entry has `digest: None` (load failed mid-flight, error
     ///   in `last_error`).
+    ///
+    /// Thin wrapper over [`Self::find_digest`] kept for callsite
+    /// readability; new callsites can use `find_digest("AgtProfile")`
+    /// directly.
     pub fn agt_profile_digest(&self) -> Option<&str> {
-        self.entries
-            .iter()
-            .find(|e| e.kind == "AgtProfile")
-            .and_then(|e| e.digest.as_deref())
+        self.find_digest("AgtProfile")
     }
 
     /// Return the `last_error` from the `AgtProfile` entry, if any.
     /// Used by the reconciler to surface a router-side parse failure
     /// as the Ready=False message instead of a generic timeout.
+    ///
+    /// Thin wrapper over [`Self::find_last_error`].
     pub fn agt_profile_last_error(&self) -> Option<&str> {
-        self.entries
-            .iter()
-            .find(|e| e.kind == "AgtProfile")
-            .and_then(|e| e.last_error.as_deref())
+        self.find_last_error("AgtProfile")
     }
 }
 
@@ -244,6 +274,89 @@ mod tests {
         assert_eq!(
             resp.agt_profile_last_error(),
             Some("parse error: unexpected mapping at line 4")
+        );
+    }
+
+    #[test]
+    fn find_digest_generalizes_over_kind() {
+        let resp: PolicyStatusResponse = serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "count": 2,
+            "entries": [
+                {
+                    "kind": "AgtProfile",
+                    "digest": "sha256:aaa",
+                    "source_path": "/etc/agt/policies",
+                    "loaded_at": "2026-05-13T09:00:00.000Z",
+                    "last_error": null
+                },
+                {
+                    "kind": "InferencePolicy",
+                    "digest": "sha256:bbb",
+                    "source_path": "/etc/inference/policies",
+                    "loaded_at": "2026-05-13T09:00:01.000Z",
+                    "last_error": null
+                }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(resp.find_digest("AgtProfile"), Some("sha256:aaa"));
+        assert_eq!(resp.find_digest("InferencePolicy"), Some("sha256:bbb"));
+        assert_eq!(resp.find_digest("Nonexistent"), None);
+    }
+
+    #[test]
+    fn find_last_error_isolates_per_kind() {
+        let resp: PolicyStatusResponse = serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "count": 2,
+            "entries": [
+                {
+                    "kind": "AgtProfile",
+                    "digest": "sha256:aaa",
+                    "source_path": "/etc/agt/policies",
+                    "loaded_at": "2026-05-13T09:00:00.000Z",
+                    "last_error": null
+                },
+                {
+                    "kind": "InferencePolicy",
+                    "digest": null,
+                    "source_path": "/etc/inference/policies",
+                    "loaded_at": "2026-05-13T09:00:01.000Z",
+                    "last_error": "schema mismatch on v2"
+                }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(resp.find_last_error("AgtProfile"), None);
+        assert_eq!(
+            resp.find_last_error("InferencePolicy"),
+            Some("schema mismatch on v2")
+        );
+    }
+
+    #[test]
+    fn agt_profile_helpers_delegate_to_find_digest() {
+        // Belt-and-braces: the wrappers must agree with the generic
+        // method for the AgtProfile kind on the same payload. If they
+        // diverge, a future refactor that touches one but not the
+        // other will be caught here.
+        let resp: PolicyStatusResponse = serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "count": 1,
+            "entries": [{
+                "kind": "AgtProfile",
+                "digest": "sha256:deadbeef",
+                "source_path": "/etc/agt/policies",
+                "loaded_at": "2026-05-13T09:00:00.000Z",
+                "last_error": null
+            }]
+        }))
+        .unwrap();
+        assert_eq!(resp.agt_profile_digest(), resp.find_digest("AgtProfile"));
+        assert_eq!(
+            resp.agt_profile_last_error(),
+            resp.find_last_error("AgtProfile")
         );
     }
 

--- a/controller/src/status/router_confirmation_io.rs
+++ b/controller/src/status/router_confirmation_io.rs
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared I/O helpers for the principles.md §3 "Ready ⇔ router echo"
+//! loop, factored out of [`crate::tool_policy_reconciler`] so that
+//! every CRD whose `spec` is loaded by the per-sandbox inference
+//! router (ToolPolicy → AGT profile, InferencePolicy, ClawMemory,
+//! McpServer egress, …) shares one implementation of:
+//!
+//! 1. Discovery — enumerate the `ClawSandbox`es that reference *this*
+//!    policy CR via a caller-supplied filter predicate.
+//! 2. Auth bootstrap — read each sandbox's
+//!    `Secret azureclaw-<sandbox>/router-admin-token` (key `token`).
+//! 3. Confirmation poll — `GET /internal/policy-status` on the
+//!    per-sandbox router service and aggregate the per-sandbox
+//!    outcomes for [`crate::status::router_confirmation`]'s pure
+//!    `decide_enforcement_state` aggregator.
+//!
+//! The functions here are deliberately split from the wire-contract
+//! types + pure HTTP poller in
+//! [`crate::status::router_confirmation`] so that the latter remains
+//! free of `kube::Client` dependencies and stays unit-testable with
+//! `wiremock` alone. This module adds the k8s glue.
+//!
+//! ## Generic over filter, not over CRD type
+//!
+//! `list_sandboxes_matching` takes a `FnMut(&ClawSandbox) -> bool`
+//! filter rather than a hard-coded `tool_policy_name: &str` because
+//! every reconciler binds to a different field on
+//! `ClawSandbox.spec`:
+//!
+//! * ToolPolicy → `spec.governance.toolPolicyRef.name`
+//! * InferencePolicy → `spec.inferenceRef`
+//! * ClawMemory → `spec.memoryRef` (future)
+//! * McpServer fleet → `spec.mcpServerRefs[*].name` (future)
+//!
+//! Keeping the predicate on the caller side preserves the
+//! "single-responsibility" principle for the helper without baking in
+//! a CRD-kind enum that would need to grow with every new consumer.
+
+use crate::crd::ClawSandbox;
+use crate::status::router_confirmation::{
+    self, ConfirmError, fetch_router_policy_status, router_admin_url,
+};
+use k8s_openapi::api::core::v1::Secret;
+use kube::{
+    Client, ResourceExt,
+    api::{Api, ListParams},
+};
+
+/// Enumerate `ClawSandbox`es in `ns` that satisfy `matches`.
+///
+/// Returns the bare sandbox `metadata.name` values. The controller
+/// convention is one router-service per sandbox at
+/// `{name}.azureclaw-{name}.svc.cluster.local:8443`, so the
+/// *router's* namespace is `azureclaw-<name>`, distinct from `ns`
+/// (which is typically `azureclaw-system`, where the policy CRs
+/// live).
+///
+/// `matches` runs against each candidate `ClawSandbox`. Typical
+/// shape from a reconciler:
+///
+/// ```ignore
+/// list_sandboxes_matching(client, "azureclaw-system", |cs| {
+///     cs.spec
+///         .governance
+///         .as_ref()
+///         .is_some_and(|g| g.tool_policy_ref.name == policy_name)
+/// })
+/// .await?;
+/// ```
+pub async fn list_sandboxes_matching<F>(
+    client: &Client,
+    ns: &str,
+    mut matches: F,
+) -> Result<Vec<String>, kube::Error>
+where
+    F: FnMut(&ClawSandbox) -> bool,
+{
+    let api: Api<ClawSandbox> = Api::namespaced(client.clone(), ns);
+    let list = api.list(&ListParams::default()).await?;
+    Ok(list
+        .items
+        .into_iter()
+        .filter(|cs| matches(cs))
+        .map(|cs| cs.name_any())
+        .collect())
+}
+
+/// Read the per-sandbox admin token from
+/// `Secret azureclaw-<sandbox>/router-admin-token` (key `token`).
+///
+/// `Ok(None)` is returned when the Secret or the `token` key is not
+/// yet present — the reconciler treats that as a transient
+/// awaiting-router condition rather than a hard failure (the
+/// sandbox reconciler may not yet have completed its first pass).
+/// An empty token string is folded into `Ok(None)` for the same
+/// reason.
+pub async fn read_admin_token(
+    client: &Client,
+    sandbox: &str,
+) -> Result<Option<String>, kube::Error> {
+    let secret_ns = format!("azureclaw-{sandbox}");
+    let api: Api<Secret> = Api::namespaced(client.clone(), &secret_ns);
+    let secret = match api.get_opt("router-admin-token").await? {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    Ok(secret
+        .data
+        .as_ref()
+        .and_then(|d| d.get("token"))
+        .and_then(|v| String::from_utf8(v.0.clone()).ok())
+        .filter(|t| !t.is_empty()))
+}
+
+/// Poll every sandbox in `sandboxes` once and assemble the per-
+/// sandbox outcome list consumed by
+/// [`router_confirmation::decide_enforcement_state`].
+///
+/// A sandbox whose admin-token Secret is missing or unreadable is
+/// recorded as `Err(`[`ConfirmError::HttpStatus`]`(0))` — the `0`
+/// sentinel is distinct from any real HTTP status code so it stays
+/// disambiguable in operator logs while still aggregating as
+/// "router unreachable" in the Ready=False detail message.
+///
+/// Polls run sequentially (one sandbox at a time). This is the
+/// right shape for the current scale (≤O(10) sandboxes per policy
+/// in practice); contention concerns belong to a future watch-based
+/// rewrite, not this helper.
+pub async fn poll_referencing_sandboxes(
+    client: &Client,
+    http: &reqwest::Client,
+    sandboxes: &[String],
+) -> Vec<(
+    String,
+    Result<router_confirmation::PolicyStatusResponse, ConfirmError>,
+)> {
+    let mut out = Vec::with_capacity(sandboxes.len());
+    for sandbox in sandboxes {
+        let token = match read_admin_token(client, sandbox).await {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                out.push((sandbox.clone(), Err(ConfirmError::HttpStatus(0))));
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    sandbox = %sandbox,
+                    error = %e,
+                    "router-admin-token Secret read failed"
+                );
+                out.push((sandbox.clone(), Err(ConfirmError::HttpStatus(0))));
+                continue;
+            }
+        };
+        let url = router_admin_url(sandbox);
+        let r = fetch_router_policy_status(http, &url, &token).await;
+        out.push((sandbox.clone(), r));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::crd::{ClawSandbox, ClawSandboxSpec};
+    use kube::core::ObjectMeta;
+
+    fn mk_sandbox(name: &str, tp_ref: Option<&str>) -> ClawSandbox {
+        let mut cs = ClawSandbox {
+            metadata: ObjectMeta {
+                name: Some(name.into()),
+                ..Default::default()
+            },
+            spec: ClawSandboxSpec::default(),
+            status: None,
+        };
+        if let Some(tp) = tp_ref {
+            cs.spec.governance = Some(crate::crd::GovernanceConfig {
+                tool_policy_ref: crate::mcp_server::LocalObjectRef { name: tp.into() },
+                ..Default::default()
+            });
+        }
+        cs
+    }
+
+    #[test]
+    fn filter_predicate_runs_against_each_item() {
+        // We can't easily run list_sandboxes_matching against a fake
+        // kube API in unit tests (it would need a httpmock-shaped
+        // kube fixture). Instead pin the predicate-shape we
+        // promise to callers so future refactors don't drift.
+        let cs_a = mk_sandbox("a", Some("prod-tools"));
+        let cs_b = mk_sandbox("b", Some("dev-tools"));
+        let cs_c = mk_sandbox("c", None);
+
+        let pred = |cs: &ClawSandbox| {
+            cs.spec
+                .governance
+                .as_ref()
+                .is_some_and(|g| g.tool_policy_ref.name == "prod-tools")
+        };
+
+        assert!(pred(&cs_a));
+        assert!(!pred(&cs_b));
+        assert!(!pred(&cs_c));
+    }
+}

--- a/controller/src/tool_policy_reconciler.rs
+++ b/controller/src/tool_policy_reconciler.rs
@@ -32,7 +32,7 @@
 
 use anyhow::Result;
 use futures::StreamExt;
-use k8s_openapi::api::core::v1::{ConfigMap, Secret};
+use k8s_openapi::api::core::v1::ConfigMap;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::{
     Client, ResourceExt,
@@ -44,12 +44,10 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::crd::ClawSandbox;
 use crate::status::conditions::{self, reason, status as cond_status};
 use crate::status::phase::{PHASE_COMPILED, PHASE_DEGRADED, PHASE_READY, PhaseEventReporter};
-use crate::status::router_confirmation::{
-    self, ConfirmError, fetch_router_policy_status, router_admin_url,
-};
+use crate::status::router_confirmation::{self, ConfirmError};
+use crate::status::router_confirmation_io::{list_sandboxes_matching, poll_referencing_sandboxes};
 use crate::tool_policy::{ToolPolicy, ToolPolicyStatus};
 use crate::tool_policy_compile::{
     AGT_PROFILE_FILENAME, agt_profile_digest, compile_to_profile, version_hash,
@@ -204,95 +202,6 @@ fn decide_enforcement_state(
     }
 }
 
-/// List `ClawSandbox`es in `ns` whose `spec.governance.toolPolicyRef.name`
-/// equals `tool_policy_name`. Returns the bare sandbox names — the
-/// controller convention is one router-service per sandbox at
-/// `{name}.azureclaw-{name}.svc.cluster.local:8443`, so the namespace
-/// of the *router* is `azureclaw-<name>`, not `ns`.
-async fn list_referencing_sandboxes(
-    client: &Client,
-    ns: &str,
-    tool_policy_name: &str,
-) -> Result<Vec<String>, kube::Error> {
-    let api: Api<ClawSandbox> = Api::namespaced(client.clone(), ns);
-    let list = api.list(&ListParams::default()).await?;
-    Ok(list
-        .items
-        .into_iter()
-        .filter(|cs| {
-            cs.spec
-                .governance
-                .as_ref()
-                .map(|g| g.tool_policy_ref.name == tool_policy_name)
-                .unwrap_or(false)
-        })
-        .map(|cs| cs.name_any())
-        .collect())
-}
-
-/// Read the per-sandbox admin token from `Secret
-/// azureclaw-<sandbox>/router-admin-token`. Returns `Ok(None)` when
-/// the secret or key is not yet present — the reconciler treats
-/// that as a transient awaiting-router condition rather than a hard
-/// failure (the sandbox reconciler may not yet have completed its
-/// first pass).
-async fn read_admin_token(client: &Client, sandbox: &str) -> Result<Option<String>, kube::Error> {
-    let secret_ns = format!("azureclaw-{sandbox}");
-    let api: Api<Secret> = Api::namespaced(client.clone(), &secret_ns);
-    let secret = match api.get_opt("router-admin-token").await? {
-        Some(s) => s,
-        None => return Ok(None),
-    };
-    Ok(secret
-        .data
-        .as_ref()
-        .and_then(|d| d.get("token"))
-        .and_then(|v| String::from_utf8(v.0.clone()).ok())
-        .filter(|t| !t.is_empty()))
-}
-
-/// Poll every referencing sandbox's router and assemble the per-
-/// sandbox outcome list consumed by [`decide_enforcement_state`].
-///
-/// A sandbox whose admin-token Secret is not yet provisioned counts
-/// as a poll failure with [`ConfirmError::HttpStatus`]`(0)` —
-/// surfaces in the Awaiting message so operators can see *why* the
-/// confirmation hasn't happened.
-async fn poll_referencing_sandboxes(
-    client: &Client,
-    http: &reqwest::Client,
-    sandboxes: &[String],
-) -> Vec<(
-    String,
-    Result<router_confirmation::PolicyStatusResponse, ConfirmError>,
-)> {
-    let mut out = Vec::with_capacity(sandboxes.len());
-    for sandbox in sandboxes {
-        let token = match read_admin_token(client, sandbox).await {
-            Ok(Some(t)) => t,
-            Ok(None) => {
-                // Sentinel: 0 means "no token yet" → distinguishable
-                // from real 401/503 in operator logs.
-                out.push((sandbox.clone(), Err(ConfirmError::HttpStatus(0))));
-                continue;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    sandbox = %sandbox,
-                    error = %e,
-                    "router-admin-token Secret read failed"
-                );
-                out.push((sandbox.clone(), Err(ConfirmError::HttpStatus(0))));
-                continue;
-            }
-        };
-        let url = router_admin_url(sandbox);
-        let r = fetch_router_policy_status(http, &url, &token).await;
-        out.push((sandbox.clone(), r));
-    }
-    out
-}
-
 async fn reconcile(tp: Arc<ToolPolicy>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
     let name = tp.name_any();
     let ns = tp.namespace().unwrap_or_else(|| "default".into());
@@ -405,7 +314,14 @@ async fn reconcile(tp: Arc<ToolPolicy>, ctx: Arc<Ctx>) -> Result<Action, Reconci
     } else {
         match (agt_profile_inline, agt_digest.as_deref()) {
             (Some(_), Some(expected)) => {
-                let referrers = match list_referencing_sandboxes(&ctx.client, &ns, &name).await {
+                let referrers = match list_sandboxes_matching(&ctx.client, &ns, |cs| {
+                    cs.spec
+                        .governance
+                        .as_ref()
+                        .is_some_and(|g| g.tool_policy_ref.name == name)
+                })
+                .await
+                {
                     Ok(v) => v,
                     Err(e) => {
                         tracing::warn!(


### PR DESCRIPTION
Pre-refactor for Slice 2 (InferencePolicy real). After Slice 1c shipped, the k8s-I/O helpers driving the principles.md §3 "Ready ⇔ router echo" loop lived inline in `tool_policy_reconciler.rs`. This PR lifts them into `controller/src/status/router_confirmation_io.rs` so InferencePolicy / ClawMemory / fleet-of-McpServer reconcilers can reuse one implementation instead of copy-pasting.

## What changed

**New module** `controller/src/status/router_confirmation_io.rs`:
- `list_sandboxes_matching(client, ns, predicate)` — generic discovery; caller supplies the `FnMut(&ClawSandbox) -> bool` filter so each CRD binds to its own ref field (`spec.governance.toolPolicyRef`, `spec.inferenceRef`, …) without baking a CRD-kind enum into the helper.
- `read_admin_token(client, sandbox)` — verbatim move.
- `poll_referencing_sandboxes(client, http, sandboxes)` — verbatim move; same `HttpStatus(0)` sentinel for "token Secret not yet present".

**`PolicyStatusResponse`** gains generic `find_digest(&self, kind: &str)` + `find_last_error(&self, kind: &str)`. Existing `agt_profile_digest()` / `agt_profile_last_error()` are now one-line wrappers — back-compat preserved.

**`tool_policy_reconciler.rs`** deletes the three inline functions and imports from the shared module.

## Why this is principles.md §5 clean (not scaffolding)

Slice 2a — `InferencePolicy` `tokenBudget.perRequestTokens` enforcement, queued as next — will be the immediate second caller of every function in the new module. The extraction is paying off in the very next PR, not speculative.

## Verification

- 522 controller tests pass (+4 net new: `find_digest_generalizes_over_kind`, `find_last_error_isolates_per_kind`, `agt_profile_helpers_delegate_to_find_digest`, `filter_predicate_runs_against_each_item`).
- `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` clean.
- `cargo fmt --all` clean.
- `helm_drift` tests green (no CRD schema changes).
- No behavior change for ToolPolicy — same callsite, same logic, same wire shape.