### PR TITLE
Slice 1d.2: Headlamp 'Router enforcement' panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1d.2 — Headlamp "Router enforcement" panel
+
+Companion to Slice 1d's CLI. Every ToolPolicy / InferencePolicy
+detail page in the Headlamp dashboard now carries a **Router
+enforcement (data-plane echo)** SectionBox that surfaces, in one
+glance, whether the policy is live in the data plane or merely
+compiled:
+
+* **Compiled digest** — the bytes the controller wrote.
+* **Loaded digest** — the bytes the router echoed back (only present
+  once §3 echo confirms).
+* **Echo** — `✓ matches` / `≠ mismatched` / `(awaiting)`.
+* **Confirmation** — the `Ready` condition's reason rendered as a
+  colored chip: `RouterEnforcing` (green), `NoSandboxesReferencing`
+  (neutral), `AwaitingRouterEnforcement` (amber), anything else
+  (red).
+
+Pure read of `status.compiledDigest` / `status.agtProfileDigest` /
+`status.loadedDigest` / `status.conditions` — fields the controller
+already writes. **Zero new API traffic, no kube-apiserver service
+proxy, no admin-token plumbing in the operator browser.** Mirrors
+the data the `azureclaw inspect <sandbox>` CLI surfaces, but on the
+producer side rather than the consumer side, so an operator can
+diagnose a Compiled-stuck-at-amber CR without leaving the dashboard.
+
+Defensive defaults: unknown phase or condition reason renders as
+amber/warning rather than success. Unknown digest format passes
+through unchanged (no slicing crash on non-sha256 algorithms).
+
 ### Slice 1d — `azureclaw inspect <sandbox>` CLI
 
 Operator-facing data-plane view of the policy CRDs a sandbox's

--- a/tools/headlamp-plugin/src/index.tsx
+++ b/tools/headlamp-plugin/src/index.tsx
@@ -184,6 +184,96 @@ function urlParams(re: RegExp): RegExpMatchArray | null {
 }
 
 // ──────────────────────────────────────────────────────────────────────
+// Router policy-status panel (crd-well-oiled-machine Slice 1d.2)
+//
+// For policy CRDs that participate in the §3 "Ready ⇔ router echo"
+// loop, the controller stamps `status.compiledDigest` /
+// `status.agtProfileDigest` (the bytes the controller wrote) plus a
+// `status.loadedDigest` (the bytes the router actually loaded — only
+// populated once every referencing sandbox echoes the digest). The
+// `Ready` condition's `reason` carries the live confirmation state
+// (`RouterEnforcing` / `AwaitingRouterEnforcement` /
+// `NoSandboxesReferencing`). This panel surfaces all three in one
+// place so operators don't have to grep `status.conditions`.
+//
+// Pure read of fields the controller already writes — zero new API
+// traffic, no kube-apiserver proxy round-trips, no admin token
+// plumbing. Mirrors the data the `azureclaw inspect <sandbox>` CLI
+// surfaces (Slice 1d) but on the producer side.
+// ──────────────────────────────────────────────────────────────────────
+
+function shortDigest(digest: string | undefined): string {
+  if (!digest) return "—";
+  const colon = digest.indexOf(":");
+  if (colon < 0 || colon + 13 >= digest.length) return digest;
+  return `${digest.slice(0, colon + 1)}${digest.slice(colon + 1, colon + 13)}…`;
+}
+
+function reasonChip(reason: string | undefined) {
+  if (!reason) return <span>—</span>;
+  const success = reason === "RouterEnforcing" || reason === "AllDigestsMatch";
+  const neutral =
+    reason === "NoSandboxesReferencing" || reason === "AsExpected";
+  const status: StatusKind = success
+    ? "success"
+    : neutral
+      ? ""
+      : reason === "AwaitingRouterEnforcement"
+        ? "warning"
+        : "error";
+  return <StatusLabel status={status as any}>{reason}</StatusLabel>;
+}
+
+function RouterPolicyStatusPanel({ crd, item }: { crd: CrdDescriptor; item: KubeObject }) {
+  // Only the policy CRDs that the router actually loads carry these
+  // fields. ClawSandbox, McpServer, etc. don't participate in the
+  // digest-echo loop yet.
+  if (crd.plural !== "toolpolicies" && crd.plural !== "inferencepolicies") {
+    return null;
+  }
+  const status = getStatus(item);
+  const conditions = (status.conditions as Array<Record<string, any>> | undefined) ?? [];
+  const ready = conditions.find(c => c.type === "Ready");
+  const compiled =
+    crd.plural === "toolpolicies"
+      ? (status.agtProfileDigest as string | undefined)
+      : (status.compiledDigest as string | undefined);
+  const loaded = status.loadedDigest as string | undefined;
+  const echo =
+    !compiled
+      ? "—"
+      : loaded && loaded === compiled
+        ? "✓ matches"
+        : loaded
+          ? "≠ mismatched"
+          : "(awaiting)";
+
+  return (
+    <SectionBox title="Router enforcement (data-plane echo)">
+      <SimpleTable
+        data={[
+          { k: "Compiled digest", v: shortDigest(compiled) },
+          { k: "Loaded digest", v: shortDigest(loaded) },
+          { k: "Echo", v: echo },
+          { k: "Confirmation", v: reasonChip(ready?.reason as string | undefined) },
+        ]}
+        columns={[
+          { label: "Field", getter: (r: any) => r.k },
+          { label: "Value", getter: (r: any) => r.v },
+        ]}
+      />
+      <p style={{ padding: "0.5rem", fontSize: "0.85rem", opacity: 0.75 }}>
+        The controller polls every referencing sandbox's router and promotes
+        <code> phase: Compiled → Ready </code> only when every router echoes
+        the exact compiled digest. While{" "}
+        <code>AwaitingRouterEnforcement</code>, the policy is parsed but
+        <strong> not</strong> live in the data plane.
+      </p>
+    </SectionBox>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
 // Overview dashboard
 // ──────────────────────────────────────────────────────────────────────
 
@@ -613,6 +703,8 @@ function CrdDetail({ crd }: { crd: CrdDescriptor }) {
       </SectionBox>
 
       {crd.plural === "clawsandboxes" && <SandboxExtras item={item} />}
+
+      <RouterPolicyStatusPanel crd={crd} item={item} />
 
       <SectionBox title="Spec">
         <pre style={{ maxHeight: "400px", overflow: "auto" }}>


### PR DESCRIPTION
Companion to Slice 1d's CLI (PR #261). Every ToolPolicy / InferencePolicy detail page in Headlamp now carries a 'Router enforcement (data-plane echo)' SectionBox showing:

- Compiled digest (bytes controller wrote)
- Loaded digest (bytes router echoed)
- Echo state: matches / mismatched / awaiting
- Confirmation: `Ready` condition reason as a colored chip

Pure read of fields the controller already writes — zero new API traffic, no apiserver service-proxy round-trips, no admin token in the operator browser.

Mirrors `azureclaw inspect <sandbox>` data on the producer side. Build clean.