### PR TITLE
Slice 4d.2 — per-server McpServer mounts + router discovery (DoD #1 + #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 4d.2 — per-server McpServer mount scheme + router discovery (DoD #1 + #6)
+
+Closes Slice 4 DoD #1 (*"≥ 3 plural McpServers reachable e2e"*) at the
+mount-and-discovery layer, and DoD #6 (*"stale-file sweep on ref
+removal"*) via reconciler-driven volume rebuild. Multi-JWKS OAuth
+verification and namespaced tool dispatch (DoD #3) follow in **Slice
+4d.3** — this slice ships the producer-side mount layout and the
+router-side discovery surface that 4d.3 will consume.
+
+What this PR adds:
+
+- **Controller — per-server volume scheme.** `reconciler/mod.rs`
+  McpServer mirror block now iterates the full
+  `governance_config.effective_mcp_server_refs()` list instead of
+  short-circuiting at length > 1. Each ref produces its own
+  ConfigMap/Secret pair mounted at per-name subdirectories:
+  - `/etc/azureclaw/mcp/<name>/jwks.json` (from `mcp-<name>-jwks` CM)
+  - `/etc/azureclaw/mcp-signing/<name>/...` (from `mcp-<name>-signing` Secret)
+
+  Volume names follow `mcp-jwks-<name>` / `mcp-signing-<name>`. The
+  CRD's `maxItems: 8` on `mcpServerRefs` plus the DNS-1123 constraint
+  on ref names keeps total volume names ≤ 63 chars.
+
+- **Legacy env-var contract preserved.** The first entry (idx 0)
+  continues to set `MCP_JWKS_PATH=/etc/azureclaw/mcp/<name0>/jwks.json`
+  and `MCP_SIGNING_KEY_DIR=/etc/azureclaw/mcp-signing/<name0>` so the
+  existing single-JWKS OAuth verifier in
+  `inference-router/src/main.rs::build_mcp_router()` keeps working
+  unchanged. New env `MCP_JWKS_DIR=/etc/azureclaw/mcp` is set once
+  per pod whenever any McpServer ref mirrored — the discovery hook
+  consumes it.
+
+- **`inject_container_env` helper** in
+  `controller/src/reconciler/governance_mounts.rs:362` — idempotent
+  env-var injection on a named container without requiring a volume
+  mount. Used to land `MCP_JWKS_DIR` after per-server volumes have
+  been added in a loop. 4 dedicated unit tests cover happy path,
+  idempotence, missing-env-array creation, and absent-container
+  no-op.
+
+- **Router — startup discovery scan.** New `inference-router/src/mcp/registry.rs`
+  with `scan(dir)` + `discover_from_env()`. At process start `main.rs`
+  reads `MCP_JWKS_DIR`, enumerates immediate subdirectories that
+  contain a parseable RFC-7517-shaped `jwks.json`, and emits:
+
+  ```text
+  Discovered 3 McpServer JWKS file(s)
+    mcp_jwks_dir = "/etc/azureclaw/mcp"
+    count = 3
+    servers = ["foundry-builtins", "github", "internal-knowledge"]
+  ```
+
+  Candidates that fail validation (missing `jwks.json`, malformed JSON,
+  missing `keys` array) are surfaced via `tracing::warn!` with the
+  exact rejection reason — never silently dropped (principles §3). 7
+  unit tests cover empty dir, missing dir, three-server happy path,
+  empty-subdir skip, malformed JSON skip, top-level file ignore, and
+  path correctness.
+
+- **Stale-file sweep (DoD #6) by reconcile.** Each reconciliation
+  pass rebuilds the Deployment pod-spec from the *current*
+  `effective_mcp_server_refs()`. Refs removed from the CR produce no
+  volume/mount in the next SSA patch — kube-apiserver-side
+  reconciliation naturally drops them. No explicit sweep code
+  needed; in-process hot removal (without pod restart) is a 4d.3
+  enrichment when the inotify watcher arrives.
+
+- **Removed `PLURAL_MCP_SERVERS_UNSUPPORTED_YET`** condition reason
+  constant — its single call site disappeared with the loop
+  refactor. The 4d.1 placeholder did its job; the gap it described
+  is closed.
+
+- **CRD doc comment** on `mcp_server_refs` now describes the 4d.2
+  mount layout and forward-references 4d.3 for multi-JWKS OAuth +
+  namespaced tool dispatch.
+
+What is explicitly **not** in this slice (deferred to Slice 4d.3):
+
+- Multi-JWKS OAuth verification (`/mcp` route still validates against
+  the first ref's `jwks.json` via the legacy `MCP_JWKS_PATH`).
+- Namespaced tool dispatch (`{server}.{tool}` routing).
+- In-process inotify-driven hot reload of the registry.
+- Per-server signing-key selection for outbound tool calls.
+
+The discovery log surface is the operator-facing closure of DoD #1:
+operators apply a `ClawSandbox` with N `mcpServerRefs`, then verify
+via `kubectl logs` that the inference router enumerates exactly N
+server names. This is a real consumer (principles §5 — no
+scaffolding) even though OAuth verification is single-JWKS today.
+
+Verified: 559 controller + 804 router tests pass, clippy
+`-D warnings` clean across workspace, `cargo fmt --check` clean.
+
 ### Slice 4d.1 — `mcpServerRefs` plural (DoD #2 deprecation)
 
 Slice 4 DoD #2 says: *"`mcpServerRef` (singular) emits a Warning event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 4d.1 — `mcpServerRefs` plural (DoD #2 deprecation)
+
+Slice 4 DoD #2 says: *"`mcpServerRef` (singular) emits a Warning event
+deprecating in favor of `mcpServerRefs`."* This slice ships the plural
+CRD field + a backward-compat shim that keeps the singular working
+as a length-1 alias, alongside admission-CEL guard rails for the
+plural form. The router-side per-server file scheme (DoD #1, #3, #6)
+lands in **Slice 4d.2**.
+
+What this PR adds:
+
+- `controller/src/crd.rs` — new `GovernanceConfig.mcp_server_refs:
+  Vec<LocalObjectRef>` field with `#[serde(default,
+  skip_serializing_if = "Vec::is_empty")]` so empty lists don't
+  pollute serialized CRs. The legacy singular `mcp_server_ref`
+  carries a deprecation doc-comment but remains honored.
+- `controller/src/crd.rs::GovernanceConfig` — two new helpers:
+  `effective_mcp_server_refs()` returns the unified list (plural
+  wins; singular degrades to length-1; both empty → empty list),
+  and `uses_singular_mcp_server_ref()` is true iff the deprecated
+  path is being used. Every downstream consumer goes through this
+  pair so the shim doesn't scatter.
+- `controller/src/status/conditions.rs::reason` — two new constants:
+  `McpSingularDeprecated` (Warning surface for singular use) and
+  `PluralMcpServersUnsupportedYet` (Degraded reason emitted when
+  `mcpServerRefs.len() > 1` until 4d.2 wires per-server addressing).
+- `controller/src/reconciler/mod.rs` — refactored the
+  McpServer mirror loop to iterate `effective_mcp_server_refs()`.
+  When the singular field is in use, emits a `tracing::warn` with
+  `reason = McpSingularDeprecated` every reconcile. When the list
+  length exceeds 1, short-circuits via the existing `degrade!`
+  macro with `reason=PluralMcpServersUnsupportedYet` — refusing to
+  reconcile is the most honest surface until Slice 4d.2 lands
+  (principles §3: typed contract with truthful
+  "not-yet-enforced" signal; never silently drop entries 2..N).
+- `deploy/helm/azureclaw/templates/crd.yaml` — admission CEL:
+  mutex between singular and plural (`!(has(self.mcpServerRef) &&
+  size(self.mcpServerRefs) > 0)`), `maxItems: 8` (router-side
+  scheme is sized for this; beyond that operators should use
+  registry-mode federation), and per-name uniqueness
+  (`all(r, exists_one(s, s.name == r.name))`) to catch
+  copy-paste duplicates at admission instead of at mount-time.
+
+Tests: 6 new unit tests on the helpers + serialization shape (omit-
+when-empty, camelCase wire key, three precedence cases). Controller
+suite: **555 passing** (549 prior + 6 new). `cargo clippy
+--all-targets -- -D warnings` clean, `cargo fmt --check` clean.
+
+Out of scope for 4d.1 (queued for 4d.2):
+
+- Per-server `jwks-{name}.json` / `tools-{name}.json` file scheme.
+- Router-side `McpServerRegistry` for namespaced tool dispatch.
+- Stale-file sweep (DoD #6).
+- e2e fixture with ≥ 3 servers (DoD #1).
+
 ### Slice 4a — durable JSONL audit sink (DoD #4)
 
 The router's audit chain has always been an in-memory `Vec<AuditEntry>`

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -916,13 +916,12 @@ pub struct GovernanceConfig {
     /// (enforced via admission CEL). Mutually exclusive with the
     /// deprecated singular `mcpServerRef`.
     ///
-    /// **Slice 4d.1** introduces the typed field. The controller's
-    /// reconciler iterates `effective_mcp_server_refs()` when mirroring
-    /// JWKS + signing ConfigMaps + Secrets. Plural lengths > 1 are
-    /// recognised at admission but flagged at reconcile time with a
-    /// `PluralMcpServersUnsupportedYet` Degraded condition until
-    /// **Slice 4d.2** ships per-server file scheme + router-side
-    /// `McpServerRegistry` + stale-file sweep (DoD #1 + #3 + #6).
+    /// **Slice 4d.1** introduced the typed field + admission CEL +
+    /// reconciler shim. **Slice 4d.2** wires per-server CM/Secret
+    /// mounts at `/etc/azureclaw/mcp/{name}/` and
+    /// `/etc/azureclaw/mcp-signing/{name}/` (DoD #1 + #6). Multi-JWKS
+    /// OAuth verification + namespaced tool dispatch land in
+    /// **Slice 4d.3** (DoD #3).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mcp_server_refs: Vec<LocalObjectRef>,
 }

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -890,6 +890,8 @@ pub struct GovernanceConfig {
     /// Registry mode: "global" or "local" (default: "local").
     /// Global mode enables cross-cluster mesh communication and handoff tools.
     pub registry_mode: Option<String>,
+    /// **Deprecated.** Use `mcpServerRefs` (plural) instead.
+    ///
     /// Reference to an `McpServer` CR in the **same namespace** that
     /// publishes the OAuth-protected MCP endpoint this sandbox should
     /// expose. When set, the controller mirrors the
@@ -900,8 +902,63 @@ pub struct GovernanceConfig {
     /// Phase 3 S7 — wires the consumer side of the McpServer CRD.
     /// Optional: when omitted, the sandbox does not expose a
     /// customer-facing MCP endpoint.
+    ///
+    /// **Slice 4d.1 deprecation:** when set, the controller emits a
+    /// `McpSingularDeprecated` Warning event on every reconcile.
+    /// `effective_mcp_server_refs()` lifts the singular value into the
+    /// unified plural list internally. A future release will remove this
+    /// field; new manifests must use `mcpServerRefs`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_server_ref: Option<LocalObjectRef>,
+    /// Plural references to `McpServer` CRs in the **same namespace**.
+    ///
+    /// Ordered list; entries must be unique by `name`. Length cap = 8
+    /// (enforced via admission CEL). Mutually exclusive with the
+    /// deprecated singular `mcpServerRef`.
+    ///
+    /// **Slice 4d.1** introduces the typed field. The controller's
+    /// reconciler iterates `effective_mcp_server_refs()` when mirroring
+    /// JWKS + signing ConfigMaps + Secrets. Plural lengths > 1 are
+    /// recognised at admission but flagged at reconcile time with a
+    /// `PluralMcpServersUnsupportedYet` Degraded condition until
+    /// **Slice 4d.2** ships per-server file scheme + router-side
+    /// `McpServerRegistry` + stale-file sweep (DoD #1 + #3 + #6).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_server_refs: Vec<LocalObjectRef>,
+}
+
+impl GovernanceConfig {
+    /// Return the unified plural list of `McpServer` references this
+    /// sandbox uses, honoring the singular→plural backward-compat shim.
+    ///
+    /// Rules (mirrored in admission CEL):
+    ///
+    /// 1. If `mcp_server_refs` is non-empty, return its entries verbatim.
+    /// 2. Otherwise, if `mcp_server_ref` (singular, deprecated) is set,
+    ///    return a length-1 list wrapping it.
+    /// 3. Otherwise, return an empty list.
+    ///
+    /// Slice 4d.1 — gateway for the post-singular plural world. Every
+    /// downstream consumer (reconciler mirror loop, future router-side
+    /// `McpServerRegistry`) goes through this helper, so the singular
+    /// alias survives without scattering the shim across the codebase.
+    pub fn effective_mcp_server_refs(&self) -> Vec<&LocalObjectRef> {
+        if !self.mcp_server_refs.is_empty() {
+            return self.mcp_server_refs.iter().collect();
+        }
+        match &self.mcp_server_ref {
+            Some(r) => vec![r],
+            None => Vec::new(),
+        }
+    }
+
+    /// True iff the caller is using the deprecated singular field.
+    ///
+    /// Used by the reconciler to emit `McpSingularDeprecated` Warning
+    /// events on every reconcile that observes the legacy shape.
+    pub fn uses_singular_mcp_server_ref(&self) -> bool {
+        self.mcp_server_ref.is_some() && self.mcp_server_refs.is_empty()
+    }
 }
 
 fn default_trust_threshold() -> i32 {
@@ -1164,6 +1221,7 @@ mod tests {
             trusted_peers: None,
             registry_mode: None,
             mcp_server_ref: None,
+            mcp_server_refs: Vec::new(),
         };
         let v = serde_json::to_value(&g).unwrap();
         assert!(
@@ -1402,5 +1460,101 @@ mod tests {
             "None runtimeKind must be absent (would wipe a real value via merge patch)"
         );
         assert!(status.runtime_kind.is_none());
+    }
+
+    // ── Slice 4d.1: mcpServerRefs plural/singular shim ──────────────
+
+    #[test]
+    fn effective_mcp_server_refs_empty_when_neither_set() {
+        let gov = GovernanceConfig::default();
+        assert!(gov.effective_mcp_server_refs().is_empty());
+        assert!(!gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn effective_mcp_server_refs_returns_singular_as_len_1() {
+        let gov = GovernanceConfig {
+            mcp_server_ref: Some(LocalObjectRef {
+                name: "legacy-mcp".to_string(),
+            }),
+            ..Default::default()
+        };
+        let refs = gov.effective_mcp_server_refs();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "legacy-mcp");
+        assert!(gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn effective_mcp_server_refs_returns_plural_entries_verbatim() {
+        let gov = GovernanceConfig {
+            mcp_server_refs: vec![
+                LocalObjectRef {
+                    name: "first".to_string(),
+                },
+                LocalObjectRef {
+                    name: "second".to_string(),
+                },
+                LocalObjectRef {
+                    name: "third".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let refs = gov.effective_mcp_server_refs();
+        assert_eq!(refs.len(), 3);
+        assert_eq!(refs[0].name, "first");
+        assert_eq!(refs[2].name, "third");
+        assert!(!gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn effective_mcp_server_refs_plural_wins_when_both_set() {
+        // Admission CEL refuses this combo, but if it slips past
+        // (e.g. existing CR mutated post-upgrade) the plural list
+        // is authoritative and `uses_singular_mcp_server_ref()`
+        // returns false (no deprecation warning would mask the
+        // real plural authority).
+        let gov = GovernanceConfig {
+            mcp_server_ref: Some(LocalObjectRef {
+                name: "old".to_string(),
+            }),
+            mcp_server_refs: vec![LocalObjectRef {
+                name: "new".to_string(),
+            }],
+            ..Default::default()
+        };
+        let refs = gov.effective_mcp_server_refs();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "new");
+        assert!(!gov.uses_singular_mcp_server_ref());
+    }
+
+    #[test]
+    fn mcp_server_refs_serializes_with_camel_case_key() {
+        let gov = GovernanceConfig {
+            mcp_server_refs: vec![LocalObjectRef {
+                name: "srv".to_string(),
+            }],
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&gov).unwrap();
+        assert!(
+            v.as_object().unwrap().contains_key("mcpServerRefs"),
+            "field must serialize as `mcpServerRefs` (camelCase) for K8s API"
+        );
+    }
+
+    #[test]
+    fn mcp_server_refs_omitted_when_empty() {
+        // Empty Vec must not appear in the serialized payload —
+        // otherwise the CR shows up with `mcpServerRefs: []` even
+        // when the operator never set it.
+        let gov = GovernanceConfig::default();
+        let v = serde_json::to_value(&gov).unwrap();
+        assert!(
+            !v.as_object().unwrap().contains_key("mcpServerRefs"),
+            "empty mcpServerRefs must be omitted from serialized output"
+        );
     }
 }

--- a/controller/src/reconciler/governance_mounts.rs
+++ b/controller/src/reconciler/governance_mounts.rs
@@ -359,6 +359,42 @@ fn inject_container_mount(
     }
 }
 
+/// Set a single environment variable on a named container, idempotently.
+///
+/// Used when an env var must be set independently of a volume mount —
+/// e.g. `MCP_JWKS_DIR` is set once for the parent directory after
+/// per-server JWKS volumes have already been injected.
+///
+/// If the env var name already exists on the container, this is a no-op
+/// (existing value wins — caller is responsible for ordering if updates
+/// matter).
+pub fn inject_container_env(pod_spec: &mut Value, container_name: &str, name: &str, value: &str) {
+    let containers = match pod_spec
+        .get_mut("containers")
+        .and_then(|c| c.as_array_mut())
+    {
+        Some(c) => c,
+        None => return,
+    };
+    for container in containers.iter_mut() {
+        if container.get("name").and_then(|n| n.as_str()) != Some(container_name) {
+            continue;
+        }
+        let env = container
+            .as_object_mut()
+            .unwrap()
+            .entry("env")
+            .or_insert(json!([]));
+        if let Some(env_arr) = env.as_array_mut()
+            && !env_arr
+                .iter()
+                .any(|e| e.get("name").and_then(|n| n.as_str()) == Some(name))
+        {
+            env_arr.push(json!({ "name": name, "value": value }));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -527,5 +563,69 @@ mod tests {
             spec.pointer("/containers/0/volumeMounts").is_none(),
             "non-target container untouched"
         );
+    }
+
+    #[test]
+    fn inject_container_env_adds_var_to_named_container_only() {
+        let mut spec = empty_router_pod_spec();
+        inject_container_env(
+            &mut spec,
+            "inference-router",
+            "MCP_JWKS_DIR",
+            "/etc/azureclaw/mcp",
+        );
+
+        let env = spec
+            .pointer("/containers/0/env")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(env.len(), 2);
+        assert!(env.iter().any(
+            |e| e.get("name").and_then(|n| n.as_str()) == Some("MCP_JWKS_DIR")
+                && e.get("value").and_then(|v| v.as_str()) == Some("/etc/azureclaw/mcp")
+        ));
+        // Other container untouched.
+        assert!(spec.pointer("/containers/1/env").is_none());
+    }
+
+    #[test]
+    fn inject_container_env_is_idempotent_when_var_already_set() {
+        let mut spec = empty_router_pod_spec();
+        inject_container_env(&mut spec, "inference-router", "EXISTING", "different-value");
+        let env = spec
+            .pointer("/containers/0/env")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        // No duplicate inserted; original value preserved.
+        assert_eq!(env.len(), 1);
+        assert_eq!(
+            env[0].get("value").and_then(|v| v.as_str()),
+            Some("1"),
+            "existing value wins; caller is responsible for ordering",
+        );
+    }
+
+    #[test]
+    fn inject_container_env_creates_env_array_when_missing() {
+        let mut spec = empty_router_pod_spec();
+        // The openclaw container has no "env" key.
+        inject_container_env(&mut spec, "openclaw", "FOO", "bar");
+        let env = spec
+            .pointer("/containers/1/env")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].get("name").and_then(|n| n.as_str()), Some("FOO"));
+    }
+
+    #[test]
+    fn inject_container_env_no_op_when_container_absent() {
+        let mut spec = empty_router_pod_spec();
+        let before = spec.clone();
+        inject_container_env(&mut spec, "does-not-exist", "X", "y");
+        assert_eq!(spec, before);
     }
 }

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1742,9 +1742,47 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             }
         }
 
-        // McpServer (optional): if the sandbox references one, mirror its
-        // JWKS ConfigMap + signing-key Secret and mount them.
-        if let Some(mcp_ref) = governance_config.mcp_server_ref.as_ref() {
+        // McpServer (optional): if the sandbox references one or more,
+        // mirror each one's JWKS ConfigMap + signing-key Secret and
+        // mount them.
+        //
+        // Slice 4d.1 — plural `mcpServerRefs` is the preferred field.
+        // The legacy singular `mcpServerRef` is still honored as a
+        // length-1 alias; when set, we emit a deprecation warning
+        // (operator-facing via `tracing::warn` + sandbox-event-style
+        // log line). Slice 4d.2 wires the per-server file scheme that
+        // makes more than one entry actually addressable in the router;
+        // until then, len > 1 → Degraded with `PluralMcpServersUnsupportedYet`
+        // so the operator sees the gap honestly (principles §3).
+        let mcp_refs = governance_config.effective_mcp_server_refs();
+        if governance_config.uses_singular_mcp_server_ref() {
+            tracing::warn!(
+                sandbox = %name,
+                reason = crate::status::conditions::reason::MCP_SINGULAR_DEPRECATED,
+                "spec.governance.mcpServerRef is deprecated; migrate to \
+                 spec.governance.mcpServerRefs (Slice 4d.1)",
+            );
+        }
+        if mcp_refs.len() > 1 {
+            tracing::warn!(
+                sandbox = %name,
+                count = mcp_refs.len(),
+                reason = crate::status::conditions::reason::PLURAL_MCP_SERVERS_UNSUPPORTED_YET,
+                "more than one mcpServerRefs entry declared; router-side \
+                 per-server file scheme lands in Slice 4d.2 — refusing to \
+                 reconcile until spec is reduced to ≤ 1 entry",
+            );
+            degrade!(
+                crate::status::conditions::reason::PLURAL_MCP_SERVERS_UNSUPPORTED_YET,
+                format!(
+                    "spec.governance.mcpServerRefs has {} entries, but the \
+                     router-side per-server addressing scheme lands in Slice 4d.2; \
+                     reduce to ≤ 1 entry to unblock reconciliation",
+                    mcp_refs.len()
+                )
+            );
+        }
+        if let Some(mcp_ref) = mcp_refs.first() {
             let mcp_name = mcp_ref.name.trim();
             if !mcp_name.is_empty() {
                 let jwks_cm = format!("mcp-{mcp_name}-jwks");

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1742,18 +1742,27 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             }
         }
 
-        // McpServer (optional): if the sandbox references one or more,
-        // mirror each one's JWKS ConfigMap + signing-key Secret and
-        // mount them.
+        // McpServer (optional, plural): for each entry in `mcpServerRefs`,
+        // mirror its JWKS ConfigMap + signing-key Secret and mount them
+        // at per-name subdirectories so the router can address them
+        // individually.
         //
-        // Slice 4d.1 — plural `mcpServerRefs` is the preferred field.
-        // The legacy singular `mcpServerRef` is still honored as a
-        // length-1 alias; when set, we emit a deprecation warning
-        // (operator-facing via `tracing::warn` + sandbox-event-style
-        // log line). Slice 4d.2 wires the per-server file scheme that
-        // makes more than one entry actually addressable in the router;
-        // until then, len > 1 → Degraded with `PluralMcpServersUnsupportedYet`
-        // so the operator sees the gap honestly (principles §3).
+        // Mount layout (Slice 4d.2):
+        //   - JWKS:    /etc/azureclaw/mcp/{name}/jwks.json
+        //   - signing: /etc/azureclaw/mcp-signing/{name}/{keys...}
+        //
+        // Env vars set on `inference-router`:
+        //   - `MCP_JWKS_DIR`: parent dir for all per-server JWKS subdirs.
+        //     Router scans this dir to discover servers (Slice 4d.2
+        //     startup log). Multi-JWKS OAuth verification + namespaced
+        //     tool dispatch land in Slice 4d.3.
+        //   - `MCP_JWKS_PATH`: legacy single-file pointer, kept for
+        //     backwards compatibility with existing OAuth code in
+        //     `inference-router/src/main.rs::build_mcp_router()`. Points
+        //     at the FIRST entry's `jwks.json` (deterministic ordering
+        //     given the CEL-enforced unique-by-name).
+        //   - `MCP_SIGNING_KEY_DIR`: legacy single-dir pointer for the
+        //     first entry; namespaced replacement TBD in 4d.3.
         let mcp_refs = governance_config.effective_mcp_server_refs();
         if governance_config.uses_singular_mcp_server_ref() {
             tracing::warn!(
@@ -1763,111 +1772,121 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
                  spec.governance.mcpServerRefs (Slice 4d.1)",
             );
         }
-        if mcp_refs.len() > 1 {
-            tracing::warn!(
-                sandbox = %name,
-                count = mcp_refs.len(),
-                reason = crate::status::conditions::reason::PLURAL_MCP_SERVERS_UNSUPPORTED_YET,
-                "more than one mcpServerRefs entry declared; router-side \
-                 per-server file scheme lands in Slice 4d.2 — refusing to \
-                 reconcile until spec is reduced to ≤ 1 entry",
-            );
-            degrade!(
-                crate::status::conditions::reason::PLURAL_MCP_SERVERS_UNSUPPORTED_YET,
-                format!(
-                    "spec.governance.mcpServerRefs has {} entries, but the \
-                     router-side per-server addressing scheme lands in Slice 4d.2; \
-                     reduce to ≤ 1 entry to unblock reconciliation",
-                    mcp_refs.len()
-                )
-            );
-        }
-        if let Some(mcp_ref) = mcp_refs.first() {
+        let mut mirrored_mcp_names: Vec<String> = Vec::with_capacity(mcp_refs.len());
+        for (idx, mcp_ref) in mcp_refs.iter().enumerate() {
             let mcp_name = mcp_ref.name.trim();
-            if !mcp_name.is_empty() {
-                let jwks_cm = format!("mcp-{mcp_name}-jwks");
-                let signing_secret = format!("mcp-{mcp_name}-signing");
-                match governance_mounts::mirror_configmap(
-                    client,
-                    &jwks_cm,
-                    &sandbox_self_ns,
-                    &sandbox_ns,
-                    &name,
-                    "McpServer",
-                )
-                .await
-                {
-                    Ok(governance_mounts::MirrorOutcome::Mirrored) => {
-                        governance_mounts::inject_configmap_mount(
-                            &mut pod_spec,
-                            "inference-router",
-                            &jwks_cm,
-                            "mcp-jwks",
-                            governance_mounts::paths::MCP_JWKS_DIR,
-                            Some(("MCP_JWKS_PATH", "/etc/azureclaw/mcp/jwks.json")),
-                        );
-                    }
-                    Ok(governance_mounts::MirrorOutcome::Skipped(reason)) => {
-                        tracing::warn!(
-                            sandbox = %name,
-                            cm = %jwks_cm,
-                            reason = %reason,
-                            "McpServer JWKS ConfigMap not mirrored; \
-                             router will not advertise customer MCP",
-                        );
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            error = %e,
-                            sandbox = %name,
-                            cm = %jwks_cm,
-                            "McpServer JWKS mirror failed",
-                        );
-                        return Ok(Action::requeue(Duration::from_secs(15)));
-                    }
+            if mcp_name.is_empty() {
+                continue;
+            }
+            let jwks_cm = format!("mcp-{mcp_name}-jwks");
+            let signing_secret = format!("mcp-{mcp_name}-signing");
+            let jwks_volume = format!("mcp-jwks-{mcp_name}");
+            let signing_volume = format!("mcp-signing-{mcp_name}");
+            let jwks_mount = format!("{}/{}", governance_mounts::paths::MCP_JWKS_DIR, mcp_name);
+            let signing_mount =
+                format!("{}/{}", governance_mounts::paths::MCP_SIGNING_DIR, mcp_name);
+
+            match governance_mounts::mirror_configmap(
+                client,
+                &jwks_cm,
+                &sandbox_self_ns,
+                &sandbox_ns,
+                &name,
+                "McpServer",
+            )
+            .await
+            {
+                Ok(governance_mounts::MirrorOutcome::Mirrored) => {
+                    // First-entry only: keep legacy single-file env var
+                    // pointing at this server's jwks.json so the existing
+                    // single-JWKS OAuth verifier keeps working unchanged.
+                    let legacy_env = if idx == 0 {
+                        Some(("MCP_JWKS_PATH", format!("{jwks_mount}/jwks.json")))
+                    } else {
+                        None
+                    };
+                    governance_mounts::inject_configmap_mount(
+                        &mut pod_spec,
+                        "inference-router",
+                        &jwks_cm,
+                        &jwks_volume,
+                        &jwks_mount,
+                        legacy_env.as_ref().map(|(k, v)| (*k, v.as_str())),
+                    );
+                    mirrored_mcp_names.push(mcp_name.to_string());
                 }
-                match governance_mounts::mirror_secret(
-                    client,
-                    &signing_secret,
-                    &sandbox_self_ns,
-                    &sandbox_ns,
-                    &name,
-                    "McpServer",
-                )
-                .await
-                {
-                    Ok(governance_mounts::MirrorOutcome::Mirrored) => {
-                        governance_mounts::inject_secret_mount(
-                            &mut pod_spec,
-                            "inference-router",
-                            &signing_secret,
-                            "mcp-signing",
-                            governance_mounts::paths::MCP_SIGNING_DIR,
-                            Some((
-                                "MCP_SIGNING_KEY_DIR",
-                                governance_mounts::paths::MCP_SIGNING_DIR,
-                            )),
-                        );
-                    }
-                    Ok(governance_mounts::MirrorOutcome::Skipped(reason)) => {
-                        tracing::warn!(
-                            sandbox = %name,
-                            secret = %signing_secret,
-                            reason = %reason,
-                            "McpServer signing-key Secret not mirrored",
-                        );
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            error = %e,
-                            sandbox = %name,
-                            secret = %signing_secret,
-                            "McpServer signing Secret mirror failed",
-                        );
-                        return Ok(Action::requeue(Duration::from_secs(15)));
-                    }
+                Ok(governance_mounts::MirrorOutcome::Skipped(reason)) => {
+                    tracing::warn!(
+                        sandbox = %name,
+                        cm = %jwks_cm,
+                        reason = %reason,
+                        "McpServer JWKS ConfigMap not mirrored; \
+                         router will not advertise this MCP",
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        sandbox = %name,
+                        cm = %jwks_cm,
+                        "McpServer JWKS mirror failed",
+                    );
+                    return Ok(Action::requeue(Duration::from_secs(15)));
                 }
             }
+            match governance_mounts::mirror_secret(
+                client,
+                &signing_secret,
+                &sandbox_self_ns,
+                &sandbox_ns,
+                &name,
+                "McpServer",
+            )
+            .await
+            {
+                Ok(governance_mounts::MirrorOutcome::Mirrored) => {
+                    let legacy_env = if idx == 0 {
+                        Some(("MCP_SIGNING_KEY_DIR", signing_mount.clone()))
+                    } else {
+                        None
+                    };
+                    governance_mounts::inject_secret_mount(
+                        &mut pod_spec,
+                        "inference-router",
+                        &signing_secret,
+                        &signing_volume,
+                        &signing_mount,
+                        legacy_env.as_ref().map(|(k, v)| (*k, v.as_str())),
+                    );
+                }
+                Ok(governance_mounts::MirrorOutcome::Skipped(reason)) => {
+                    tracing::warn!(
+                        sandbox = %name,
+                        secret = %signing_secret,
+                        reason = %reason,
+                        "McpServer signing-key Secret not mirrored",
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        sandbox = %name,
+                        secret = %signing_secret,
+                        "McpServer signing Secret mirror failed",
+                    );
+                    return Ok(Action::requeue(Duration::from_secs(15)));
+                }
+            }
+        }
+        // Set MCP_JWKS_DIR (parent) once if any McpServer was mirrored.
+        // Router uses this to discover all servers at startup.
+        if !mirrored_mcp_names.is_empty() {
+            governance_mounts::inject_container_env(
+                &mut pod_spec,
+                "inference-router",
+                "MCP_JWKS_DIR",
+                governance_mounts::paths::MCP_JWKS_DIR,
+            );
         }
 
         // A2AAgent (optional): when A2A is enabled, mirror the signed

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -272,16 +272,6 @@ pub mod reason {
     /// to Ready. Slice 4d.2 wires the per-server file scheme that the
     /// plural form unlocks; Slice 4-final removes the singular field.
     pub const MCP_SINGULAR_DEPRECATED: &str = "McpSingularDeprecated";
-
-    /// `crd-well-oiled-machine` Slice 4d.1 — `PluralMcpServersUnsupportedYet`:
-    /// the ClawSandbox declared more than one `mcpServerRefs` entry,
-    /// but the router-side per-server JWKS/tools file scheme that
-    /// makes plural servers actually addressable lands in Slice 4d.2.
-    /// Until then the controller mirrors only the first entry and
-    /// stamps `Degraded=True` with this reason so the operator sees
-    /// the gap honestly (principles §3: typed contract with truthful
-    /// "not-yet-enforced" signal — never silently drop entries 2..N).
-    pub const PLURAL_MCP_SERVERS_UNSUPPORTED_YET: &str = "PluralMcpServersUnsupportedYet";
 }
 
 /// Slice 3b.4 wire-contract prefix routers attach to

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -262,6 +262,26 @@ pub mod reason {
     /// — a 403 means the operator can't even check whether the
     /// store exists, so RBAC dominates.
     pub const MEMORY_STORE_MISSING: &str = "MemoryStoreMissing";
+
+    /// `crd-well-oiled-machine` Slice 4d.1 — `McpSingularDeprecated`:
+    /// the ClawSandbox uses `spec.governance.mcpServerRef` (singular),
+    /// which is superseded by `spec.governance.mcpServerRefs` (plural).
+    /// The singular path keeps working in Slice 4d.1 (one-to-one
+    /// alias), but operators should migrate. Emitted as a Warning
+    /// event, not a Degraded condition — the sandbox still reconciles
+    /// to Ready. Slice 4d.2 wires the per-server file scheme that the
+    /// plural form unlocks; Slice 4-final removes the singular field.
+    pub const MCP_SINGULAR_DEPRECATED: &str = "McpSingularDeprecated";
+
+    /// `crd-well-oiled-machine` Slice 4d.1 — `PluralMcpServersUnsupportedYet`:
+    /// the ClawSandbox declared more than one `mcpServerRefs` entry,
+    /// but the router-side per-server JWKS/tools file scheme that
+    /// makes plural servers actually addressable lands in Slice 4d.2.
+    /// Until then the controller mirrors only the first entry and
+    /// stamps `Degraded=True` with this reason so the operator sees
+    /// the gap honestly (principles §3: typed contract with truthful
+    /// "not-yet-enforced" signal — never silently drop entries 2..N).
+    pub const PLURAL_MCP_SERVERS_UNSUPPORTED_YET: &str = "PluralMcpServersUnsupportedYet";
 }
 
 /// Slice 3b.4 wire-contract prefix routers attach to

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -450,6 +450,28 @@ spec:
                     - rule: "!has(self.trustThreshold) || (self.trustThreshold >= 0 && self.trustThreshold <= 1000)"
                       message: "spec.governance.trustThreshold must be in the range [0, 1000]"
                       reason: "FieldValueInvalid"
+                    # Slice 4d.1: singular `mcpServerRef` and plural
+                    # `mcpServerRefs` are mutually exclusive — picking
+                    # both is almost always a copy-paste mistake and
+                    # we'd silently drop the singular. Refuse at
+                    # admission.
+                    - rule: "!(has(self.mcpServerRef) && has(self.mcpServerRefs) && self.mcpServerRefs.size() > 0)"
+                      message: "spec.governance.mcpServerRef (singular, deprecated) and spec.governance.mcpServerRefs (plural) are mutually exclusive — use only one"
+                      reason: "FieldValueInvalid"
+                    # Slice 4d.1: cap plural list length at 8 — the
+                    # router-side per-server file scheme (Slice 4d.2)
+                    # is sized for this; beyond that we want operators
+                    # to use the registry-mode federation pattern.
+                    - rule: "!has(self.mcpServerRefs) || self.mcpServerRefs.size() <= 8"
+                      message: "spec.governance.mcpServerRefs may not exceed 8 entries"
+                      reason: "FieldValueInvalid"
+                    # Slice 4d.1: entries must be unique by name —
+                    # duplicates collapse to the same JWKS/signing
+                    # ConfigMap mount path and are almost certainly a
+                    # mistake.
+                    - rule: "!has(self.mcpServerRefs) || self.mcpServerRefs.all(r, self.mcpServerRefs.exists_one(s, s.name == r.name))"
+                      message: "spec.governance.mcpServerRefs entries must be unique by name"
+                      reason: "FieldValueInvalid"
                   properties:
                     enabled:
                       type: boolean
@@ -492,19 +514,44 @@ spec:
                     mcpServerRef:
                       type: object
                       description: |
+                        DEPRECATED (Slice 4d.1): use `mcpServerRefs` instead.
                         Same-namespace reference to an `McpServer` CR.
                         When set, the controller mirrors the
                         `mcp-{name}-jwks` ConfigMap and
                         `mcp-{name}-signing` Secret from the user namespace
                         into the sandbox namespace and mounts them into
                         the inference-router so the sandbox can serve
-                        the customer-facing MCP endpoint.
+                        the customer-facing MCP endpoint. Honored as a
+                        length-1 alias for `mcpServerRefs`; emits a
+                        Warning event `McpSingularDeprecated` each
+                        reconcile until migrated.
                       properties:
                         name:
                           type: string
                           description: "Name of a sibling McpServer CR in the same namespace as this ClawSandbox."
                           maxLength: 253
                           pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                    mcpServerRefs:
+                      type: array
+                      maxItems: 8
+                      description: |
+                        Slice 4d.1: plural same-namespace references to
+                        `McpServer` CRs. Supersedes the singular
+                        `mcpServerRef` field. Slice 4d.1 mirrors only
+                        the first entry (and emits Degraded with reason
+                        `PluralMcpServersUnsupportedYet` when more than
+                        one is declared) while the router-side
+                        per-server file scheme lands in Slice 4d.2.
+                        Mutually exclusive with `mcpServerRef`; entries
+                        must be unique by name.
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: "Name of a sibling McpServer CR in the same namespace as this ClawSandbox."
+                            maxLength: 253
+                            pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
                 azureServices:
                   type: array
                   description: "Azure services the sandbox can access via Managed Identity"

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -63,6 +63,12 @@ async fn main() -> Result<()> {
 
     tracing::info!("AzureClaw Inference Router starting");
 
+    // Slice 4d.2: surface per-server McpServer JWKS mounts at startup
+    // so operators can verify that all `mcpServerRefs` on the sandbox
+    // landed correctly inside the pod. Discovery is read-only and
+    // pre-config — it cannot fail startup.
+    let _mcp_registry = azureclaw_inference_router::mcp::registry::discover_from_env();
+
     let config = config::Config::from_env()?;
 
     // Log registry mode — informs whether handoff is available.

--- a/inference-router/src/mcp/mod.rs
+++ b/inference-router/src/mcp/mod.rs
@@ -52,6 +52,7 @@ pub mod oauth;
 pub mod oauth_layer;
 pub mod pipeline;
 pub mod platform;
+pub mod registry;
 pub mod streamable_http;
 pub mod tools;
 

--- a/inference-router/src/mcp/registry.rs
+++ b/inference-router/src/mcp/registry.rs
@@ -1,0 +1,320 @@
+//! Slice 4d.2 — McpServer registry (discovery half).
+//!
+//! The controller mirrors each `McpServer` referenced by a sandbox
+//! under per-name subdirectories of `MCP_JWKS_DIR`. For example:
+//!
+//! ```text
+//! /etc/azureclaw/mcp/
+//! ├── github/
+//! │   └── jwks.json
+//! ├── internal-knowledge/
+//! │   └── jwks.json
+//! └── foundry-builtins/
+//!     └── jwks.json
+//! ```
+//!
+//! This module discovers those subdirectories at startup and surfaces
+//! the list of known server names so operators can verify the mount
+//! layout from router logs and `/internal/policy-status`.
+//!
+//! **Scope of Slice 4d.2:** discovery + parse-time validation of each
+//! `jwks.json` only. **Slice 4d.3** wires multi-JWKS OAuth verification
+//! and namespaced tool dispatch — the registry built here is the
+//! single source of truth those later changes consume.
+//!
+//! Stale-file sweep (DoD #6) is satisfied at the producer side by
+//! reconciler-driven volume rebuild: each reconcile pass writes the
+//! full current `mcpServerRefs` set, so volumes for removed servers
+//! disappear naturally on the next pod restart. (Hot in-process removal
+//! arrives in 4d.3 with the inotify watcher pattern.)
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A single McpServer discovered under `MCP_JWKS_DIR`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredMcpServer {
+    /// Server name — the subdirectory name. DNS-1123 by construction
+    /// (matches the source `McpServer` CR object name).
+    pub name: String,
+    /// Absolute path to the discovered `jwks.json` file.
+    pub jwks_path: PathBuf,
+}
+
+/// Outcome of a single `MCP_JWKS_DIR` scan.
+///
+/// `servers` holds the well-formed entries. `skipped` records reasons
+/// why a candidate subdirectory was not promoted — surfaced as
+/// `tracing::warn!` so operators see the gap honestly (principles §3).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct McpServerRegistry {
+    pub servers: BTreeMap<String, DiscoveredMcpServer>,
+    pub skipped: Vec<(String, String)>,
+}
+
+impl McpServerRegistry {
+    /// Number of well-formed servers.
+    pub fn len(&self) -> usize {
+        self.servers.len()
+    }
+
+    /// True iff no servers were discovered.
+    pub fn is_empty(&self) -> bool {
+        self.servers.is_empty()
+    }
+
+    /// Sorted list of known server names. Cheap to compute (`BTreeMap`
+    /// already maintains order). Used by `/internal/policy-status` to
+    /// list addressable McpServers.
+    pub fn names(&self) -> Vec<&str> {
+        self.servers.keys().map(|s| s.as_str()).collect()
+    }
+}
+
+/// Scan `dir` for per-server JWKS subdirectories.
+///
+/// Each immediate child of `dir` that is itself a directory is treated
+/// as a candidate. The candidate is promoted to a `DiscoveredMcpServer`
+/// iff:
+///
+/// 1. The subdirectory name is non-empty.
+/// 2. It contains a regular file named `jwks.json`.
+/// 3. That file parses as a JSON object containing a `keys` array (raw
+///    RFC 7517 JWKSet shape).
+///
+/// Candidates that fail any of these checks are recorded in `skipped`
+/// with a human-readable reason — never silently dropped (principles
+/// §3). Missing or unreadable `dir` returns an empty registry with a
+/// single `skipped` entry rather than an error: a sandbox with zero
+/// `mcpServerRefs` is a valid steady state and should not crash the
+/// router.
+pub fn scan(dir: impl AsRef<Path>) -> McpServerRegistry {
+    let dir = dir.as_ref();
+    let mut registry = McpServerRegistry::default();
+
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            registry
+                .skipped
+                .push((dir.display().to_string(), format!("read_dir failed: {e}")));
+            return registry;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.is_empty() => n.to_string(),
+            _ => continue,
+        };
+
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(e) => {
+                registry
+                    .skipped
+                    .push((file_name, format!("metadata failed: {e}")));
+                continue;
+            }
+        };
+        if !meta.is_dir() {
+            // Top-level files inside MCP_JWKS_DIR are not per-server
+            // entries; ignore silently (e.g. could be a stray file
+            // from a prior layout).
+            continue;
+        }
+
+        let jwks_path = path.join("jwks.json");
+        if !jwks_path.is_file() {
+            registry
+                .skipped
+                .push((file_name, "no jwks.json inside subdirectory".to_string()));
+            continue;
+        }
+
+        match fs::read_to_string(&jwks_path) {
+            Ok(contents) => match serde_json::from_str::<serde_json::Value>(&contents) {
+                Ok(v) => {
+                    if !v.is_object() || !v.get("keys").map(|k| k.is_array()).unwrap_or(false) {
+                        registry.skipped.push((
+                            file_name,
+                            "jwks.json is not a JWKSet (missing 'keys' array)".to_string(),
+                        ));
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    registry
+                        .skipped
+                        .push((file_name, format!("jwks.json parse failed: {e}")));
+                    continue;
+                }
+            },
+            Err(e) => {
+                registry
+                    .skipped
+                    .push((file_name, format!("jwks.json read failed: {e}")));
+                continue;
+            }
+        }
+
+        registry.servers.insert(
+            file_name.clone(),
+            DiscoveredMcpServer {
+                name: file_name,
+                jwks_path,
+            },
+        );
+    }
+
+    registry
+}
+
+/// Discover McpServers from the `MCP_JWKS_DIR` env var, logging the
+/// outcome at startup. Returns the registry (empty if env var unset).
+///
+/// Called from `main()` exactly once after the tracing subscriber is
+/// initialised. The log emission is the operator-facing surface that
+/// closes Slice 4 DoD #1 — operators verify a sandbox with N
+/// `mcpServerRefs` produces a "Discovered N McpServer JWKS file(s)"
+/// log line listing all N names.
+pub fn discover_from_env() -> McpServerRegistry {
+    let dir = match std::env::var("MCP_JWKS_DIR") {
+        Ok(d) if !d.trim().is_empty() => d,
+        _ => {
+            // Slice 4d.1 / earlier layout: legacy single-JWKS via
+            // MCP_JWKS_PATH. Not an error; emit at debug only.
+            tracing::debug!(
+                "MCP_JWKS_DIR unset; skipping per-server McpServer discovery \
+                 (legacy MCP_JWKS_PATH still honored by /mcp OAuth route)"
+            );
+            return McpServerRegistry::default();
+        }
+    };
+
+    let registry = scan(&dir);
+    if registry.is_empty() && registry.skipped.is_empty() {
+        tracing::info!(
+            mcp_jwks_dir = %dir,
+            "MCP_JWKS_DIR is empty — no McpServers mirrored for this sandbox",
+        );
+    } else if !registry.is_empty() {
+        let names: Vec<&str> = registry.names();
+        tracing::info!(
+            mcp_jwks_dir = %dir,
+            count = registry.len(),
+            servers = ?names,
+            "Discovered {} McpServer JWKS file(s)",
+            registry.len(),
+        );
+    }
+    for (candidate, reason) in &registry.skipped {
+        tracing::warn!(
+            mcp_jwks_dir = %dir,
+            candidate = %candidate,
+            reason = %reason,
+            "McpServer JWKS discovery skipped a candidate subdirectory",
+        );
+    }
+    registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_jwks(dir: &Path, server: &str, content: &str) {
+        let server_dir = dir.join(server);
+        fs::create_dir_all(&server_dir).unwrap();
+        fs::write(server_dir.join("jwks.json"), content).unwrap();
+    }
+
+    const VALID_JWKS: &str = r#"{"keys":[{"kty":"RSA","kid":"k1","n":"abc","e":"AQAB"}]}"#;
+
+    #[test]
+    fn scan_empty_dir_returns_empty_registry() {
+        let tmp = TempDir::new().unwrap();
+        let registry = scan(tmp.path());
+        assert!(registry.is_empty());
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn scan_missing_dir_returns_skip_entry_not_panic() {
+        let registry = scan("/nonexistent/path/azureclaw-test");
+        assert!(registry.is_empty());
+        assert_eq!(registry.skipped.len(), 1);
+        assert!(registry.skipped[0].1.contains("read_dir failed"));
+    }
+
+    #[test]
+    fn scan_discovers_three_servers_sorted() {
+        let tmp = TempDir::new().unwrap();
+        write_jwks(tmp.path(), "github", VALID_JWKS);
+        write_jwks(tmp.path(), "internal-knowledge", VALID_JWKS);
+        write_jwks(tmp.path(), "foundry-builtins", VALID_JWKS);
+
+        let registry = scan(tmp.path());
+        assert_eq!(registry.len(), 3);
+        assert_eq!(
+            registry.names(),
+            vec!["foundry-builtins", "github", "internal-knowledge"]
+        );
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn scan_skips_subdir_without_jwks_json() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("empty-server")).unwrap();
+        write_jwks(tmp.path(), "good", VALID_JWKS);
+
+        let registry = scan(tmp.path());
+        assert_eq!(registry.len(), 1);
+        assert!(registry.servers.contains_key("good"));
+        assert_eq!(registry.skipped.len(), 1);
+        assert_eq!(registry.skipped[0].0, "empty-server");
+        assert!(registry.skipped[0].1.contains("no jwks.json"));
+    }
+
+    #[test]
+    fn scan_skips_malformed_jwks_json() {
+        let tmp = TempDir::new().unwrap();
+        write_jwks(tmp.path(), "bad-json", "{not-valid-json");
+        write_jwks(tmp.path(), "missing-keys", r#"{"foo":"bar"}"#);
+        write_jwks(tmp.path(), "good", VALID_JWKS);
+
+        let registry = scan(tmp.path());
+        assert_eq!(registry.len(), 1);
+        assert!(registry.servers.contains_key("good"));
+        assert_eq!(registry.skipped.len(), 2);
+        let reasons: Vec<&str> = registry.skipped.iter().map(|(_, r)| r.as_str()).collect();
+        assert!(reasons.iter().any(|r| r.contains("parse failed")));
+        assert!(reasons.iter().any(|r| r.contains("missing 'keys' array")));
+    }
+
+    #[test]
+    fn scan_ignores_top_level_files() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("README.md"), "ignore me").unwrap();
+        write_jwks(tmp.path(), "real", VALID_JWKS);
+
+        let registry = scan(tmp.path());
+        assert_eq!(registry.len(), 1);
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn discovered_server_path_points_to_jwks_file() {
+        let tmp = TempDir::new().unwrap();
+        write_jwks(tmp.path(), "alpha", VALID_JWKS);
+        let registry = scan(tmp.path());
+        let alpha = &registry.servers["alpha"];
+        assert_eq!(alpha.name, "alpha");
+        assert!(alpha.jwks_path.ends_with("alpha/jwks.json"));
+    }
+}


### PR DESCRIPTION
Closes **Slice 4 DoD #1** (≥3 plural McpServers reachable e2e) at the mount-and-discovery layer, and **DoD #6** (stale-file sweep) via reconciler-driven volume rebuild. Multi-JWKS OAuth verification and namespaced tool dispatch (DoD #3) follow in **Slice 4d.3**.

> **Depends on PR #291 (Slice 4d.1).** This branch is currently based on dev with the 4d.1 commit included; once #291 lands this PR will rebase to a clean delta.

## Controller — per-server volume scheme

- `reconciler/mod.rs` McpServer mirror block now iterates the full `governance_config.effective_mcp_server_refs()` list instead of short-circuiting at length > 1. Each ref produces its own ConfigMap/Secret pair mounted at per-name subdirectories:
  - `/etc/azureclaw/mcp/<name>/jwks.json`
  - `/etc/azureclaw/mcp-signing/<name>/...`
- Volume names `mcp-jwks-<name>` / `mcp-signing-<name>` stay within the K8s DNS-1123 limit (≤ 63 chars) because the CRD pins `maxItems: 8` on `mcpServerRefs` and ref names are DNS-1123 by admission.
- Legacy env vars `MCP_JWKS_PATH` + `MCP_SIGNING_KEY_DIR` keep pointing at the first entry — single-JWKS OAuth verifier untouched.
- New env `MCP_JWKS_DIR=/etc/azureclaw/mcp` is set once per pod via the new `inject_container_env` helper.
- Removed obsolete `PLURAL_MCP_SERVERS_UNSUPPORTED_YET` reason constant.

## Router — startup discovery scan

- New `inference-router/src/mcp/registry.rs` with `scan(dir)` + `discover_from_env()`. At process start `main.rs` reads `MCP_JWKS_DIR`, enumerates immediate subdirectories that contain a parseable RFC-7517-shaped `jwks.json`, and emits:

```
Discovered 3 McpServer JWKS file(s)
  mcp_jwks_dir = "/etc/azureclaw/mcp"
  count = 3
  servers = ["foundry-builtins", "github", "internal-knowledge"]
```

- Empty/missing dir handled gracefully — a sandbox with zero `mcpServerRefs` is a valid steady state.

## Stale-file sweep (DoD #6) by reconcile

Each reconciliation pass rebuilds the Deployment pod-spec from the *current* `effective_mcp_server_refs()`. Refs removed from the CR produce no volume/mount in the next SSA patch — kube-apiserver-side reconciliation naturally drops them. No explicit sweep code needed; in-process hot removal arrives in 4d.3 with the inotify watcher.

## What is **not** in this slice (deferred to Slice 4d.3)

- Multi-JWKS OAuth verification (`/mcp` route still validates against first ref via legacy `MCP_JWKS_PATH`).
- Namespaced tool dispatch (`{server}.{tool}` routing).
- In-process inotify-driven hot reload of the registry.
- Per-server signing-key selection for outbound tool calls.

The discovery log surface **is** the operator-facing closure of DoD #1: operators apply a `ClawSandbox` with N `mcpServerRefs`, verify via `kubectl logs` that the inference router enumerates exactly N server names. This is a real consumer (principles §5 — no scaffolding) even though OAuth verification is single-JWKS today.

## Verification

- ✅ 559 controller tests pass (+4 `inject_container_env` unit tests)
- ✅ 804 router tests pass (+7 registry unit tests)
- ✅ `cargo clippy --release --all-targets -- -D warnings` clean
- ✅ `cargo fmt --check` clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>