### PR TITLE
controller: Slice 3b.4 — ClawMemory Degraded=AuthMisconfigured for router-reported 403s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 3b.4 — `AuthMisconfigured` Degraded condition for ClawMemory
+
+When a referencing sandbox's router reports an upstream authentication
+failure on the compiled ClawMemory binding (today: Foundry Memory Store
+returning 403 on `foundry.memory.{search,update}` because the
+project MI is missing `Azure AI User` on the resource group — see the
+`azureclaw-deployment` skill notes), the controller now elevates the
+status to `Degraded=True / reason=AuthMisconfigured / Ready=False`
+instead of folding it into a generic
+`Awaiting / AwaitingRouterEnforcement` message. Auth misconfigs are
+not transient digest gaps; operators need a clear pointer at RBAC.
+
+- New reason constant `reason::AUTH_MISCONFIGURED` and shared
+  wire-prefix `conditions::AUTH_MISCONFIGURED_PREFIX = "AuthMisconfigured:"`
+  in `controller/src/status/conditions.rs`. The prefix is the
+  producer↔consumer wire contract: routers prepend it to
+  `PolicyStatusRegistry::record_error` messages on the `Memory`
+  policy kind, the controller scans for it on the
+  `/internal/policy-status` echo.
+- `claw_memory_reconciler::first_auth_misconfigured_message` is a
+  pure helper over `&[(String, Result<PolicyStatusResponse,
+  ConfirmError>)]` that scans **before** `decide_enforcement_state`
+  collapses per-sandbox structure into the aggregated Awaiting
+  message. Returns a deterministic `"<sandbox>: <error>"` (with a
+  trailing `(+N more sandbox(es) affected)` when multiple). Skips
+  unrelated `last_error` strings and other policy kinds.
+- Pre-scan runs in `reconcile` after `poll_referencing_sandboxes`;
+  on hit, `degraded = Some((reason::AUTH_MISCONFIGURED, msg))` and
+  the enforcement state short-circuits to `NotApplicable`, which
+  flows naturally through the existing `build_conditions` degraded
+  branch (Ready=False, Degraded=True, Progressing=False/Failed).
+- Controller-side only — the router-side producer (emitting the
+  `AuthMisconfigured:` prefix from the Foundry 403 path in
+  `mcp/platform.rs::post_json`) is a future slice. The contract is
+  pinned now so both sides land additively when the producer ships.
+- 5 new reconciler unit tests: detector returns `None` on clean polls,
+  ignores non-prefixed errors, ignores other policy kinds, returns the
+  first-match with multi-hit annotation, and skips failed polls. Plus
+  a `build_conditions` test asserting the final condition shape.
+
+Verified: 543 controller tests pass (+5 from 538 prior), clippy
+`-D warnings` clean across workspace, fmt clean.
+
 ### Slice 3b.3 — `foundry.memory` MCP tool reads ClawMemory binding
 
 The first **real consumer** of the Slice 3a ClawMemory binding: when

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -205,6 +205,17 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
     // router, and let the result drive both `phase` and the `Ready`
     // condition. The `compiled_digest` we just wrote is the value
     // every router must echo before we promote to Ready.
+    //
+    // Slice 3b.4 — auth probe surfacing. The pre-aggregation
+    // `results` carry per-sandbox `last_error` strings. We scan them
+    // for the router-side `AuthMisconfigured:` prefix (wire contract
+    // pinned in `crate::status::conditions::AUTH_MISCONFIGURED_PREFIX`)
+    // *before* the aggregator collapses them into the Awaiting
+    // message. When any sandbox surfaces an auth failure, we elevate
+    // `degraded` directly so the resulting `Degraded=True` /
+    // `reason=AuthMisconfigured` condition jumps to the top instead
+    // of getting buried inside a generic Awaiting message — RBAC
+    // misconfigs are not transient.
     let enforcement_state = if degraded.is_some() {
         RouterEnforcementState::NotApplicable
     } else {
@@ -225,7 +236,12 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
             }
         };
         let results = poll_referencing_sandboxes(&ctx.client, &ctx.http, &referrers).await;
-        decide_enforcement_state(&compiled_digest, "Memory", &results)
+        if let Some(msg) = first_auth_misconfigured_message(&results) {
+            degraded = Some((conditions::reason::AUTH_MISCONFIGURED, msg));
+            RouterEnforcementState::NotApplicable
+        } else {
+            decide_enforcement_state(&compiled_digest, "Memory", &results)
+        }
     };
 
     let loaded_digest: Option<String> = match &enforcement_state {
@@ -317,6 +333,45 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
 
 fn rfc3339_now() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Slice 3b.4 — scan the per-sandbox poll outcomes for a router-side
+/// `AuthMisconfigured:` `last_error` on the `Memory` policy kind. If
+/// any referencing sandbox surfaces one, return a deterministic
+/// message attributing the failure to that sandbox so the controller
+/// can elevate it to a `Degraded=True / reason=AuthMisconfigured`
+/// condition instead of folding it into a generic Awaiting message.
+///
+/// Returns the first match (sandbox iteration order is preserved by
+/// the upstream pollers, so this is stable across reconciles).
+/// Multiple-sandbox cases are flagged in the message tail.
+fn first_auth_misconfigured_message(
+    results: &[(
+        String,
+        Result<
+            crate::status::router_confirmation::PolicyStatusResponse,
+            crate::status::router_confirmation::ConfirmError,
+        >,
+    )],
+) -> Option<String> {
+    let mut hits: Vec<(String, String)> = Vec::new();
+    for (sandbox, outcome) in results {
+        if let Ok(resp) = outcome
+            && let Some(err) = resp.find_last_error("Memory")
+            && err.starts_with(conditions::AUTH_MISCONFIGURED_PREFIX)
+        {
+            hits.push((sandbox.clone(), err.to_string()));
+        }
+    }
+    if hits.is_empty() {
+        return None;
+    }
+    let (first_sb, first_err) = &hits[0];
+    let mut msg = format!("{first_sb}: {first_err}");
+    if hits.len() > 1 {
+        msg.push_str(&format!(" (+{} more sandbox(es) affected)", hits.len() - 1));
+    }
+    Some(msg)
 }
 
 fn build_conditions(
@@ -760,6 +815,121 @@ mod tests {
         let (domain, key) = FINALIZER.split_once('/').unwrap();
         assert_eq!(domain, "azureclaw.azure.com");
         assert!(!key.is_empty());
+    }
+
+    fn ok_resp(kind: &str, last_error: Option<&str>) -> router_confirmation::PolicyStatusResponse {
+        router_confirmation::PolicyStatusResponse {
+            schema_version: router_confirmation::SUPPORTED_SCHEMA_VERSION,
+            count: 1,
+            entries: vec![router_confirmation::PolicyStatusEntry {
+                kind: kind.to_string(),
+                digest: Some("sha256:dead".to_string()),
+                source_path: "/etc/azureclaw/memory/binding.json".to_string(),
+                loaded_at: "1970-01-01T00:00:00Z".to_string(),
+                last_error: last_error.map(str::to_string),
+            }],
+        }
+    }
+
+    #[test]
+    fn first_auth_misconfigured_message_none_when_no_errors() {
+        let results = vec![
+            ("sb-a".to_string(), Ok(ok_resp("Memory", None))),
+            ("sb-b".to_string(), Ok(ok_resp("Memory", None))),
+        ];
+        assert!(first_auth_misconfigured_message(&results).is_none());
+    }
+
+    #[test]
+    fn first_auth_misconfigured_message_ignores_unrelated_errors() {
+        // A non-prefixed `last_error` on Memory must not trip the
+        // AuthMisconfigured detector — generic transient errors stay
+        // in the Awaiting bucket.
+        let results = vec![(
+            "sb-a".to_string(),
+            Ok(ok_resp("Memory", Some("upstream 500"))),
+        )];
+        assert!(first_auth_misconfigured_message(&results).is_none());
+    }
+
+    #[test]
+    fn first_auth_misconfigured_message_ignores_other_kinds() {
+        // Router echoed AuthMisconfigured on a different policy kind
+        // — the ClawMemory reconciler must scope its scan to
+        // `kind == "Memory"`.
+        let results = vec![(
+            "sb-a".to_string(),
+            Ok(ok_resp(
+                "InferencePolicy",
+                Some("AuthMisconfigured: 403 from Foundry"),
+            )),
+        )];
+        assert!(first_auth_misconfigured_message(&results).is_none());
+    }
+
+    #[test]
+    fn first_auth_misconfigured_message_returns_first_hit() {
+        let results = vec![
+            (
+                "sb-a".to_string(),
+                Ok(ok_resp(
+                    "Memory",
+                    Some("AuthMisconfigured: 403 search_memories"),
+                )),
+            ),
+            (
+                "sb-b".to_string(),
+                Ok(ok_resp(
+                    "Memory",
+                    Some("AuthMisconfigured: 403 update_memories"),
+                )),
+            ),
+        ];
+        let msg = first_auth_misconfigured_message(&results).unwrap();
+        assert!(msg.starts_with("sb-a: AuthMisconfigured: 403 search_memories"));
+        assert!(msg.contains("+1 more sandbox(es) affected"));
+    }
+
+    #[test]
+    fn first_auth_misconfigured_message_skips_failed_polls() {
+        // Poll failures (Err) don't carry a router-reported
+        // last_error, so the detector must ignore them and not
+        // misattribute the failure as AuthMisconfigured.
+        let results = vec![(
+            "sb-a".to_string(),
+            Err(router_confirmation::ConfirmError::HttpStatus(503)),
+        )];
+        assert!(first_auth_misconfigured_message(&results).is_none());
+    }
+
+    #[test]
+    fn build_conditions_auth_misconfigured_sets_degraded_true_with_reason() {
+        // Slice 3b.4 — when the reconciler pre-scan elevates an
+        // AuthMisconfigured router error to `degraded`, the resulting
+        // conditions must surface that reason on Degraded (not a
+        // generic Awaiting) so operators get a clear pointer at the
+        // RBAC misconfig rather than a transient-looking digest gap.
+        let conds = build_conditions(
+            &[],
+            Some(1),
+            Some((
+                reason::AUTH_MISCONFIGURED,
+                "sb-a: AuthMisconfigured: 403 from Foundry",
+            )),
+            &RouterEnforcementState::NotApplicable,
+        );
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::FALSE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::TRUE);
+        assert_eq!(degraded.reason, reason::AUTH_MISCONFIGURED);
+        assert!(degraded.message.contains("AuthMisconfigured: 403"));
     }
 
     #[test]

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -222,7 +222,34 @@ pub mod reason {
     /// policy, the reconciler retries and (on success) promotes to
     /// `Ready` / `RouterEnforcing`.
     pub const NO_SANDBOXES_REFERENCING: &str = "NoSandboxesReferencing";
+
+    /// `crd-well-oiled-machine` Slice 3b.4 — `AuthMisconfigured`: at
+    /// least one referencing sandbox's router reported an upstream
+    /// authentication failure while consuming the compiled policy
+    /// (today: Foundry Memory Store returning 403 on the
+    /// `foundry.memory` MCP tool). This is *not* a transient network
+    /// error; it indicates a misconfigured project-MI or wrong
+    /// `Azure AI User` role assignment (see the
+    /// `azureclaw-deployment` skill notes on the project-MI
+    /// gotcha). The controller stamps `Ready=False` / `Degraded=True`
+    /// with this reason so operators don't waste time chasing
+    /// transient digest mismatches when the real problem is RBAC.
+    ///
+    /// Wire contract: the router records auth failures via
+    /// `PolicyStatusRegistry::record_error` with an
+    /// `AuthMisconfigured:` prefix on the message; the controller
+    /// matches that exact prefix on the `last_error` returned in
+    /// `/internal/policy-status` to elevate the condition.
+    pub const AUTH_MISCONFIGURED: &str = "AuthMisconfigured";
 }
+
+/// Slice 3b.4 wire-contract prefix routers attach to
+/// `PolicyStatusRegistry::record_error` messages when the upstream
+/// (Foundry Memory Store, today) rejected auth. The controller scans
+/// for this prefix to elevate the Degraded condition with
+/// `reason=AuthMisconfigured`. Kept here in `conditions` so producer
+/// and consumer share one source of truth.
+pub const AUTH_MISCONFIGURED_PREFIX: &str = "AuthMisconfigured:";
 
 /// Build a condition with a freshly-stamped `lastTransitionTime`.
 ///


### PR DESCRIPTION
Slice 3b.4 of `crd-well-oiled-machine`. Controller-side AuthMisconfigured Degraded condition for ClawMemory.

## What changes
When a referencing sandbox's router reports an upstream auth failure on the compiled ClawMemory binding (today: Foundry Memory Store 403 from a misconfigured project-MI / missing `Azure AI User` on the resource group — see the `azureclaw-deployment` skill notes), the controller now elevates to `Degraded=True / reason=AuthMisconfigured / Ready=False` instead of folding it into a generic `AwaitingRouterEnforcement` message.

## Why
Auth misconfigs are not transient digest gaps. Operators hitting a 403 from Foundry need a clear pointer at RBAC ("the project's MI needs Azure AI User on the resource group"), not a noisy "awaiting router enforcement" loop that masks the real problem.

## Wire contract (pinned now, producer lands separately)
- Routers prepend `AuthMisconfigured:` to `PolicyStatusRegistry::record_error` messages on the `Memory` policy kind.
- Controller scans for that exact prefix on the `/internal/policy-status` echo.
- One source of truth: `controller/src/status/conditions.rs::AUTH_MISCONFIGURED_PREFIX`.

## How
- `reason::AUTH_MISCONFIGURED` + `AUTH_MISCONFIGURED_PREFIX` constants in `controller/src/status/conditions.rs`.
- New pure helper `first_auth_misconfigured_message` in `claw_memory_reconciler` scans per-sandbox `last_error` on the `Memory` kind **before** `decide_enforcement_state` collapses them. Returns deterministic `"<sandbox>: <error>"` with a multi-hit tail; ignores non-prefixed errors, other kinds, and failed polls.
- Pre-scan in `reconcile` after `poll_referencing_sandboxes`; on hit sets `degraded` and short-circuits enforcement state to `NotApplicable`, flowing into the existing degraded branch of `build_conditions` unchanged.

## What's deferred
Router-side producer — emitting the `AuthMisconfigured:` prefix from the Foundry 403 path in `mcp/platform.rs::post_json` — is a follow-up slice. Touches more files (dispatcher gains a `PolicyStatusRegistry` handle, every constructor + test site updates). Wire contract pinned now so both sides land additively.

## Tests
- 5 new unit tests on the detector: clean polls return `None`; non-prefixed errors ignored; other policy kinds ignored; first-hit with multi-hit tail; failed polls skipped.
- 1 new `build_conditions` test asserting final condition shape (`Ready=False`, `Degraded=True`, `reason=AuthMisconfigured`).
- Existing reconciler suite untouched.

## Verification
- `cargo test --package azureclaw-controller` → **543 passed** (+5 from 538 baseline)
- `cargo clippy --all-targets -- -D warnings` → clean across workspace
- `cargo fmt --all -- --check` → clean

## Principles
- §3 (Ready ⇔ router echo): pre-scan happens **before** the aggregator so per-sandbox structure isn't lost; the controller still authoritatively decides Ready based on the router echo.
- §5 (no scaffolding): the consumer side ships first because it's safely additive — the producer side (router emitting the prefix) needs its own consumer-coupled PR. Half a contract is fine if both halves land before any UX promises are made.
- §6 (dev-only + tested): every new line covered by unit test.