### PR TITLE
Slice 1d: `azureclaw inspect <sandbox>` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1d — `azureclaw inspect <sandbox>` CLI
+
+Operator-facing data-plane view of the policy CRDs a sandbox's
+router is actually enforcing. Hits the router's
+`/internal/policy-status` endpoint (Slice 1a) over a `kubectl exec`
+in-pod curl tunnel — **no `kubectl port-forward` lifecycle**, so the
+command never collides with another agent already bound to 18789
+or any other local port.
+
+Three operator pain points solved at once:
+
+* **No port collisions.** Single-shot `kubectl exec` to the
+  `openclaw` container, curls `127.0.0.1:8443` over loopback, exits.
+  No background tunnel, no port-forward retries.
+* **Admin token never crosses argv.** The token is resolved either
+  from the `router-admin-token` Secret (fast path, same pattern as
+  `azureclaw handoff`'s `getAksAdminToken`) or — when RBAC blocks
+  the secret read — from the `/etc/azureclaw/secrets/admin-token`
+  file inside the pod. It then flows to the in-pod curl on **stdin**
+  (`read -r AZURECLAW_ADMIN_TOKEN <&0`), never `ps`-visible.
+* **Latency-free.** Zero new server-side work — every byte the
+  command renders was already produced by the router's
+  `PolicyStatusRegistry` snapshot. The CLI is a pure consumer.
+
+Default render is a grouped tree: one section per policy kind
+(`AGT profile`, `InferencePolicy`, `ToolPolicy`, …), each row showing
+the source file basename, the 12-hex truncated sha256 digest, and
+the relative load age (`5m ago`, `3h ago`, never-loaded marker for
+the loader's `UNIX_EPOCH` sentinel). `--json` emits the raw
+schema-version-1 envelope for scripting + JQ.
+
+The Headlamp plugin panel — the second deliverable in the Slice 1d
+spec — is deferred to Slice 1d.2; the CLI alone is independently
+shippable and the panel can land against the same wire contract
+without a second round-trip.
+
 ### Slice 2d.1 — InferencePolicy `modelPreference.primary.deployment` deployment override
 
 First wire of `modelPreference` end-to-end. When an `InferencePolicy`

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -30,6 +30,7 @@ import { toolPolicyCommand } from "./commands/toolpolicy.js";
 import { inferencePolicyCommand } from "./commands/inferencepolicy.js";
 import { mcpCommand } from "./commands/mcp.js";
 import { memoryCommand } from "./commands/memory.js";
+import { inspectCommand } from "./commands/inspect.js";
 
 export function createCli(): Command {
   const program = new Command();
@@ -53,6 +54,7 @@ export function createCli(): Command {
   program.addCommand(statusCommand());
   program.addCommand(listCommand());
   program.addCommand(logsCommand());
+  program.addCommand(inspectCommand());
 
   // Configuration
   program.addCommand(credentialsCommand());
@@ -89,7 +91,7 @@ export function createCli(): Command {
   program.addHelpText("after", `
 Command groups:
   Lifecycle       up, dev, add, push, destroy
-  Operations      connect, status, list, logs
+  Operations      connect, status, list, logs, inspect
   Configuration   credentials, model, policy, egress
   Observability   trace, eval, operator
   Agent mobility  handoff, mesh, pair

--- a/cli/src/commands/inspect.test.ts
+++ b/cli/src/commands/inspect.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "vitest";
+import { __test__ } from "./inspect.js";
+
+const { renderEntry, shortDigest, formatLoadedAt, POLICY_KIND_LABEL } =
+  __test__;
+
+describe("inspect — shortDigest", () => {
+  it("truncates sha256 digests to the controller convention", () => {
+    // The controller logs digests at 12 hex chars; match that so an
+    // operator can grep across both.
+    expect(shortDigest("sha256:0123456789abcdef0123456789abcdef")).toBe(
+      "sha256:0123456789ab…"
+    );
+  });
+
+  it("returns the input unchanged when no algorithm prefix is present", () => {
+    expect(shortDigest("abc")).toBe("abc");
+  });
+
+  it("preserves the algorithm prefix on alternate algos", () => {
+    expect(shortDigest("sha512:abcdef0123456789aaaaaaaaaaaaaaaa")).toBe(
+      "sha512:abcdef012345…"
+    );
+  });
+});
+
+describe("inspect — formatLoadedAt", () => {
+  it("renders seconds-old timestamps as Ns", () => {
+    const ts = new Date(Date.now() - 12_000).toISOString();
+    expect(formatLoadedAt(ts)).toBe("12s ago");
+  });
+
+  it("renders minute-old timestamps as Nm", () => {
+    const ts = new Date(Date.now() - 5 * 60_000).toISOString();
+    expect(formatLoadedAt(ts)).toBe("5m ago");
+  });
+
+  it("renders hour-old timestamps as Nh", () => {
+    const ts = new Date(Date.now() - 3 * 3_600_000).toISOString();
+    expect(formatLoadedAt(ts)).toBe("3h ago");
+  });
+
+  it("renders day-old timestamps as Nd past the 48h threshold", () => {
+    const ts = new Date(Date.now() - 5 * 86_400_000).toISOString();
+    expect(formatLoadedAt(ts)).toBe("5d ago");
+  });
+
+  it("returns undefined on the loader's zero-marker (1970-01-01)", () => {
+    // The router renders `SystemTime::UNIX_EPOCH` as "1970-01-01T00:00:00Z"
+    // when an entry has never been loaded. The TS side returns
+    // undefined so `renderEntry` substitutes the "(never loaded)"
+    // label rather than printing "55y ago".
+    expect(formatLoadedAt("1970-01-01T00:00:00Z")).toBeUndefined();
+  });
+
+  it("returns undefined on garbage input rather than NaN", () => {
+    expect(formatLoadedAt("not a date")).toBeUndefined();
+  });
+
+  it("handles clock-skew (future) gracefully", () => {
+    const ts = new Date(Date.now() + 60_000).toISOString();
+    expect(formatLoadedAt(ts)).toBe("in the future");
+  });
+});
+
+describe("inspect — renderEntry", () => {
+  it("renders a healthy entry with source basename + short digest + age", () => {
+    const out = renderEntry({
+      kind: "ToolPolicy",
+      digest: "sha256:0123456789abcdef0123456789abcdef",
+      source_path: "/var/run/azureclaw/toolpolicy/tools.json",
+      loaded_at: new Date(Date.now() - 30_000).toISOString(),
+      last_error: null,
+    });
+    // ANSI stripping kept lightweight — we just check key substrings.
+    expect(out).toContain("tools.json");
+    expect(out).toContain("sha256:0123456789ab…");
+    expect(out).toMatch(/30s ago/);
+    expect(out).not.toContain("last_error");
+  });
+
+  it("surfaces last_error on a second line so operators see the cause", () => {
+    const out = renderEntry({
+      kind: "ToolPolicy",
+      digest: null,
+      source_path: "/var/run/azureclaw/toolpolicy/tools.json",
+      loaded_at: "1970-01-01T00:00:00Z",
+      last_error: "parse error: unexpected EOF",
+    });
+    expect(out).toContain("(no digest)");
+    expect(out).toContain("(never loaded)");
+    expect(out).toContain("last_error: parse error: unexpected EOF");
+  });
+});
+
+describe("inspect — POLICY_KIND_LABEL", () => {
+  it("maps every PolicyKind wire string we render today + the planned ones", () => {
+    // Today the router only emits `AgtProfile` + `InferencePolicy`
+    // (`inference-router/src/policy_status.rs::PolicyKind::as_str`).
+    // The CLI carries defensive mappings for the kinds Slice 1b/3/4/5
+    // will add (ToolPolicy/MemoryStore/Egress) so a partial-rollout
+    // cluster where the router is ahead of the CLI still prints
+    // sensible labels.
+    for (const wire of [
+      "ToolPolicy",
+      "AgtProfile",
+      "InferencePolicy",
+      "Egress",
+      "MemoryStore",
+    ]) {
+      expect(POLICY_KIND_LABEL[wire]).toBeTypeOf("string");
+      expect(POLICY_KIND_LABEL[wire]).not.toBe("");
+    }
+  });
+});

--- a/cli/src/commands/inspect.ts
+++ b/cli/src/commands/inspect.ts
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `azureclaw inspect <sandbox>` — pretty-print the data-plane view of
+//! every policy CRD bound to a sandbox.
+//!
+//! Hits the router's `GET /internal/policy-status` endpoint and prints
+//! a per-`PolicyKind` summary: the digest the router has actually
+//! loaded, when it was loaded, and the source path. This is the
+//! operator-facing complement to `kubectl get clawsandbox`: that
+//! command shows the controller's view of the world (compiled digests,
+//! phases). `inspect` shows the data plane's view — which is what
+//! actually matters for "is my policy enforcing right now?".
+//!
+//! Slice 1d in `docs/internal/crd-well-oiled-machine/slice-1-toolpolicy-agt-and-shared-infra.md`.
+//! The §7 mock-up in that doc shows the visual tree this command
+//! produces.
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { execa } from "execa";
+
+const POLICY_KIND_LABEL: Record<string, string> = {
+  // Wire kinds emitted by `crate::policy_status::PolicyKind::as_str`.
+  // Kept in sync with `inference-router/src/policy_status.rs`.
+  ToolPolicy: "ToolPolicy",
+  AgtProfile: "AGT profile",
+  InferencePolicy: "InferencePolicy",
+  Egress: "Egress",
+  MemoryStore: "ClawMemory",
+};
+
+interface PolicyStatusEntry {
+  kind: string;
+  digest: string | null;
+  source_path: string;
+  loaded_at: string;
+  last_error: string | null;
+}
+
+interface PolicyStatusResponse {
+  schema_version: number;
+  count: number;
+  entries: PolicyStatusEntry[];
+}
+
+interface InspectOptions {
+  namespace?: string;
+  json?: boolean;
+}
+
+export function inspectCommand(): Command {
+  return new Command("inspect")
+    .description(
+      "Show the data-plane view of every policy CRD loaded by a sandbox's router"
+    )
+    .argument("<sandbox>", "Sandbox name (the `metadata.name` of the ClawSandbox)")
+    .option(
+      "-n, --namespace <ns>",
+      "Sandbox pod namespace (default: 'azureclaw-<sandbox>')"
+    )
+    .option("--json", "Emit raw JSON instead of the formatted tree")
+    .action(async (sandbox: string, opts: InspectOptions) => {
+      try {
+        await runInspect(sandbox, opts);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(chalk.red(`\n  inspect failed: ${msg}\n`));
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runInspect(
+  sandbox: string,
+  opts: InspectOptions
+): Promise<void> {
+  const ns = opts.namespace ?? `azureclaw-${sandbox}`;
+
+  const token = await readAdminToken(sandbox, ns);
+  if (!token) {
+    throw new Error(
+      `Could not read admin token from secret 'router-admin-token' in '${ns}'.\n` +
+        `  The sandbox may not be fully provisioned yet. Try 'azureclaw status ${sandbox}'.`
+    );
+  }
+
+  const response = await fetchPolicyStatus(sandbox, ns, token);
+
+  if (opts.json) {
+    console.log(JSON.stringify(response, null, 2));
+    return;
+  }
+
+  renderTree(sandbox, ns, response);
+}
+
+/// Try every documented location for the admin token in priority order
+/// (Slice 1's `router-admin-token` secret first, then the in-pod file
+/// fallback). Returns `undefined` rather than throwing on a missing
+/// secret so the caller can surface a more actionable error.
+async function readAdminToken(
+  sandbox: string,
+  ns: string
+): Promise<string | undefined> {
+  // Preferred path — controller-managed Secret.
+  try {
+    const { stdout } = await execa(
+      "kubectl",
+      [
+        "get",
+        "secret",
+        "router-admin-token",
+        "-n",
+        ns,
+        "-o",
+        "jsonpath={.data.token}",
+      ],
+      { stdio: "pipe", reject: false }
+    );
+    if (stdout.trim()) {
+      return Buffer.from(stdout.trim(), "base64").toString("utf8").trim();
+    }
+  } catch {
+    /* fall through */
+  }
+  // Fallback — read from inside the openclaw container (mount path
+  // matches `handoff/helpers.ts:getAksAdminToken`).
+  for (const container of ["inference-router", "openclaw"]) {
+    try {
+      const { stdout } = await execa(
+        "kubectl",
+        [
+          "exec",
+          "-n",
+          ns,
+          `deploy/${sandbox}`,
+          "-c",
+          container,
+          "--",
+          "cat",
+          "/etc/azureclaw/secrets/admin-token",
+        ],
+        { stdio: "pipe", reject: false }
+      );
+      if (stdout.trim()) return stdout.trim();
+    } catch {
+      /* try next */
+    }
+  }
+  return undefined;
+}
+
+/// Execute the policy-status fetch inside the openclaw container via
+/// `curl` rather than via `kubectl port-forward`. Port-forward suffers
+/// from local-port collisions (see the conversation history in this
+/// repo) and is harder to clean up on Ctrl-C; in-pod curl is a single
+/// shot and inherits the pod's localhost loopback to the router on
+/// :8443.
+async function fetchPolicyStatus(
+  sandbox: string,
+  ns: string,
+  token: string
+): Promise<PolicyStatusResponse> {
+  // Wrap the token in a shell variable instead of inlining it on the
+  // command line — `ps`-visible argv would leak the secret. We pass
+  // the token through stdin and let bash read it; --quiet keeps curl
+  // off stderr so parsing stdout stays trivial.
+  const script =
+    'read -r AZURECLAW_ADMIN_TOKEN <&0 && ' +
+    'curl --silent --show-error --fail --max-time 10 ' +
+    '-H "Authorization: Bearer $AZURECLAW_ADMIN_TOKEN" ' +
+    "http://127.0.0.1:8443/internal/policy-status";
+
+  const result = await execa(
+    "kubectl",
+    [
+      "exec",
+      "-i",
+      "-n",
+      ns,
+      `deploy/${sandbox}`,
+      "-c",
+      "openclaw",
+      "--",
+      "bash",
+      "-c",
+      script,
+    ],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+      input: `${token}\n`,
+      reject: false,
+    }
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Router /internal/policy-status fetch failed (exit ${result.exitCode}). ` +
+        `stderr: ${result.stderr?.toString().trim() ?? "<empty>"}`
+    );
+  }
+
+  try {
+    return JSON.parse(result.stdout) as PolicyStatusResponse;
+  } catch {
+    throw new Error(
+      `Router returned non-JSON response: ${result.stdout.slice(0, 200)}`
+    );
+  }
+}
+
+function renderTree(
+  sandbox: string,
+  ns: string,
+  response: PolicyStatusResponse
+): void {
+  console.log("");
+  console.log(
+    chalk.bold(`  ClawSandbox: ${sandbox}`) + chalk.dim(` (${ns})`)
+  );
+
+  if (response.entries.length === 0) {
+    console.log(
+      chalk.dim(
+        "  └── (no policies loaded — router has not registered any consumer yet)"
+      )
+    );
+    console.log("");
+    return;
+  }
+
+  // Group entries by kind so a single CRD with multiple artifacts
+  // (e.g., ToolPolicy → tools.json + agt-profile.yaml after Slice 1b)
+  // collapses under one header.
+  const grouped = new Map<string, PolicyStatusEntry[]>();
+  for (const entry of response.entries) {
+    const key = POLICY_KIND_LABEL[entry.kind] ?? entry.kind;
+    const bucket = grouped.get(key) ?? [];
+    bucket.push(entry);
+    grouped.set(key, bucket);
+  }
+
+  const kinds = [...grouped.keys()];
+  kinds.forEach((kind, kindIdx) => {
+    const isLastKind = kindIdx === kinds.length - 1;
+    const prefix = isLastKind ? "  └──" : "  ├──";
+    console.log(`${chalk.dim(prefix)} ${chalk.cyan(kind)}`);
+
+    const entries = grouped.get(kind)!;
+    entries.forEach((entry, entryIdx) => {
+      const isLastEntry = entryIdx === entries.length - 1;
+      const branch = isLastKind ? "    " : "  │ ";
+      const tee = isLastEntry ? "└──" : "├──";
+      console.log(
+        `${chalk.dim(branch)}${chalk.dim(tee)} ${renderEntry(entry)}`
+      );
+    });
+  });
+  console.log("");
+}
+
+function renderEntry(entry: PolicyStatusEntry): string {
+  const source = sourceLabel(entry.source_path);
+  const digest = entry.digest
+    ? chalk.green(shortDigest(entry.digest))
+    : chalk.yellow("(no digest)");
+  const age = formatLoadedAt(entry.loaded_at);
+  const ageDisplay = age
+    ? chalk.dim(`(${age})`)
+    : chalk.yellow("(never loaded)");
+  const err = entry.last_error
+    ? chalk.red(`\n        last_error: ${entry.last_error}`)
+    : "";
+  return `${chalk.bold(source)} ${digest} ${ageDisplay}${err}`;
+}
+
+function shortDigest(digest: string): string {
+  // Match the controller's `…/admission/util.rs` truncation length so
+  // the operator can copy-paste between `inspect` output and a
+  // controller log line.
+  const colon = digest.indexOf(":");
+  if (colon < 0) return digest;
+  const prefix = digest.slice(0, colon + 1);
+  const hex = digest.slice(colon + 1);
+  return `${prefix}${hex.slice(0, 12)}…`;
+}
+
+function sourceLabel(path: string): string {
+  if (!path) return "?";
+  const trimmed = path.replace(/\/+$/, "");
+  const last = trimmed.split("/").pop();
+  return last || trimmed;
+}
+
+/// `loaded_at` ships as RFC 3339 (`format_rfc3339` in
+/// `routes/internal.rs`). Render relative-to-now for the eyeballed
+/// view; absolute timestamp is available via `--json`.
+function formatLoadedAt(rfc3339: string): string | undefined {
+  const t = Date.parse(rfc3339);
+  if (!Number.isFinite(t) || t <= 0) return undefined;
+  const deltaMs = Date.now() - t;
+  if (deltaMs < 0) return "in the future";
+  const s = Math.round(deltaMs / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+
+// Internal exports for unit tests — keep these surface-area-minimal.
+export const __test__ = {
+  renderEntry,
+  shortDigest,
+  formatLoadedAt,
+  POLICY_KIND_LABEL,
+};


### PR DESCRIPTION
Operator-facing data-plane policy view. Hits router `/internal/policy-status` via single-shot `kubectl exec` in-pod curl — no port-forward, no local-port collisions.

Admin token flows on stdin (avoids `ps`-visible argv leak), resolved via `router-admin-token` Secret with pod-file fallback.

Default render: grouped tree per PolicyKind, 12-hex digest truncation, relative load-age with UNIX_EPOCH sentinel detection. `--json` emits raw schema-version-1 envelope.

Pure consumer of the router's PolicyStatusRegistry (Slice 1a) — zero new server-side work.

Headlamp plugin panel deferred to Slice 1d.2.

Tests: 13 new unit tests; full CLI suite 652 passing. Typecheck + lint clean.