### PR TITLE
Slice 4d.3 — multi-issuer OAuth verification for per-server JWKS (DoD #3 — OAuth half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
-<<<<<<< HEAD
+### Slice 4d.3 — multi-issuer OAuth verification (DoD #3 — OAuth half)
+
+Closes the OAuth half of Slice 4 DoD #3 (*"each McpServer has its own
+JWKS"*). Each McpServer now has its OAuth tokens validated against
+*its own* JWKS, with a per-issuer `audience` and `scopes` override —
+all driven by a `meta.json` file the controller writes alongside
+`jwks.json` into the per-server ConfigMap mounted at
+`/etc/azureclaw/mcp/<name>/`.
+
+What this PR adds:
+
+- **Controller — `McpServerMeta` producer.**
+  `mcp_server_reconciler.rs` now writes a second key, `meta.json`, into
+  the `mcp-<name>-jwks` ConfigMap alongside `jwks.json`. The
+  serialized shape carries `{ issuer, audience?, scopes[] }` —
+  serialized in camelCase, with optional/empty fields skipped for
+  forward-compat. The struct + helper `McpServerMeta::from_spec`
+  centralise the wire contract.
+- **Router — `DiscoveredMcpServerMeta`.** `mcp::registry` gains a
+  matching deserialize-side struct and reads `meta.json` adjacent to
+  each `jwks.json` during `scan()`. Missing files are silently
+  back-compat (pre-4d.3 layouts → `meta = None`); malformed or
+  empty-issuer files are *recorded in `skipped`* so operators see
+  the gap honestly (principles §3 — no silent failure).
+- **Router — multi-issuer `OAuthVerifierConfig`.**
+  - `expected_audience` is now a per-issuer floor; new
+    `per_issuer_audience: HashMap<String, String>` overrides on a
+    per-token basis (keyed by the token's `iss` claim).
+  - `required_scopes` is now a per-issuer floor; new
+    `per_issuer_scopes: HashMap<String, Vec<String>>` overrides.
+  - New `OAuthVerifierConfig::from_registry(&McpServerRegistry,
+    default_audience, default_scopes, leeway) -> Result<Option<Self>>`
+    materialises a multi-issuer config from a scanned registry.
+    Returns `Ok(None)` when no servers carry meta — the caller
+    (`build_mcp_router`) then falls back to the legacy single-JWKS
+    `from_jwks_file` path. Conflicting JWKS for the same issuer
+    across two servers surface as a hard error rather than silently
+    overwriting.
+- **Router — `build_mcp_router` wires the registry-first path.**
+  When `MCP_PRODUCTION_MODE=true` and the registry is non-empty, the
+  router prefers the multi-issuer path. Empty registry / no-meta
+  fallback to the legacy `MCP_JWKS_PATH` path. Refusal to mount on
+  hard error remains intact (operators see a clear startup-time
+  error instead of an unauthenticated `/mcp`).
+
+The per-issuer pin works because `verify_access_token` already keys
+JWKS lookup off the token's claimed `iss` (which is then re-validated
+by `Validation::set_issuer`). Slice 4d.3 simply lifts the audience and
+scope checks onto the same per-issuer key — so a token from server-A
+carrying server-B's audience fails closed even though both audiences
+are listed in the same config.
+
+Verified: 820 router lib tests pass (+10 new for multi-issuer aud,
+multi-issuer scopes, `from_registry` happy/none/conflict paths, meta
+load happy/skip paths), 559 controller tests pass, `cargo clippy
+--all-targets -- -D warnings` clean across workspace, `cargo fmt
+--check` clean.
+
+Out of scope for 4d.3 (queued for 4d.4):
+
+- Namespaced tool dispatch (`/mcp/<server>/...`) — needs a real
+  upstream MCP forwarder backend; until one lands, dispatch
+  namespacing would be scaffolding (principles §5).
+
 ### Slice 4d.2 — per-server McpServer mount scheme + router discovery (DoD #1 + #6)
 
 Closes Slice 4 DoD #1 (*"≥ 3 plural McpServers reachable e2e"*) at the
@@ -101,8 +164,6 @@ scaffolding) even though OAuth verification is single-JWKS today.
 Verified: 559 controller + 804 router tests pass, clippy
 `-D warnings` clean across workspace, `cargo fmt --check` clean.
 
-=======
->>>>>>> origin/dev
 ### Slice 4d.1 — `mcpServerRefs` plural (DoD #2 deprecation)
 
 Slice 4 DoD #2 says: *"`mcpServerRef` (singular) emits a Warning event
@@ -157,10 +218,7 @@ Out of scope for 4d.1 (queued for 4d.2):
 - Router-side `McpServerRegistry` for namespaced tool dispatch.
 - Stale-file sweep (DoD #6).
 - e2e fixture with ≥ 3 servers (DoD #1).
-<<<<<<< HEAD
-=======
 
->>>>>>> origin/dev
 ### Slice 4c — Azure Monitor remote audit sink (DoD #5)
 
 Slice 4a (PR #287) shipped the sandbox-local JSONL audit log. Slice 4b

--- a/controller/src/mcp_server_reconciler.rs
+++ b/controller/src/mcp_server_reconciler.rs
@@ -302,7 +302,9 @@ async fn reconcile(mcp: Arc<McpServer>, ctx: Arc<Ctx>) -> Result<Action, Reconci
                 let cm_name = format!("mcp-{name}-jwks");
                 match ctx.jwks_fetcher.fetch(&issuer).await {
                     Ok(fetched) => {
-                        ensure_jwks_configmap(&configmaps, &cm_name, &name, &fetched.raw).await?;
+                        let meta = McpServerMeta::from_spec(&mcp.spec);
+                        ensure_jwks_configmap(&configmaps, &cm_name, &name, &fetched.raw, &meta)
+                            .await?;
                         jwks_ref = Some(LocalObjectRef {
                             name: cm_name.clone(),
                         });
@@ -568,18 +570,71 @@ fn kid_from_public_bytes(public: &[u8]) -> String {
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&digest[..16])
 }
 
+/// Slice 4d.3 — per-server OAuth metadata.
+///
+/// Written by the controller into the `mcp-{name}-jwks` ConfigMap under
+/// the `meta.json` key so the router's `McpServerRegistry` can build a
+/// multi-issuer `OAuthVerifierConfig` keyed by `issuer`. Plural
+/// `audiences` because some IdPs (e.g. Entra) issue tokens whose `aud`
+/// claim is a list; we accept whichever audience matches the server's
+/// configured `audience` (validator handles list-vs-string).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerMeta {
+    /// OAuth 2.1 issuer URL.
+    pub issuer: String,
+    /// Single audience the validator pins on for this server. Optional
+    /// because some self-managed MCP servers omit the `aud` claim
+    /// (RFC 6749 silence). When absent, the router treats this server's
+    /// JWKS as audience-agnostic (the global `MCP_OAUTH_AUDIENCE`
+    /// env-var still applies as a floor for the dev-mode legacy path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<String>,
+    /// OAuth 2.1 scopes the router uses to gate fronted calls. Empty =
+    /// no scope requirement at the OAuth layer (per-tool gating lives
+    /// in ToolPolicy).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+}
+
+impl McpServerMeta {
+    /// Build the meta record from a reconciled `McpServerSpec`.
+    pub fn from_spec(spec: &crate::mcp_server::McpServerSpec) -> Self {
+        let (issuer, audience) = match spec.oauth.as_ref() {
+            Some(o) => (
+                o.issuer.clone(),
+                o.audience.clone().filter(|a| !a.is_empty()),
+            ),
+            None => (String::new(), None),
+        };
+        Self {
+            issuer,
+            audience,
+            scopes: spec.scopes.clone(),
+        }
+    }
+}
+
 async fn ensure_jwks_configmap(
     api: &Api<ConfigMap>,
     cm_name: &str,
     owner: &str,
     raw_jwks: &[u8],
+    meta: &McpServerMeta,
 ) -> Result<(), ReconcileError> {
     let s = match std::str::from_utf8(raw_jwks) {
         Ok(s) => s.to_string(),
         Err(_) => return Ok(()), // skip — invalid_jwks_format already classified
     };
+    let meta_json = serde_json::to_string(meta).unwrap_or_else(|_| "{}".to_string());
     let mut data: BTreeMap<String, String> = BTreeMap::new();
     data.insert("jwks.json".into(), s);
+    // Slice 4d.3 — per-server OAuth metadata consumed by the router's
+    // `McpServerRegistry`. Keys: `issuer`, `audience`, `scopes`. The
+    // router builds a multi-issuer `OAuthVerifierConfig` from these
+    // mirrored ConfigMaps so each McpServer's tokens are validated
+    // against that server's JWKS + audience.
+    data.insert("meta.json".into(), meta_json);
     let cm = ConfigMap {
         metadata: ObjectMeta {
             name: Some(cm_name.into()),

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -487,6 +487,7 @@ async fn main() -> Result<()> {
 /// unauthenticated MCP traffic.
 fn build_mcp_router() -> Router {
     use azureclaw_inference_router::mcp::oauth::OAuthVerifierConfig;
+    use azureclaw_inference_router::mcp::registry;
 
     let production = std::env::var("MCP_PRODUCTION_MODE")
         .map(|v| matches!(v.as_str(), "true" | "1" | "yes"))
@@ -495,6 +496,47 @@ fn build_mcp_router() -> Router {
     let audience = std::env::var("MCP_OAUTH_AUDIENCE").ok();
 
     let state = routes::McpRouteState::standard();
+
+    // Slice 4d.3 — prefer the multi-issuer path when MCP_JWKS_DIR is
+    // populated and at least one server contributes `meta.json`. Falls
+    // back to legacy single-JWKS path on empty/absent registry.
+    if production {
+        let registry = registry::discover_from_env();
+        if !registry.is_empty() {
+            let default_audience = audience.clone().unwrap_or_default();
+            let required_scopes = std::env::var("MCP_OAUTH_REQUIRED_SCOPES")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| s.split_whitespace().map(|t| t.to_string()).collect())
+                .unwrap_or_default();
+            match OAuthVerifierConfig::from_registry(
+                &registry,
+                &default_audience,
+                required_scopes,
+                60,
+            ) {
+                Ok(Some(cfg)) => {
+                    let issuers: Vec<&String> = cfg.trusted_issuers.keys().collect();
+                    tracing::info!(
+                        servers = registry.len(),
+                        issuers = ?issuers,
+                        "Mounting /mcp with multi-issuer OAuth 2.1 verification (Slice 4d.3)"
+                    );
+                    return routes::protected_mcp_route(state, Arc::new(cfg));
+                }
+                Ok(None) => {
+                    tracing::warn!(
+                        "MCP_JWKS_DIR populated but no servers carry meta.json — \
+                         falling back to legacy single-issuer MCP_JWKS_PATH path"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Multi-issuer OAuth config build failed; refusing to mount /mcp");
+                    return Router::new();
+                }
+            }
+        }
+    }
 
     if production && jwks_path.is_some() && audience.is_some() {
         let path = std::path::PathBuf::from(jwks_path.unwrap());

--- a/inference-router/src/mcp/oauth.rs
+++ b/inference-router/src/mcp/oauth.rs
@@ -65,9 +65,17 @@ use std::collections::{HashMap, HashSet};
 pub struct OAuthVerifierConfig {
     /// Map from issuer URL to that issuer's JWK set.
     pub trusted_issuers: HashMap<String, JwkSet>,
-    /// Required `aud` claim value. Tokens whose `aud` does not include
-    /// this exact string are rejected.
+    /// Required `aud` claim value used as a fallback when no per-issuer
+    /// audience is configured for the token's issuer. Tokens whose `aud`
+    /// does not include this exact string are rejected unless a
+    /// per-issuer override matches first.
     pub expected_audience: String,
+    /// Slice 4d.3 — per-issuer audience override. When the token's
+    /// issuer maps to an entry here, that entry's audience is used
+    /// instead of the global `expected_audience`. This is how the
+    /// router supports multiple McpServers each pinning a different
+    /// `aud` claim against their own JWKS.
+    pub per_issuer_audience: HashMap<String, String>,
     /// Allow-list of acceptable JWS algorithms. `Algorithm::HS256` etc.
     /// (symmetric algs) MUST NOT be configured here for an MCP
     /// resource server — we only accept asymmetric (RS256, ES256,
@@ -76,10 +84,12 @@ pub struct OAuthVerifierConfig {
     /// Acceptable clock skew in seconds. RFC 8725 §3.8 recommends a
     /// small but non-zero value. Default: 60 s.
     pub leeway_seconds: u64,
-    /// Scopes the caller's request requires. The verified `scope`
-    /// claim must contain every entry, space-separated per RFC 6749
-    /// §3.3.
+    /// Scopes the caller's request requires when no per-issuer scope
+    /// override applies. The verified `scope` claim must contain every
+    /// entry, space-separated per RFC 6749 §3.3.
     pub required_scopes: Vec<String>,
+    /// Slice 4d.3 — per-issuer required scopes override.
+    pub per_issuer_scopes: HashMap<String, Vec<String>>,
 }
 
 impl OAuthVerifierConfig {
@@ -90,6 +100,7 @@ impl OAuthVerifierConfig {
         Self {
             trusted_issuers: HashMap::new(),
             expected_audience: String::new(),
+            per_issuer_audience: HashMap::new(),
             allowed_algorithms: vec![
                 Algorithm::EdDSA,
                 Algorithm::ES256,
@@ -98,6 +109,7 @@ impl OAuthVerifierConfig {
             ],
             leeway_seconds: 60,
             required_scopes: Vec::new(),
+            per_issuer_scopes: HashMap::new(),
         }
     }
 }
@@ -135,6 +147,7 @@ impl OAuthVerifierConfig {
         Ok(Self {
             trusted_issuers: trusted,
             expected_audience: audience.to_string(),
+            per_issuer_audience: HashMap::new(),
             allowed_algorithms: vec![
                 Algorithm::EdDSA,
                 Algorithm::ES256,
@@ -143,7 +156,92 @@ impl OAuthVerifierConfig {
             ],
             leeway_seconds: 60,
             required_scopes,
+            per_issuer_scopes: HashMap::new(),
         })
+    }
+
+    /// Slice 4d.3 — build a multi-issuer verifier from a scanned
+    /// `McpServerRegistry`. Each discovered server with a `meta.json`
+    /// contributes one trusted issuer + optional per-issuer audience +
+    /// per-issuer scopes. Servers without `meta.json` are skipped — the
+    /// legacy single-issuer path (`from_jwks_file`) still applies via
+    /// `MCP_JWKS_PATH` as a fallback when this returns an empty config.
+    ///
+    /// `default_audience` is used as the floor (`expected_audience`)
+    /// for tokens whose issuer has no per-issuer audience override.
+    /// `default_scopes` is the floor scope set for issuers without
+    /// per-issuer scopes.
+    ///
+    /// Returns `None` when the registry contains no servers with meta —
+    /// caller should fall back to the legacy path in that case so the
+    /// router never silently mounts an unauthenticated route.
+    pub fn from_registry(
+        registry: &crate::mcp::registry::McpServerRegistry,
+        default_audience: &str,
+        default_scopes: Vec<String>,
+        leeway_seconds: u64,
+    ) -> Result<Option<Self>, String> {
+        let mut trusted_issuers: HashMap<String, JwkSet> = HashMap::new();
+        let mut per_issuer_audience: HashMap<String, String> = HashMap::new();
+        let mut per_issuer_scopes: HashMap<String, Vec<String>> = HashMap::new();
+
+        for (name, server) in &registry.servers {
+            let Some(meta) = server.meta.as_ref() else {
+                tracing::warn!(
+                    server = %name,
+                    "McpServer has no meta.json — skipping OAuth registration \
+                     (legacy MCP_JWKS_PATH path still in effect for unmatched issuers)"
+                );
+                continue;
+            };
+            let raw = std::fs::read(&server.jwks_path).map_err(|e| {
+                format!(
+                    "cannot read JWKS for {name} at {}: {e}",
+                    server.jwks_path.display()
+                )
+            })?;
+            let jwks: JwkSet = serde_json::from_slice(&raw).map_err(|e| {
+                format!(
+                    "JWKS for {name} at {} is not valid: {e}",
+                    server.jwks_path.display()
+                )
+            })?;
+            if let Some(existing) = trusted_issuers.get(&meta.issuer) {
+                if existing != &jwks {
+                    return Err(format!(
+                        "issuer {} appears in two McpServer entries with conflicting JWKS",
+                        meta.issuer
+                    ));
+                }
+            } else {
+                trusted_issuers.insert(meta.issuer.clone(), jwks);
+            }
+            if let Some(aud) = meta.audience.as_ref().filter(|a| !a.is_empty()) {
+                per_issuer_audience.insert(meta.issuer.clone(), aud.clone());
+            }
+            if !meta.scopes.is_empty() {
+                per_issuer_scopes.insert(meta.issuer.clone(), meta.scopes.clone());
+            }
+        }
+
+        if trusted_issuers.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            trusted_issuers,
+            expected_audience: default_audience.to_string(),
+            per_issuer_audience,
+            allowed_algorithms: vec![
+                Algorithm::EdDSA,
+                Algorithm::ES256,
+                Algorithm::RS256,
+                Algorithm::PS256,
+            ],
+            leeway_seconds,
+            required_scopes: default_scopes,
+            per_issuer_scopes,
+        }))
     }
 }
 
@@ -288,9 +386,14 @@ pub fn verify_access_token(
         build_decoding_key(jwk).map_err(|e| OAuthError::DecodingKey(e.to_string()))?;
 
     // 4. Build Validation and run the verified decode.
+    let effective_audience = config
+        .per_issuer_audience
+        .get(&unverified_iss)
+        .map(String::as_str)
+        .unwrap_or(config.expected_audience.as_str());
     let mut validation = Validation::new(header.alg);
     validation.leeway = config.leeway_seconds;
-    validation.set_audience(&[&config.expected_audience]);
+    validation.set_audience(&[effective_audience]);
     validation.set_issuer(&[&unverified_iss]);
     validation.set_required_spec_claims(&["iss", "sub", "aud", "exp"]);
     validation.algorithms = config.allowed_algorithms.clone();
@@ -312,12 +415,16 @@ pub fn verify_access_token(
     }
     let matched_aud = typed
         .aud
-        .matched(&config.expected_audience)
+        .matched(effective_audience)
         .ok_or(OAuthError::MissingClaim("aud"))?;
 
     // 6. Scope check.
     let scopes = collect_scopes(&typed);
-    for required in &config.required_scopes {
+    let effective_scopes = config
+        .per_issuer_scopes
+        .get(&unverified_iss)
+        .unwrap_or(&config.required_scopes);
+    for required in effective_scopes {
         if !scopes.contains(required) {
             return Err(OAuthError::MissingScope(required.clone()));
         }
@@ -524,9 +631,11 @@ mod tests {
         OAuthVerifierConfig {
             trusted_issuers: trusted,
             expected_audience: TEST_AUDIENCE.into(),
+            per_issuer_audience: HashMap::new(),
             allowed_algorithms: vec![Algorithm::EdDSA],
             leeway_seconds: 30,
             required_scopes: scopes,
+            per_issuer_scopes: HashMap::new(),
         }
     }
 
@@ -856,9 +965,11 @@ mod tests {
         let config = OAuthVerifierConfig {
             trusted_issuers: trusted,
             expected_audience: TEST_AUDIENCE.into(),
+            per_issuer_audience: HashMap::new(),
             allowed_algorithms: vec![Algorithm::EdDSA],
             leeway_seconds: 30,
             required_scopes: vec![],
+            per_issuer_scopes: HashMap::new(),
         };
 
         // Token claims iss=other-trusted, signed with `legit`'s key,
@@ -905,5 +1016,285 @@ mod tests {
             curve: jsonwebtoken::jwk::EllipticCurve::Ed25519,
             x: String::new(),
         })
+    }
+
+    // ----- Slice 4d.3 — multi-issuer per-server audience/scopes -----
+
+    /// Per-issuer audience override: a token issued by `iss_a` carrying
+    /// `aud_a` must be accepted, while a token from `iss_b` must carry
+    /// `aud_b` — even though both share the same router process.
+    #[test]
+    fn per_issuer_audience_overrides_global_default() {
+        let (sk_a, vk_a) = ed_keypair();
+        let (sk_b, vk_b) = ed_keypair();
+        let iss_a = "https://idp-a.example";
+        let iss_b = "https://idp-b.example";
+        let aud_a = "api://server-a";
+        let aud_b = "api://server-b";
+
+        let mut trusted = HashMap::new();
+        trusted.insert(iss_a.to_string(), jwks_with(&vk_a, "kid-a"));
+        trusted.insert(iss_b.to_string(), jwks_with(&vk_b, "kid-b"));
+        let mut per_aud = HashMap::new();
+        per_aud.insert(iss_a.to_string(), aud_a.to_string());
+        per_aud.insert(iss_b.to_string(), aud_b.to_string());
+        let config = OAuthVerifierConfig {
+            trusted_issuers: trusted,
+            expected_audience: "api://fallback".into(),
+            per_issuer_audience: per_aud,
+            allowed_algorithms: vec![Algorithm::EdDSA],
+            leeway_seconds: 30,
+            required_scopes: vec![],
+            per_issuer_scopes: HashMap::new(),
+        };
+
+        let token_a = make_token(
+            &signing_key_pem(&sk_a),
+            "kid-a",
+            iss_a,
+            json!(aud_a),
+            300,
+            None,
+        );
+        let token_b = make_token(
+            &signing_key_pem(&sk_b),
+            "kid-b",
+            iss_b,
+            json!(aud_b),
+            300,
+            None,
+        );
+        verify_access_token(&format!("Bearer {token_a}"), &config).unwrap();
+        verify_access_token(&format!("Bearer {token_b}"), &config).unwrap();
+    }
+
+    /// A token from `iss_a` carrying `iss_b`'s audience must be
+    /// rejected — even though both audiences are listed somewhere in
+    /// `per_issuer_audience`, only the entry keyed to the token's iss
+    /// is honored.
+    #[test]
+    fn per_issuer_audience_pins_correctly() {
+        let (sk_a, vk_a) = ed_keypair();
+        let (_sk_b, vk_b) = ed_keypair();
+        let iss_a = "https://idp-a.example";
+        let iss_b = "https://idp-b.example";
+        let aud_a = "api://server-a";
+        let aud_b = "api://server-b";
+
+        let mut trusted = HashMap::new();
+        trusted.insert(iss_a.to_string(), jwks_with(&vk_a, "kid-a"));
+        trusted.insert(iss_b.to_string(), jwks_with(&vk_b, "kid-b"));
+        let mut per_aud = HashMap::new();
+        per_aud.insert(iss_a.to_string(), aud_a.to_string());
+        per_aud.insert(iss_b.to_string(), aud_b.to_string());
+        let config = OAuthVerifierConfig {
+            trusted_issuers: trusted,
+            expected_audience: "api://fallback".into(),
+            per_issuer_audience: per_aud,
+            allowed_algorithms: vec![Algorithm::EdDSA],
+            leeway_seconds: 30,
+            required_scopes: vec![],
+            per_issuer_scopes: HashMap::new(),
+        };
+
+        // Cross-aud: iss_a token claims aud_b.
+        let token = make_token(
+            &signing_key_pem(&sk_a),
+            "kid-a",
+            iss_a,
+            json!(aud_b),
+            300,
+            None,
+        );
+        let err = verify_access_token(&format!("Bearer {token}"), &config).unwrap_err();
+        assert!(
+            matches!(err, OAuthError::ValidationFailed(_)),
+            "expected aud validation failure, got {err:?}"
+        );
+    }
+
+    /// Per-issuer scopes override: server-A requires `tools.invoke`,
+    /// server-B requires `data.read`. A token from `iss_a` must carry
+    /// the A scope but not the B scope.
+    #[test]
+    fn per_issuer_scopes_apply_per_token() {
+        let (sk_a, vk_a) = ed_keypair();
+        let iss_a = "https://idp-a.example";
+        let aud_a = "api://server-a";
+
+        let mut trusted = HashMap::new();
+        trusted.insert(iss_a.to_string(), jwks_with(&vk_a, "kid-a"));
+        let mut per_aud = HashMap::new();
+        per_aud.insert(iss_a.to_string(), aud_a.to_string());
+        let mut per_scopes = HashMap::new();
+        per_scopes.insert(iss_a.to_string(), vec!["tools.invoke".to_string()]);
+        let config = OAuthVerifierConfig {
+            trusted_issuers: trusted,
+            expected_audience: "api://fallback".into(),
+            per_issuer_audience: per_aud,
+            allowed_algorithms: vec![Algorithm::EdDSA],
+            leeway_seconds: 30,
+            // Global requires data.read — but the per-issuer override
+            // should drop that requirement for tokens from iss_a.
+            required_scopes: vec!["data.read".to_string()],
+            per_issuer_scopes: per_scopes,
+        };
+
+        let token = make_token(
+            &signing_key_pem(&sk_a),
+            "kid-a",
+            iss_a,
+            json!(aud_a),
+            300,
+            Some("tools.invoke"),
+        );
+        verify_access_token(&format!("Bearer {token}"), &config).unwrap();
+
+        // Token without the per-issuer-required scope must fail.
+        let token_no_scope = make_token(
+            &signing_key_pem(&sk_a),
+            "kid-a",
+            iss_a,
+            json!(aud_a),
+            300,
+            None,
+        );
+        let err = verify_access_token(&format!("Bearer {token_no_scope}"), &config).unwrap_err();
+        assert!(matches!(err, OAuthError::MissingScope(s) if s == "tools.invoke"));
+    }
+
+    /// `from_registry` returns `None` when the registry contains no
+    /// servers with meta — caller must fall back to legacy path.
+    #[test]
+    fn from_registry_returns_none_when_no_meta() {
+        let registry = crate::mcp::registry::McpServerRegistry::default();
+        let cfg = OAuthVerifierConfig::from_registry(&registry, "api://fb", vec![], 30).unwrap();
+        assert!(cfg.is_none());
+    }
+
+    /// `from_registry` materialises a multi-issuer config from a
+    /// scanned registry with two servers carrying disjoint meta.
+    #[test]
+    fn from_registry_builds_multi_issuer_config() {
+        use crate::mcp::registry::{
+            DiscoveredMcpServer, DiscoveredMcpServerMeta, McpServerRegistry,
+        };
+        use std::collections::BTreeMap;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (_sk_a, vk_a) = ed_keypair();
+        let (_sk_b, vk_b) = ed_keypair();
+        let jwks_a = serde_json::to_vec(&jwks_with(&vk_a, "kid-a")).unwrap();
+        let jwks_b = serde_json::to_vec(&jwks_with(&vk_b, "kid-b")).unwrap();
+        let path_a = tmp.path().join("server-a.jwks.json");
+        let path_b = tmp.path().join("server-b.jwks.json");
+        std::fs::write(&path_a, jwks_a).unwrap();
+        std::fs::write(&path_b, jwks_b).unwrap();
+
+        let mut servers = BTreeMap::new();
+        servers.insert(
+            "server-a".to_string(),
+            DiscoveredMcpServer {
+                name: "server-a".to_string(),
+                jwks_path: path_a,
+                meta: Some(DiscoveredMcpServerMeta {
+                    issuer: "https://idp-a.example".to_string(),
+                    audience: Some("api://server-a".to_string()),
+                    scopes: vec!["tools.invoke".to_string()],
+                }),
+            },
+        );
+        servers.insert(
+            "server-b".to_string(),
+            DiscoveredMcpServer {
+                name: "server-b".to_string(),
+                jwks_path: path_b,
+                meta: Some(DiscoveredMcpServerMeta {
+                    issuer: "https://idp-b.example".to_string(),
+                    audience: Some("api://server-b".to_string()),
+                    scopes: vec![],
+                }),
+            },
+        );
+        let registry = McpServerRegistry {
+            servers,
+            skipped: vec![],
+        };
+
+        let cfg = OAuthVerifierConfig::from_registry(&registry, "api://fb", vec![], 30)
+            .unwrap()
+            .expect("two servers with meta → Some");
+        assert_eq!(cfg.trusted_issuers.len(), 2);
+        assert!(cfg.trusted_issuers.contains_key("https://idp-a.example"));
+        assert!(cfg.trusted_issuers.contains_key("https://idp-b.example"));
+        assert_eq!(
+            cfg.per_issuer_audience.get("https://idp-a.example"),
+            Some(&"api://server-a".to_string())
+        );
+        assert_eq!(
+            cfg.per_issuer_audience.get("https://idp-b.example"),
+            Some(&"api://server-b".to_string())
+        );
+        assert_eq!(
+            cfg.per_issuer_scopes.get("https://idp-a.example"),
+            Some(&vec!["tools.invoke".to_string()])
+        );
+        // server-b's empty scopes should NOT be recorded as an override.
+        assert!(!cfg.per_issuer_scopes.contains_key("https://idp-b.example"));
+        assert_eq!(cfg.expected_audience, "api://fb");
+    }
+
+    /// Conflicting JWKS for the same issuer across two servers must
+    /// surface as a hard error — never silently overwrite, never
+    /// merge unrelated key sets.
+    #[test]
+    fn from_registry_rejects_conflicting_jwks_for_same_issuer() {
+        use crate::mcp::registry::{
+            DiscoveredMcpServer, DiscoveredMcpServerMeta, McpServerRegistry,
+        };
+        use std::collections::BTreeMap;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (_sk_a, vk_a) = ed_keypair();
+        let (_sk_b, vk_b) = ed_keypair();
+        let jwks_a = serde_json::to_vec(&jwks_with(&vk_a, "kid-a")).unwrap();
+        let jwks_b = serde_json::to_vec(&jwks_with(&vk_b, "kid-b")).unwrap();
+        let path_a = tmp.path().join("a.jwks.json");
+        let path_b = tmp.path().join("b.jwks.json");
+        std::fs::write(&path_a, jwks_a).unwrap();
+        std::fs::write(&path_b, jwks_b).unwrap();
+
+        let issuer = "https://shared.example".to_string();
+        let mut servers = BTreeMap::new();
+        servers.insert(
+            "a".to_string(),
+            DiscoveredMcpServer {
+                name: "a".to_string(),
+                jwks_path: path_a,
+                meta: Some(DiscoveredMcpServerMeta {
+                    issuer: issuer.clone(),
+                    audience: Some("api://a".to_string()),
+                    scopes: vec![],
+                }),
+            },
+        );
+        servers.insert(
+            "b".to_string(),
+            DiscoveredMcpServer {
+                name: "b".to_string(),
+                jwks_path: path_b,
+                meta: Some(DiscoveredMcpServerMeta {
+                    issuer: issuer.clone(),
+                    audience: Some("api://b".to_string()),
+                    scopes: vec![],
+                }),
+            },
+        );
+        let registry = McpServerRegistry {
+            servers,
+            skipped: vec![],
+        };
+
+        let err =
+            OAuthVerifierConfig::from_registry(&registry, "api://fb", vec![], 30).unwrap_err();
+        assert!(err.contains("conflicting JWKS"));
     }
 }

--- a/inference-router/src/mcp/oauth_layer.rs
+++ b/inference-router/src/mcp/oauth_layer.rs
@@ -258,9 +258,11 @@ mod tests {
         Arc::new(OAuthVerifierConfig {
             trusted_issuers: trusted,
             expected_audience: TEST_AUD.into(),
+            per_issuer_audience: HashMap::new(),
             allowed_algorithms: vec![Algorithm::EdDSA],
             leeway_seconds: 30,
             required_scopes: vec![],
+            per_issuer_scopes: HashMap::new(),
         })
     }
 

--- a/inference-router/src/mcp/registry.rs
+++ b/inference-router/src/mcp/registry.rs
@@ -32,6 +32,24 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// Per-server OAuth metadata mirrored from the controller-side
+/// `McpServerMeta` struct. Written to `meta.json` adjacent to
+/// `jwks.json` inside each per-server subdirectory.
+///
+/// Slice 4d.3 consumes this to build a multi-issuer
+/// `OAuthVerifierConfig` — `trusted_issuers` keyed by `issuer`,
+/// `expected_audiences` aggregated from all servers' optional
+/// audience fields.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredMcpServerMeta {
+    pub issuer: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+}
+
 /// A single McpServer discovered under `MCP_JWKS_DIR`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveredMcpServer {
@@ -40,6 +58,11 @@ pub struct DiscoveredMcpServer {
     pub name: String,
     /// Absolute path to the discovered `jwks.json` file.
     pub jwks_path: PathBuf,
+    /// Slice 4d.3 — OAuth metadata when `meta.json` is present and
+    /// parses cleanly. `None` for servers mirrored before 4d.3 (pure
+    /// jwks-only layout) or when the meta file is unreadable; those
+    /// servers fall back to the legacy single-issuer behaviour.
+    pub meta: Option<DiscoveredMcpServerMeta>,
 }
 
 /// Outcome of a single `MCP_JWKS_DIR` scan.
@@ -163,13 +186,56 @@ pub fn scan(dir: impl AsRef<Path>) -> McpServerRegistry {
         registry.servers.insert(
             file_name.clone(),
             DiscoveredMcpServer {
-                name: file_name,
+                name: file_name.clone(),
                 jwks_path,
+                meta: load_meta(&path, &file_name, &mut registry.skipped),
             },
         );
     }
 
     registry
+}
+
+/// Try to load `meta.json` adjacent to `jwks.json`. Missing file is OK
+/// (returns `None` silently — back-compat with pre-4d.3 mirrors). Any
+/// other error (read failure, parse failure, missing `issuer`) is
+/// recorded in `skipped` so operators see the gap honestly.
+fn load_meta(
+    server_dir: &Path,
+    server_name: &str,
+    skipped: &mut Vec<(String, String)>,
+) -> Option<DiscoveredMcpServerMeta> {
+    let meta_path = server_dir.join("meta.json");
+    if !meta_path.is_file() {
+        return None;
+    }
+    let contents = match fs::read_to_string(&meta_path) {
+        Ok(c) => c,
+        Err(e) => {
+            skipped.push((
+                server_name.to_string(),
+                format!("meta.json read failed: {e}"),
+            ));
+            return None;
+        }
+    };
+    match serde_json::from_str::<DiscoveredMcpServerMeta>(&contents) {
+        Ok(m) if m.issuer.is_empty() => {
+            skipped.push((
+                server_name.to_string(),
+                "meta.json has empty issuer".to_string(),
+            ));
+            None
+        }
+        Ok(m) => Some(m),
+        Err(e) => {
+            skipped.push((
+                server_name.to_string(),
+                format!("meta.json parse failed: {e}"),
+            ));
+            None
+        }
+    }
 }
 
 /// Discover McpServers from the `MCP_JWKS_DIR` env var, logging the
@@ -316,5 +382,55 @@ mod tests {
         let alpha = &registry.servers["alpha"];
         assert_eq!(alpha.name, "alpha");
         assert!(alpha.jwks_path.ends_with("alpha/jwks.json"));
+        assert!(alpha.meta.is_none(), "no meta.json → meta should be None");
+    }
+
+    #[test]
+    fn scan_loads_meta_json_when_present() {
+        let tmp = TempDir::new().unwrap();
+        write_jwks(tmp.path(), "github", VALID_JWKS);
+        fs::write(
+            tmp.path().join("github").join("meta.json"),
+            r#"{"issuer":"https://idp.example/o","audience":"api://github","scopes":["mcp.tools.invoke"]}"#,
+        )
+        .unwrap();
+
+        let registry = scan(tmp.path());
+        let github = &registry.servers["github"];
+        let meta = github.meta.as_ref().expect("meta.json should load");
+        assert_eq!(meta.issuer, "https://idp.example/o");
+        assert_eq!(meta.audience.as_deref(), Some("api://github"));
+        assert_eq!(meta.scopes, vec!["mcp.tools.invoke".to_string()]);
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn scan_records_skip_for_meta_with_empty_issuer() {
+        let tmp = TempDir::new().unwrap();
+        write_jwks(tmp.path(), "broken", VALID_JWKS);
+        fs::write(
+            tmp.path().join("broken").join("meta.json"),
+            r#"{"issuer":"","audience":"api://x"}"#,
+        )
+        .unwrap();
+
+        let registry = scan(tmp.path());
+        assert!(registry.servers.contains_key("broken"));
+        assert!(registry.servers["broken"].meta.is_none());
+        assert_eq!(registry.skipped.len(), 1);
+        assert!(registry.skipped[0].1.contains("empty issuer"));
+    }
+
+    #[test]
+    fn scan_records_skip_for_malformed_meta_json() {
+        let tmp = TempDir::new().unwrap();
+        write_jwks(tmp.path(), "borked", VALID_JWKS);
+        fs::write(tmp.path().join("borked").join("meta.json"), "{not json").unwrap();
+
+        let registry = scan(tmp.path());
+        assert!(registry.servers.contains_key("borked"));
+        assert!(registry.servers["borked"].meta.is_none());
+        assert_eq!(registry.skipped.len(), 1);
+        assert!(registry.skipped[0].1.contains("meta.json parse failed"));
     }
 }

--- a/inference-router/src/routes/mcp.rs
+++ b/inference-router/src/routes/mcp.rs
@@ -669,9 +669,11 @@ mod tests {
         Arc::new(OAuthVerifierConfig {
             trusted_issuers: trusted,
             expected_audience: ROUTE_TEST_AUD.into(),
+            per_issuer_audience: HashMap::new(),
             allowed_algorithms: vec![Algorithm::EdDSA],
             leeway_seconds: 30,
             required_scopes: vec![],
+            per_issuer_scopes: HashMap::new(),
         })
     }
 


### PR DESCRIPTION
## Summary

Closes the OAuth half of Slice 4 DoD #3 ("each McpServer has its own JWKS"). Each McpServer now has its OAuth tokens validated against *its own* JWKS, with a per-issuer audience and scopes override — all driven by a `meta.json` file the controller writes alongside `jwks.json` into the per-server ConfigMap.

## Producer (controller)

- `mcp_server_reconciler.rs` `ensure_jwks_configmap` writes a second key, `meta.json`, alongside `jwks.json`. Wire shape (camelCase): `{ issuer, audience?, scopes[] }`.
- New `McpServerMeta` struct + `from_spec` helper.

## Consumer (router)

- `DiscoveredMcpServerMeta` in `mcp::registry`, loaded adjacent to `jwks.json` during `scan()`. Missing → back-compat `None`; malformed/empty-issuer → recorded in `skipped` (principles §3).
- `OAuthVerifierConfig` gains `per_issuer_audience` + `per_issuer_scopes`. `verify_access_token` uses the per-issuer entry keyed off the token's `iss` claim, falling back to the global floor when absent. `iss` is already pinned per-issuer via JWKS lookup — this lifts audience/scope checks onto the same secure key.
- New `OAuthVerifierConfig::from_registry`: `Ok(None)` on empty (caller falls back to legacy `MCP_JWKS_PATH`), hard-errors on conflicting JWKS for the same issuer.
- `build_mcp_router` prefers the registry-first multi-issuer path when `MCP_PRODUCTION_MODE=true` and the registry is non-empty.

## Verification

- 820 router lib tests pass (+10 new), 559 controller tests pass.
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

## Out of scope (Slice 4d.4)

- Namespaced tool dispatch (`/mcp/<server>/...`) — waits on a real upstream MCP forwarder backend so dispatch isn't scaffolding (principles §5).