### PR TITLE
Slice 3b.3: foundry.memory MCP tool prefers ClawMemory binding store_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 3b.3 — `foundry.memory` MCP tool reads ClawMemory binding
+
+The first **real consumer** of the Slice 3a ClawMemory binding: when
+a sandbox attaches a `ClawMemory` via `spec.memoryRef`, the compiled
+binding's `store_name` now wins over the chart-fed
+`FOUNDRY_MEMORY_STORE_ID` env on every `foundry.memory.{search,update}`
+call. CRD is the source of truth; env stays as the backward-compatible
+fallback for sandboxes without `spec.memoryRef`.
+
+- `PlatformDispatcher` gains an optional
+  `memory_binding: LoadedMemoryBindingHandle` field +
+  `with_memory_binding(handle)` builder +
+  `effective_memory_store_id()` resolver. `foundry.memory` calls
+  switched from `self.memory_store_id` direct to the resolver.
+- Resolver precedence: binding loaded with non-empty `store_name` →
+  use binding; otherwise (no handle, no binding loaded, empty/whitespace
+  `store_name`) → fall back to env-fed `memory_store_id`. Other 8
+  Foundry tools are unaffected.
+- `McpRouteState::platform(memory_binding)` and the
+  `build_platform_mcp_router` helper in `main.rs` now thread the
+  handle from `AppState.memory_binding` (clone before `with_state`)
+  into the dispatcher. The handle is the same `Arc<RwLock<…>>` the
+  Slice 3a loader writes into, so a controller-driven re-mirror
+  flips routing on the very next request without restarting the
+  dispatcher.
+- Three new dispatcher tests:
+  `memory_binding_store_name_overrides_env_store_id`,
+  `memory_empty_binding_store_name_falls_back_to_env`,
+  `memory_without_binding_handle_uses_env_store_id`. All against
+  `wiremock`. Lib tests now 766 (+3 above Slice 3b.2 baseline 763).
+
+No CRD/Helm/controller change. Pure router-side consumer of the
+binding contract Slice 3a published.
+
 ### Slice 3b.2 — ClawMemory no-inherit invariant for sub-agent spawn
 
 Pins the design rule that ClawMemory bindings are scoped to the agent

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -297,6 +297,7 @@ async fn main() -> Result<()> {
                 }
             });
 
+        let memory_binding_for_platform = state.memory_binding.clone();
         let merged = public
             .merge(protected)
             .merge(handoff_init)
@@ -304,7 +305,7 @@ async fn main() -> Result<()> {
             .merge(handoff_status)
             .with_state(state)
             .merge(build_mcp_router())
-            .merge(build_platform_mcp_router());
+            .merge(build_platform_mcp_router(Some(memory_binding_for_platform)));
 
         let merged = if let Some(a2a) = a2a_router_opt {
             merged.merge(a2a)
@@ -513,8 +514,12 @@ fn build_mcp_router() -> Router {
 ///    without changing the actual exposure surface.
 ///
 /// See `mcp/platform.rs` and `plan.md` S10.B for the full rationale.
-fn build_platform_mcp_router() -> Router {
-    let state = routes::McpRouteState::platform();
+fn build_platform_mcp_router(
+    memory_binding: Option<
+        azureclaw_inference_router::memory_binding_loader::LoadedMemoryBindingHandle,
+    >,
+) -> Router {
+    let state = routes::McpRouteState::platform(memory_binding);
     tracing::info!(
         "Mounting /platform/mcp (Foundry-shim discovery surface, loopback-only, no OAuth)"
     );

--- a/inference-router/src/mcp/platform.rs
+++ b/inference-router/src/mcp/platform.rs
@@ -277,6 +277,16 @@ pub struct PlatformDispatcher {
     base_url: String,
     sandbox_name: String,
     memory_store_id: String,
+    /// Slice 3b.3: optional handle into the ClawMemory binding loaded
+    /// by `memory_binding_loader`. When `Some` and the handle resolves
+    /// to a binding with a non-empty `store_name`, that value wins
+    /// over the chart-fed `FOUNDRY_MEMORY_STORE_ID` env (i.e. CRD
+    /// trumps env). When `None`, or when the binding is missing/empty
+    /// (mount absent, parse failed), we fall back to
+    /// `memory_store_id`. This is the consumer that closes the Slice
+    /// 3a `MEMORY_STORE_ID` deferred work without changing any other
+    /// behaviour — non-`foundry.memory` tools are unaffected.
+    memory_binding: Option<crate::memory_binding_loader::LoadedMemoryBindingHandle>,
     http: reqwest::Client,
 }
 
@@ -303,6 +313,7 @@ impl PlatformDispatcher {
             base_url,
             sandbox_name,
             memory_store_id,
+            memory_binding: None,
             http,
         }
     }
@@ -326,6 +337,38 @@ impl PlatformDispatcher {
     pub fn with_memory_store_id(mut self, id: impl Into<String>) -> Self {
         self.memory_store_id = id.into();
         self
+    }
+
+    /// Slice 3b.3: attach a `ClawMemory` binding handle. When the
+    /// handle resolves to a binding with a non-empty `store_name`,
+    /// `foundry.memory` calls use that store id instead of the
+    /// env-fed `memory_store_id`. Lets the CRD-driven binding take
+    /// precedence over the legacy chart env without breaking the
+    /// env-only fallback path (sandboxes with no `spec.memoryRef`
+    /// keep working exactly as before).
+    pub fn with_memory_binding(
+        mut self,
+        handle: crate::memory_binding_loader::LoadedMemoryBindingHandle,
+    ) -> Self {
+        self.memory_binding = Some(handle);
+        self
+    }
+
+    /// Resolve the effective Memory Store id for a `foundry.memory`
+    /// call. Returns the ClawMemory binding's `store_name` when one
+    /// is loaded with a non-empty value; otherwise the configured
+    /// env-fed `memory_store_id`. The CRD-driven binding wins.
+    async fn effective_memory_store_id(&self) -> String {
+        if let Some(handle) = self.memory_binding.as_ref() {
+            let guard = handle.read().await;
+            if let Some(binding) = guard.as_ref() {
+                let name = binding.store_name.trim();
+                if !name.is_empty() {
+                    return name.to_string();
+                }
+            }
+        }
+        self.memory_store_id.clone()
     }
 
     pub fn with_catalog(mut self, catalog: ToolCatalog) -> Self {
@@ -435,7 +478,8 @@ impl PlatformDispatcher {
                 });
             }
         };
-        let path = format!("/memory_stores/{}{}", self.memory_store_id, suffix);
+        let store_id = self.effective_memory_store_id().await;
+        let path = format!("/memory_stores/{store_id}{suffix}");
         self.post_json("foundry.memory", &path, &body).await
     }
 
@@ -950,6 +994,112 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(err, DispatchError::InvalidArguments { .. }));
+    }
+
+    /// Slice 3b.3: when a ClawMemory binding is attached and carries
+    /// a non-empty `store_name`, that name wins over the env-fed
+    /// `memory_store_id`. The compiled CRD is the source of truth.
+    #[tokio::test]
+    async fn memory_binding_store_name_overrides_env_store_id() {
+        use crate::memory_binding_loader::{LoadedMemoryBinding, empty_handle};
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/from-crd:search_memories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"items": []})))
+            .mount(&server)
+            .await;
+        let handle = empty_handle();
+        {
+            let mut g = handle.write().await;
+            *g = Some(LoadedMemoryBinding {
+                digest: "sha256:deadbeef".into(),
+                source_path: "/etc/azureclaw/memory/binding.json".into(),
+                store_name: "from-crd".into(),
+                scope: "agent:test".into(),
+                raw: json!({"storeName": "from-crd"}),
+            });
+        }
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("from-env")
+            .with_memory_binding(handle);
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        // Mock was registered for the CRD-driven path; if the env id
+        // had won we'd see zero matched requests and the mock would
+        // 404.
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "foundry.memory must route to the CRD-driven store name"
+        );
+    }
+
+    /// Slice 3b.3: when the binding handle resolves to a binding
+    /// whose `store_name` is empty (or whitespace), we fall back to
+    /// the env-fed id. Avoids tripping on a malformed compiled
+    /// binding.
+    #[tokio::test]
+    async fn memory_empty_binding_store_name_falls_back_to_env() {
+        use crate::memory_binding_loader::{LoadedMemoryBinding, empty_handle};
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/from-env:update_memories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"updated": 1})))
+            .mount(&server)
+            .await;
+        let handle = empty_handle();
+        {
+            let mut g = handle.write().await;
+            *g = Some(LoadedMemoryBinding {
+                digest: "sha256:deadbeef".into(),
+                source_path: "/etc/azureclaw/memory/binding.json".into(),
+                store_name: "   ".into(),
+                scope: "agent:test".into(),
+                raw: json!({}),
+            });
+        }
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("from-env")
+            .with_memory_binding(handle);
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "update", "text": "remember"}),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "empty store_name in binding must fall back to env"
+        );
+    }
+
+    /// Slice 3b.3: when no binding handle is attached at all, the
+    /// dispatcher behaves exactly as before (env-fed id wins). This
+    /// is the path sandboxes without `spec.memoryRef` follow.
+    #[tokio::test]
+    async fn memory_without_binding_handle_uses_env_store_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/from-env:search_memories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"items": []})))
+            .mount(&server)
+            .await;
+        let d = PlatformDispatcher::with_base_url(server.uri()).with_memory_store_id("from-env");
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/inference-router/src/routes/mcp.rs
+++ b/inference-router/src/routes/mcp.rs
@@ -88,11 +88,22 @@ impl McpRouteState {
     /// runtime adapter (OpenClaw, OpenAI Agents Python, Microsoft
     /// Agent Framework, BYO) discovers them through one MCP endpoint.
     /// See `mcp/platform.rs` and `plan.md` S10.B.
-    pub fn platform() -> Self {
+    ///
+    /// Slice 3b.3: takes an optional ClawMemory binding handle so the
+    /// dispatcher's `foundry.memory` calls can prefer the CRD-driven
+    /// `store_name` over the chart-fed env. `None` keeps the legacy
+    /// env-only behaviour (for sandboxes without `spec.memoryRef`).
+    pub fn platform(
+        memory_binding: Option<crate::memory_binding_loader::LoadedMemoryBindingHandle>,
+    ) -> Self {
+        let mut dispatcher = crate::mcp::PlatformDispatcher::standard();
+        if let Some(handle) = memory_binding {
+            dispatcher = dispatcher.with_memory_binding(handle);
+        }
         Self {
             config: Arc::new(InitializeConfig::default()),
             minter: Arc::new(OsRngSessionMinter),
-            tools: Arc::new(crate::mcp::PlatformDispatcher::standard()),
+            tools: Arc::new(dispatcher),
         }
     }
 }
@@ -435,7 +446,7 @@ mod tests {
 
     #[tokio::test]
     async fn platform_state_publishes_nine_foundry_tools() {
-        let s = McpRouteState::platform();
+        let s = McpRouteState::platform(None);
         assert_eq!(
             s.tools.catalog().tools().len(),
             9,


### PR DESCRIPTION
Slice 3b.3 of the crd-well-oiled-machine grind. **First real consumer of the Slice 3a ClawMemory binding** — closes one of the deferred items called out in Slice 3a's CHANGELOG entry.

When a sandbox attaches a `ClawMemory` via `spec.memoryRef`, the compiled binding's `store_name` now wins over the chart-fed `FOUNDRY_MEMORY_STORE_ID` env on every `foundry.memory.{search,update}` MCP call. CRD is the source of truth; env stays as the backward-compatible fallback for sandboxes without `spec.memoryRef`.

## Changes

- `PlatformDispatcher` gains an optional `memory_binding: LoadedMemoryBindingHandle` field + `with_memory_binding(handle)` builder + `effective_memory_store_id()` async resolver. `foundry.memory` swapped from raw `self.memory_store_id` to the resolver.
- Resolver precedence: binding loaded with non-empty `store_name` → use binding; otherwise (no handle, no binding loaded, empty/whitespace store_name) → fall back to env. Other 8 Foundry tools unaffected.
- `McpRouteState::platform(memory_binding)` + `build_platform_mcp_router(memory_binding)` in main.rs thread `AppState.memory_binding` (cloned before `with_state`) into the dispatcher. Same `Arc<RwLock<…>>` the Slice 3a loader writes into, so a controller-driven re-mirror flips routing on the next request without restarting.
- 3 new wiremock-backed unit tests on the dispatcher; 766 router lib tests (+3 above Slice 3b.2's 763).

## Verified

- `cargo test --package azureclaw-inference-router` → 766 lib + all integration suites green.
- `cargo clippy --all-targets -- -D warnings` clean across workspace.
- `cargo fmt --all` clean.

No CRD / Helm / controller change. Pure router consumer wiring.