### PR TITLE
clawmemory: Slice 3b.5 — MemoryStoreMissing Degraded on Foundry 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 3b.5 — `MemoryStoreMissing` Degraded condition for ClawMemory
+
+When the upstream Foundry Memory Store returns HTTP 404 on a
+`foundry.memory.{search,update}` call — the bound store does not
+exist on the Foundry account yet — the controller now elevates the
+ClawMemory status to `Degraded=True / reason=MemoryStoreMissing /
+Ready=False`. Today the openclaw runtime auto-creates stores lazily
+on first sync via `ensureMemoryStore`, but until that fires any
+direct router-side `foundry.memory.*` call against a fresh
+ClawMemory will 404, and operators need to know. Slice 3c.1 will
+ship router-side auto-provision at binding install, retiring this
+surface.
+
+- New reason constant `reason::MEMORY_STORE_MISSING` + shared wire
+  prefix `MEMORY_STORE_MISSING_PREFIX = "MemoryStoreMissing:"` in
+  `controller/src/status/conditions.rs`. Lives next to the Slice
+  3b.4 `AuthMisconfigured` siblings.
+- `claw_memory_reconciler` factors the auth-misconfigured detector
+  and the new missing-store detector through a shared
+  `first_prefixed_memory_error` helper. Both pre-scan
+  `find_last_error("Memory")` for the prefix and emit a
+  deterministic `"<sandbox>: <error>"` message with multi-hit tail.
+- Precedence in the reconcile pre-scan: `AuthMisconfigured` first,
+  `MemoryStoreMissing` second. RBAC dominates — if we can't read
+  the store, a 404 is not trustworthy as a "missing" signal.
+- Router-side producer in `inference-router/src/mcp/platform.rs::memory()`:
+  on `Some(404)` from the upstream, records
+  `MemoryStoreMissing:` prefixed `last_error` against
+  `PolicyKind::Memory`. 5xx/429 remain unrecorded (transient).
+  `record_error` preserves the prior digest as before.
+- 6 new controller tests (5 detector + 1 build_conditions) and 3
+  new router wiremock tests covering the 404 producer hook and the
+  no-handle legacy path. Controller 549 (+6), router lib 774 (+3).
+
 ### Slice 3b.4-producer — router records `AuthMisconfigured:` on Foundry Memory Store 401/403
 
 Closes the wire contract opened in Slice 3b.4. The inference router's

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -239,6 +239,16 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
         if let Some(msg) = first_auth_misconfigured_message(&results) {
             degraded = Some((conditions::reason::AUTH_MISCONFIGURED, msg));
             RouterEnforcementState::NotApplicable
+        } else if let Some(msg) = first_memory_store_missing_message(&results) {
+            // Slice 3b.5 — `MemoryStoreMissing:` is the second-tier
+            // Degraded signal. `AuthMisconfigured:` is checked first
+            // (RBAC dominates: if we can't read the store, we can't
+            // even tell if it's missing). A 404 means the bound
+            // store does not exist on the upstream — operator-
+            // visible until Slice 3c's router-side auto-provision
+            // ships.
+            degraded = Some((conditions::reason::MEMORY_STORE_MISSING, msg));
+            RouterEnforcementState::NotApplicable
         } else {
             decide_enforcement_state(&compiled_digest, "Memory", &results)
         }
@@ -354,11 +364,51 @@ fn first_auth_misconfigured_message(
         >,
     )],
 ) -> Option<String> {
+    first_prefixed_memory_error(results, conditions::AUTH_MISCONFIGURED_PREFIX)
+}
+
+/// Slice 3b.5 — scan the per-sandbox poll outcomes for a router-side
+/// `MemoryStoreMissing:` `last_error` on the `Memory` policy kind.
+/// Mirrors [`first_auth_misconfigured_message`] but matches the
+/// missing-store prefix.
+///
+/// Lower precedence than auth misconfigs: callers must check
+/// AuthMisconfigured first. 404 only tells you the store does not
+/// exist *given* the operator has access to ask; if RBAC is broken
+/// (403) the controller cannot trust a 404 result at all.
+fn first_memory_store_missing_message(
+    results: &[(
+        String,
+        Result<
+            crate::status::router_confirmation::PolicyStatusResponse,
+            crate::status::router_confirmation::ConfirmError,
+        >,
+    )],
+) -> Option<String> {
+    first_prefixed_memory_error(results, conditions::MEMORY_STORE_MISSING_PREFIX)
+}
+
+/// Shared scan-for-prefixed-error helper used by Slice 3b.4
+/// (`AuthMisconfigured:`) and Slice 3b.5 (`MemoryStoreMissing:`).
+/// Walks per-sandbox `PolicyStatusResponse` results, looks for
+/// `find_last_error("Memory")` starting with `prefix`, and returns a
+/// deterministic `"<sandbox>: <error>"` message with a tail when
+/// multiple sandboxes are affected.
+fn first_prefixed_memory_error(
+    results: &[(
+        String,
+        Result<
+            crate::status::router_confirmation::PolicyStatusResponse,
+            crate::status::router_confirmation::ConfirmError,
+        >,
+    )],
+    prefix: &str,
+) -> Option<String> {
     let mut hits: Vec<(String, String)> = Vec::new();
     for (sandbox, outcome) in results {
         if let Ok(resp) = outcome
             && let Some(err) = resp.find_last_error("Memory")
-            && err.starts_with(conditions::AUTH_MISCONFIGURED_PREFIX)
+            && err.starts_with(prefix)
         {
             hits.push((sandbox.clone(), err.to_string()));
         }
@@ -930,6 +980,112 @@ mod tests {
         assert_eq!(degraded.status, cond_status::TRUE);
         assert_eq!(degraded.reason, reason::AUTH_MISCONFIGURED);
         assert!(degraded.message.contains("AuthMisconfigured: 403"));
+    }
+
+    // ----- Slice 3b.5: MemoryStoreMissing detector + condition -----
+
+    #[test]
+    fn first_memory_store_missing_message_none_when_no_errors() {
+        let results = vec![
+            ("sb-a".to_string(), Ok(ok_resp("Memory", None))),
+            ("sb-b".to_string(), Ok(ok_resp("Memory", None))),
+        ];
+        assert!(first_memory_store_missing_message(&results).is_none());
+    }
+
+    #[test]
+    fn first_memory_store_missing_message_ignores_unrelated_errors() {
+        // A generic transient error and an AuthMisconfigured error
+        // must not trip the MemoryStoreMissing detector — those
+        // belong to other buckets (Awaiting / AuthMisconfigured).
+        let results = vec![
+            (
+                "sb-a".to_string(),
+                Ok(ok_resp("Memory", Some("upstream 500"))),
+            ),
+            (
+                "sb-b".to_string(),
+                Ok(ok_resp("Memory", Some("AuthMisconfigured: 403 search"))),
+            ),
+        ];
+        assert!(first_memory_store_missing_message(&results).is_none());
+    }
+
+    #[test]
+    fn first_memory_store_missing_message_ignores_other_kinds() {
+        // Router echoed `MemoryStoreMissing:` against a different
+        // policy kind. The ClawMemory reconciler scans only Memory.
+        let results = vec![(
+            "sb-a".to_string(),
+            Ok(ok_resp(
+                "InferencePolicy",
+                Some("MemoryStoreMissing: 404 search_memories"),
+            )),
+        )];
+        assert!(first_memory_store_missing_message(&results).is_none());
+    }
+
+    #[test]
+    fn first_memory_store_missing_message_returns_first_hit() {
+        let results = vec![
+            (
+                "sb-a".to_string(),
+                Ok(ok_resp(
+                    "Memory",
+                    Some("MemoryStoreMissing: 404 search_memories"),
+                )),
+            ),
+            (
+                "sb-b".to_string(),
+                Ok(ok_resp(
+                    "Memory",
+                    Some("MemoryStoreMissing: 404 update_memories"),
+                )),
+            ),
+        ];
+        let msg = first_memory_store_missing_message(&results).unwrap();
+        assert!(msg.starts_with("sb-a: MemoryStoreMissing: 404 search_memories"));
+        assert!(msg.contains("+1 more sandbox(es) affected"));
+    }
+
+    #[test]
+    fn first_memory_store_missing_message_skips_failed_polls() {
+        let results = vec![(
+            "sb-a".to_string(),
+            Err(router_confirmation::ConfirmError::HttpStatus(503)),
+        )];
+        assert!(first_memory_store_missing_message(&results).is_none());
+    }
+
+    #[test]
+    fn build_conditions_memory_store_missing_sets_degraded_true_with_reason() {
+        // Slice 3b.5 — when the reconciler pre-scan elevates a
+        // MemoryStoreMissing router error to `degraded`, the
+        // resulting conditions must surface that reason on Degraded
+        // (not Awaiting, not AuthMisconfigured) so operators get a
+        // clear pointer at the missing-store fact rather than a
+        // transient-looking digest gap.
+        let conds = build_conditions(
+            &[],
+            Some(1),
+            Some((
+                reason::MEMORY_STORE_MISSING,
+                "sb-a: MemoryStoreMissing: 404 from Foundry",
+            )),
+            &RouterEnforcementState::NotApplicable,
+        );
+        let ready = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_READY)
+            .unwrap();
+        assert_eq!(ready.status, cond_status::FALSE);
+        let degraded = conds
+            .iter()
+            .find(|c| c.type_ == conditions::TYPE_DEGRADED)
+            .unwrap();
+        assert_eq!(degraded.status, cond_status::TRUE);
+        assert_eq!(degraded.reason, reason::MEMORY_STORE_MISSING);
+        assert!(degraded.message.contains("MemoryStoreMissing: 404"));
     }
 
     #[test]

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -241,6 +241,27 @@ pub mod reason {
     /// matches that exact prefix on the `last_error` returned in
     /// `/internal/policy-status` to elevate the condition.
     pub const AUTH_MISCONFIGURED: &str = "AuthMisconfigured";
+
+    /// `crd-well-oiled-machine` Slice 3b.5 — `MemoryStoreMissing`: at
+    /// least one referencing sandbox's router observed an HTTP 404
+    /// from the upstream Foundry Memory Store on a
+    /// `foundry.memory.{search,update,...}` call. The store the
+    /// compiled `ClawMemory` binding points at does not exist (yet)
+    /// on the Foundry side. Today the openclaw runtime lazily
+    /// auto-creates stores via `ensureMemoryStore` on first sync, so
+    /// 404 is operator-visible up to the first runtime sync. Slice
+    /// 3c (router-side auto-provision at binding install) eliminates
+    /// the 404 path entirely.
+    ///
+    /// Wire contract: the router records 404s via
+    /// `PolicyStatusRegistry::record_error` with a
+    /// `MemoryStoreMissing:` prefix on the message; the controller
+    /// matches the exact prefix to elevate `Degraded=True`.
+    ///
+    /// Precedence: `AuthMisconfigured` outranks `MemoryStoreMissing`
+    /// — a 403 means the operator can't even check whether the
+    /// store exists, so RBAC dominates.
+    pub const MEMORY_STORE_MISSING: &str = "MemoryStoreMissing";
 }
 
 /// Slice 3b.4 wire-contract prefix routers attach to
@@ -250,6 +271,15 @@ pub mod reason {
 /// `reason=AuthMisconfigured`. Kept here in `conditions` so producer
 /// and consumer share one source of truth.
 pub const AUTH_MISCONFIGURED_PREFIX: &str = "AuthMisconfigured:";
+
+/// Slice 3b.5 wire-contract prefix routers attach to
+/// `PolicyStatusRegistry::record_error` messages when the upstream
+/// Foundry Memory Store returned HTTP 404 for the bound store. The
+/// controller scans for this prefix to elevate the Degraded
+/// condition with `reason=MemoryStoreMissing`. Lives next to
+/// `AUTH_MISCONFIGURED_PREFIX` so producer and consumer share one
+/// source of truth.
+pub const MEMORY_STORE_MISSING_PREFIX: &str = "MemoryStoreMissing:";
 
 /// Build a condition with a freshly-stamped `lastTransitionTime`.
 ///

--- a/inference-router/src/mcp/platform.rs
+++ b/inference-router/src/mcp/platform.rs
@@ -538,6 +538,34 @@ impl PlatformDispatcher {
             );
             registry.record_error(PolicyKind::Memory, &source_path, &msg);
         }
+        // Slice 3b.5 — surface "store does not exist on the upstream"
+        // as a Degraded condition. The runtime openclaw `ensureMemoryStore`
+        // path lazily auto-creates stores on first sync, but until that
+        // happens, any direct router-side `foundry.memory.*` call against
+        // a fresh ClawMemory CR will 404. Routers record the 404 with a
+        // `MemoryStoreMissing:` prefix on `PolicyKind::Memory`; the
+        // controller's `first_memory_store_missing_message` pre-scan
+        // (claw_memory_reconciler) elevates the condition to
+        // `Degraded=True / reason=MemoryStoreMissing`. Slice 3c.1 will
+        // ship router-side auto-provision at binding install, retiring
+        // this surface. The wire prefix is pinned controller-side as
+        // `conditions::MEMORY_STORE_MISSING_PREFIX`; replicated here as
+        // a literal because no cross-binary dep is allowed.
+        if status == Some(404)
+            && let Some(registry) = self.policy_status.as_ref()
+        {
+            let source_path = registry
+                .get(PolicyKind::Memory)
+                .map(|e| e.source_path)
+                .unwrap_or_else(|| "/etc/azureclaw/memory/binding.json".to_string());
+            let msg = format!(
+                "MemoryStoreMissing: foundry.memory:{op} returned HTTP 404 from {path} \
+                 (the bound store does not exist on the upstream Foundry account; \
+                 it will be auto-created on the next runtime sync, or you can \
+                 pre-create it via the Foundry portal)",
+            );
+            registry.record_error(PolicyKind::Memory, &source_path, &msg);
+        }
         Ok(output)
     }
 
@@ -1631,5 +1659,117 @@ mod tests {
         assert!(out.is_error);
         let ToolContent::Text { text } = &out.content[0];
         assert!(text.contains("HTTP 403"));
+    }
+
+    // ----- Slice 3b.5: foundry.memory 404 → MemoryStoreMissing -----
+
+    /// 404 from the upstream Memory Store records a
+    /// `MemoryStoreMissing:` prefixed `last_error` on
+    /// `PolicyKind::Memory` while preserving the prior digest. The
+    /// controller's `first_memory_store_missing_message` pre-scan
+    /// (claw_memory_reconciler) elevates this to
+    /// `Degraded=True / reason=MemoryStoreMissing`. 404 has lower
+    /// precedence than 401/403 (RBAC dominates), so callers must
+    /// check AuthMisconfigured first — which they do.
+    #[tokio::test]
+    async fn memory_404_records_memory_store_missing_on_policy_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:search_memories"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        let registry = Arc::new(PolicyStatusRegistry::new());
+        registry.record_success(
+            PolicyKind::Memory,
+            "/etc/azureclaw/memory/binding.json",
+            b"binding",
+        );
+        let prior_digest = registry
+            .get(PolicyKind::Memory)
+            .and_then(|e| e.digest)
+            .unwrap();
+
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("store-xyz")
+            .with_policy_status(registry.clone());
+        let out = AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        assert!(out.is_error);
+
+        let entry = registry.get(PolicyKind::Memory).expect("entry present");
+        let err = entry.last_error.expect("last_error recorded");
+        assert!(
+            err.starts_with("MemoryStoreMissing:"),
+            "expected MemoryStoreMissing: prefix, got {err}"
+        );
+        assert!(err.contains("HTTP 404"), "should mention status: {err}");
+        assert!(err.contains("search"), "should mention operation: {err}");
+        // Digest preserved through the error record (matches the
+        // 3b.4 design — record_error never wipes the digest).
+        assert_eq!(entry.digest, Some(prior_digest));
+    }
+
+    /// 404 must NOT trip the AuthMisconfigured surface — the
+    /// controller would attribute a missing store to RBAC and
+    /// mislead the operator. The `MemoryStoreMissing:` prefix is
+    /// the only signal recorded.
+    #[tokio::test]
+    async fn memory_404_does_not_record_auth_misconfigured() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:update_memories"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        let registry = Arc::new(PolicyStatusRegistry::new());
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("store-xyz")
+            .with_policy_status(registry.clone());
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "update", "text": "x"}),
+        )
+        .await
+        .unwrap();
+        let err = registry
+            .get(PolicyKind::Memory)
+            .and_then(|e| e.last_error)
+            .expect("404 must record an error");
+        assert!(
+            !err.starts_with("AuthMisconfigured:"),
+            "404 must not be classified as AuthMisconfigured: {err}"
+        );
+        assert!(err.starts_with("MemoryStoreMissing:"));
+    }
+
+    /// Without a `PolicyStatusRegistry` handle, the dispatcher still
+    /// surfaces 404 to the agent envelope but cannot reach the CRD.
+    /// Legacy path — must not panic.
+    #[tokio::test]
+    async fn memory_404_without_policy_status_handle_is_silent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:search_memories"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        let d = PlatformDispatcher::with_base_url(server.uri()).with_memory_store_id("store-xyz");
+        let out = AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "text": "q"}),
+        )
+        .await
+        .unwrap();
+        assert!(out.is_error);
+        let ToolContent::Text { text } = &out.content[0];
+        assert!(text.contains("HTTP 404"));
     }
 }


### PR DESCRIPTION
Follow-on to Slice 3b.4 (PRs #271 + #272). Same wire-contract pattern, second prefix.

## What

When the upstream Foundry Memory Store returns HTTP 404 on a `foundry.memory.{search,update}` call, the controller now elevates the ClawMemory status to `Degraded=True / reason=MemoryStoreMissing`.

## Wire contract

- Prefix literal: `MemoryStoreMissing:` (pinned controller-side in `status::conditions::MEMORY_STORE_MISSING_PREFIX`).
- Producer: router records on `PolicyKind::Memory` on 404.
- Consumer: controller `first_memory_store_missing_message` in `claw_memory_reconciler`.

## Precedence

`AuthMisconfigured` (Slice 3b.4) outranks `MemoryStoreMissing`. If RBAC is broken (403), a 404 isn't a trustworthy 'missing store' signal — the operator can't even check.

## Why factor a shared helper

Both `first_auth_misconfigured_message` and `first_memory_store_missing_message` now route through `first_prefixed_memory_error(prefix)`. One scan implementation, two callers. Lets future Slice 3c.x prefixes plug in without copy-paste.

## Tests

- 6 new controller tests (5 detector + 1 build_conditions)
- 3 new router wiremock tests:
  - `memory_404_records_memory_store_missing_on_policy_status`
  - `memory_404_does_not_record_auth_misconfigured`
  - `memory_404_without_policy_status_handle_is_silent`

Controller 549 (+6), router lib 774 (+3). `cargo clippy -D warnings` clean, `cargo fmt --check` clean.

## §5/§6 compliance

§5 — both producer and consumer ship in this PR, end-to-end loop closes.
§6 — dev-only branch, every new line tested.