### PR TITLE
Slice 3b.2: pin ClawMemory no-inherit invariant for sub-agent spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 3b.2 — ClawMemory no-inherit invariant for sub-agent spawn
+
+Pins the design rule that ClawMemory bindings are scoped to the agent
+that declared them: a parent's `spec.memoryRef` MUST NOT propagate
+onto sub-agents created via `inference-router/src/spawn` (regular
+spawn or handoff). Today this holds by construction — `SpawnRequest`
+has no `memory_ref` field and `build_sub_agent_crd` writes no
+`spec.memoryRef` key — but it was an implicit invariant. This slice
+makes it explicit:
+
+- Doc comment above `build_sub_agent_crd` calls out the no-inherit
+  rule and points at the test that enforces it.
+- New test `sub_agent_crd_never_inherits_memory_ref` exercises both
+  the regular spawn path and the handoff path and asserts that
+  `spec.memoryRef` and `spec.governance.memoryRef` are absent on the
+  built CRD. A future field addition can't silently break the
+  invariant.
+
+No producer/consumer behaviour change. Pure invariant-pinning slice.
+
 ### Slice 3b.1 — ClawMemory operator UX (inspect CLI + Headlamp panel)
 
 Operator-facing surface for the §3 echo loop closed in Slice 3a. The

--- a/inference-router/src/spawn/mod.rs
+++ b/inference-router/src/spawn/mod.rs
@@ -633,6 +633,14 @@ pub async fn collect_sub_agent_snapshots(
 /// `spec.inference`, `governance.toolPolicy: <string>`,
 /// top-level `spec.handoff`/`spec.model` — all rejected by
 /// `additionalProperties: false` at admission).
+///
+/// **No-inherit invariant (Slice 3a/3b)**: the parent's
+/// `spec.memoryRef` is deliberately NOT propagated onto the spawned
+/// sub-agent. ClawMemory bindings are scoped to the agent that
+/// declared them and must not flow through `handoff` or `spawn`. The
+/// contract test `sub_agent_crd_never_inherits_memory_ref` asserts
+/// this by construction — if a future caller adds a `memory_ref`
+/// field to `SpawnRequest`, the test fails before the CRD ships.
 pub(crate) fn build_sub_agent_crd(
     parent_name: &str,
     namespace: &str,
@@ -890,5 +898,46 @@ mod tests {
         // Legacy must still be absent.
         assert!(crd["spec"].get("handoff").is_none());
         assert!(crd["spec"].get("model").is_none());
+    }
+
+    #[test]
+    fn sub_agent_crd_never_inherits_memory_ref() {
+        // No-inherit invariant for ClawMemory (Slice 3a/3b):
+        // a parent's compiled memory binding must NEVER flow through
+        // sub-agent spawn or handoff. The builder takes no
+        // `memory_ref` input from `SpawnRequest`, and `spec.memoryRef`
+        // must be absent on the built CRD — period. This test pins
+        // the invariant so a future field addition can't silently
+        // break it.
+        //
+        // Both the regular spawn path and the handoff path are
+        // exercised.
+        for handoff in [None, Some("predecessor-x")] {
+            let mut req = minimal_req("child");
+            if let Some(predecessor) = handoff {
+                req.handoff = Some(HandoffMeta {
+                    mode: "restore".into(),
+                    predecessor: Some(predecessor.into()),
+                });
+            }
+            let crd = build_sub_agent_crd(
+                "parent-with-memory",
+                "azureclaw-parent",
+                "default",
+                "gpt-5.4",
+                &req,
+            );
+            assert!(
+                crd["spec"].get("memoryRef").is_none(),
+                "spec.memoryRef leaked into spawned sub-agent CRD (handoff={handoff:?}); \
+                 ClawMemory bindings must not inherit (Slice 3a no-inherit rule)"
+            );
+            // Belt-and-suspenders: governance block must also not
+            // carry a memoryRef.
+            assert!(
+                crd["spec"]["governance"].get("memoryRef").is_none(),
+                "memoryRef snuck into spec.governance — same Slice 3a invariant applies"
+            );
+        }
     }
 }


### PR DESCRIPTION
Slice 3b.2 of the crd-well-oiled-machine grind.

Makes explicit the design rule that a parent ClawSandbox's `spec.memoryRef` must not propagate onto sub-agents created via `inference-router/src/spawn` (regular spawn or handoff).

The invariant holds by construction today (`SpawnRequest` has no `memory_ref` field; `build_sub_agent_crd` writes no `spec.memoryRef` key), but was implicit. This slice:

- Adds a doc comment above `build_sub_agent_crd` calling out the rule and pointing at the enforcing test.
- Adds `sub_agent_crd_never_inherits_memory_ref` exercising both spawn and handoff paths, asserting `spec.memoryRef` and `spec.governance.memoryRef` are absent on the built CRD.

No producer/consumer behaviour change. Pure invariant-pinning.

### Verified
- `cargo test --package azureclaw-inference-router sub_agent_crd_never_inherits` passes.
- `cargo clippy --package azureclaw-inference-router --all-targets -- -D warnings` clean.
- `cargo fmt --all` clean.