### PR TITLE
feat(cli): azureclaw audit tail — stream durable JSONL audit log (Slice 4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
-### Slice 4a — durable JSONL audit sink (DoD #4)
+### Slice 4b — `azureclaw audit tail` CLI (DoD #7)
+
+Slice 4a wrote a durable JSONL audit log to
+`/var/log/azureclaw/audit/{YYYY-MM-DD}.jsonl` inside the
+`inference-router` container. Slice 4b gives operators a first-class
+way to read it — no port-forward, no `kubectl exec` incantation
+memorisation, no jq pipelines on a 50 KB-line file.
+
+What this PR adds:
+
+- New `cli/src/commands/audit.ts` — `azureclaw audit tail <sandbox>`
+  shells into the sandbox pod's `inference-router` container and
+  `tail`s the day-keyed JSONL file. Supports `--follow` for live
+  streams, `--lines N` (cap 10000), `--decision`, `--agent`,
+  `--action` substring filters, `--date YYYY-MM-DD` for historical
+  files, `--json` for machine-readable output, and `--dir` to
+  override the in-pod audit directory when the operator has changed
+  `AZURECLAW_AUDIT_DIR`.
+- Pretty render colours by decision (`allowed`/`success` green,
+  `denied`/`flagged`/`rejected` red, `sanitized` yellow); truncates
+  long agent_ids and actions with `…`; aligns columns for grep.
+- `--date` input is regex-validated (`^\d{4}-\d{2}-\d{2}$`) before
+  the shell escape — shell-metacharacter attempts via `--date` are
+  rejected at the CLI boundary.
+- Wired into `cli.ts` under the Observability command group
+  (`trace`, `eval`, `operator`, `audit`).
+- 26 new vitest cases cover line parsing, filter combinations,
+  date-key validation, lines bounds, pretty rendering, and graceful
+  handling of malformed input lines (the tail keeps going).
+
+**DoD coverage:** Slice 4 DoD #7 satisfied. Remaining 4b deferrals
+(historical multi-day search, jq-friendly raw-row alias) tracked
+under Slice 4c.
+
+
 
 The router's audit chain has always been an in-memory `Vec<AuditEntry>`
 (via `agentmesh::AuditLogger`). On router restart, every audit row was

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -31,6 +31,7 @@ import { inferencePolicyCommand } from "./commands/inferencepolicy.js";
 import { mcpCommand } from "./commands/mcp.js";
 import { memoryCommand } from "./commands/memory.js";
 import { inspectCommand } from "./commands/inspect.js";
+import { auditCommand } from "./commands/audit.js";
 
 export function createCli(): Command {
   const program = new Command();
@@ -67,6 +68,7 @@ export function createCli(): Command {
   program.addCommand(traceCommand());
   program.addCommand(evalCommand());
   program.addCommand(operatorCommand());
+  program.addCommand(auditCommand());
 
   // Agent mobility
   program.addCommand(handoffCommand());
@@ -93,7 +95,7 @@ Command groups:
   Lifecycle       up, dev, add, push, destroy
   Operations      connect, status, list, logs, inspect
   Configuration   credentials, model, policy, egress
-  Observability   trace, eval, operator
+  Observability   trace, eval, operator, audit
   Agent mobility  handoff, mesh, pair
   Interop         convert, a2a, a2a-agent, migrate
   Governance      toolpolicy, inferencepolicy, mcp

--- a/cli/src/commands/audit.test.ts
+++ b/cli/src/commands/audit.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "vitest";
+import {
+  AuditRow,
+  matchesFilters,
+  parseLines,
+  parseRow,
+  renderPrettyLine,
+  renderHeader,
+  todayUtcKey,
+  validateDateKey,
+} from "./audit.js";
+
+const sample: AuditRow = {
+  sandbox: "test-bot",
+  seq: 42,
+  ts: "2026-05-13T11:22:33.456Z",
+  agent_id: "agent-alpha",
+  action: "tool.call.search_web",
+  decision: "allowed",
+  prev_hash: "0".repeat(64),
+  hash: "1".repeat(64),
+};
+
+describe("audit tail — parseLines", () => {
+  it("returns the default when undefined", () => {
+    expect(parseLines(undefined)).toBe(50);
+  });
+  it("parses valid positive integers", () => {
+    expect(parseLines("200")).toBe(200);
+  });
+  it("rejects non-numeric input", () => {
+    expect(() => parseLines("nope")).toThrow(/positive integer/);
+  });
+  it("rejects zero", () => {
+    expect(() => parseLines("0")).toThrow(/positive integer/);
+  });
+  it("rejects negatives", () => {
+    expect(() => parseLines("-5")).toThrow(/positive integer/);
+  });
+  it("rejects values above the cap", () => {
+    expect(() => parseLines("10001")).toThrow(/safe cap of 10000/);
+  });
+  it("accepts the cap exactly", () => {
+    expect(parseLines("10000")).toBe(10000);
+  });
+});
+
+describe("audit tail — todayUtcKey", () => {
+  it("formats UTC date as YYYY-MM-DD", () => {
+    const fixed = new Date(Date.UTC(2026, 4, 13, 23, 59, 59));
+    expect(todayUtcKey(fixed)).toBe("2026-05-13");
+  });
+  it("pads single-digit month and day", () => {
+    const fixed = new Date(Date.UTC(2030, 0, 7, 0, 0, 0));
+    expect(todayUtcKey(fixed)).toBe("2030-01-07");
+  });
+});
+
+describe("audit tail — validateDateKey", () => {
+  it("accepts well-formed keys", () => {
+    expect(() => validateDateKey("2026-05-13")).not.toThrow();
+  });
+  it("rejects shorter formats", () => {
+    expect(() => validateDateKey("26-5-13")).toThrow(/YYYY-MM-DD/);
+  });
+  it("rejects extra text", () => {
+    expect(() => validateDateKey("2026-05-13.jsonl")).toThrow();
+  });
+  it("rejects shell-metacharacter attempts", () => {
+    expect(() => validateDateKey("2026-05-13' || rm -rf /")).toThrow();
+  });
+});
+
+describe("audit tail — parseRow", () => {
+  it("round-trips a valid record", () => {
+    const line = JSON.stringify(sample);
+    expect(parseRow(line)).toEqual(sample);
+  });
+  it("ignores extra fields gracefully (forward-compat)", () => {
+    const line = JSON.stringify({ ...sample, future_field: "x" });
+    const parsed = parseRow(line);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.seq).toBe(sample.seq);
+  });
+  it("returns null on malformed JSON", () => {
+    expect(parseRow("{ not json")).toBeNull();
+  });
+  it("returns null when fields have wrong types", () => {
+    const bad = JSON.stringify({ ...sample, seq: "not a number" });
+    expect(parseRow(bad)).toBeNull();
+  });
+  it("returns null when fields are missing", () => {
+    const partial = JSON.stringify({ sandbox: "s", seq: 1 });
+    expect(parseRow(partial)).toBeNull();
+  });
+});
+
+describe("audit tail — matchesFilters", () => {
+  it("matches by decision exactly", () => {
+    expect(matchesFilters(sample, { decision: "allowed" })).toBe(true);
+    expect(matchesFilters(sample, { decision: "denied" })).toBe(false);
+  });
+  it("matches by agent_id exactly", () => {
+    expect(matchesFilters(sample, { agent: "agent-alpha" })).toBe(true);
+    expect(matchesFilters(sample, { agent: "agent-beta" })).toBe(false);
+  });
+  it("matches by action substring", () => {
+    expect(matchesFilters(sample, { action: "search_web" })).toBe(true);
+    expect(matchesFilters(sample, { action: "tool.call" })).toBe(true);
+    expect(matchesFilters(sample, { action: "nope" })).toBe(false);
+  });
+  it("combines filters via AND", () => {
+    expect(
+      matchesFilters(sample, {
+        decision: "allowed",
+        agent: "agent-alpha",
+        action: "tool.call",
+      })
+    ).toBe(true);
+    expect(
+      matchesFilters(sample, {
+        decision: "allowed",
+        agent: "agent-alpha",
+        action: "missing",
+      })
+    ).toBe(false);
+  });
+  it("passes through when no filters are set", () => {
+    expect(matchesFilters(sample, {})).toBe(true);
+  });
+});
+
+describe("audit tail — rendering", () => {
+  it("produces a header row with the expected columns", () => {
+    const header = renderHeader();
+    expect(header).toContain("seq");
+    expect(header).toContain("timestamp");
+    expect(header).toContain("decision");
+    expect(header).toContain("agent");
+    expect(header).toContain("action");
+  });
+  it("renders a row with seq, truncated timestamp, decision, agent, action", () => {
+    const line = renderPrettyLine(sample);
+    expect(line).toContain("42");
+    expect(line).toContain("2026-05-13T11:22:33");
+    expect(line).toContain("allowed");
+    expect(line).toContain("agent-alpha");
+    expect(line).toContain("tool.call.search_web");
+  });
+  it("truncates very long agent_ids and actions", () => {
+    const long: AuditRow = {
+      ...sample,
+      agent_id: "x".repeat(120),
+      action: "y".repeat(200),
+    };
+    const line = renderPrettyLine(long);
+    expect(line).toContain("…");
+  });
+});

--- a/cli/src/commands/audit.ts
+++ b/cli/src/commands/audit.ts
@@ -1,0 +1,319 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `azureclaw audit tail <sandbox>` — stream the durable JSONL audit
+//! log produced by the router's `audit_jsonl::JsonlAuditWriter`
+//! (Slice 4 DoD #4 + #7).
+//!
+//! The router writes one JSON line per `agentmesh::AuditEntry` to
+//! `/var/log/azureclaw/audit/{YYYY-MM-DD}.jsonl` inside the
+//! `inference-router` container. This command shells into the pod
+//! and runs `cat`/`tail` against today's file, optionally filtering
+//! and pretty-printing the rows.
+//!
+//! No port-forward, no host process — matches the operational
+//! pattern established by `azureclaw inspect`. The router's local
+//! file is the authoritative source; remote sinks (Slice 4c) will
+//! mirror the same lines.
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { execa } from "execa";
+
+/// Default audit-log directory inside the sandbox pod. Matches
+/// `AZURECLAW_AUDIT_DIR` default in `inference-router/src/governance/mod.rs::open_jsonl_writer`.
+export const DEFAULT_AUDIT_DIR = "/var/log/azureclaw/audit";
+
+/// Shape of one row written by `JsonlAuditWriter::write`.
+/// Mirrors `audit_jsonl::AuditRow` byte-for-byte (additive: tests
+/// gracefully ignore extra fields).
+export interface AuditRow {
+  sandbox: string;
+  seq: number;
+  ts: string;
+  agent_id: string;
+  action: string;
+  decision: string;
+  prev_hash: string;
+  hash: string;
+}
+
+export interface AuditTailOptions {
+  namespace?: string;
+  lines?: string;
+  follow?: boolean;
+  decision?: string;
+  agent?: string;
+  action?: string;
+  json?: boolean;
+  date?: string;
+  dir?: string;
+}
+
+export function auditCommand(): Command {
+  const cmd = new Command("audit").description(
+    "Inspect the durable JSONL audit log of a sandbox's router (Slice 4)"
+  );
+
+  cmd
+    .command("tail <sandbox>")
+    .description(
+      "Stream the durable JSONL audit log of a sandbox's router"
+    )
+    .option(
+      "-n, --namespace <ns>",
+      "Sandbox pod namespace (default: 'azureclaw-<sandbox>')"
+    )
+    .option(
+      "-l, --lines <n>",
+      "Number of trailing lines to show (default: 50, max: 10000)",
+      "50"
+    )
+    .option("-f, --follow", "Keep streaming new audit rows as they arrive")
+    .option(
+      "--decision <state>",
+      "Filter by decision (e.g. 'allowed', 'denied', 'flagged', 'sanitized')"
+    )
+    .option("--agent <id>", "Filter by agent_id (exact match)")
+    .option(
+      "--action <substring>",
+      "Filter rows whose action contains this substring (case-sensitive)"
+    )
+    .option(
+      "--date <YYYY-MM-DD>",
+      "Read a specific date's file instead of today's (UTC)"
+    )
+    .option(
+      "--dir <path>",
+      `Override the in-pod audit directory (default: ${DEFAULT_AUDIT_DIR})`
+    )
+    .option("--json", "Emit each row as raw JSON instead of the pretty table")
+    .action(async (sandbox: string, opts: AuditTailOptions) => {
+      try {
+        await runAuditTail(sandbox, opts);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(chalk.red(`\n  audit tail failed: ${msg}\n`));
+        process.exitCode = 1;
+      }
+    });
+
+  return cmd;
+}
+
+export async function runAuditTail(
+  sandbox: string,
+  opts: AuditTailOptions
+): Promise<void> {
+  const ns = opts.namespace ?? `azureclaw-${sandbox}`;
+  const dir = opts.dir ?? DEFAULT_AUDIT_DIR;
+  const lines = parseLines(opts.lines);
+  const dateKey = opts.date ?? todayUtcKey();
+  validateDateKey(dateKey);
+  const file = `${dir}/${dateKey}.jsonl`;
+
+  // Build the in-pod command. We deliberately use `tail` (not `cat`)
+  // even for the non-follow case so a huge log file doesn't blow up
+  // the kubectl pipe — the router writes one ~300 byte JSON line per
+  // audited request, and the operator-friendly default is "show me
+  // the recent ones".
+  const tailArgs = [`-n${lines}`];
+  if (opts.follow) tailArgs.push("-F");
+  // The router writes one line per entry, and entries are written
+  // strictly in seq order, so trailing tail is a chronological tail.
+  const script =
+    `if [ ! -f ${shellQuote(file)} ]; then echo "AUDIT_FILE_MISSING ${shellQuote(file)}" >&2; exit 2; fi; ` +
+    `exec tail ${tailArgs.join(" ")} ${shellQuote(file)}`;
+
+  const child = execa(
+    "kubectl",
+    [
+      "exec",
+      ...(opts.follow ? [] : []),
+      "-n",
+      ns,
+      `deploy/${sandbox}`,
+      "-c",
+      "inference-router",
+      "--",
+      "sh",
+      "-c",
+      script,
+    ],
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+      reject: false,
+      buffer: false,
+    }
+  );
+
+  if (!child.stdout || !child.stderr) {
+    throw new Error("kubectl exec did not yield a stdout/stderr pipe");
+  }
+
+  let printedHeader = false;
+  const renderRow = (raw: string) => {
+    if (!raw.trim()) return;
+    const row = parseRow(raw);
+    if (!row) {
+      // Malformed line — surface but don't crash the stream.
+      console.error(chalk.yellow(`  (skipping malformed audit line)`));
+      return;
+    }
+    if (!matchesFilters(row, opts)) return;
+    if (opts.json) {
+      console.log(JSON.stringify(row));
+      return;
+    }
+    if (!printedHeader) {
+      console.log(renderHeader());
+      printedHeader = true;
+    }
+    console.log(renderPrettyLine(row));
+  };
+
+  let buffer = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    buffer += chunk;
+    let idx: number;
+    while ((idx = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 1);
+      renderRow(line);
+    }
+  });
+
+  child.stderr.setEncoding("utf8");
+  let stderrBuf = "";
+  child.stderr.on("data", (chunk: string) => {
+    stderrBuf += chunk;
+  });
+
+  const result = await child;
+  if (buffer.trim()) renderRow(buffer);
+
+  if (result.exitCode !== 0) {
+    const msg = stderrBuf.trim() || `kubectl exec exited with ${result.exitCode}`;
+    if (msg.includes("AUDIT_FILE_MISSING")) {
+      throw new Error(
+        `No audit log file at ${file} in pod 'deploy/${sandbox}' (ns '${ns}').\n` +
+          `  Either nothing has been audited yet on that date or the router\n` +
+          `  is running with AZURECLAW_AUDIT_DIR=disabled.`
+      );
+    }
+    throw new Error(msg);
+  }
+}
+
+/// Today's date key in UTC — matches the router's
+/// `audit_jsonl::date_key_from_timestamp` which slices `entry.timestamp[..10]`.
+/// We honour UTC so an operator on a US west-coast laptop sees the same
+/// file name the router wrote at boot in eastern-time UTC.
+export function todayUtcKey(now: Date = new Date()): string {
+  const yyyy = now.getUTCFullYear().toString().padStart(4, "0");
+  const mm = (now.getUTCMonth() + 1).toString().padStart(2, "0");
+  const dd = now.getUTCDate().toString().padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateDateKey(key: string): void {
+  if (!DATE_KEY_RE.test(key)) {
+    throw new Error(
+      `Invalid --date '${key}' — expected YYYY-MM-DD (matches router rotation key)`
+    );
+  }
+}
+
+export function parseLines(raw: string | undefined): number {
+  const n = Number.parseInt(raw ?? "50", 10);
+  if (!Number.isFinite(n) || n < 1) {
+    throw new Error(`Invalid --lines '${raw}' — must be a positive integer`);
+  }
+  if (n > 10000) {
+    throw new Error(`--lines ${n} exceeds the safe cap of 10000`);
+  }
+  return n;
+}
+
+export function parseRow(line: string): AuditRow | null {
+  try {
+    const parsed = JSON.parse(line) as Partial<AuditRow>;
+    if (
+      typeof parsed.sandbox !== "string" ||
+      typeof parsed.seq !== "number" ||
+      typeof parsed.ts !== "string" ||
+      typeof parsed.agent_id !== "string" ||
+      typeof parsed.action !== "string" ||
+      typeof parsed.decision !== "string" ||
+      typeof parsed.prev_hash !== "string" ||
+      typeof parsed.hash !== "string"
+    ) {
+      return null;
+    }
+    return parsed as AuditRow;
+  } catch {
+    return null;
+  }
+}
+
+export function matchesFilters(row: AuditRow, opts: AuditTailOptions): boolean {
+  if (opts.decision && row.decision !== opts.decision) return false;
+  if (opts.agent && row.agent_id !== opts.agent) return false;
+  if (opts.action && !row.action.includes(opts.action)) return false;
+  return true;
+}
+
+export function renderHeader(): string {
+  return chalk.dim(
+    [
+      "seq".padEnd(6),
+      "timestamp".padEnd(22),
+      "decision".padEnd(12),
+      "agent".padEnd(28),
+      "action",
+    ].join("  ")
+  );
+}
+
+export function renderPrettyLine(row: AuditRow): string {
+  const decisionColor = colorForDecision(row.decision);
+  return [
+    row.seq.toString().padEnd(6),
+    row.ts.slice(0, 19).padEnd(22),
+    decisionColor(row.decision.padEnd(12)),
+    truncate(row.agent_id, 28).padEnd(28),
+    truncate(row.action, 80),
+  ].join("  ");
+}
+
+function colorForDecision(decision: string): (s: string) => string {
+  switch (decision) {
+    case "allowed":
+    case "success":
+      return chalk.green;
+    case "denied":
+    case "flagged":
+    case "rejected":
+      return chalk.red;
+    case "sanitized":
+      return chalk.yellow;
+    default:
+      return chalk.white;
+  }
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  if (n <= 1) return s.slice(0, n);
+  return `${s.slice(0, n - 1)}…`;
+}
+
+/// Single-quote-shell-quote a path that may contain spaces. The
+/// caller controls the input (a path under /var/log/azureclaw/audit)
+/// but we still defend against the user passing --dir with a quote.
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}


### PR DESCRIPTION
Closes Slice 4 DoD #7. Builds directly on Slice 4a (PR #287).

## What

`azureclaw audit tail <sandbox>` shells into the sandbox's
`inference-router` container and tails the day-keyed JSONL file the
Slice 4a sink writes at `/var/log/azureclaw/audit/{YYYY-MM-DD}.jsonl`.

Flags:

| flag | default | purpose |
|------|---------|---------|
| `-l, --lines N` | 50 | trailing lines to print (capped at 10000) |
| `-f, --follow` | off | `tail -F` semantics: stream as the router writes |
| `--decision <state>` | — | filter by AuditEntry.decision exact-match |
| `--agent <id>` | — | filter by agent_id exact-match |
| `--action <substr>` | — | filter by action substring |
| `--date YYYY-MM-DD` | today (UTC) | read a historical day file |
| `--dir <path>` | `/var/log/azureclaw/audit` | non-default `AZURECLAW_AUDIT_DIR` |
| `--json` | off | emit one JSON object per line instead of the pretty tree |
| `-n, --namespace <ns>` | `azureclaw-<sandbox>` | override pod namespace |

Pretty render colours by decision (allowed/success green,
denied/flagged/rejected red, sanitized yellow), truncates long
`agent_id` and `action` with `…`, and prints a one-line header.

## Wire contract

Matches `audit_jsonl::JsonlRecord` byte-for-byte: `sandbox, seq, ts,
agent_id, action, decision, prev_hash, hash`. `parseRow` is
forward-compatible — extra fields are preserved on the row but ignored
by the renderer.

## Safety

`--date` is regex-validated (`^\\d{4}-\\d{2}-\\d{2}$`) before
interpolation into the in-pod shell command. `--dir` is single-quoted
with embedded-quote escape. There is no `--exec`/raw-shell escape
hatch.

## Tests

26 new vitest cases (`cli/src/commands/audit.test.ts`) cover:

- `parseLines` boundary (default, valid, zero, negative, non-numeric, over-cap, cap-exact)
- `todayUtcKey` formatting and zero-padding
- `validateDateKey` accepting valid + rejecting metacharacter attempts
- `parseRow` round-trip + forward-compat + malformed-JSON + wrong-type + missing-field paths
- `matchesFilters` decision / agent / action / AND-combined / no-filter
- `renderHeader` column set, `renderPrettyLine` content + truncation

Suite total: **679 passing** (was 652 on dev). `npm run typecheck` +
`npm run lint` + `npm run build` all clean.

## DoD coverage

Slice 4 DoD #7 ✅. Remaining 4b deferrals (cross-day search, jq-friendly
alias) tracked under Slice 4c.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>