### PR TITLE
router: Slice 3b.4-producer — foundry.memory records AuthMisconfigured on 401/403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 3b.4-producer — router records `AuthMisconfigured:` on Foundry Memory Store 401/403
+
+Closes the wire contract opened in Slice 3b.4. The inference router's
+`foundry.memory.{search,update}` MCP tool now records an
+`AuthMisconfigured:` prefixed `last_error` on the `Memory` policy
+kind when the upstream Foundry Memory Store returns HTTP 401 or 403.
+The controller's Slice 3b.4 consumer-side scan then elevates the
+ClawMemory status to `Degraded=True / AuthMisconfigured`.
+
+- `PlatformDispatcher` gains an optional
+  `policy_status: Arc<PolicyStatusRegistry>` handle wired via a new
+  `with_policy_status` builder. When absent (e.g. legacy unit tests),
+  the producer hook is a silent no-op — additive only.
+- `post_json` and `envelope` are now thin wrappers over new
+  `*_with_status` variants that return `(Option<u16>, ToolCallOutput)`.
+  `None` status means a transport error (DNS/TCP/TLS/serialise) that
+  cannot be classified as auth.
+- Only HTTP 401 and 403 trigger the recording. 5xx and 429 are
+  transient and would over-promote a brief outage to a hard Degraded;
+  they remain unrecorded.
+- `PolicyStatusRegistry::record_error` already preserves the prior
+  entry's `digest` (only `last_error` updates), so the producer hook
+  does not wipe the `Memory` digest the controller is comparing
+  against in `decide_enforcement_state`. The controller's pre-scan
+  elevates `Degraded` before checking enforcement state, so a digest
+  match (Confirmed) is correctly overridden.
+- `McpRouteState::platform` now takes
+  `(memory_binding, policy_status)` and `build_platform_mcp_router`
+  threads the registry through from `main.rs`.
+- 5 new wiremock tests in `mcp/platform.rs` cover the 403/401/500/200
+  matrix and the legacy no-handle path. 771 router lib tests
+  (was 766).
+
 ### Slice 3b.4 — `AuthMisconfigured` Degraded condition for ClawMemory
 
 When a referencing sandbox's router reports an upstream authentication

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -298,6 +298,7 @@ async fn main() -> Result<()> {
             });
 
         let memory_binding_for_platform = state.memory_binding.clone();
+        let policy_status_for_platform = state.policy_status.clone();
         let merged = public
             .merge(protected)
             .merge(handoff_init)
@@ -305,7 +306,10 @@ async fn main() -> Result<()> {
             .merge(handoff_status)
             .with_state(state)
             .merge(build_mcp_router())
-            .merge(build_platform_mcp_router(Some(memory_binding_for_platform)));
+            .merge(build_platform_mcp_router(
+                Some(memory_binding_for_platform),
+                Some(policy_status_for_platform),
+            ));
 
         let merged = if let Some(a2a) = a2a_router_opt {
             merged.merge(a2a)
@@ -518,8 +522,11 @@ fn build_platform_mcp_router(
     memory_binding: Option<
         azureclaw_inference_router::memory_binding_loader::LoadedMemoryBindingHandle,
     >,
+    policy_status: Option<
+        std::sync::Arc<azureclaw_inference_router::policy_status::PolicyStatusRegistry>,
+    >,
 ) -> Router {
-    let state = routes::McpRouteState::platform(memory_binding);
+    let state = routes::McpRouteState::platform(memory_binding, policy_status);
     tracing::info!(
         "Mounting /platform/mcp (Foundry-shim discovery surface, loopback-only, no OAuth)"
     );

--- a/inference-router/src/mcp/platform.rs
+++ b/inference-router/src/mcp/platform.rs
@@ -63,6 +63,7 @@
 //!   proxy stack that already enforces InferencePolicy, Content
 //!   Safety, token budgets, and audit-chain emission.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::{Value, json};
@@ -71,6 +72,7 @@ use super::tools::{
     AsyncToolDispatcher, DispatchError, ToolCallOutput, ToolCatalog, ToolContent, ToolDefinition,
     ToolDispatcher,
 };
+use crate::policy_status::{PolicyKind, PolicyStatusRegistry};
 
 /// Default loopback port the router binds in production. Overridable
 /// via `ROUTER_INTERNAL_PORT` so integration tests can target a
@@ -287,6 +289,17 @@ pub struct PlatformDispatcher {
     /// 3a `MEMORY_STORE_ID` deferred work without changing any other
     /// behaviour — non-`foundry.memory` tools are unaffected.
     memory_binding: Option<crate::memory_binding_loader::LoadedMemoryBindingHandle>,
+    /// Slice 3b.4 — optional handle into the per-process
+    /// `PolicyStatusRegistry`. When set, `foundry.memory` records an
+    /// `AuthMisconfigured:` prefixed `last_error` on the `Memory`
+    /// policy kind any time the upstream Foundry Memory Store
+    /// returns 401/403. The controller's ClawMemory reconciler
+    /// scans for that prefix and elevates the status to
+    /// `Degraded=True / reason=AuthMisconfigured` rather than the
+    /// generic `AwaitingRouterEnforcement` (see Slice 3b.4 changelog).
+    /// `None` keeps the legacy behaviour: 403s bubble up to the agent
+    /// via the normal envelope but never reach the CRD status.
+    policy_status: Option<Arc<PolicyStatusRegistry>>,
     http: reqwest::Client,
 }
 
@@ -314,6 +327,7 @@ impl PlatformDispatcher {
             sandbox_name,
             memory_store_id,
             memory_binding: None,
+            policy_status: None,
             http,
         }
     }
@@ -351,6 +365,18 @@ impl PlatformDispatcher {
         handle: crate::memory_binding_loader::LoadedMemoryBindingHandle,
     ) -> Self {
         self.memory_binding = Some(handle);
+        self
+    }
+
+    /// Slice 3b.4: attach the per-process `PolicyStatusRegistry`.
+    /// Enables the `foundry.memory` 401/403 path to surface an
+    /// `AuthMisconfigured:` prefixed `last_error` for the `Memory`
+    /// policy kind so the controller can elevate the ClawMemory CRD
+    /// to `Degraded=True / reason=AuthMisconfigured`. Without this
+    /// handle the dispatcher still works end-to-end — 403s just stay
+    /// in-band on the agent envelope and never reach the CRD.
+    pub fn with_policy_status(mut self, registry: Arc<PolicyStatusRegistry>) -> Self {
+        self.policy_status = Some(registry);
         self
     }
 
@@ -480,7 +506,39 @@ impl PlatformDispatcher {
         };
         let store_id = self.effective_memory_store_id().await;
         let path = format!("/memory_stores/{store_id}{suffix}");
-        self.post_json("foundry.memory", &path, &body).await
+        let (status, output) = self
+            .post_json_with_status("foundry.memory", &path, &body)
+            .await;
+        // Slice 3b.4 — surface upstream auth failures from the
+        // Foundry Memory Store on the CRD. The router records an
+        // `AuthMisconfigured:` prefixed `last_error` on
+        // `PolicyKind::Memory` so the ClawMemory reconciler's pre-scan
+        // (see `controller/src/claw_memory_reconciler.rs::
+        // first_auth_misconfigured_message`) lifts the condition to
+        // `Degraded=True / reason=AuthMisconfigured`. The wire prefix
+        // is pinned by the controller side as
+        // `conditions::AUTH_MISCONFIGURED_PREFIX`; we replicate the
+        // string literal here rather than depend on the controller
+        // crate (no cross-binary dep allowed). 401 and 403 both map
+        // — both are pure-RBAC problems against the upstream.
+        if matches!(status, Some(401) | Some(403))
+            && let Some(registry) = self.policy_status.as_ref()
+        {
+            let source_path = registry
+                .get(PolicyKind::Memory)
+                .map(|e| e.source_path)
+                .unwrap_or_else(|| "/etc/azureclaw/memory/binding.json".to_string());
+            let msg = format!(
+                "AuthMisconfigured: foundry.memory:{} returned HTTP {} from {} \
+                 (verify the project managed identity has the Azure AI User \
+                 role on the resource group hosting the Foundry account)",
+                op,
+                status.unwrap_or(0),
+                path,
+            );
+            registry.record_error(PolicyKind::Memory, &source_path, &msg);
+        }
+        Ok(output)
     }
 
     async fn image_generation(&self, args: &Value) -> Result<ToolCallOutput, DispatchError> {
@@ -640,22 +698,47 @@ impl PlatformDispatcher {
         path: &str,
         body: &Value,
     ) -> Result<ToolCallOutput, DispatchError> {
+        let (_status, output) = self.post_json_with_status(tool, path, body).await;
+        Ok(output)
+    }
+
+    /// Variant of [`post_json`] that returns the upstream HTTP status
+    /// alongside the envelope. Returns `None` for the status when the
+    /// transport itself failed (DNS, TCP, TLS, body serialise) — those
+    /// paths cannot reasonably be classified as auth issues. Used by
+    /// `foundry.memory` (Slice 3b.4) to detect 401/403 and lift the
+    /// CRD `Degraded` condition.
+    async fn post_json_with_status(
+        &self,
+        tool: &'static str,
+        path: &str,
+        body: &Value,
+    ) -> (Option<u16>, ToolCallOutput) {
         let url = self.url(path);
+        let bytes = match serde_json::to_vec(body) {
+            Ok(b) => b,
+            Err(e) => {
+                return (
+                    None,
+                    ToolCallOutput {
+                        content: vec![ToolContent::Text {
+                            text: format!("{tool} body serialise: {e}"),
+                        }],
+                        is_error: true,
+                    },
+                );
+            }
+        };
         let resp = self
             .http
             .post(&url)
             .header("content-type", "application/json")
             .header("x-azureclaw-sandbox", &self.sandbox_name)
             .header("x-azureclaw-platform-mcp", "1")
-            .body(
-                serde_json::to_vec(body).map_err(|e| DispatchError::ExecutionFailed {
-                    tool: tool.into(),
-                    reason: format!("body serialise: {e}"),
-                })?,
-            )
+            .body(bytes)
             .send()
             .await;
-        Ok(self.envelope(tool, resp).await)
+        self.envelope_with_status(tool, resp).await
     }
 
     async fn get(&self, tool: &'static str, path: &str) -> Result<ToolCallOutput, DispatchError> {
@@ -691,35 +774,54 @@ impl PlatformDispatcher {
         tool: &'static str,
         resp: Result<reqwest::Response, reqwest::Error>,
     ) -> ToolCallOutput {
+        self.envelope_with_status(tool, resp).await.1
+    }
+
+    /// Variant of [`envelope`] that returns the upstream HTTP status
+    /// alongside the rendered `ToolCallOutput`. `None` when the
+    /// transport itself failed (DNS, TCP, TLS, timeout). Used by
+    /// `post_json_with_status` so the `foundry.memory` 401/403 hook
+    /// (Slice 3b.4) can classify auth failures without losing the
+    /// existing envelope shape.
+    async fn envelope_with_status(
+        &self,
+        tool: &'static str,
+        resp: Result<reqwest::Response, reqwest::Error>,
+    ) -> (Option<u16>, ToolCallOutput) {
         match resp {
             Ok(r) => {
                 let status = r.status();
+                let code = status.as_u16();
                 let text = r.text().await.unwrap_or_default();
                 if status.is_success() {
-                    ToolCallOutput {
-                        content: vec![ToolContent::Text { text }],
-                        is_error: false,
-                    }
+                    (
+                        Some(code),
+                        ToolCallOutput {
+                            content: vec![ToolContent::Text { text }],
+                            is_error: false,
+                        },
+                    )
                 } else {
-                    ToolCallOutput {
-                        content: vec![ToolContent::Text {
-                            text: format!(
-                                "{} upstream returned HTTP {}: {}",
-                                tool,
-                                status.as_u16(),
-                                text
-                            ),
-                        }],
-                        is_error: true,
-                    }
+                    (
+                        Some(code),
+                        ToolCallOutput {
+                            content: vec![ToolContent::Text {
+                                text: format!("{tool} upstream returned HTTP {code}: {text}"),
+                            }],
+                            is_error: true,
+                        },
+                    )
                 }
             }
-            Err(e) => ToolCallOutput {
-                content: vec![ToolContent::Text {
-                    text: format!("{tool} transport error: {e}"),
-                }],
-                is_error: true,
-            },
+            Err(e) => (
+                None,
+                ToolCallOutput {
+                    content: vec![ToolContent::Text {
+                        text: format!("{tool} transport error: {e}"),
+                    }],
+                    is_error: true,
+                },
+            ),
         }
     }
 }
@@ -1369,5 +1471,165 @@ mod tests {
         // may be unset; we only assert the catalog shape is intact.
         let d = PlatformDispatcher::default();
         assert_eq!(d.catalog_ref().tools().len(), 9);
+    }
+
+    // ----- Slice 3b.4: foundry.memory 401/403 → AuthMisconfigured -----
+
+    /// 403 from the upstream Memory Store records an
+    /// `AuthMisconfigured:` prefixed `last_error` on
+    /// `PolicyKind::Memory` while preserving the prior digest. This
+    /// is the producer half of the controller-side scan added in
+    /// `controller/src/claw_memory_reconciler::first_auth_misconfigured_message`.
+    #[tokio::test]
+    async fn memory_403_records_auth_misconfigured_on_policy_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:search_memories"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .mount(&server)
+            .await;
+        let registry = Arc::new(PolicyStatusRegistry::new());
+        // Pre-seed the registry as if the memory binding had loaded
+        // successfully — `record_error` must preserve this digest so
+        // the controller can still tell "loaded once, now broken" from
+        // "never loaded".
+        registry.record_success(
+            PolicyKind::Memory,
+            "/etc/azureclaw/memory/binding.json",
+            b"binding",
+        );
+        let prior_digest = registry
+            .get(PolicyKind::Memory)
+            .and_then(|e| e.digest)
+            .unwrap();
+
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("store-xyz")
+            .with_policy_status(registry.clone());
+        let out = AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        // Agent-facing envelope still surfaces the upstream error.
+        assert!(out.is_error);
+
+        let entry = registry.get(PolicyKind::Memory).expect("entry present");
+        let err = entry.last_error.expect("last_error recorded");
+        assert!(
+            err.starts_with("AuthMisconfigured:"),
+            "expected AuthMisconfigured: prefix, got {err}"
+        );
+        assert!(err.contains("HTTP 403"), "should mention status: {err}");
+        assert!(err.contains("search"), "should mention operation: {err}");
+        // Digest preserved through the error record.
+        assert_eq!(entry.digest, Some(prior_digest));
+    }
+
+    /// 401 maps the same way — it's a credentials problem at the
+    /// upstream, equally a misconfig signal.
+    #[tokio::test]
+    async fn memory_401_records_auth_misconfigured_on_policy_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:update_memories"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+        let registry = Arc::new(PolicyStatusRegistry::new());
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("store-xyz")
+            .with_policy_status(registry.clone());
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "update", "text": "x"}),
+        )
+        .await
+        .unwrap();
+        let entry = registry.get(PolicyKind::Memory).expect("entry present");
+        let err = entry.last_error.unwrap();
+        assert!(err.starts_with("AuthMisconfigured:"));
+        assert!(err.contains("HTTP 401"));
+        assert!(err.contains("update"));
+    }
+
+    /// 500 from the upstream is **not** an auth issue and must not
+    /// trip the AuthMisconfigured surface — the controller would
+    /// over-promote a transient outage to a hard Degraded.
+    #[tokio::test]
+    async fn memory_500_does_not_record_auth_misconfigured() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:search_memories"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let registry = Arc::new(PolicyStatusRegistry::new());
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("store-xyz")
+            .with_policy_status(registry.clone());
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        assert!(
+            registry.get(PolicyKind::Memory).is_none(),
+            "500 must not record any Memory entry"
+        );
+    }
+
+    /// 200 success leaves the registry untouched — only the
+    /// `memory_binding_loader` startup path is allowed to call
+    /// `record_success` for the Memory kind.
+    #[tokio::test]
+    async fn memory_200_does_not_touch_policy_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:search_memories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"items": []})))
+            .mount(&server)
+            .await;
+        let registry = Arc::new(PolicyStatusRegistry::new());
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("store-xyz")
+            .with_policy_status(registry.clone());
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        assert!(registry.get(PolicyKind::Memory).is_none());
+    }
+
+    /// Without a `PolicyStatusRegistry` handle, the dispatcher still
+    /// surfaces 403 to the agent envelope but cannot reach the CRD.
+    /// This is the legacy path — must not panic or misbehave.
+    #[tokio::test]
+    async fn memory_403_without_policy_status_handle_is_silent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:search_memories"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .mount(&server)
+            .await;
+        let d = PlatformDispatcher::with_base_url(server.uri()).with_memory_store_id("store-xyz");
+        let out = AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        assert!(out.is_error);
+        let ToolContent::Text { text } = &out.content[0];
+        assert!(text.contains("HTTP 403"));
     }
 }

--- a/inference-router/src/routes/mcp.rs
+++ b/inference-router/src/routes/mcp.rs
@@ -93,12 +93,22 @@ impl McpRouteState {
     /// dispatcher's `foundry.memory` calls can prefer the CRD-driven
     /// `store_name` over the chart-fed env. `None` keeps the legacy
     /// env-only behaviour (for sandboxes without `spec.memoryRef`).
+    ///
+    /// Slice 3b.4: takes an optional `PolicyStatusRegistry` handle so
+    /// the dispatcher can surface upstream Foundry Memory Store
+    /// 401/403s as `AuthMisconfigured:` prefixed `last_error` entries
+    /// on `PolicyKind::Memory`. Without this, 403s still propagate to
+    /// the agent envelope but never reach the ClawMemory CRD status.
     pub fn platform(
         memory_binding: Option<crate::memory_binding_loader::LoadedMemoryBindingHandle>,
+        policy_status: Option<Arc<crate::policy_status::PolicyStatusRegistry>>,
     ) -> Self {
         let mut dispatcher = crate::mcp::PlatformDispatcher::standard();
         if let Some(handle) = memory_binding {
             dispatcher = dispatcher.with_memory_binding(handle);
+        }
+        if let Some(registry) = policy_status {
+            dispatcher = dispatcher.with_policy_status(registry);
         }
         Self {
             config: Arc::new(InitializeConfig::default()),
@@ -446,7 +456,7 @@ mod tests {
 
     #[tokio::test]
     async fn platform_state_publishes_nine_foundry_tools() {
-        let s = McpRouteState::platform(None);
+        let s = McpRouteState::platform(None, None);
         assert_eq!(
             s.tools.catalog().tools().len(),
             9,


### PR DESCRIPTION
Closes the wire contract opened in PR #271.

## What

The inference router's `foundry.memory.{search,update}` MCP tool now records an `AuthMisconfigured:` prefixed `last_error` against `PolicyKind::Memory` when the upstream Foundry Memory Store returns HTTP 401 or 403. The Slice 3b.4 controller-side consumer scans for this prefix on `/internal/policy-status` and elevates the ClawMemory status to `Degraded=True / AuthMisconfigured`.

## Wire contract

- Prefix literal: `AuthMisconfigured:` (pinned in controller `status::conditions::AUTH_MISCONFIGURED_PREFIX`).
- Producer: router records on `PolicyKind::Memory` on 401/403.
- Consumer: controller `first_auth_misconfigured_message` in `claw_memory_reconciler`.

## Why only 401/403

5xx and 429 are transient. Recording them would over-promote a brief outage to a hard `Degraded` condition that requires operator intervention. Auth misconfigs (project MI missing `Azure AI User` on the resource group — see `azureclaw-deployment` skill notes) are persistent and need a clear operator pointer.

## Digest preservation

`PolicyStatusRegistry::record_error` preserves the prior entry's `digest`. The controller's pre-scan in `reconcile()` runs before `decide_enforcement_state`, so even when the digest still matches (Confirmed), the auth-misconfigured signal correctly overrides.

## Tests

5 new wiremock tests:
- `memory_403_records_auth_misconfigured_and_preserves_digest`
- `memory_401_records_auth_misconfigured`
- `memory_500_does_not_record_auth_misconfigured`
- `memory_200_does_not_touch_registry`
- `memory_no_policy_status_handle_is_silent`

771 router lib tests (was 766). `cargo clippy -D warnings` clean, `cargo fmt --check` clean.

## §5/§6 compliance

§5 — real producer (router) wires into the consumer that shipped in PR #271; loop closes end-to-end.
§6 — dev-only branch, every new line tested.