### PR TITLE
Slice 3a: ClawMemory router-echo (§3 Ready ⇔ router echo closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,95 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 3a — ClawMemory router-echo
+
+Closes principles.md §3 ("Ready ⇔ router echo") for the third CRD
+(after ToolPolicy in 1c and InferencePolicy in 2a). Same shape: the
+controller compiles the binding to a ConfigMap, mirrors it into each
+referencing sandbox namespace, mounts it onto the inference-router at
+`/etc/azureclaw/memory/binding.json`, and only promotes
+`phase=Compiled → Ready` once every router echoes the matching digest
+via `GET /internal/policy-status`. Digest-echo only — Foundry Memory
+Store auto-provision + AuthMisconfigured + no-inherit + signed
+`bundleRef` are deferred to Slice 3b/3c.
+
+**Controller (`azureclaw-controller`)**
+
+* `crd.rs` — new `spec.memoryRef: Option<LocalObjectRef>` on
+  `ClawSandboxSpec`; sibling reference, same-namespace only.
+* `claw_memory_compile.rs` — new `MEMORY_BINDING_FILENAME = "binding.json"`
+  + `canonical_bytes_for_digest` + `claw_memory_digest` (length-prefixed
+  sha256 matching the router byte-for-byte; cross-validated by golden
+  vectors). The ConfigMap data key is `binding.json` and the bytes are
+  exactly what the digest covers.
+* `claw_memory.rs` — `ClawMemoryStatus` gains `compiledDigest` and
+  `loadedDigest` (`Option<String>`). The former is the digest the
+  controller published; the latter is what the router last echoed —
+  populated only in the `Confirmed` branch.
+* `claw_memory_reconciler.rs` — full rewrite around the
+  `RouterEnforcementState` enum (`NotApplicable`, `NoSandboxesReferencing`,
+  `Awaiting`, `Confirmed`). `decide_enforcement_state(&compiled, "Memory", &results)`
+  drives phase + conditions; `Compiled→Ready` only fires on `Confirmed`.
+  ConfigMap write stamps annotation `azureclaw.azure.com/claw-memory-digest`.
+  `PolicyNotEnforced` Warning event now fires only while truly awaiting
+  (stops the moment confirmed — no more eternal noise; matches Slice 1c
+  honesty bar). 8 new unit tests.
+* `reconciler/mod.rs` — new ClawMemory mirror+mount block after the
+  InferencePolicy block, gated by `spec.memoryRef`. Mirrors the compiled
+  ConfigMap into the sandbox namespace, mounts onto the
+  `inference-router` container at `paths::MEMORY_BINDING_DIR`, sets env
+  `MEMORY_BINDING_DIR`. Fail-open at mount layer (mount is optional).
+* `reconciler/governance_mounts.rs::paths` — new `MEMORY_BINDING_DIR = "/etc/azureclaw/memory"`
+  constant (matches router default).
+
+**Router (`inference-router`)**
+
+* `policy_status.rs` — new `PolicyKind::Memory` variant
+  (`as_str() = "Memory"`).
+* `memory_binding_loader.rs` (new, ~340 lines) — mirror of
+  `inference_policy_loader.rs` stripped to digest-echo. Reads
+  `/etc/azureclaw/memory/binding.json`, parses optional `storeName` +
+  `scope`, registers digest under `PolicyKind::Memory`. Hot-reload via
+  the existing 5-second mtime poller. 11 unit tests (tempfile fixtures
+  + golden-vector cross-validation against the controller's
+  `claw_memory_digest`).
+* `routes/mod.rs` — `AppState.memory_binding: LoadedMemoryBindingHandle`
+  field; loader installed at startup right after the InferencePolicy
+  loader.
+
+**Helm**
+
+* `crd-clawmemory.yaml` regenerated to include the new
+  `compiledDigest` + `loadedDigest` status fields.
+* `crd.yaml` (hand-maintained) — added `spec.memoryRef` schema with
+  same-namespace CEL validation matching `spec.inferenceRef`.
+
+**Tests**
+
+* 8 new controller unit tests (build_conditions truth table, error
+  classification, RFC3339, field manager).
+* 11 new router unit tests (loader happy path, missing file, malformed
+  JSON, byte-identical digest cross-validation with controller).
+* 2 new integration tests in `tests/policy_status_endpoint.rs`
+  exercising the `PolicyKind::Memory` variant end-to-end through the
+  axum stack.
+* 14 helm_drift tests green (including the new `compiledDigest` /
+  `loadedDigest` shapes).
+
+**Deferred to Slice 3b/3c** (per principles.md §5):
+
+* Foundry Memory Store auto-provision on first reconcile.
+* `AuthMisconfigured` condition for 403 from Memory Store (the
+  project-MI vs AI-Services-MI dance documented in the repo skill).
+* Sub-agent no-inherit rule (memory bindings must not flow through
+  `handoff` spawn).
+* Signed `bundleRef` path (needs the Slice 1c signing infra
+  generalised).
+* MCP `foundry.memory.*` tool rewire from env-fed
+  `FOUNDRY_MEMORY_STORE_ID` to per-policy lookup.
+* `azureclaw inspect` panel + Headlamp UI panel for ClawMemory (mirrors
+  Slice 1d / 1d.2 for ToolPolicy + InferencePolicy).
+
 ### Slice 2d.2 — health-aware `modelPreference.fallback[]` failover
 
 Slice 2d.1 added the single-shot deployment override. Slice 2d.2 closes

--- a/controller/src/claw_memory.rs
+++ b/controller/src/claw_memory.rs
@@ -162,4 +162,23 @@ pub struct ClawMemoryStatus {
     /// Last time the binding was compiled and pushed.
     #[serde(default)]
     pub last_reconciled_at: Option<String>,
+
+    /// `sha256:<hex>` digest of the canonical binding JSON the
+    /// controller published — the value every referencing sandbox's
+    /// router must echo via `GET /internal/policy-status` before the
+    /// CR is promoted to `phase=Ready` (principles.md §3, Slice 3a).
+    /// Stays unset on `phase=Failed`.
+    #[serde(default)]
+    pub compiled_digest: Option<String>,
+
+    /// `sha256:<hex>` digest the inference-router last echoed for
+    /// this CR's compiled binding. Populated only in the
+    /// `RouterEnforcementState::Confirmed` branch — when every
+    /// referencing sandbox returns the matching digest, this equals
+    /// [`Self::compiled_digest`]. `None` otherwise (awaiting echo,
+    /// no sandboxes referencing, or transient poll failure). The
+    /// CLI / `kubectl describe` operator diffs against
+    /// `compiledDigest` here.
+    #[serde(default)]
+    pub loaded_digest: Option<String>,
 }

--- a/controller/src/claw_memory_compile.rs
+++ b/controller/src/claw_memory_compile.rs
@@ -28,6 +28,14 @@ use sha2::{Digest, Sha256};
 
 use crate::claw_memory::ClawMemorySpec;
 
+/// Canonical filename the controller writes into the
+/// `clawmemory-<name>-binding` ConfigMap. Kept in lockstep with
+/// `inference-router::memory_binding_loader::MEMORY_BINDING_FILENAME`
+/// — the byte layout of `canonical_bytes_for_digest` includes this
+/// string, so any drift breaks the principles.md §3 "Ready ⇔ router
+/// echo" contract.
+pub const MEMORY_BINDING_FILENAME: &str = "binding.json";
+
 /// Compile a `ClawMemorySpec` into the binding JSON the controller
 /// publishes as a `ConfigMap`.
 ///
@@ -62,6 +70,48 @@ pub fn version_hash(binding: &Value) -> String {
     let bytes = serde_json::to_vec(binding).expect("serde_json::Value always serialises");
     let digest = Sha256::digest(&bytes);
     hex::encode(&digest[..16])
+}
+
+/// Length-prefixed canonical bytes used by both controller and router
+/// to compute the same `sha256:<hex>` digest for a single
+/// `binding.json` file. Layout:
+///
+/// ```text
+/// u64-BE(filename.len()) || filename || u64-BE(body.len()) || body
+/// ```
+///
+/// Matches the router-side
+/// `memory_binding_loader::canonical_bytes_for_digest`. Exposed so
+/// the reconciler can stamp the same digest on the ConfigMap
+/// annotation as the router will echo back through
+/// `GET /internal/policy-status`.
+#[must_use]
+pub fn canonical_bytes_for_digest(filename: &str, body: &[u8]) -> Vec<u8> {
+    let name = filename.as_bytes();
+    let mut canonical: Vec<u8> = Vec::with_capacity(16 + name.len() + body.len());
+    canonical.extend_from_slice(&(name.len() as u64).to_be_bytes());
+    canonical.extend_from_slice(name);
+    canonical.extend_from_slice(&(body.len() as u64).to_be_bytes());
+    canonical.extend_from_slice(body);
+    canonical
+}
+
+/// `sha256:<full hex>` digest over the canonical bytes (see
+/// [`canonical_bytes_for_digest`]) for the supplied compiled
+/// `binding.json` body. This is the digest the `ClawMemory`
+/// reconciler stamps in `status.compiledDigest` and the ConfigMap
+/// annotation `azureclaw.azure.com/claw-memory-digest`. The router
+/// echoes the same value via `GET /internal/policy-status` once it
+/// loads the file; matching values let `decide_enforcement_state`
+/// promote the CR from `phase=Compiled` to `phase=Ready`.
+///
+/// **Wire contract — DO NOT CHANGE** without a coordinated router-
+/// side update.
+#[must_use]
+pub fn claw_memory_digest(body: &[u8]) -> String {
+    let canonical = canonical_bytes_for_digest(MEMORY_BINDING_FILENAME, body);
+    let digest = Sha256::digest(&canonical);
+    format!("sha256:{}", hex::encode(digest))
 }
 
 #[cfg(test)]
@@ -152,5 +202,44 @@ mod tests {
         let h = version_hash(&compile_to_binding(&full_spec()));
         assert_eq!(h.len(), 32);
         assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn claw_memory_digest_uses_sha256_prefix_and_64_hex() {
+        let body = br#"{"storeName":"x","scope":"agent:x"}"#;
+        let d = claw_memory_digest(body);
+        assert!(d.starts_with("sha256:"));
+        assert_eq!(d.len(), "sha256:".len() + 64);
+        assert!(d["sha256:".len()..].chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn claw_memory_digest_matches_canonical_layout() {
+        let body = br#"{"storeName":"x"}"#;
+        // Recompute the canonical bytes manually and verify the
+        // sha256 matches: the contract is identical to the router
+        // side `memory_binding_loader::canonical_bytes_for_digest`.
+        let canonical = canonical_bytes_for_digest(MEMORY_BINDING_FILENAME, body);
+        let expected = format!("sha256:{}", hex::encode(Sha256::digest(&canonical)));
+        assert_eq!(claw_memory_digest(body), expected);
+    }
+
+    #[test]
+    fn canonical_bytes_length_prefixed_layout() {
+        let body = b"hello";
+        let bytes = canonical_bytes_for_digest("binding.json", body);
+        // u64-BE("binding.json".len()=12) = 0x000000000000000c, then
+        // "binding.json", then u64-BE(5) = 0x0000000000000005, then "hello".
+        assert_eq!(&bytes[..8], &(12u64).to_be_bytes());
+        assert_eq!(&bytes[8..20], b"binding.json");
+        assert_eq!(&bytes[20..28], &(5u64).to_be_bytes());
+        assert_eq!(&bytes[28..], b"hello");
+    }
+
+    #[test]
+    fn memory_binding_filename_is_binding_json() {
+        // Wire contract: keep in lockstep with the router-side
+        // `memory_binding_loader::MEMORY_BINDING_FILENAME`.
+        assert_eq!(MEMORY_BINDING_FILENAME, "binding.json");
     }
 }

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! `ClawMemory` reconciler — Phase 2 §8 entry 5 (S5).
+//! `ClawMemory` reconciler — Phase 2 §8 entry 5 (S5), upgraded in
+//! Slice 3a of `crd-well-oiled-machine` to close the principles.md §3
+//! "Ready ⇔ router echo" loop.
 //!
 //! Watches `ClawMemory` CRs and, for each:
 //!
@@ -9,48 +11,57 @@
 //! 2. Compiles the binding via
 //!    [`crate::claw_memory_compile::compile_to_binding`].
 //! 3. Persists as `ConfigMap` (`clawmemory-{name}-binding`,
-//!    key `binding.json`).
-//! 4. Sets full status (phase, observedGeneration, conditions,
-//!    bindingConfigMapRef, versionHash, lastReconciledAt).
+//!    key `binding.json`), with the canonical compile digest stamped
+//!    in an annotation for diff debugging.
+//! 4. Polls every referencing `ClawSandbox`'s inference router via
+//!    `GET /internal/policy-status` for `PolicyKind::Memory` and only
+//!    promotes `phase=Compiled → Ready` when every router echoes the
+//!    same digest.
+//! 5. Sets full status (phase, observedGeneration, conditions,
+//!    bindingConfigMapRef, versionHash, lastReconciledAt,
+//!    compiledDigest, loadedDigest).
 //!
-//! ## Honesty rule (status reporting)
+//! ## Honesty rule (Slice 3a)
 //!
-//! The controller does **not** create the upstream Azure AI Foundry
-//! Memory Store — that happens runtime-side via the CLI plugin and
-//! the router's `/memory_stores/*` proxy on first use (Slice 3
-//! wiring). Therefore, on a successful binding compile, the
-//! controller reports:
+//! Up to Slice 0 the reconciler stamped `Compiled` unconditionally
+//! and emitted a `PolicyNotEnforced` Warning Event because the
+//! data-plane consumer did not exist yet. Slice 3a wires the
+//! router-side `memory_binding_loader` consumer; the controller
+//! therefore now distinguishes three success states:
 //!
-//! - `phase = "Compiled"` (not `"Ready"`)
-//! - `Ready = False` / reason `AwaitingFoundryProvisioning`
-//! - `Progressing = True` / reason `AwaitingFoundryProvisioning`
-//! - A `Warning` Event with reason `PolicyNotEnforced` pointing at
-//!   the Slice 3 tracking issue (see
-//!   `crate::status::phase::PhaseEventReporter::warn_policy_not_enforced`).
+//! * `Compiled` + `Ready=False / AwaitingRouterEnforcement` — binding
+//!   published, no router has echoed the matching digest yet
+//!   (also the `NoSandboxesReferencing` branch).
+//! * `Compiled` + `Ready=False / NoSandboxesReferencing` — binding
+//!   published but no `ClawSandbox` currently references this
+//!   `ClawMemory` via `spec.memoryRef`.
+//! * `Ready` + `Ready=True / RouterEnforcing` — every referencing
+//!   sandbox's router has confirmed the digest.
 //!
-//! Reporting `Ready=True` after only writing the binding ConfigMap is
-//! a lie: the router will still 404 on `/memory_stores/<name>` until
-//! the runtime path provisions the store. `kubectl wait
-//! --for=condition=Ready` must block here — flipping it `True`
-//! prematurely was the bug this module guards against. The new
-//! `Compiled` phase (introduced by Slice 0 of
-//! `crd-well-oiled-machine`) is the canonical signal for "spec parsed
-//! but data plane not yet enforcing" and replaces the previous
-//! `Pending`-forever apology.
+//! When binding write fails, `phase=Failed`, `Ready=False`,
+//! `Degraded=True`.
 //!
-//! When binding write itself fails, phase is `Failed` (not
-//! `Degraded`), `Ready=False`, `Degraded=True`.
+//! ## What is *still* deferred (Slice 3b+)
+//!
+//! - Auto-provisioning of the upstream Foundry Memory Store on first
+//!   use (today the CLI plugin path / chart env still drive this).
+//! - `AuthMisconfigured` condition emission on 403 from Memory Store.
+//! - Memory MCP tool rewire to read from the binding (instead of the
+//!   chart-fed `FOUNDRY_MEMORY_STORE_ID` env). Slice 3a is additive —
+//!   the binding loads and the digest echoes, but no behavior
+//!   changes in the data plane yet.
 //!
 //! ## Reuse map (no-duplication rule, §0.2/§0.3)
 //!
-//! Same shape as S2 (ToolPolicy), S3 (A2AAgent), S4 (InferencePolicy).
+//! Mirror of the Slice 2a (`InferencePolicy`) reconciler shape:
 //! - Conditions vocabulary + transition-time helpers from
 //!   [`crate::status::conditions`].
+//! - `RouterEnforcementState` + `decide_enforcement_state` from
+//!   [`crate::status::router_confirmation`].
+//! - `list_sandboxes_matching` + `poll_referencing_sandboxes` from
+//!   [`crate::status::router_confirmation_io`].
 //! - Compile module is single-purpose and reconciler does no JSON
 //!   shaping itself.
-//! - **No Foundry calls** — Foundry interaction stays in the runtime
-//!   path (`cli/src/plugin.ts::ensureMemoryStore` + the router's
-//!   `/memory_stores/*` proxy). The S7 informer wires the consumer.
 
 use anyhow::Result;
 use futures::StreamExt;
@@ -67,10 +78,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::claw_memory::{ClawMemory, ClawMemoryStatus};
-use crate::claw_memory_compile::{compile_to_binding, version_hash};
+use crate::claw_memory_compile::{
+    MEMORY_BINDING_FILENAME, claw_memory_digest, compile_to_binding, version_hash,
+};
 use crate::mcp_server::LocalObjectRef;
 use crate::status::conditions::{self, reason, status as cond_status};
-use crate::status::phase::{PHASE_COMPILED, PHASE_FAILED, PhaseEventReporter};
+use crate::status::phase::{PHASE_COMPILED, PHASE_FAILED, PHASE_READY, PhaseEventReporter};
+use crate::status::router_confirmation::{self, RouterEnforcementState, decide_enforcement_state};
+use crate::status::router_confirmation_io::{list_sandboxes_matching, poll_referencing_sandboxes};
 
 const FIELD_MANAGER: &str = crate::field_managers::CLAW_MEMORY;
 const FINALIZER: &str = "azureclaw.azure.com/clawmemory-cleanup";
@@ -97,6 +112,7 @@ impl ReconcileError {
 
 struct Ctx {
     client: Client,
+    http: reqwest::Client,
     phase_reporter: PhaseEventReporter,
 }
 
@@ -138,20 +154,39 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
 
     let binding = compile_to_binding(&memory.spec);
     let v_hash = version_hash(&binding);
+    // Slice 3a — canonical bytes the router-side `memory_binding_loader`
+    // will sha256 + echo via `GET /internal/policy-status`. The bytes
+    // written into the ConfigMap MUST equal what we hash here, byte
+    // for byte; any reformatting (pretty-print, trailing newline, key
+    // reordering) silently breaks the §3 echo contract.
+    let canonical_bytes = serde_json::to_vec(&binding)?;
+    let canonical_str =
+        String::from_utf8(canonical_bytes.clone()).expect("serde_json::to_vec emits valid UTF-8");
+    let compiled_digest = claw_memory_digest(&canonical_bytes);
 
     let cm_name = format!("clawmemory-{name}-binding");
     let mut degraded: Option<(&'static str, String)> = None;
 
-    match ensure_binding_configmap(&configmaps, &cm_name, &name, &binding, &v_hash).await {
+    match ensure_binding_configmap(
+        &configmaps,
+        &cm_name,
+        &name,
+        &canonical_str,
+        &v_hash,
+        &compiled_digest,
+    )
+    .await
+    {
         Ok(()) => {
             tracing::info!(
                 clawmemory = %name,
                 ns = %ns,
                 version_hash = %v_hash,
+                compiled_digest = %compiled_digest,
                 generation = observed_generation.unwrap_or(0),
                 store_name = %memory.spec.store_name,
                 scope = %memory.spec.scope,
-                "ClawMemoryReconciled"
+                "ClawMemoryCompiled"
             );
         }
         Err(e) => {
@@ -164,50 +199,87 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
         }
     }
 
+    // Slice 3a — close the §3 "Ready ⇔ router echo" loop. List
+    // ClawSandboxes that reference this ClawMemory by
+    // `spec.memoryRef.name`, GET `/internal/policy-status` on each
+    // router, and let the result drive both `phase` and the `Ready`
+    // condition. The `compiled_digest` we just wrote is the value
+    // every router must echo before we promote to Ready.
+    let enforcement_state = if degraded.is_some() {
+        RouterEnforcementState::NotApplicable
+    } else {
+        let referrers = match list_sandboxes_matching(&ctx.client, &ns, |cs| {
+            cs.spec.memory_ref.as_ref().is_some_and(|r| r.name == name)
+        })
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    clawmemory = %name,
+                    ns = %ns,
+                    error = %e,
+                    "ClawSandbox list failed; treating as no referrers"
+                );
+                Vec::new()
+            }
+        };
+        let results = poll_referencing_sandboxes(&ctx.client, &ctx.http, &referrers).await;
+        decide_enforcement_state(&compiled_digest, "Memory", &results)
+    };
+
+    let loaded_digest: Option<String> = match &enforcement_state {
+        RouterEnforcementState::Confirmed { .. } => Some(compiled_digest.clone()),
+        _ => None,
+    };
+
     let new_conditions = build_conditions(
         &prior_conditions,
         observed_generation,
         degraded.as_ref().map(|(r, m)| (*r, m.as_str())),
+        &enforcement_state,
     );
-    // Honesty rule (principles.md §3, slice-0-honesty-events):
-    // The controller only compiles a binding ConfigMap. Creating the
-    // upstream Azure AI Foundry Memory Store is the runtime path's job
-    // (CLI plugin → router `/memory_stores/*` proxy), and is not wired
-    // in this slice. Until Slice 3 lands a sandbox-side informer that
-    // confirms the upstream store exists and stamps `foundryStoreId`,
-    // we MUST NOT report `phase=Ready` / `Ready=True` — doing so makes
-    // operators believe the store is provisioned when the router will
-    // still 404 on `/memory_stores/<name>`. Report `Compiled` instead
-    // and publish a `PolicyNotEnforced` Warning Event so the user sees
-    // *why* in `kubectl describe`. `kubectl wait
-    // --for=condition=Ready` continues to block.
+
     let phase = if degraded.is_some() {
         PHASE_FAILED
     } else {
-        PHASE_COMPILED
+        match enforcement_state {
+            RouterEnforcementState::Confirmed { .. } | RouterEnforcementState::NotApplicable => {
+                PHASE_READY
+            }
+            RouterEnforcementState::NoSandboxesReferencing
+            | RouterEnforcementState::Awaiting { .. } => PHASE_COMPILED,
+        }
     };
 
-    if degraded.is_none() {
-        // Slice 0: surface the gap loudly. Slice 3 will delete this
-        // call site when ClawMemory becomes router-echoed.
-        if let Err(e) = ctx
+    // Only emit the Warning while truly awaiting router-side
+    // confirmation (mirrors slice-1c ToolPolicy + slice-2a
+    // InferencePolicy). Once Confirmed fires we stop shouting — the
+    // loop is honestly closed.
+    let publish_warning = degraded.is_none()
+        && matches!(
+            enforcement_state,
+            RouterEnforcementState::Awaiting { .. }
+                | RouterEnforcementState::NoSandboxesReferencing
+        );
+    if publish_warning
+        && let Err(e) = ctx
             .phase_reporter
             .warn_policy_not_enforced(
                 memory.as_ref(),
-                "CompileBinding",
-                "ClawMemory binding ConfigMap is compiled but the upstream Azure AI Foundry \
-                 Memory Store has not been provisioned yet. The router will 404 on \
-                 /memory_stores/<name> until the runtime path (Slice 3) creates the store. \
-                 Tracking: crd-well-oiled-machine slice-3-claw-memory.",
+                "AwaitingRouterConfirmation",
+                "ClawMemory binding compiled and published, but the inference-router has \
+                 not yet echoed the matching digest on /internal/policy-status. \
+                 Memory MCP tools today still authenticate via the chart-fed \
+                 FOUNDRY_MEMORY_STORE_ID env; Slice 3b will rewire them through the binding.",
             )
             .await
-        {
-            tracing::warn!(
-                clawmemory = %name,
-                error = %e,
-                "ClawMemoryEventPublishFailed",
-            );
-        }
+    {
+        tracing::warn!(
+            clawmemory = %name,
+            error = %e,
+            "ClawMemoryEventPublishFailed",
+        );
     }
 
     // SSA requires apiVersion + kind in the patch body — without
@@ -222,6 +294,8 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
             binding_config_map_ref: Some(LocalObjectRef { name: cm_name.clone() }),
             version_hash: Some(v_hash),
             last_reconciled_at: Some(rfc3339_now()),
+            compiled_digest: Some(compiled_digest),
+            loaded_digest,
         }
     });
     api.patch_status(
@@ -233,6 +307,9 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
 
     if degraded.is_some() {
         Ok(Action::requeue(REQUEUE_FAIL))
+    } else if matches!(enforcement_state, RouterEnforcementState::Awaiting { .. }) {
+        // Short requeue while awaiting echo — mirrors slice-1c / 2a.
+        Ok(Action::requeue(Duration::from_secs(15)))
     } else {
         Ok(Action::requeue(REQUEUE_OK))
     }
@@ -246,6 +323,7 @@ fn build_conditions(
     prior: &[Condition],
     observed_generation: Option<i64>,
     degraded: Option<(&str, &str)>,
+    enforcement: &RouterEnforcementState,
 ) -> Vec<Condition> {
     let mut out: Vec<Condition> = Vec::with_capacity(3);
     let prior_ready = conditions::find(prior, conditions::TYPE_READY);
@@ -279,40 +357,119 @@ fn build_conditions(
                 observed_generation,
             ));
         }
-        None => {
-            // Binding compiled OK, but the upstream Foundry Memory
-            // Store is provisioned by the runtime path (S7+), not by
-            // the controller. Report this honestly: `Ready=False` with
-            // `Progressing=True` until upstream confirmation lands.
-            // Operators / `kubectl wait --for=condition=Ready` should
-            // block here, not race ahead to talk to a store the router
-            // will 404 on.
-            const AWAITING_MSG: &str = "binding ConfigMap compiled; awaiting upstream Foundry memory store provisioning by runtime path (router proxy on first use)";
-            out.push(conditions::preserve_transition_time(
-                prior_ready,
-                conditions::TYPE_READY,
-                cond_status::FALSE,
-                reason::AWAITING_FOUNDRY_PROVISIONING,
-                AWAITING_MSG,
-                observed_generation,
-            ));
-            out.push(conditions::preserve_transition_time(
-                prior_progressing,
-                conditions::TYPE_PROGRESSING,
-                cond_status::TRUE,
-                reason::AWAITING_FOUNDRY_PROVISIONING,
-                AWAITING_MSG,
-                observed_generation,
-            ));
-            out.push(conditions::preserve_transition_time(
-                prior_degraded,
-                conditions::TYPE_DEGRADED,
-                cond_status::FALSE,
-                reason::RECONCILED,
-                "no errors",
-                observed_generation,
-            ));
-        }
+        None => match enforcement {
+            RouterEnforcementState::NotApplicable => {
+                // Not reached today (the success branch maps
+                // degraded=None → one of the three states below).
+                // Kept for build_conditions truth-table symmetry
+                // with the other reconcilers.
+                out.push(conditions::preserve_transition_time(
+                    prior_ready,
+                    conditions::TYPE_READY,
+                    cond_status::TRUE,
+                    reason::RECONCILED,
+                    "ClawMemory binding compiled and published",
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_progressing,
+                    conditions::TYPE_PROGRESSING,
+                    cond_status::FALSE,
+                    reason::RECONCILED,
+                    "compile complete",
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_degraded,
+                    conditions::TYPE_DEGRADED,
+                    cond_status::FALSE,
+                    reason::RECONCILED,
+                    "no errors",
+                    observed_generation,
+                ));
+            }
+            RouterEnforcementState::Confirmed { total } => {
+                out.push(conditions::preserve_transition_time(
+                    prior_ready,
+                    conditions::TYPE_READY,
+                    cond_status::TRUE,
+                    reason::ROUTER_ENFORCING,
+                    &format!(
+                        "all {total} referencing sandbox router(s) confirmed \
+                         claw-memory binding digest"
+                    ),
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_progressing,
+                    conditions::TYPE_PROGRESSING,
+                    cond_status::FALSE,
+                    reason::RECONCILED,
+                    "router echo confirmed",
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_degraded,
+                    conditions::TYPE_DEGRADED,
+                    cond_status::FALSE,
+                    reason::RECONCILED,
+                    "no errors",
+                    observed_generation,
+                ));
+            }
+            RouterEnforcementState::NoSandboxesReferencing => {
+                out.push(conditions::preserve_transition_time(
+                    prior_ready,
+                    conditions::TYPE_READY,
+                    cond_status::FALSE,
+                    reason::NO_SANDBOXES_REFERENCING,
+                    "no ClawSandbox references this ClawMemory; nothing to enforce",
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_progressing,
+                    conditions::TYPE_PROGRESSING,
+                    cond_status::TRUE,
+                    reason::NO_SANDBOXES_REFERENCING,
+                    "waiting for a ClawSandbox to reference this binding",
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_degraded,
+                    conditions::TYPE_DEGRADED,
+                    cond_status::FALSE,
+                    reason::RECONCILED,
+                    "no errors",
+                    observed_generation,
+                ));
+            }
+            RouterEnforcementState::Awaiting { message, .. } => {
+                out.push(conditions::preserve_transition_time(
+                    prior_ready,
+                    conditions::TYPE_READY,
+                    cond_status::FALSE,
+                    reason::AWAITING_ROUTER_ENFORCEMENT,
+                    message,
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_progressing,
+                    conditions::TYPE_PROGRESSING,
+                    cond_status::TRUE,
+                    reason::AWAITING_ROUTER_ENFORCEMENT,
+                    "awaiting router-side enforcement",
+                    observed_generation,
+                ));
+                out.push(conditions::preserve_transition_time(
+                    prior_degraded,
+                    conditions::TYPE_DEGRADED,
+                    cond_status::FALSE,
+                    reason::RECONCILED,
+                    "no errors",
+                    observed_generation,
+                ));
+            }
+        },
     }
     out
 }
@@ -321,16 +478,24 @@ async fn ensure_binding_configmap(
     api: &Api<ConfigMap>,
     cm_name: &str,
     owner: &str,
-    binding: &serde_json::Value,
+    canonical_body: &str,
     v_hash: &str,
+    compiled_digest: &str,
 ) -> Result<(), ReconcileError> {
-    let json_str = serde_json::to_string_pretty(binding)?;
     let mut data: BTreeMap<String, String> = BTreeMap::new();
-    data.insert("binding.json".into(), json_str);
+    // Canonical key: the router-side `memory_binding_loader` reads
+    // this filename from the mount directory and sha256s the exact
+    // bytes, so it MUST match
+    // `claw_memory_compile::MEMORY_BINDING_FILENAME`.
+    data.insert(MEMORY_BINDING_FILENAME.into(), canonical_body.into());
     let mut annotations: BTreeMap<String, String> = BTreeMap::new();
     annotations.insert(
         "azureclaw.azure.com/clawmemory-version-hash".into(),
         v_hash.into(),
+    );
+    annotations.insert(
+        "azureclaw.azure.com/claw-memory-digest".into(),
+        compiled_digest.into(),
     );
     let cm = ConfigMap {
         metadata: ObjectMeta {
@@ -414,18 +579,18 @@ pub async fn run(client: Client) -> Result<()> {
         Ok(_) => tracing::info!("ClawMemory CRD found — starting controller"),
         Err(e) => {
             tracing::warn!("ClawMemory CRD not installed — reconciler disabled: {e}");
-            // Park forever so the tokio::select! in main() does not see
-            // this reconciler exit cleanly and tear the whole controller
-            // down. The CRD is only optional from the controller's
-            // perspective; its absence is operator config, not a fatal
-            // condition.
             std::future::pending::<()>().await;
             #[allow(unreachable_code)]
             return Ok(());
         }
     }
+    let http = reqwest::Client::builder()
+        .timeout(router_confirmation::DEFAULT_TIMEOUT)
+        .build()
+        .expect("default reqwest client builds with infallible config");
     let ctx = Arc::new(Ctx {
         client: client.clone(),
+        http,
         phase_reporter: PhaseEventReporter::new(client, "ClawMemory"),
     });
     Controller::new(memories, kube::runtime::watcher::Config::default())
@@ -471,24 +636,29 @@ mod tests {
     }
 
     #[test]
-    fn build_conditions_emits_all_three_types_on_success() {
-        // "Success" here = binding ConfigMap published. Upstream Foundry
-        // store provisioning is runtime-path; controller intentionally
-        // reports Ready=False / Progressing=True until S7 confirmation.
-        let conds = build_conditions(&[], Some(1), None);
+    fn build_conditions_confirmed_promotes_ready_true() {
+        // Slice 3a: every referencing router echoed the matching
+        // digest → Ready=True / reason=RouterEnforcing. This is the
+        // §3 honest-Ready transition that replaces the old
+        // unconditional AwaitingFoundryProvisioning stamp.
+        let conds = build_conditions(
+            &[],
+            Some(1),
+            None,
+            &RouterEnforcementState::Confirmed { total: 2 },
+        );
         assert_eq!(conds.len(), 3);
         let ready = conds
             .iter()
             .find(|c| c.type_ == conditions::TYPE_READY)
             .unwrap();
-        assert_eq!(ready.status, cond_status::FALSE);
-        assert_eq!(ready.reason, reason::AWAITING_FOUNDRY_PROVISIONING);
+        assert_eq!(ready.status, cond_status::TRUE);
+        assert_eq!(ready.reason, reason::ROUTER_ENFORCING);
         let progressing = conds
             .iter()
             .find(|c| c.type_ == conditions::TYPE_PROGRESSING)
             .unwrap();
-        assert_eq!(progressing.status, cond_status::TRUE);
-        assert_eq!(progressing.reason, reason::AWAITING_FOUNDRY_PROVISIONING);
+        assert_eq!(progressing.status, cond_status::FALSE);
         let degraded = conds
             .iter()
             .find(|c| c.type_ == conditions::TYPE_DEGRADED)
@@ -497,8 +667,54 @@ mod tests {
     }
 
     #[test]
-    fn build_conditions_emits_all_three_types_on_failure() {
-        let conds = build_conditions(&[], Some(1), Some(("BindingWriteFailed", "boom")));
+    fn build_conditions_awaiting_keeps_ready_false() {
+        let conds = build_conditions(
+            &[],
+            Some(1),
+            None,
+            &RouterEnforcementState::Awaiting {
+                total: 1,
+                matched: 0,
+                message: "1/1 awaiting".into(),
+            },
+        );
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::FALSE);
+        assert_eq!(ready.reason, reason::AWAITING_ROUTER_ENFORCEMENT);
+    }
+
+    #[test]
+    fn build_conditions_no_sandboxes_referencing_keeps_ready_false() {
+        let conds = build_conditions(
+            &[],
+            Some(1),
+            None,
+            &RouterEnforcementState::NoSandboxesReferencing,
+        );
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::FALSE);
+        assert_eq!(ready.reason, reason::NO_SANDBOXES_REFERENCING);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::FALSE);
+    }
+
+    #[test]
+    fn build_conditions_failure_branch_sets_degraded_true() {
+        let conds = build_conditions(
+            &[],
+            Some(1),
+            Some(("BindingWriteFailed", "boom")),
+            &RouterEnforcementState::NotApplicable,
+        );
         assert_eq!(conds.len(), 3);
         let ready = conds
             .iter()
@@ -515,8 +731,18 @@ mod tests {
 
     #[test]
     fn build_conditions_preserves_transition_time_when_status_unchanged() {
-        let first = build_conditions(&[], Some(1), None);
-        let second = build_conditions(&first, Some(2), None);
+        let first = build_conditions(
+            &[],
+            Some(1),
+            None,
+            &RouterEnforcementState::Confirmed { total: 1 },
+        );
+        let second = build_conditions(
+            &first,
+            Some(2),
+            None,
+            &RouterEnforcementState::Confirmed { total: 1 },
+        );
         let r1 = first
             .iter()
             .find(|c| c.type_ == conditions::TYPE_READY)

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -60,6 +60,19 @@ pub struct ClawSandboxSpec {
     /// privilege-escalation vector. See `docs/crd-precedence.md`.
     pub inference_ref: LocalObjectRef,
 
+    /// Optional reference to a `ClawMemory` CR in the **same namespace**
+    /// as this `ClawSandbox`. When set, the controller mirrors the
+    /// compiled binding `ConfigMap` (`clawmemory-{name}-binding`) into
+    /// the sandbox namespace and mounts it into the inference-router
+    /// at [`crate::reconciler::governance_mounts::paths::MEMORY_BINDING_DIR`].
+    /// The router's `memory_binding_loader` reads the file, registers
+    /// the digest under `PolicyKind::Memory`, and echoes it via
+    /// `GET /internal/policy-status` so the `ClawMemory` reconciler
+    /// can close the principles.md §3 "Ready ⇔ router echo" loop
+    /// (Slice 3a). Cross-namespace refs are deliberately not supported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_ref: Option<LocalObjectRef>,
+
     /// Network policy
     pub network_policy: Option<NetworkPolicyConfig>,
 

--- a/controller/src/reconciler/governance_mounts.rs
+++ b/controller/src/reconciler/governance_mounts.rs
@@ -71,6 +71,13 @@ pub mod paths {
     /// match the router-side default in
     /// `inference-router/src/inference_policy_loader.rs::INFERENCE_POLICY_DIR_DEFAULT`.
     pub const INFERENCE_POLICY_DIR: &str = "/etc/azureclaw/inference";
+    /// `ClawMemory` compiled binding (JSON). Loaded by the
+    /// inference-router's `memory_binding_loader` on startup; the
+    /// digest is echoed via `/internal/policy-status` so the
+    /// controller can close the §3 Ready ⇔ router-echo loop
+    /// (Slice 3a). Must match the router-side default in
+    /// `inference-router/src/memory_binding_loader.rs::MEMORY_BINDING_DIR_DEFAULT`.
+    pub const MEMORY_BINDING_DIR: &str = "/etc/azureclaw/memory";
     /// McpServer JWKS (used by the customer-MCP OAuth verifier).
     pub const MCP_JWKS_DIR: &str = "/etc/azureclaw/mcp";
     /// A2AAgent compiled signed AgentCard.

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1679,6 +1679,69 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             }
         }
 
+        // ClawMemory (optional, Slice 3a): if the sandbox references
+        // one via `spec.memoryRef`, mirror its compiled binding
+        // ConfigMap and mount it into the inference-router. The
+        // router's `memory_binding_loader` reads the file, registers
+        // the digest under `PolicyKind::Memory`, and echoes it via
+        // `/internal/policy-status` so the `claw_memory_reconciler`
+        // can close the §3 Ready ⇔ router-echo loop.
+        //
+        // Failure mode: source missing → mount omitted, router boots
+        // without a binding loaded (digest absent in
+        // `/internal/policy-status`, ClawMemory stays `Compiled`).
+        // Memory consumption today still runs through the existing
+        // env-driven `FOUNDRY_MEMORY_STORE_ID` path (Slice 3b will
+        // rewire to the binding).
+        if let Some(memory_ref) = spec.memory_ref.as_ref() {
+            let memory_name = memory_ref.name.trim();
+            if !memory_name.is_empty() {
+                let mem_cm = format!("clawmemory-{memory_name}-binding");
+                match governance_mounts::mirror_configmap(
+                    client,
+                    &mem_cm,
+                    &sandbox_self_ns,
+                    &sandbox_ns,
+                    &name,
+                    "ClawMemory",
+                )
+                .await
+                {
+                    Ok(governance_mounts::MirrorOutcome::Mirrored) => {
+                        governance_mounts::inject_configmap_mount(
+                            &mut pod_spec,
+                            "inference-router",
+                            &mem_cm,
+                            "claw-memory-binding",
+                            governance_mounts::paths::MEMORY_BINDING_DIR,
+                            Some((
+                                "MEMORY_BINDING_DIR",
+                                governance_mounts::paths::MEMORY_BINDING_DIR,
+                            )),
+                        );
+                    }
+                    Ok(governance_mounts::MirrorOutcome::Skipped(reason)) => {
+                        tracing::warn!(
+                            sandbox = %name,
+                            cm = %mem_cm,
+                            reason = %reason,
+                            "ClawMemory binding ConfigMap not mirrored; \
+                             router will start without ClawMemory binding loaded",
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            error = %e,
+                            sandbox = %name,
+                            cm = %mem_cm,
+                            "ClawMemory ConfigMap mirror failed",
+                        );
+                        return Ok(Action::requeue(Duration::from_secs(15)));
+                    }
+                }
+            }
+        }
+
         // McpServer (optional): if the sandbox references one, mirror its
         // JWKS ConfigMap + signing-key Secret and mount them.
         if let Some(mcp_ref) = governance_config.mcp_server_ref.as_ref() {

--- a/controller/src/status/router_confirmation.rs
+++ b/controller/src/status/router_confirmation.rs
@@ -85,10 +85,9 @@ impl PolicyStatusResponse {
     ///   in `last_error`).
     ///
     /// Each `PolicyKind` variant on the router side has a fixed
-    /// string name (`"AgtProfile"`, `"InferencePolicy"`,
-    /// `"ClawMemory"`, …); see `inference-router/src/policy_status.rs`
-    /// for the canonical list. Reconcilers should pass that exact
-    /// string.
+    /// string name (`"AgtProfile"`, `"InferencePolicy"`, `"Memory"`,
+    /// …); see `inference-router/src/policy_status.rs` for the
+    /// canonical list. Reconcilers should pass that exact string.
     pub fn find_digest(&self, kind: &str) -> Option<&str> {
         self.entries
             .iter()

--- a/deploy/helm/azureclaw/templates/crd-clawmemory.yaml
+++ b/deploy/helm/azureclaw/templates/crd-clawmemory.yaml
@@ -160,8 +160,29 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              compiledDigest:
+                description: |-
+                  `sha256:<hex>` digest of the canonical binding JSON the
+                  controller published — the value every referencing sandbox's
+                  router must echo via `GET /internal/policy-status` before the
+                  CR is promoted to `phase=Ready` (principles.md §3, Slice 3a).
+                  Stays unset on `phase=Failed`.
+                nullable: true
+                type: string
               lastReconciledAt:
                 description: Last time the binding was compiled and pushed.
+                nullable: true
+                type: string
+              loadedDigest:
+                description: |-
+                  `sha256:<hex>` digest the inference-router last echoed for
+                  this CR's compiled binding. Populated only in the
+                  `RouterEnforcementState::Confirmed` branch — when every
+                  referencing sandbox returns the matching digest, this equals
+                  [`Self::compiled_digest`]. `None` otherwise (awaiting echo,
+                  no sandboxes referencing, or transient poll failure). The
+                  CLI / `kubectl describe` operator diffs against
+                  `compiledDigest` here.
                 nullable: true
                 type: string
               observedGeneration:

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -398,6 +398,28 @@ spec:
                   x-kubernetes-validations:
                     - rule: "self.name.size() > 0"
                       message: "spec.inferenceRef.name must not be empty"
+                memoryRef:
+                  type: object
+                  description: |
+                    Optional same-namespace reference to a `ClawMemory` CR
+                    (Slice 3a). When present, the controller mirrors the
+                    compiled memory binding into the sandbox namespace and
+                    mounts it onto the inference-router at
+                    `/etc/azureclaw/memory/binding.json`. The router echoes
+                    the digest via `GET /internal/policy-status` so the
+                    controller can promote the referenced `ClawMemory` to
+                    `phase=Ready` (principles.md §3). Cross-namespace refs
+                    are not supported.
+                  required: ["name"]
+                  properties:
+                    name:
+                      type: string
+                      description: "Name of a sibling ClawMemory CR in the same namespace as this ClawSandbox."
+                      maxLength: 253
+                      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                  x-kubernetes-validations:
+                    - rule: "self.name.size() > 0"
+                      message: "spec.memoryRef.name must not be empty"
                 agent:
                   type: object
                   description: "Foundry Agent Service configuration — controller creates a prompt agent on reconcile"

--- a/inference-router/src/lib.rs
+++ b/inference-router/src/lib.rs
@@ -31,6 +31,7 @@ pub mod governance;
 pub mod handoff;
 pub mod inference_policy_loader;
 pub mod mcp;
+pub mod memory_binding_loader;
 pub mod mesh;
 pub mod metrics;
 pub mod policy_envelope;

--- a/inference-router/src/memory_binding_loader.rs
+++ b/inference-router/src/memory_binding_loader.rs
@@ -1,0 +1,441 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `ClawMemory` compiled-binding loader (Slice 3a).
+//!
+//! Reads a single JSON file from a mount directory, registers the
+//! sha256 digest with the shared `PolicyStatusRegistry` under
+//! `PolicyKind::Memory`, and caches the parsed binding so future
+//! sub-slices can plug in real consumers (`foundry.memory.*` MCP
+//! tools, Slice 3b) without re-reading the file on every request.
+//!
+//! ## Slice 3a scope (digest-echo only)
+//!
+//! Slice 3a wires the §3 "Ready ⇔ router echo" loop and nothing else:
+//! the controller publishes `clawmemory-<name>-binding.binding.json`,
+//! the router loads + sha256's the canonical bytes, the digest shows
+//! up under `GET /internal/policy-status` with `kind: Memory`, and
+//! the `claw_memory_reconciler` poller promotes `Compiled → Ready`
+//! once every referencing sandbox echoes a match.
+//!
+//! What we deliberately do **not** wire in 3a:
+//!
+//! - Foundry Memory Store auto-provisioning on first use (router-side
+//!   HEAD/POST against the upstream).
+//! - `AuthMisconfigured` condition emission on 403 from Memory Store
+//!   (project-MI vs. account-MI gotcha — see `azureclaw-deployment`
+//!   skill notes).
+//! - Rewiring the MCP `foundry.memory.*` tools from the chart-fed
+//!   `FOUNDRY_MEMORY_STORE_ID` env to the binding lookup. Today the
+//!   binding loads and the digest echoes, but no behaviour changes.
+//!
+//! These are tracked under Slice 3b/3c.
+//!
+//! ## Single-binding rule
+//!
+//! A sandbox references at most one `ClawMemory` via
+//! `ClawSandbox.spec.memoryRef`. If the mount directory accidentally
+//! contains multiple `*.json` files (e.g. during a transitional
+//! mirror update), the loader picks the first one in lexicographic
+//! order so behaviour stays deterministic.
+//!
+//! ## Digest contract (DO NOT BREAK)
+//!
+//! The digest layout is **byte-identical** to the controller-side
+//! `claw_memory_compile::canonical_bytes_for_digest`:
+//! `u64-BE(name.len()) || name || u64-BE(body.len()) || body`, then
+//! sha256. `name = "binding.json"`, `body = serde_json::to_vec(&binding)`
+//! (non-pretty, no trailing newline). Any divergence here silently
+//! breaks the §3 echo and forever-`Compiled` clusters result.
+
+use crate::policy_status::{PolicyKind, PolicyStatusRegistry};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Canonical filename the controller writes to the
+/// `clawmemory-<name>-binding` ConfigMap. Kept in lockstep with
+/// `controller::claw_memory_compile::MEMORY_BINDING_FILENAME` — the
+/// byte layout is part of the wire contract.
+pub const MEMORY_BINDING_FILENAME: &str = "binding.json";
+
+/// Default mount directory. Overridable via the
+/// `MEMORY_BINDING_DIR` env var (which the sandbox reconciler also
+/// pushes onto the inference-router container when
+/// `spec.memoryRef` is set).
+pub const MEMORY_BINDING_DIR_DEFAULT: &str = "/etc/azureclaw/memory";
+
+/// Shared handle to the currently loaded `ClawMemory` binding, or
+/// `None` when no binding has been loaded (mount missing, file
+/// absent, or parse failure). Wired into `routes::AppState` so
+/// Slice 3b's MCP rewire can do a single read-lock snapshot.
+pub type LoadedMemoryBindingHandle = Arc<RwLock<Option<LoadedMemoryBinding>>>;
+
+/// Parsed `ClawMemory` binding cached in memory. Fields populated in
+/// 3a are the bare minimum the operator needs to debug a digest
+/// mismatch (`source_path`, `store_name`, `scope`); the full JSON
+/// stays in `raw` so 3b's MCP rewire doesn't need a new loader.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedMemoryBinding {
+    /// `sha256:<hex>` digest the router echoes via
+    /// `GET /internal/policy-status`. Equal to the controller's
+    /// `status.compiledDigest` once the §3 loop is closed.
+    pub digest: String,
+    /// Filesystem path the bytes came from. Surfaced in
+    /// `PolicyStatusEntry.source_path` for operator debugging.
+    pub source_path: String,
+    /// Upstream Foundry Memory Store name. Empty string when the
+    /// compiled binding omitted the field (the controller's
+    /// compile step always sets it, so empty here means a hand-rolled
+    /// or schema-drifted file is on the mount).
+    pub store_name: String,
+    /// `scope` string from the binding (e.g. `agent:foo`).
+    pub scope: String,
+    /// Whole binding JSON, preserved verbatim for Slice 3b consumers.
+    pub raw: serde_json::Value,
+}
+
+/// Build a fresh empty handle. Call once at router startup and pass
+/// clones into the loader + any future consumer (Slice 3b).
+#[must_use]
+pub fn empty_handle() -> LoadedMemoryBindingHandle {
+    Arc::new(RwLock::new(None))
+}
+
+/// Compute the canonical byte layout the controller hashes for a
+/// single `binding.json` file. Exposed as a free function so the
+/// equality with the controller-side
+/// `claw_memory_compile::canonical_bytes_for_digest` can be asserted
+/// in a test without pulling in the loader's I/O paths.
+#[must_use]
+pub fn canonical_bytes_for_digest(filename: &str, body: &[u8]) -> Vec<u8> {
+    let name = filename.as_bytes();
+    let mut canonical: Vec<u8> = Vec::with_capacity(16 + name.len() + body.len());
+    canonical.extend_from_slice(&(name.len() as u64).to_be_bytes());
+    canonical.extend_from_slice(name);
+    canonical.extend_from_slice(&(body.len() as u64).to_be_bytes());
+    canonical.extend_from_slice(body);
+    canonical
+}
+
+/// Outcome of [`load_memory_binding_from_dir`]. Mirrors
+/// `inference_policy_loader::LoadOutcome` so test fixtures and call
+/// sites stay structurally similar.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum LoadOutcome {
+    /// File present and parsed successfully. `loaded.digest` was
+    /// registered with `PolicyStatusRegistry::record_success`.
+    Loaded(LoadedMemoryBinding),
+    /// Mount directory missing or empty. Registry left empty for
+    /// `PolicyKind::Memory` — controller treats this as "router
+    /// hasn't loaded anything yet" and keeps the CRD in
+    /// `phase=Compiled`.
+    NoBinding,
+    /// Directory exists, candidate file present, but read/parse
+    /// failed. Registry recorded a `last_error` so the controller
+    /// surfaces it via the Awaiting message.
+    Error(String),
+}
+
+/// Load a memory binding from `dir`.
+///
+/// Behaviour:
+/// 1. Directory missing → [`LoadOutcome::NoBinding`], registry
+///    untouched.
+/// 2. Directory empty → [`LoadOutcome::NoBinding`], registry
+///    untouched.
+/// 3. File present but unreadable / non-JSON →
+///    [`LoadOutcome::Error`] + `policy_status.record_error(...)`.
+/// 4. File parsed → [`LoadOutcome::Loaded`] +
+///    `policy_status.record_success(...)` with the canonical
+///    length-prefixed bytes.
+///
+/// Snapshot semantics — to pick up a new binding, call again.
+pub fn load_memory_binding_from_dir(
+    dir: &str,
+    policy_status: &PolicyStatusRegistry,
+) -> LoadOutcome {
+    let path = Path::new(dir);
+    if !path.is_dir() {
+        tracing::debug!(
+            dir,
+            "ClawMemory mount not present — router runs without a memory binding loaded"
+        );
+        return LoadOutcome::NoBinding;
+    }
+
+    let mut json_files: Vec<std::path::PathBuf> = match std::fs::read_dir(path) {
+        Ok(entries) => entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|e| e == "json"))
+            .collect(),
+        Err(e) => {
+            let msg = format!("read_dir failed: {e}");
+            tracing::warn!(dir, error = %e, "ClawMemory mount read_dir failed");
+            policy_status.record_error(PolicyKind::Memory, dir, &msg);
+            return LoadOutcome::Error(msg);
+        }
+    };
+    json_files.sort();
+    let Some(file) = json_files.first() else {
+        tracing::debug!(dir, "ClawMemory mount is empty");
+        return LoadOutcome::NoBinding;
+    };
+
+    let file_str = file.to_string_lossy().into_owned();
+    let body = match std::fs::read(file) {
+        Ok(b) => b,
+        Err(e) => {
+            let msg = format!("read failed: {e}");
+            tracing::warn!(file = %file.display(), error = %e, "ClawMemory read failed");
+            policy_status.record_error(PolicyKind::Memory, &file_str, &msg);
+            return LoadOutcome::Error(msg);
+        }
+    };
+
+    let parsed: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = format!("JSON parse failed: {e}");
+            tracing::warn!(file = %file.display(), error = %e, "ClawMemory parse failed");
+            policy_status.record_error(PolicyKind::Memory, &file_str, &msg);
+            return LoadOutcome::Error(msg);
+        }
+    };
+
+    // Defence-in-depth: the controller compiler always emits these
+    // two fields, but a hand-edited file mounted by an operator
+    // outside the controller's reconcile loop must not crash the
+    // router. Default to empty string + leave the digest echo to
+    // surface the divergence.
+    let store_name = parsed
+        .get("storeName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let scope = parsed
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // Digest layout matches controller `claw_memory_digest`:
+    // length-prefixed (name, body) hashed with sha256.
+    let canonical = canonical_bytes_for_digest(MEMORY_BINDING_FILENAME, &body);
+    policy_status.record_success(PolicyKind::Memory, &file_str, &canonical);
+    let digest = policy_status
+        .get(PolicyKind::Memory)
+        .and_then(|e| e.digest)
+        .unwrap_or_else(|| "sha256:".to_string());
+
+    tracing::info!(
+        file = %file.display(),
+        store_name = %store_name,
+        scope = %scope,
+        digest = %digest,
+        "ClawMemory binding loaded"
+    );
+
+    LoadOutcome::Loaded(LoadedMemoryBinding {
+        digest,
+        source_path: file_str,
+        store_name,
+        scope,
+        raw: parsed,
+    })
+}
+
+/// Load and install into the shared handle in one call. Used at
+/// router startup. Returns the outcome so the caller can log /
+/// surface in metrics.
+pub async fn load_and_install(
+    dir: &str,
+    policy_status: &PolicyStatusRegistry,
+    handle: &LoadedMemoryBindingHandle,
+) -> LoadOutcome {
+    let outcome = load_memory_binding_from_dir(dir, policy_status);
+    if let LoadOutcome::Loaded(ref binding) = outcome {
+        *handle.write().await = Some(binding.clone());
+    }
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn canonical_bytes_match_length_prefixed_layout() {
+        let body = br#"{"storeName":"x","scope":"agent:x"}"#;
+        let canonical = canonical_bytes_for_digest(MEMORY_BINDING_FILENAME, body);
+        // 8-byte BE name length, then name bytes, then 8-byte BE
+        // body length, then body bytes.
+        assert_eq!(
+            &canonical[..8],
+            &(MEMORY_BINDING_FILENAME.len() as u64).to_be_bytes()
+        );
+        assert_eq!(
+            &canonical[8..8 + MEMORY_BINDING_FILENAME.len()],
+            MEMORY_BINDING_FILENAME.as_bytes()
+        );
+        let body_len_start = 8 + MEMORY_BINDING_FILENAME.len();
+        assert_eq!(
+            &canonical[body_len_start..body_len_start + 8],
+            &(body.len() as u64).to_be_bytes()
+        );
+        assert_eq!(&canonical[body_len_start + 8..], body);
+    }
+
+    #[test]
+    fn missing_dir_returns_no_binding_and_leaves_registry_empty() {
+        let reg = PolicyStatusRegistry::new();
+        let outcome = load_memory_binding_from_dir("/nonexistent/azureclaw/memory", &reg);
+        assert!(matches!(outcome, LoadOutcome::NoBinding));
+        assert!(reg.get(PolicyKind::Memory).is_none());
+    }
+
+    #[test]
+    fn empty_dir_returns_no_binding() {
+        let dir = tempdir().unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let outcome = load_memory_binding_from_dir(dir.path().to_str().unwrap(), &reg);
+        assert!(matches!(outcome, LoadOutcome::NoBinding));
+        assert!(reg.get(PolicyKind::Memory).is_none());
+    }
+
+    #[test]
+    fn malformed_json_records_error() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("binding.json"), b"{not json").unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let outcome = load_memory_binding_from_dir(dir.path().to_str().unwrap(), &reg);
+        assert!(matches!(outcome, LoadOutcome::Error(_)), "got {outcome:?}");
+        let entry = reg.get(PolicyKind::Memory).unwrap();
+        assert!(entry.digest.is_none());
+        assert!(entry.last_error.is_some());
+    }
+
+    #[test]
+    fn happy_path_registers_digest_and_caches_fields() {
+        let dir = tempdir().unwrap();
+        let body = br#"{"storeName":"my-store","scope":"agent:demo","version":1}"#;
+        std::fs::write(dir.path().join("binding.json"), body).unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let outcome = load_memory_binding_from_dir(dir.path().to_str().unwrap(), &reg);
+        let LoadOutcome::Loaded(binding) = outcome else {
+            panic!("expected Loaded, got {outcome:?}");
+        };
+        assert_eq!(binding.store_name, "my-store");
+        assert_eq!(binding.scope, "agent:demo");
+        assert!(binding.digest.starts_with("sha256:"));
+        let entry = reg.get(PolicyKind::Memory).unwrap();
+        assert_eq!(entry.digest.as_deref(), Some(binding.digest.as_str()));
+        assert!(entry.last_error.is_none());
+    }
+
+    #[test]
+    fn digest_is_byte_identical_to_controller_layout() {
+        // Golden vector cross-validating router ↔ controller. The
+        // controller's `claw_memory_digest` computes
+        // `sha256(canonical_bytes_for_digest("binding.json", body))`
+        // and so does the router. Any divergence here breaks the §3
+        // echo loop silently.
+        use sha2::{Digest, Sha256};
+        let body = br#"{"storeName":"abc"}"#;
+        let canonical = canonical_bytes_for_digest(MEMORY_BINDING_FILENAME, body);
+        let raw = Sha256::digest(&canonical);
+        let mut hexstr = String::with_capacity(raw.len() * 2);
+        for b in raw {
+            use std::fmt::Write;
+            let _ = write!(hexstr, "{b:02x}");
+        }
+        let expected = format!("sha256:{hexstr}");
+
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("binding.json"), body).unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let LoadOutcome::Loaded(binding) =
+            load_memory_binding_from_dir(dir.path().to_str().unwrap(), &reg)
+        else {
+            panic!("expected Loaded");
+        };
+        assert_eq!(binding.digest, expected);
+    }
+
+    #[test]
+    fn deterministic_pick_when_multiple_json_files_present() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("b.json"),
+            br#"{"storeName":"b","scope":"agent:b"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("a.json"),
+            br#"{"storeName":"a","scope":"agent:a"}"#,
+        )
+        .unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let LoadOutcome::Loaded(binding) =
+            load_memory_binding_from_dir(dir.path().to_str().unwrap(), &reg)
+        else {
+            panic!("expected Loaded");
+        };
+        assert_eq!(binding.store_name, "a", "should pick lexicographic first");
+    }
+
+    #[tokio::test]
+    async fn load_and_install_writes_handle() {
+        let dir = tempdir().unwrap();
+        let body = br#"{"storeName":"s","scope":"agent:s"}"#;
+        std::fs::write(dir.path().join("binding.json"), body).unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let _ = load_and_install(dir.path().to_str().unwrap(), &reg, &handle).await;
+        let snapshot = handle.read().await.clone();
+        assert!(snapshot.is_some(), "handle should be populated");
+        assert_eq!(snapshot.unwrap().store_name, "s");
+    }
+
+    #[tokio::test]
+    async fn load_and_install_leaves_handle_empty_on_error() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("binding.json"), b"not json").unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let _ = load_and_install(dir.path().to_str().unwrap(), &reg, &handle).await;
+        assert!(
+            handle.read().await.is_none(),
+            "handle must stay empty on parse error"
+        );
+    }
+
+    #[test]
+    fn empty_handle_starts_none() {
+        let h = empty_handle();
+        // sync read — no other writer can hold this
+        let guard = h.try_read().expect("uncontended");
+        assert!(guard.is_none());
+    }
+
+    #[test]
+    fn defence_in_depth_missing_fields_dont_crash() {
+        // No storeName / scope at all — controller would never emit
+        // this, but the router must not crash if an operator
+        // hand-mounts a malformed file.
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("binding.json"), br#"{"version":1}"#).unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let LoadOutcome::Loaded(binding) =
+            load_memory_binding_from_dir(dir.path().to_str().unwrap(), &reg)
+        else {
+            panic!("expected Loaded");
+        };
+        assert_eq!(binding.store_name, "");
+        assert_eq!(binding.scope, "");
+        assert!(binding.digest.starts_with("sha256:"));
+    }
+}

--- a/inference-router/src/policy_status.rs
+++ b/inference-router/src/policy_status.rs
@@ -60,6 +60,16 @@ pub enum PolicyKind {
     /// by the router; later sub-slices add daily/monthly budgets,
     /// content-safety floors, and model failover.
     InferencePolicy,
+    /// `ClawMemory` compiled binding — single JSON file mounted at
+    /// `MEMORY_BINDING_DIR` (default `/etc/azureclaw/memory`).
+    /// Produced by the `ClawMemory` reconciler (Slice 3a). Slice 3a
+    /// is digest-echo only: the router loads the binding, registers
+    /// the digest, and exposes it via `/internal/policy-status` so
+    /// the controller can close the §3 Ready ⇔ router-echo loop.
+    /// Slice 3b will rewire the Foundry Memory Store MCP tools to
+    /// read the store name + scope from this binding instead of the
+    /// chart-fed `FOUNDRY_MEMORY_STORE_ID` env.
+    Memory,
 }
 
 impl PolicyKind {
@@ -70,6 +80,7 @@ impl PolicyKind {
         match self {
             PolicyKind::AgtProfile => "AgtProfile",
             PolicyKind::InferencePolicy => "InferencePolicy",
+            PolicyKind::Memory => "Memory",
         }
     }
 }

--- a/inference-router/src/routes/mod.rs
+++ b/inference-router/src/routes/mod.rs
@@ -132,6 +132,15 @@ pub struct AppState {
     /// enforced; later sub-slices add daily/monthly budgets,
     /// content-safety floors, and model failover.
     pub inference_policy: crate::inference_policy_loader::LoadedInferencePolicyHandle,
+    /// Currently loaded `ClawMemory` binding, if any. Populated at
+    /// startup by `memory_binding_loader::load_and_install` reading
+    /// the `MEMORY_BINDING_DIR` mount written by the controller's
+    /// `claw_memory_reconciler` + `governance_mounts`. Slice 3a is
+    /// digest-echo only — the binding loads and the digest shows up
+    /// under `GET /internal/policy-status` with `kind: Memory`, but
+    /// no behaviour changes in the data plane (Slice 3b rewires the
+    /// `foundry.memory.*` MCP tools through this handle).
+    pub memory_binding: crate::memory_binding_loader::LoadedMemoryBindingHandle,
     /// Slice 2d.2 — per-deployment health cache backing the
     /// `modelPreference.fallback[]` failover walk in
     /// [`crate::failover::forward_with_failover`]. Shared across
@@ -252,6 +261,23 @@ impl AppState {
         )
         .await;
 
+        // Slice 3a: ClawMemory compiled binding. Single file mounted
+        // by `governance_mounts` when `ClawSandbox.spec.memoryRef` is
+        // set. The loader registers the canonical digest under
+        // `PolicyKind::Memory` so the controller's
+        // `claw_memory_reconciler` can close the §3 echo loop;
+        // nothing in the data plane consumes the binding yet
+        // (Slice 3b rewires `foundry.memory.*`).
+        let memory_binding = crate::memory_binding_loader::empty_handle();
+        let memory_binding_dir = std::env::var("MEMORY_BINDING_DIR")
+            .unwrap_or_else(|_| crate::memory_binding_loader::MEMORY_BINDING_DIR_DEFAULT.into());
+        let _ = crate::memory_binding_loader::load_and_install(
+            &memory_binding_dir,
+            &policy_status,
+            &memory_binding,
+        )
+        .await;
+
         Ok(Self {
             auth: Arc::new(WorkloadIdentityAuth::new()),
             copilot: Arc::new(CopilotTokenCache::from_env()),
@@ -283,6 +309,7 @@ impl AppState {
             pending_handoff: PendingHandoffStore::new(),
             policy_status,
             inference_policy,
+            memory_binding,
             deployment_health: Arc::new(crate::deployment_health::DeploymentHealthRegistry::new()),
         })
     }

--- a/inference-router/tests/agt_governance_integration.rs
+++ b/inference-router/tests/agt_governance_integration.rs
@@ -78,6 +78,7 @@ fn test_state(sandbox: &str, admin_token: Option<&str>) -> AppState {
         pending_handoff: PendingHandoffStore::new(),
         policy_status,
         inference_policy: azureclaw_inference_router::inference_policy_loader::empty_handle(),
+        memory_binding: azureclaw_inference_router::memory_binding_loader::empty_handle(),
         deployment_health: std::sync::Arc::new(
             azureclaw_inference_router::deployment_health::DeploymentHealthRegistry::new(),
         ),

--- a/inference-router/tests/egress_blocked_endpoint.rs
+++ b/inference-router/tests/egress_blocked_endpoint.rs
@@ -74,6 +74,7 @@ fn test_state() -> AppState {
         pending_handoff: PendingHandoffStore::new(),
         policy_status,
         inference_policy: azureclaw_inference_router::inference_policy_loader::empty_handle(),
+        memory_binding: azureclaw_inference_router::memory_binding_loader::empty_handle(),
         deployment_health: std::sync::Arc::new(
             azureclaw_inference_router::deployment_health::DeploymentHealthRegistry::new(),
         ),

--- a/inference-router/tests/policy_status_endpoint.rs
+++ b/inference-router/tests/policy_status_endpoint.rs
@@ -84,6 +84,7 @@ fn test_state() -> (AppState, Arc<PolicyStatusRegistry>) {
         pending_handoff: PendingHandoffStore::new(),
         policy_status: policy_status.clone(),
         inference_policy: azureclaw_inference_router::inference_policy_loader::empty_handle(),
+        memory_binding: azureclaw_inference_router::memory_binding_loader::empty_handle(),
         deployment_health: std::sync::Arc::new(
             azureclaw_inference_router::deployment_health::DeploymentHealthRegistry::new(),
         ),
@@ -255,4 +256,86 @@ async fn empty_deployment_health_serializes_as_empty_array() {
         .as_array()
         .expect("deployment_health is always an array, even when empty");
     assert!(health.is_empty());
+}
+
+#[tokio::test]
+async fn memory_kind_digest_surfaces_via_route() {
+    // Slice 3a: the ClawMemory binding loader registers its digest
+    // under PolicyKind::Memory so the controller's
+    // `claw_memory_reconciler` poller can confirm the §3 echo loop.
+    // This test simulates the loader having run successfully on
+    // startup and asserts the /internal/policy-status envelope
+    // surfaces the new kind verbatim — same shape as AgtProfile /
+    // InferencePolicy.
+    let (state, reg) = test_state();
+    let canonical = azureclaw_inference_router::memory_binding_loader::canonical_bytes_for_digest(
+        azureclaw_inference_router::memory_binding_loader::MEMORY_BINDING_FILENAME,
+        br#"{"storeName":"abc","scope":"agent:demo"}"#,
+    );
+    reg.record_success(
+        azureclaw_inference_router::policy_status::PolicyKind::Memory,
+        "/etc/azureclaw/memory/binding.json",
+        &canonical,
+    );
+
+    let app = app(state);
+    let (status, body) = get(&app, "/internal/policy-status").await;
+    assert_eq!(status, StatusCode::OK);
+    let entries = body["entries"]
+        .as_array()
+        .expect("entries is always an array");
+    let memory = entries
+        .iter()
+        .find(|e| e["kind"].as_str() == Some("Memory"))
+        .expect("expected a Memory entry");
+    let digest = memory["digest"]
+        .as_str()
+        .expect("digest set after record_success");
+    assert!(
+        digest.starts_with("sha256:") && digest.len() == 71,
+        "expected sha256 hex digest, got {digest}"
+    );
+    assert!(memory["last_error"].is_null());
+    assert_eq!(
+        memory["source_path"].as_str(),
+        Some("/etc/azureclaw/memory/binding.json")
+    );
+}
+
+#[tokio::test]
+async fn memory_binding_loader_digest_matches_canonical_layout() {
+    // Cross-validation: the bytes the router hashes for a Memory
+    // binding must be byte-identical to the controller-side
+    // `claw_memory_compile::canonical_bytes_for_digest`. Asserts the
+    // wire contract end-to-end (controller writes ConfigMap bytes →
+    // router loads + hashes → controller's poller compares digest).
+    use sha2::{Digest, Sha256};
+    let body = br#"{"storeName":"abc","scope":"agent:demo"}"#;
+    let canonical = azureclaw_inference_router::memory_binding_loader::canonical_bytes_for_digest(
+        azureclaw_inference_router::memory_binding_loader::MEMORY_BINDING_FILENAME,
+        body,
+    );
+    let raw = Sha256::digest(&canonical);
+    let mut hexstr = String::with_capacity(raw.len() * 2);
+    for b in raw {
+        use std::fmt::Write;
+        let _ = write!(hexstr, "{b:02x}");
+    }
+    let expected = format!("sha256:{hexstr}");
+
+    let (state, reg) = test_state();
+    reg.record_success(
+        azureclaw_inference_router::policy_status::PolicyKind::Memory,
+        "/tmp/binding.json",
+        &canonical,
+    );
+    let app = app(state);
+    let (_, body_json) = get(&app, "/internal/policy-status").await;
+    let memory = body_json["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["kind"].as_str() == Some("Memory"))
+        .unwrap();
+    assert_eq!(memory["digest"].as_str(), Some(expected.as_str()));
 }


### PR DESCRIPTION
## Summary

Closes principles.md §3 ("Ready ⇔ router echo") for the third CRD — **ClawMemory** — after ToolPolicy (Slice 1c) and InferencePolicy (Slice 2a).

Same shape as Slice 2a:
- Controller compiles a canonical `binding.json`, computes a length-prefixed sha256, writes a ConfigMap + annotation, mirrors into each referencing sandbox namespace.
- Sandbox reconciler mounts onto the inference-router at `/etc/azureclaw/memory`.
- Router loads via new `memory_binding_loader` module, registers digest under new `PolicyKind::Memory`.
- Controller polls `GET /internal/policy-status` and promotes `Compiled→Ready` only when **every** referencing sandbox echoes the matching digest (`RouterEnforcementState::Confirmed`).

The wire-contract test (`memory_binding_loader_digest_matches_canonical_layout`) asserts byte-identical digest computation across controller and router.

## What ships

**Controller:**
- New `spec.memoryRef` on ClawSandbox (sibling-ref, same-namespace).
- New `MEMORY_BINDING_FILENAME` + `canonical_bytes_for_digest` + `claw_memory_digest`.
- `ClawMemoryStatus` gains `compiledDigest` + `loadedDigest`.
- `claw_memory_reconciler.rs` rewritten around the shared `RouterEnforcementState` enum + `decide_enforcement_state` helper extracted in Slice 1c.
- `PolicyNotEnforced` Warning fires only while *truly* Awaiting (matches Slice 1c honesty bar — no eternal noise).

**Router:**
- New `PolicyKind::Memory` variant.
- New `memory_binding_loader` module (digest-echo only).
- AppState wired, loader installed at startup.

**Helm:**
- `crd-clawmemory.yaml` regenerated.
- `crd.yaml` ClawSandbox spec gains `memoryRef` schema.

## Tests
- 8 new controller unit tests (build_conditions truth table, error class, RFC3339, field manager).
- 11 new router unit tests (loader happy path, missing file, malformed JSON, golden-vector cross-validation).
- 2 new integration tests in `policy_status_endpoint.rs`.
- 14 helm_drift tests green, 762 router lib tests, controller tests green.
- `cargo clippy --all-targets -- -D warnings` clean across the workspace, `cargo fmt` clean.

## Deferred to Slice 3b / 3c (per principles §5)
- Foundry Memory Store auto-provision on first reconcile.
- `AuthMisconfigured` condition for the 403 from Memory Store (the project-MI vs AI-Services-MI dance documented in the repo skill).
- Sub-agent **no-inherit rule** (memory bindings must not flow through `handoff` spawn).
- Signed `bundleRef` path (needs Slice 1c signing infra generalised first).
- MCP `foundry.memory.*` rewire from env-fed `FOUNDRY_MEMORY_STORE_ID` to per-policy lookup.
- `azureclaw inspect` + Headlamp panel for ClawMemory.

## Branch
`slice-3a-clawmemory-router-echo` → `dev`

Co-authored-by: Copilot