### PR TITLE
Slice 1e phase 1: BundledProfileInUse deprecation condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1e (phase 1) — `BundledProfileInUse` deprecation condition
+
+Surfaces the deprecated bundled `AGT_POLICY_PROFILE` env-var
+fallback as a Kubernetes status condition on `ClawSandbox` CRs, so
+operators see it in `kubectl describe` / Headlamp / dashboards
+rather than only as a one-line warning buried in entrypoint logs.
+
+**Detection logic** (controller): `governance.enabled=true`,
+`toolPolicyRef` resolves, but the referenced `ToolPolicy` has no
+`spec.agtProfile.inline` (or it's whitespace-only). That sandbox
+runs off `/opt/azureclaw-plugin/policies/azureclaw-<profile>.yaml`
+baked into the image — exactly the path Slice 1e phase 2 will
+remove.
+
+**Wire contract:**
+
+* `Type: BundledProfileInUse`
+* `Status: True`
+* `Reason: BundledProfileFallback`
+* `Message: ToolPolicy lacks spec.agtProfile.inline; sandbox is
+  using the deprecated bundled AGT profile path (…). Migrate to
+  ToolPolicy.spec.agtProfile.inline before the bundled path is
+  removed.`
+
+When the operator adds `agtProfile.inline` to the ToolPolicy, the
+condition is **dropped** on the next reconcile rather than stamped
+`False` — dashboards don't accumulate stale-but-resolved
+deprecation noise (mirrors the §3 "only stamp Suspended=False if
+ever suspended" pattern).
+
+Phase 2 (actual fallback removal) is deferred: existing sandboxes
+without `agtProfile.inline` still function. This phase only adds
+the visibility surface so operators can drive migration on their
+own schedule.
+
 ### Slice 1d.2 — Headlamp "Router enforcement" panel
 
 Companion to Slice 1d's CLI. Every ToolPolicy / InferencePolicy

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -550,6 +550,14 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     // is authoritative; missing target → Degraded with reason
     // `ToolPolicyNotFound`. The resolved CR's `metadata.name` doubles as
     // the AGT policy profile name carried into the sandbox.
+    //
+    // Slice 1e (phase 1): also detect the bundled-profile fallback path
+    // — governance enabled, toolPolicyRef set, but the referenced
+    // ToolPolicy has no `spec.agtProfile.inline`. That sandbox will run
+    // off `/opt/azureclaw-plugin/policies/azureclaw-<profile>.yaml`
+    // inside the image. We surface the condition so operators see the
+    // deprecation in `kubectl describe`, not just in entrypoint logs.
+    let mut bundled_profile_in_use = false;
     let tool_policy_profile: String = if governance_config.enabled {
         let tp_ref_name = governance_config.tool_policy_ref.name.clone();
         if tp_ref_name.is_empty() {
@@ -562,7 +570,24 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         let tp_api: Api<crate::tool_policy::ToolPolicy> =
             Api::namespaced(client.clone(), &sandbox_self_ns);
         match tp_api.get(&tp_ref_name).await {
-            Ok(_) => tp_ref_name,
+            Ok(tp) => {
+                let inline_empty = tp
+                    .spec
+                    .agt_profile
+                    .as_ref()
+                    .and_then(|p| p.inline.as_deref())
+                    .map(|s| s.trim().is_empty())
+                    .unwrap_or(true);
+                bundled_profile_in_use = inline_empty;
+                if inline_empty {
+                    tracing::warn!(
+                        sandbox = %name,
+                        tool_policy = %tp_ref_name,
+                        "ToolPolicy has no agtProfile.inline; sandbox will use deprecated bundled AGT profile path (Slice 1e: migrate to ToolPolicy.spec.agtProfile.inline)",
+                    );
+                }
+                tp_ref_name
+            }
             Err(kube::Error::Api(ae)) if ae.code == 404 => {
                 tracing::error!(
                     sandbox = %name,
@@ -2231,6 +2256,33 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
         // empty list when `networkPolicy` itself is unset). The
         // fetcher itself short-circuits before any network IO.
         let mut extras: Vec<_> = allowlist_resolution.conditions.clone();
+
+        // Slice 1e (phase 1): surface the bundled AGT profile fallback as
+        // a status condition so operators see the deprecation in
+        // `kubectl describe`. Only stamped when the fallback is actually
+        // active — once the operator adds `agtProfile.inline` to the
+        // referenced ToolPolicy, the condition is dropped (not stamped
+        // False) on the next reconcile so dashboards don't accumulate
+        // stale-but-resolved deprecation noise.
+        if bundled_profile_in_use {
+            let prior_conditions_for_bundled = sandbox
+                .status
+                .as_ref()
+                .map(|s| s.conditions.as_slice())
+                .unwrap_or(&[]);
+            let prior_bundled = crate::status::conditions::find(
+                prior_conditions_for_bundled,
+                crate::status::conditions::TYPE_BUNDLED_PROFILE_IN_USE,
+            );
+            extras.push(crate::status::conditions::preserve_transition_time(
+                prior_bundled,
+                crate::status::conditions::TYPE_BUNDLED_PROFILE_IN_USE,
+                crate::status::conditions::status::TRUE,
+                crate::status::conditions::reason::BUNDLED_PROFILE_FALLBACK,
+                "ToolPolicy lacks spec.agtProfile.inline; sandbox is using the deprecated bundled AGT profile path (/opt/azureclaw-plugin/policies/). Migrate to ToolPolicy.spec.agtProfile.inline before the bundled path is removed.",
+                sandbox.metadata.generation,
+            ));
+        }
 
         // Phase G P1 #4: stamp Suspended condition when spec.suspended
         // is true, or surface Suspended=False/Active when there is a

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -121,6 +121,26 @@ pub const TYPE_ALLOWLIST_AUTHORITATIVE: &str = "AllowlistAuthoritative";
 ///   the resolution before it disappears from status.
 pub const TYPE_ALLOWLIST_DRIFT: &str = "AllowlistDrift";
 
+/// `crd-well-oiled-machine` Slice 1e (phase 1) — `BundledProfileInUse`:
+/// the sandbox has `governance.enabled=true` and **no**
+/// `governance.toolPolicyRef`, so the runtime falls back to the bundled
+/// `AGT_POLICY_PROFILE` env-var path (`/opt/azureclaw-plugin/policies/`
+/// inside the sandbox image). This path is deprecated and will be
+/// removed once every cluster in scope has migrated to inline
+/// `ToolPolicy.spec.agtProfile.inline`. Stamping the condition on the
+/// CR surfaces the deprecation in `kubectl describe` rather than only
+/// in entrypoint logs, so operators see it on the same status panel
+/// as `Suspended` / `Ready`.
+///
+/// Reasons:
+/// - `BundledProfileFallback` (status=True) — fallback path active.
+///   Operators should create a `ToolPolicy` CR with
+///   `spec.agtProfile.inline` and set `spec.governance.toolPolicyRef`.
+/// - The condition is dropped (not stamped False) once a
+///   `toolPolicyRef` is set, since `ToolPolicyNotFound` /
+///   `AwaitingRouterEnforcement` already cover the migrated state.
+pub const TYPE_BUNDLED_PROFILE_IN_USE: &str = "BundledProfileInUse";
+
 /// `status` canonical values.
 pub mod status {
     pub const TRUE: &str = "True";
@@ -187,6 +207,12 @@ pub mod reason {
     /// kept visible briefly so operators see the cleanup before it is
     /// dropped from status.
     pub const INLINE_CLEARED: &str = "InlineCleared";
+    /// `crd-well-oiled-machine` Slice 1e — `BundledProfileFallback`:
+    /// governance is enabled but no `toolPolicyRef` is set; the runtime
+    /// falls back to the bundled `AGT_POLICY_PROFILE` env-var path
+    /// (`/opt/azureclaw-plugin/policies/`). Deprecated; operators
+    /// should migrate to `ToolPolicy.spec.agtProfile.inline`.
+    pub const BUNDLED_PROFILE_FALLBACK: &str = "BundledProfileFallback";
     /// Phase 2 S5 — `AwaitingFoundryProvisioning`: the controller has
     /// successfully compiled and published the binding ConfigMap, but
     /// the upstream Azure AI Foundry Memory Store is created by the
@@ -480,5 +506,41 @@ mod tests {
     fn observed_generation_propagates_from_none() {
         let c = new_condition(TYPE_READY, status::TRUE, reason::RECONCILED, "ok", None);
         assert_eq!(c.observed_generation, None);
+    }
+
+    #[test]
+    fn bundled_profile_in_use_constants_are_stable() {
+        // Slice 1e (phase 1): the dashboards / Headlamp panel / a future
+        // controller release that ships the actual removal all key off
+        // these exact wire values. Pin them so a rename doesn't silently
+        // orphan downstream consumers.
+        assert_eq!(TYPE_BUNDLED_PROFILE_IN_USE, "BundledProfileInUse");
+        assert_eq!(reason::BUNDLED_PROFILE_FALLBACK, "BundledProfileFallback");
+    }
+
+    #[test]
+    fn bundled_profile_in_use_preserves_transition_time_on_repeat() {
+        // The condition must persist across reconciles without churning
+        // its lastTransitionTime — operators watching `kubectl get
+        // clawsandbox` should see a stable "since" age rather than a
+        // timestamp that resets every 30s. Mirrors the suspension
+        // pattern in the reconciler.
+        let prior = new_condition(
+            TYPE_BUNDLED_PROFILE_IN_USE,
+            status::TRUE,
+            reason::BUNDLED_PROFILE_FALLBACK,
+            "msg",
+            Some(1),
+        );
+        let next = preserve_transition_time(
+            Some(&prior),
+            TYPE_BUNDLED_PROFILE_IN_USE,
+            status::TRUE,
+            reason::BUNDLED_PROFILE_FALLBACK,
+            "msg",
+            Some(2),
+        );
+        assert_eq!(next.last_transition_time, prior.last_transition_time);
+        assert_eq!(next.observed_generation, Some(2));
     }
 }


### PR DESCRIPTION
Surfaces the bundled AGT_POLICY_PROFILE fallback as a status condition on ClawSandbox CRs. Phase 2 (actual removal) deferred — still needs the controller fail-closed branch + a release deprecation window.

Detection: governance.enabled=true AND toolPolicyRef resolves AND the referenced ToolPolicy lacks spec.agtProfile.inline.

Wire contract: Type=BundledProfileInUse, Status=True, Reason=BundledProfileFallback. Condition is dropped (not stamped False) once operator migrates — mirrors the suspension pattern so dashboards don't accumulate stale-but-resolved deprecation noise.

Tests: 2 new condition unit tests, full controller suite (531 + 1 → 533), clippy -D warnings clean.

Part of crd-well-oiled-machine grind.