### PR TITLE
slice-2 dod #7: inference_policy_digest on every inference audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 2 DoD #7 — `inference_policy_digest` on every audit log emission
+
+Every inference-path audit log emitted from the router now carries
+`inference_policy_digest = <hex>` as a structured tracing field, so
+forensics can map a denial / budget-reject / content-safety-floor
+violation back to the exact `InferencePolicy` snapshot the router
+was operating on at the time. Closes Slice 2 DoD #7.
+
+What this PR adds:
+
+- `routes/chat_completions.rs`: snapshot `InferencePolicy` moved
+  above the AGT denial check (was below), so the AGT deny warn,
+  the budget-exceeded warn, the perRequestTokens reject warn, the
+  buffered `contentSafety` floor warn, the streaming `contentSafety`
+  floor warn (digest cloned into the `move` closure), the
+  post-response per-request-limit warn, and the output-policy deny
+  warn all carry `inference_policy_digest` alongside `decision`
+  and `gate` fields under `target: "inference.audit"`.
+- `routes/inference.rs`: same treatment for `responses()`. Snapshot
+  hoisted above the AGT denial branch; the new budget-exceeded
+  audit warn (was previously silent — the handler returned 429
+  without a tracing line) and the per-request "Responses API
+  request" info line both carry the digest.
+- No new dependency on `tracing-test`. The fields are emitted to
+  every subscriber attached to the `inference.audit` target —
+  asserted indirectly by the existing 784 router lib tests + 3
+  failover walk integration tests staying green.
+
+What this PR intentionally does not do:
+
+- No change to the wire format of any handler response — only
+  observability surface.
+- No new structured-log subscriber config in the Helm chart. The
+  `inference.audit` target is reachable from the default
+  tracing-subscriber pipeline (env-filter `info,inference.audit=info`
+  works out of the box); operators wanting to ship audit JSON to a
+  separate sink can add a per-target layer in a follow-up slice.
+- No change to the governance hash-chain `audit.log()` path —
+  that's a separate audit surface (handoff routes only) and is
+  already tamper-evident.
+
 ### Slice 3c.1 — Router-side auto-provision Foundry Memory Store on 404
 
 When a `foundry.memory.{search,update}` MCP call hits a Foundry

--- a/inference-router/src/routes/chat_completions.rs
+++ b/inference-router/src/routes/chat_completions.rs
@@ -43,6 +43,20 @@ pub(super) async fn chat_completions(
         })
         .unwrap_or("unknown");
 
+    // Slice 2 DoD #7 — `inference_policy_digest` on the audit log
+    // surface. Snapshot the loaded `InferencePolicy` first so every
+    // structured log emitted from this handler (denial warns,
+    // budget rejects, per-request cap rejects, content-safety floor
+    // violations, forward success/fail) can carry the same digest
+    // field. Forensics can then map "request denied at 14:32" to
+    // "router was operating on policy digest X" without inferring
+    // the policy state from coincident time windows. The read is
+    // cheap (one `RwLock::read().await` over a snapshot type that
+    // clones in O(1)), so moving it above the AGT check costs nothing
+    // on the hot path. Slice 2c had this same read further down for
+    // budget enforcement only — DoD #7 unifies the timing.
+    let policy = crate::inference_policy_loader::current_snapshot(&state.inference_policy).await;
+
     // Foundry guardrails (DefaultV2) handle content safety and prompt shields
     // at inference time — no pre-flight calls needed. We parse the response
     // annotations after forwarding and report flags to AGT governance.
@@ -57,7 +71,15 @@ pub(super) async fn chat_completions(
         if let super::inference_policy::InferenceDecision::Deny(reason) =
             super::inference_policy::check(&state, sandbox_name, &action).await
         {
-            tracing::warn!(sandbox = %sandbox_name, %reason, "AGT policy DENIED inference (enforcing)");
+            tracing::warn!(
+                target: "inference.audit",
+                sandbox = %sandbox_name,
+                inference_policy_digest = %policy.digest,
+                decision = "deny",
+                gate = "agt_policy",
+                %reason,
+                "AGT policy DENIED inference (enforcing)"
+            );
             return (
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!({
@@ -72,15 +94,10 @@ pub(super) async fn chat_completions(
         }
     }
 
-    // Slice 2c latency optimisation: take **one** snapshot of the
-    // loaded `InferencePolicy` at the top of the handler and reuse
-    // it for every downstream enforcement axis (daily/monthly tokens,
-    // perRequestTokens cap, contentSafety floor — both buffered and
-    // streaming branches). Previously the handler took three
-    // independent `RwLock::read().await`s per request; this
-    // consolidates them to one, removing two awaits from every
-    // forwarded request on the hot path.
-    let policy = crate::inference_policy_loader::current_snapshot(&state.inference_policy).await;
+    // Slice 2c latency optimisation kept its shape: `policy` snapshot
+    // is reused across every enforcement axis below (daily/monthly
+    // tokens, perRequestTokens cap, contentSafety floor — both
+    // buffered and streaming branches).
 
     // Check token budget before forwarding — daily/monthly limits
     // come from the loaded `InferencePolicy` (Slice 2b) with the
@@ -90,7 +107,14 @@ pub(super) async fn chat_completions(
         .check_budget(sandbox_name, policy.daily_tokens, policy.monthly_tokens)
         .await
     {
-        tracing::warn!(sandbox = %sandbox_name, "Token budget exceeded: {msg}");
+        tracing::warn!(
+            target: "inference.audit",
+            sandbox = %sandbox_name,
+            inference_policy_digest = %policy.digest,
+            decision = "deny",
+            gate = "token_budget",
+            "Token budget exceeded: {msg}"
+        );
         return (
             StatusCode::TOO_MANY_REQUESTS,
             Json(serde_json::json!({
@@ -120,10 +144,13 @@ pub(super) async fn chat_completions(
             decide_per_request_gate(Some(cap), Some(requested))
     {
         tracing::warn!(
+            target: "inference.audit",
             sandbox = %sandbox_name,
             requested,
             cap,
-            digest = %policy.digest,
+            inference_policy_digest = %policy.digest,
+            decision = "deny",
+            gate = "per_request_tokens",
             "InferencePolicy perRequestTokens exceeded — rejecting"
         );
         return (
@@ -313,6 +340,7 @@ pub(super) async fn chat_completions(
         // for the in-flight request; acceptable since policies change
         // rarely vs. single-request lifetime.
         let stream_floor = policy.content_safety.clone();
+        let stream_policy_digest = policy.digest.clone();
         match proxy::forward_stream(
             state.auth.clone(),
             Some(state.copilot.clone()),
@@ -419,6 +447,7 @@ pub(super) async fn chat_completions(
                 // stream.
                 let stream_blocked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                 let floor_for_stream = stream_floor.clone();
+                let digest_for_stream = stream_policy_digest.clone();
                 let wrapped = stream.map(move |chunk| {
                     use std::sync::atomic::Ordering;
                     if stream_blocked.load(Ordering::Relaxed) {
@@ -461,8 +490,12 @@ pub(super) async fn chat_completions(
                                 {
                                     stream_blocked.store(true, Ordering::Relaxed);
                                     tracing::warn!(
+                                        target: "inference.audit",
                                         sandbox = %sandbox_for_flags,
                                         code = violation.code(),
+                                        inference_policy_digest = %digest_for_stream,
+                                        decision = "deny",
+                                        gate = "content_safety_floor_stream",
                                         "InferencePolicy contentSafety floor (stream): {}",
                                         violation.message()
                                     );
@@ -615,7 +648,14 @@ pub(super) async fn chat_completions(
                     state.budget.record_usage(sandbox_name, total).await;
 
                     if let Err(msg) = state.budget.check_per_request(total) {
-                        tracing::warn!(sandbox = %sandbox_name, "Per-request limit: {msg}");
+                        tracing::warn!(
+                            target: "inference.audit",
+                            sandbox = %sandbox_name,
+                            inference_policy_digest = %policy.digest,
+                            decision = "post_response_warn",
+                            gate = "per_request_tokens",
+                            "Per-request limit: {msg}"
+                        );
                     }
                 }
 
@@ -665,8 +705,12 @@ pub(super) async fn chat_completions(
                             safety::enforce_floor(&body_json, &policy.content_safety)
                         {
                             tracing::warn!(
+                                target: "inference.audit",
                                 sandbox = %sandbox_name,
                                 code = violation.code(),
+                                inference_policy_digest = %policy.digest,
+                                decision = "deny",
+                                gate = "content_safety_floor",
                                 "InferencePolicy contentSafety floor: {}",
                                 violation.message()
                             );
@@ -709,8 +753,15 @@ pub(super) async fn chat_completions(
                             if let super::inference_policy::InferenceDecision::Deny(reason) =
                                 super::inference_policy::check(&state, sandbox_name, &action).await
                             {
-                                tracing::warn!(sandbox = %sandbox_name, %reason,
-                                    "AGT: model response blocked by output policy");
+                                tracing::warn!(
+                                    target: "inference.audit",
+                                    sandbox = %sandbox_name,
+                                    %reason,
+                                    inference_policy_digest = %policy.digest,
+                                    decision = "deny",
+                                    gate = "output_policy",
+                                    "AGT: model response blocked by output policy"
+                                );
                                 return (
                                     axum::http::StatusCode::FORBIDDEN,
                                     Body::from(

--- a/inference-router/src/routes/inference.rs
+++ b/inference-router/src/routes/inference.rs
@@ -250,6 +250,10 @@ async fn responses(
         })
         .unwrap_or("unknown");
 
+    // Slice 2 DoD #7 — snapshot policy early so every audit log
+    // emitted from this handler can carry `inference_policy_digest`.
+    let policy = crate::inference_policy_loader::current_snapshot(&state.inference_policy).await;
+
     // AGT policy check via the four-seam PolicyDecisionProvider.
     {
         let model = serde_json::from_slice::<serde_json::Value>(&body)
@@ -260,7 +264,15 @@ async fn responses(
         if let super::inference_policy::InferenceDecision::Deny(reason) =
             super::inference_policy::check(&state, sandbox_name, &action).await
         {
-            tracing::warn!(sandbox = %sandbox_name, %reason, "AGT policy DENIED responses inference");
+            tracing::warn!(
+                target: "inference.audit",
+                sandbox = %sandbox_name,
+                %reason,
+                inference_policy_digest = %policy.digest,
+                decision = "deny",
+                gate = "agt_policy",
+                "AGT policy DENIED responses inference"
+            );
             return (
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!({
@@ -278,13 +290,19 @@ async fn responses(
     // Budget check — daily/monthly limits sourced from the loaded
     // `InferencePolicy` (Slice 2b); falls back to the env-driven
     // `TOKEN_BUDGET_DAILY` default when no policy is loaded.
-    // Latency: one snapshot read per request (mirrors chat_completions).
-    let policy = crate::inference_policy_loader::current_snapshot(&state.inference_policy).await;
     if let Err(msg) = state
         .budget
         .check_budget(sandbox_name, policy.daily_tokens, policy.monthly_tokens)
         .await
     {
+        tracing::warn!(
+            target: "inference.audit",
+            sandbox = %sandbox_name,
+            inference_policy_digest = %policy.digest,
+            decision = "deny",
+            gate = "token_budget",
+            "Token budget exceeded: {msg}"
+        );
         return errors::openai(
             StatusCode::TOO_MANY_REQUESTS,
             msg,
@@ -301,7 +319,15 @@ async fn responses(
     // (`build_candidates` starts with `primary.deployment` and walks
     // outward), so this single call subsumes the override + the
     // retry loop in one place.
-    tracing::info!(sandbox = %sandbox_name, model = %upstream.deployment, "Responses API request");
+    tracing::info!(
+        target: "inference.audit",
+        sandbox = %sandbox_name,
+        model = %upstream.deployment,
+        inference_policy_digest = %policy.digest,
+        decision = "allow",
+        gate = "forward",
+        "Responses API request"
+    );
 
     match crate::failover::forward_with_failover(
         &state.auth,


### PR DESCRIPTION
Closes Slice 2 DoD #7 — every inference-path audit log carries `inference_policy_digest` so forensics can map decisions back to the exact policy snapshot the router was operating on. See CHANGELOG entry for details. 784 router lib tests green, clippy -D warnings clean, fmt clean.