### PR TITLE
Slice 5 §7: docs reframe — router is the policy point, NetworkPolicy + egress-guard are safety nets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 5 §7 — docs reframe: router is the policy point, NetworkPolicy + egress-guard are safety nets
+
+Closes one of the eight Slice 5 sub-items (the only one in that slice
+that can ship as a no-code-change PR). Reframes user-facing
+documentation so the conceptual model matches what the code actually
+does:
+
+* **Policy point** = `inference-router` — every byte that leaves the
+  pod is matched against the egress allowlist by the router.
+* **Safety nets** = the K8s `NetworkPolicy` generated per sandbox
+  and the `egress-guard` iptables init container. They limit blast
+  radius if the router process is bypassed or compromised. They do
+  not *decide* what is allowed.
+
+Files reframed:
+
+* `README.md` — ASCII diagram caption, "no network of its own"
+  paragraph, dev-vs-prod isolation table row.
+* `docs/architecture.md` — prod-mode bullet list under
+  "Pod shape" + "Isolation"; the data-path-of-one-external-call
+  numbered list.
+* `docs/egress-proxy.md` — "two enforcement points" → "one
+  enforcement point + one safety net"; "Layer 1 (kernel)" and
+  "Layer 2 (application)" relabelled "Layer 1 (safety net)" and
+  "Layer 2 (the policy point)" with admonitions.
+
+Aligns with the framing already locked in
+`docs/internal/crd-well-oiled-machine/principles.md` §7 (the rest of
+Slice 5 — `EgressApproval` CRD, `BlockedBuffer` surfacing CLI/plugin,
+mode unification — remains queued; each needs its own producer→
+consumer loop and doesn't fit a single overnight PR).
+
 ### Slice 1e (phase 1) — `BundledProfileInUse` deprecation condition
 
 Surfaces the deprecated bundled `AGT_POLICY_PROFILE` env-var

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ It is built for three audiences:
                     │  └─────────────────┬──────────────────┘     │
                     │                    │                        │
                     │            init: egress-guard               │
-                    │       (iptables: only the router            │
-                    │        can talk to the outside)             │
+                    │      (iptables safety net: agent UID         │
+                    │       can only reach the router locally)     │
                     └────────────────────┼────────────────────────┘
                                          │
                             Workload Identity (no keys)
@@ -72,7 +72,7 @@ It is built for three audiences:
            └─────────────────┘
 ```
 
-**The agent has no network of its own.** Every byte that leaves the pod leaves through the router. Compromise of the agent does not compromise the cloud account, the model, the audit log, or the peer mesh.
+**The agent has no network of its own.** Every byte that leaves the pod leaves through the router — that's the policy point where egress, governance, content-safety, token budgets, and audit are enforced. The K8s `NetworkPolicy` and the `egress-guard` iptables init container are **safety nets** that contain blast radius if the router is bypassed or compromised — they are not the policy layer. Compromise of the agent does not compromise the cloud account, the model, the audit log, or the peer mesh.
 
 **Pluggable inference backend.** Three providers are wired in today:
 
@@ -94,7 +94,7 @@ You write the same `ClawSandbox` YAML for both. The difference is where it runs 
 |---|---|---|
 | Where | One Docker container on your laptop | An AKS cluster in your subscription |
 | Pod shape | **Single container** — agent + router co-located in one image | **Multi-container pod** — agent (UID 1000) + router (UID 1001) + init `egress-guard` |
-| Network isolation | Docker network, no egress guard | NetworkPolicy + `egress-guard` initContainer + per-namespace isolation |
+| Network isolation | Docker network, no egress guard | Router is the policy point; `NetworkPolicy` + `egress-guard` initContainer act as safety nets containing blast radius |
 | Identity | Provider credential — Copilot OAuth token, Foundry resource key, or GitHub PAT (mounted from a local secret) | Workload Identity (federated, no keys on disk) |
 | Optional VM isolation | n/a | Kata + AMD SEV-SNP (Confidential Containers) |
 | Use it for | Inner-loop dev, plugin authoring, demos | Real workloads, multi-tenant, production |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,10 +46,10 @@ The router still runs the same code path it does in prod. So the policies, the c
 ### Prod mode (`azureclaw up` / Helm install)
 
 - **Pod shape:** multi-container Kubernetes pod.
-  - `init: egress-guard` — installs iptables rules so only the router's UID can reach the outside.
+  - `init: egress-guard` — installs iptables rules so the agent UID can only reach the router on localhost. **Safety net**, not the policy point — the router is.
   - `agent` — the runtime, **UID 1000**, no direct egress.
-  - `inference-router` — the Rust router, **UID 1001**, listens on `127.0.0.1:8443` (HTTP) and `127.0.0.1:8444` (forward proxy).
-- **Isolation:** Kubernetes NetworkPolicy on the namespace pins egress to exactly DNS, Foundry, the AgentMesh relay, and the A2A gateway. Optionally Kata + AMD SEV-SNP for hardware-enforced isolation.
+  - `inference-router` — the Rust router, **UID 1001**, listens on `127.0.0.1:8443` (HTTP) and `127.0.0.1:8444` (forward proxy). This is where egress, governance, content-safety, token-budget, and audit are actually enforced.
+- **Isolation:** The router enforces the egress allowlist on every outbound request. A Kubernetes NetworkPolicy on the namespace is generated as a **safety net** that limits blast radius if the router process is bypassed or compromised; it pins egress to DNS, Foundry, the AgentMesh relay, and the A2A gateway. Optionally Kata + AMD SEV-SNP for hardware-enforced isolation.
 - **Identity:** Workload Identity. The router exchanges the projected service-account token for a federated AAD token. No keys on disk.
 - **What it is for:** real workloads, multi-tenant fleets, anything that touches customer data.
 
@@ -110,7 +110,7 @@ sequenceDiagram
 
 In prose:
 
-1. The agent SDK is configured (by the runtime adapter) to point at `http://127.0.0.1:8443`. There is no way for it to reach the model directly — `egress-guard` would drop the packet.
+1. The agent SDK is configured (by the runtime adapter) to point at `http://127.0.0.1:8443`. The router is the policy point — it decides whether an outbound call is allowed; `egress-guard` iptables and the K8s NetworkPolicy are safety nets that drop the packet only if the router is bypassed.
 2. The router receives the request. It asks the **governance** layer (`InferencePolicy` + AGT `PolicyDecisionProvider`) whether this call is allowed. Deny → 403.
 3. It checks the **token budget** for the tenant. Over → 429.
 4. It branches by provider (read from `~/.azureclaw/config.json` → `provider`):

--- a/docs/egress-proxy.md
+++ b/docs/egress-proxy.md
@@ -22,13 +22,16 @@ spec:
       digest: sha256:abc123…
 ```
 
-The controller compiles this into **two** enforcement points:
+The controller compiles this into **one enforcement point with one safety net**:
 
-- **Kubernetes `NetworkPolicy`** — L3/L4 egress to peer pods, cluster DNS, and
-  the explicit pod-IP allowlist generated from `allowedEndpoints`.
-- **Router-side allowlist** — L7 host-header / SNI matching for outbound HTTP,
-  served from `inference-router` shared state and reloaded on `ClawSandbox`
-  updates.
+- **Router-side allowlist** (the **policy point**) — L7 host-header / SNI
+  matching on every outbound HTTP request, served from `inference-router`
+  shared state and reloaded on `ClawSandbox` updates. This is where egress
+  policy is actually decided.
+- **Kubernetes `NetworkPolicy`** (a **safety net**) — L3/L4 egress to peer
+  pods, cluster DNS, and the explicit pod-IP allowlist generated from
+  `allowedEndpoints`. Only matters if the router process itself is bypassed
+  or compromised. Don't rely on it as the policy layer.
 
 `allowlistRef` is an _advisory_ second source today (cosign-signed OCI artifact
 for supply-chain integrity); when set, the controller verifies it on every
@@ -55,7 +58,12 @@ The inference-router (UID 1001) runs **two listeners** in the same process:
 All three paths resolve to the **same** `blocklist::check_egress()` decision
 function — there is no policy-bypass route.
 
-## Layer 1: iptables (kernel level)
+## Layer 1: iptables egress-guard (safety net)
+
+> The router is the policy point — see "Layer 2" below. The iptables rules
+> described here are a **safety net** that contains blast radius if the
+> router process is compromised or bypassed. Do not treat them as
+> policy.
 
 An init container (`egress-guard`) runs at pod startup with `NET_ADMIN`/`NET_RAW`
 and installs the rules below for the agent container (UID 1000 / `openclaw`).
@@ -92,7 +100,12 @@ This denies, by construction:
 
 Source: `controller/src/reconciler/mod.rs::1356–1369` (egress-guard init container).
 
-## Layer 2: Forward proxy (application level)
+## Layer 2: Forward proxy (the policy point)
+
+> This is where egress policy is **actually enforced**: every L7 destination
+> is matched against the allowlist before bytes leave the router.
+> The iptables layer above and the K8s `NetworkPolicy` below it are
+> safety nets, not policy.
 
 `inference-router/src/forward_proxy.rs` listens on `:8444` and handles **both**
 paths B and C:


### PR DESCRIPTION
Pure documentation reframe. No code changes.

Aligns user-facing docs (README, docs/architecture.md, docs/egress-proxy.md) with the framing already locked in docs/internal/crd-well-oiled-machine/principles.md §7:

* **Policy point** = inference-router — every byte that leaves the pod is matched against the egress allowlist by the router.
* **Safety nets** = K8s NetworkPolicy + egress-guard iptables init. They contain blast radius if the router is bypassed; they do not *decide* what is allowed.

This is the only Slice 5 sub-item that can ship as a no-code PR. Rest of Slice 5 (EgressApproval CRD, BlockedBuffer surfacing, mode unification, signed approvals, policyHistory) remains queued.

Part of crd-well-oiled-machine grind.