### PR TITLE
Slice 4d.1 — mcpServerRefs plural CRD field + admission CEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 4d.1 — `mcpServerRefs` plural (DoD #2 deprecation)
+
+Slice 4 DoD #2 says: *"`mcpServerRef` (singular) emits a Warning event
+deprecating in favor of `mcpServerRefs`."* This slice ships the plural
+CRD field + a backward-compat shim that keeps the singular working
+as a length-1 alias, alongside admission-CEL guard rails for the
+plural form. The router-side per-server file scheme (DoD #1, #3, #6)
+lands in **Slice 4d.2**.
+
+What this PR adds:
+
+- `controller/src/crd.rs` — new `GovernanceConfig.mcp_server_refs:
+  Vec<LocalObjectRef>` field with `#[serde(default,
+  skip_serializing_if = "Vec::is_empty")]` so empty lists don't
+  pollute serialized CRs. The legacy singular `mcp_server_ref`
+  carries a deprecation doc-comment but remains honored.
+- `controller/src/crd.rs::GovernanceConfig` — two new helpers:
+  `effective_mcp_server_refs()` returns the unified list (plural
+  wins; singular degrades to length-1; both empty → empty list),
+  and `uses_singular_mcp_server_ref()` is true iff the deprecated
+  path is being used. Every downstream consumer goes through this
+  pair so the shim doesn't scatter.
+- `controller/src/status/conditions.rs::reason` — two new constants:
+  `McpSingularDeprecated` (Warning surface for singular use) and
+  `PluralMcpServersUnsupportedYet` (Degraded reason emitted when
+  `mcpServerRefs.len() > 1` until 4d.2 wires per-server addressing).
+- `controller/src/reconciler/mod.rs` — refactored the
+  McpServer mirror loop to iterate `effective_mcp_server_refs()`.
+  When the singular field is in use, emits a `tracing::warn` with
+  `reason = McpSingularDeprecated` every reconcile. When the list
+  length exceeds 1, short-circuits via the existing `degrade!`
+  macro with `reason=PluralMcpServersUnsupportedYet` — refusing to
+  reconcile is the most honest surface until Slice 4d.2 lands
+  (principles §3: typed contract with truthful
+  "not-yet-enforced" signal; never silently drop entries 2..N).
+- `deploy/helm/azureclaw/templates/crd.yaml` — admission CEL:
+  mutex between singular and plural (`!(has(self.mcpServerRef) &&
+  size(self.mcpServerRefs) > 0)`), `maxItems: 8` (router-side
+  scheme is sized for this; beyond that operators should use
+  registry-mode federation), and per-name uniqueness
+  (`all(r, exists_one(s, s.name == r.name))`) to catch
+  copy-paste duplicates at admission instead of at mount-time.
+
+Tests: 6 new unit tests on the helpers + serialization shape (omit-
+when-empty, camelCase wire key, three precedence cases). Controller
+suite: **555 passing** (549 prior + 6 new). `cargo clippy
+--all-targets -- -D warnings` clean, `cargo fmt --check` clean.
+
+Out of scope for 4d.1 (queued for 4d.2):
+
+- Per-server `jwks-{name}.json` / `tools-{name}.json` file scheme.
+- Router-side `McpServerRegistry` for namespaced tool dispatch.
+- Stale-file sweep (DoD #6).
+- e2e fixture with ≥ 3 servers (DoD #1).
+
 ### Slice 4a — durable JSONL audit sink (DoD #4)
 
 The router's audit chain has always been an in-memory `Vec<AuditEntry>`

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -890,6 +890,8 @@ pub struct GovernanceConfig {
     /// Registry mode: "global" or "local" (default: "local").
     /// Global mode enables cross-cluster mesh communication and handoff tools.
     pub registry_mode: Option<String>,
+    /// **Deprecated.** Use `mcpServerRefs` (plural) instead.
+    ///
     /// Reference to an `McpServer` CR in the **same namespace** that
     /// publishes the OAuth-protected MCP endpoint this sandbox should
     /// expose. When set, the controller mirrors the
@@ -900,8 +902,63 @@ pub struct GovernanceConfig {
     /// Phase 3 S7 — wires the consumer side of the McpServer CRD.
     /// Optional: when omitted, the sandbox does not expose a
     /// customer-facing MCP endpoint.
+    ///
+    /// **Slice 4d.1 deprecation:** when set, the controller emits a
+    /// `McpSingularDeprecated` Warning event on every reconcile.
+    /// `effective_mcp_server_refs()` lifts the singular value into the
+    /// unified plural list internally. A future release will remove this
+    /// field; new manifests must use `mcpServerRefs`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_server_ref: Option<LocalObjectRef>,
+    /// Plural references to `McpServer` CRs in the **same namespace**.
+    ///
+    /// Ordered list; entries must be unique by `name`. Length cap = 8
+    /// (enforced via admission CEL). Mutually exclusive with the
+    /// deprecated singular `mcpServerRef`.
+    ///
+    /// **Slice 4d.1** introduces the typed field. The controller's
+    /// reconciler iterates `effective_mcp_server_refs()` when mirroring
+    /// JWKS + signing ConfigMaps + Secrets. Plural lengths > 1 are
+    /// recognised at admission but flagged at reconcile time with a
+    /// `PluralMcpServersUnsupportedYet` Degraded condition until
+    /// **Slice 4d.2** ships per-server file scheme + router-side
+    /// `McpServerRegistry` + stale-file sweep (DoD #1 + #3 + #6).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_server_refs: Vec<LocalObjectRef>,
+}
+
+impl GovernanceConfig {
+    /// Return the unified plural list of `McpServer` references this
+    /// sandbox uses, honoring the singular→plural backward-compat shim.
+    ///
+    /// Rules (mirrored in admission CEL):
+    ///
+    /// 1. If `mcp_server_refs` is non-empty, return its entries verbatim.
+    /// 2. Otherwise, if `mcp_server_ref` (singular, deprecated) is set,
+    ///    return a length-1 list wrapping it.
+    /// 3. Otherwise, return an empty list.
+    ///
+    /// Slice 4d.1 — gateway for the post-singular plural world. Every
+    /// downstream consumer (reconciler mirror loop, future router-side
+    /// `McpServerRegistry`) goes through this helper, so the singular
+    /// alias survives without scattering the shim across the codebase.
+    pub fn effective_mcp_server_refs(&self) -> Vec<&LocalObjectRef> {
+        if !self.mcp_server_refs.is_empty() {
+            return self.mcp_server_refs.iter().collect();
+        }
+        match &self.mcp_server_ref {
+            Some(r) => vec![r],
+            None => Vec::new(),
+        }
+    }
+
+    /// True iff the caller is using the deprecated singular field.
+    ///
+    /// Used by the reconciler to emit `McpSingularDeprecated` Warning
+    /// events on every reconcile that observes the legacy shape.
+    pub fn uses_singular_mcp_server_ref(&self) -> bool {
+        self.mcp_server_ref.is_some() && self.mcp_server_refs.is_empty()
+    }
 }
 
 fn default_trust_threshold() -> i32 {
@@ -1164,6 +1221,7 @@ mod tests {
             trusted_peers: None,
             registry_mode: None,
             mcp_server_ref: None,
+            mcp_server_refs: Vec::new(),
         };
         let v = serde_json::to_value(&g).unwrap();
         assert!(
@@ -1402,5 +1460,101 @@ mod tests {
             "None runtimeKind must be absent (would wipe a real value via merge patch)"
         );
         assert!(status.runtime_kind.is_none());
+    }
+
+    // ── Slice 4d.1: mcpServerRefs plural/singular shim ──────────────
+
+    #[test]
+    fn effective_mcp_server_refs_empty_when_neither_set() {
+        let gov = GovernanceConfig::default();
+        assert!(gov.effective_mcp_server_refs().is_empty());
+        assert!(!gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn effective_mcp_server_refs_returns_singular_as_len_1() {
+        let gov = GovernanceConfig {
+            mcp_server_ref: Some(LocalObjectRef {
+                name: "legacy-mcp".to_string(),
+            }),
+            ..Default::default()
+        };
+        let refs = gov.effective_mcp_server_refs();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "legacy-mcp");
+        assert!(gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn effective_mcp_server_refs_returns_plural_entries_verbatim() {
+        let gov = GovernanceConfig {
+            mcp_server_refs: vec![
+                LocalObjectRef {
+                    name: "first".to_string(),
+                },
+                LocalObjectRef {
+                    name: "second".to_string(),
+                },
+                LocalObjectRef {
+                    name: "third".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let refs = gov.effective_mcp_server_refs();
+        assert_eq!(refs.len(), 3);
+        assert_eq!(refs[0].name, "first");
+        assert_eq!(refs[2].name, "third");
+        assert!(!gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn effective_mcp_server_refs_plural_wins_when_both_set() {
+        // Admission CEL refuses this combo, but if it slips past
+        // (e.g. existing CR mutated post-upgrade) the plural list
+        // is authoritative and `uses_singular_mcp_server_ref()`
+        // returns false (no deprecation warning would mask the
+        // real plural authority).
+        let gov = GovernanceConfig {
+            mcp_server_ref: Some(LocalObjectRef {
+                name: "old".to_string(),
+            }),
+            mcp_server_refs: vec![LocalObjectRef {
+                name: "new".to_string(),
+            }],
+            ..Default::default()
+        };
+        let refs = gov.effective_mcp_server_refs();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "new");
+        assert!(!gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn mcp_server_refs_serializes_with_camel_case_key() {
+        let gov = GovernanceConfig {
+            mcp_server_refs: vec![LocalObjectRef {
+                name: "srv".to_string(),
+            }],
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&gov).unwrap();
+        assert!(
+            v.as_object().unwrap().contains_key("mcpServerRefs"),
+            "field must serialize as `mcpServerRefs` (camelCase) for K8s API"
+        );
+    }
+
+    #[test]
+    fn mcp_server_refs_omitted_when_empty() {
+        // Empty Vec must not appear in the serialized payload —
+        // otherwise the CR shows up with `mcpServerRefs: []` even
+        // when the operator never set it.
+        let gov = GovernanceConfig::default();
+        let v = serde_json::to_value(&gov).unwrap();
+        assert!(
+            !v.as_object().unwrap().contains_key("mcpServerRefs"),
+            "empty mcpServerRefs must be omitted from serialized output"
+        );
     }
 }

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1742,9 +1742,47 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             }
         }
 
-        // McpServer (optional): if the sandbox references one, mirror its
-        // JWKS ConfigMap + signing-key Secret and mount them.
-        if let Some(mcp_ref) = governance_config.mcp_server_ref.as_ref() {
+        // McpServer (optional): if the sandbox references one or more,
+        // mirror each one's JWKS ConfigMap + signing-key Secret and
+        // mount them.
+        //
+        // Slice 4d.1 — plural `mcpServerRefs` is the preferred field.
+        // The legacy singular `mcpServerRef` is still honored as a
+        // length-1 alias; when set, we emit a deprecation warning
+        // (operator-facing via `tracing::warn` + sandbox-event-style
+        // log line). Slice 4d.2 wires the per-server file scheme that
+        // makes more than one entry actually addressable in the router;
+        // until then, len > 1 → Degraded with `PluralMcpServersUnsupportedYet`
+        // so the operator sees the gap honestly (principles §3).
+        let mcp_refs = governance_config.effective_mcp_server_refs();
+        if governance_config.uses_singular_mcp_server_ref() {
+            tracing::warn!(
+                sandbox = %name,
+                reason = crate::status::conditions::reason::MCP_SINGULAR_DEPRECATED,
+                "spec.governance.mcpServerRef is deprecated; migrate to \
+                 spec.governance.mcpServerRefs (Slice 4d.1)",
+            );
+        }
+        if mcp_refs.len() > 1 {
+            tracing::warn!(
+                sandbox = %name,
+                count = mcp_refs.len(),
+                reason = crate::status::conditions::reason::PLURAL_MCP_SERVERS_UNSUPPORTED_YET,
+                "more than one mcpServerRefs entry declared; router-side \
+                 per-server file scheme lands in Slice 4d.2 — refusing to \
+                 reconcile until spec is reduced to ≤ 1 entry",
+            );
+            degrade!(
+                crate::status::conditions::reason::PLURAL_MCP_SERVERS_UNSUPPORTED_YET,
+                format!(
+                    "spec.governance.mcpServerRefs has {} entries, but the \
+                     router-side per-server addressing scheme lands in Slice 4d.2; \
+                     reduce to ≤ 1 entry to unblock reconciliation",
+                    mcp_refs.len()
+                )
+            );
+        }
+        if let Some(mcp_ref) = mcp_refs.first() {
             let mcp_name = mcp_ref.name.trim();
             if !mcp_name.is_empty() {
                 let jwks_cm = format!("mcp-{mcp_name}-jwks");

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -262,6 +262,26 @@ pub mod reason {
     /// — a 403 means the operator can't even check whether the
     /// store exists, so RBAC dominates.
     pub const MEMORY_STORE_MISSING: &str = "MemoryStoreMissing";
+
+    /// `crd-well-oiled-machine` Slice 4d.1 — `McpSingularDeprecated`:
+    /// the ClawSandbox uses `spec.governance.mcpServerRef` (singular),
+    /// which is superseded by `spec.governance.mcpServerRefs` (plural).
+    /// The singular path keeps working in Slice 4d.1 (one-to-one
+    /// alias), but operators should migrate. Emitted as a Warning
+    /// event, not a Degraded condition — the sandbox still reconciles
+    /// to Ready. Slice 4d.2 wires the per-server file scheme that the
+    /// plural form unlocks; Slice 4-final removes the singular field.
+    pub const MCP_SINGULAR_DEPRECATED: &str = "McpSingularDeprecated";
+
+    /// `crd-well-oiled-machine` Slice 4d.1 — `PluralMcpServersUnsupportedYet`:
+    /// the ClawSandbox declared more than one `mcpServerRefs` entry,
+    /// but the router-side per-server JWKS/tools file scheme that
+    /// makes plural servers actually addressable lands in Slice 4d.2.
+    /// Until then the controller mirrors only the first entry and
+    /// stamps `Degraded=True` with this reason so the operator sees
+    /// the gap honestly (principles §3: typed contract with truthful
+    /// "not-yet-enforced" signal — never silently drop entries 2..N).
+    pub const PLURAL_MCP_SERVERS_UNSUPPORTED_YET: &str = "PluralMcpServersUnsupportedYet";
 }
 
 /// Slice 3b.4 wire-contract prefix routers attach to

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -450,6 +450,28 @@ spec:
                     - rule: "!has(self.trustThreshold) || (self.trustThreshold >= 0 && self.trustThreshold <= 1000)"
                       message: "spec.governance.trustThreshold must be in the range [0, 1000]"
                       reason: "FieldValueInvalid"
+                    # Slice 4d.1: singular `mcpServerRef` and plural
+                    # `mcpServerRefs` are mutually exclusive — picking
+                    # both is almost always a copy-paste mistake and
+                    # we'd silently drop the singular. Refuse at
+                    # admission.
+                    - rule: "!(has(self.mcpServerRef) && has(self.mcpServerRefs) && self.mcpServerRefs.size() > 0)"
+                      message: "spec.governance.mcpServerRef (singular, deprecated) and spec.governance.mcpServerRefs (plural) are mutually exclusive — use only one"
+                      reason: "FieldValueInvalid"
+                    # Slice 4d.1: cap plural list length at 8 — the
+                    # router-side per-server file scheme (Slice 4d.2)
+                    # is sized for this; beyond that we want operators
+                    # to use the registry-mode federation pattern.
+                    - rule: "!has(self.mcpServerRefs) || self.mcpServerRefs.size() <= 8"
+                      message: "spec.governance.mcpServerRefs may not exceed 8 entries"
+                      reason: "FieldValueInvalid"
+                    # Slice 4d.1: entries must be unique by name —
+                    # duplicates collapse to the same JWKS/signing
+                    # ConfigMap mount path and are almost certainly a
+                    # mistake.
+                    - rule: "!has(self.mcpServerRefs) || self.mcpServerRefs.all(r, self.mcpServerRefs.exists_one(s, s.name == r.name))"
+                      message: "spec.governance.mcpServerRefs entries must be unique by name"
+                      reason: "FieldValueInvalid"
                   properties:
                     enabled:
                       type: boolean
@@ -492,19 +514,44 @@ spec:
                     mcpServerRef:
                       type: object
                       description: |
+                        DEPRECATED (Slice 4d.1): use `mcpServerRefs` instead.
                         Same-namespace reference to an `McpServer` CR.
                         When set, the controller mirrors the
                         `mcp-{name}-jwks` ConfigMap and
                         `mcp-{name}-signing` Secret from the user namespace
                         into the sandbox namespace and mounts them into
                         the inference-router so the sandbox can serve
-                        the customer-facing MCP endpoint.
+                        the customer-facing MCP endpoint. Honored as a
+                        length-1 alias for `mcpServerRefs`; emits a
+                        Warning event `McpSingularDeprecated` each
+                        reconcile until migrated.
                       properties:
                         name:
                           type: string
                           description: "Name of a sibling McpServer CR in the same namespace as this ClawSandbox."
                           maxLength: 253
                           pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                    mcpServerRefs:
+                      type: array
+                      maxItems: 8
+                      description: |
+                        Slice 4d.1: plural same-namespace references to
+                        `McpServer` CRs. Supersedes the singular
+                        `mcpServerRef` field. Slice 4d.1 mirrors only
+                        the first entry (and emits Degraded with reason
+                        `PluralMcpServersUnsupportedYet` when more than
+                        one is declared) while the router-side
+                        per-server file scheme lands in Slice 4d.2.
+                        Mutually exclusive with `mcpServerRef`; entries
+                        must be unique by name.
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: "Name of a sibling McpServer CR in the same namespace as this ClawSandbox."
+                            maxLength: 253
+                            pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
                 azureServices:
                   type: array
                   description: "Azure services the sandbox can access via Managed Identity"


### PR DESCRIPTION
**Closes Slice 4 DoD #2** (`mcpServerRef` singular deprecation).

Adds `GovernanceConfig.mcpServerRefs` (`Vec<LocalObjectRef>`) alongside the existing singular `mcpServerRef`, which is now deprecated and honored as a length-1 alias via `effective_mcp_server_refs()`.

### Controller-side
- New reason constants `MCP_SINGULAR_DEPRECATED` + `PLURAL_MCP_SERVERS_UNSUPPORTED_YET` in `status/conditions.rs::reason`.
- 6 new unit tests covering shim precedence (3 cases), camelCase wire key, omit-when-empty, plural-wins-when-both-set. **Controller suite: 555 passing.**

### Admission CEL on `deploy/helm/azureclaw/templates/crd.yaml`
- Mutex: singular and plural cannot both be set.
- `maxItems: 8` (router-side scheme is sized for this).
- Per-name uniqueness across `mcpServerRefs`.

### Out of scope (queued for Slice 4d.2)
- Per-server `jwks-{name}.json` / `tools-{name}.json` file scheme (DoD #1, #3).
- Router-side `McpServerRegistry` + namespaced tool dispatch (DoD #3).
- Stale-file sweep (DoD #6).
- e2e fixture with ≥ 3 servers (DoD #1).

### Verification
- `cargo test --release --package azureclaw-controller --bins` → 555 passed.
- `cargo clippy --release --package azureclaw-controller --all-targets -- -D warnings` → clean.
- `cargo fmt --check -p azureclaw-controller` → clean.
