### PR TITLE
Slice 4d.4: namespaced MCP tool forwarder (DoD #3 dispatch half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,119 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 4d.4 — namespaced MCP tool forwarder (DoD #3 — dispatch half)
+
+Closes the dispatch half of Slice 4 DoD #3 (*"…with namespaced tool
+names; tool calls route to the correct upstream"*). The router no
+longer serves only the in-tree `EchoDispatcher` at `/mcp` — when at
+least one McpServer is discovered with a usable upstream URL, traffic
+is dispatched to a new `RouterToolDispatcher` that proxies into the
+upstream MCP server declared by `McpServer.spec.url`.
+
+What this PR adds:
+
+- **Controller — `McpServerMeta` extension.** `mcp_server_reconciler.rs`
+  now writes two additional fields into the per-server `meta.json`
+  key alongside Slice 4d.3's OAuth metadata: `url` (the upstream MCP
+  server URL) and `allowedTools` (the per-server allow-list). Empty
+  fields are skipped via `skip_serializing_if` to keep the wire shape
+  forward-compatible.
+- **Router — `DiscoveredMcpServerMeta` extension.** `mcp::registry`'s
+  consumer-side struct gains the matching `url` + `allowed_tools`
+  fields. The struct now derives `Default` so future field additions
+  don't break test fixtures (4 existing test literals updated to use
+  `..Default::default()` trailing spread for forward-compat).
+- **Router — `mcp::forwarder` module (new).** Introduces
+  `RouterToolDispatcher` implementing `AsyncToolDispatcher`. At
+  startup, `RouterToolDispatcher::discover()` walks the registry and
+  for each server:
+    - POSTs JSON-RPC `tools/list` to `meta.url` (per-call timeout,
+      default 5 s, configurable via `MCP_FORWARDER_DISCOVERY_TIMEOUT_SECS`).
+    - Filters the response through `meta.allowed_tools` (`["*"]`
+      exposes every upstream tool; an explicit list selects the
+      named subset; empty fails closed).
+    - Prefixes each tool with the server's snake_case name (so
+      `github-mcp` exposing `search` is advertised as
+      `github_mcp.search`).
+  Servers with empty URL, empty allow-list, an OAuth requirement
+  (deferred to Slice 4d.5), unreachable upstreams, or HTTP/JSON-RPC
+  errors during discovery are recorded in `skipped` with a human-
+  readable reason and excluded from the catalog. The router still
+  starts — operators see the gap via the structured logs at startup.
+- **Router — `mcp::tools::AsyncToolDispatcher` swap-in.**
+  `McpRouteState` gains a `with_tools()` builder. When the registry
+  is non-empty, `main::build_mcp_router()` swaps the default
+  `EchoDispatcher` for the forwarder via that builder; otherwise
+  the existing dev/echo behaviour is preserved untouched.
+- **Dispatch path.** On `tools/call`, `RouterToolDispatcher::invoke`
+  splits the namespaced name on the first `.` to find the
+  destination server, then forwards a JSON-RPC `tools/call`
+  envelope to the upstream URL. Upstream protocol errors surface
+  as `is_error: true` `ToolCallOutput`s; HTTP 5xx/4xx surface as
+  `DispatchError::ExecutionFailed`; missing prefixes / unknown
+  suffixes surface as `DispatchError::UnknownTool`.
+
+Outbound auth scope: **unauthenticated upstreams only.** Servers
+whose `meta.json` carries an `issuer` are deliberately skipped with
+`reason = "outbound OAuth unsupported in 4d.4 …"` — outbound OAuth
+(client-credentials / on-behalf-of) lands in Slice 4d.5 once we
+have a real credential source wired (sandbox-mounted secret per
+McpServer). This is the §5 anti-scaffolding boundary: the consumer
+that ships in 4d.4 is the one we can actually drive end-to-end.
+
+Test coverage (15 new unit tests in `mcp::forwarder::tests`,
+exercising both happy path and every skip-reason branch):
+
+- `server_name_to_prefix_converts_hyphens` — name→prefix mapping.
+- `split_namespaced_name_happy_and_edge` — dispatch parser including
+  multi-dot tool suffixes (`foundry.memory.update` survives intact).
+- `filter_by_allowlist_star_returns_all` / `_named_subset` — the
+  two allow-list semantics, asserted on real `ToolDefinition`s.
+- `discover_happy_path_builds_namespaced_catalog` — full end-to-end:
+  mock upstream `tools/list` → forwarder catalog carries the
+  prefixed names.
+- `discover_filters_by_allow_list` — same, with a non-`*` allow-list.
+- `discover_skips_servers_with_empty_url` /
+  `_requiring_outbound_oauth` / `_with_empty_allow_list` /
+  `_whose_upstream_returns_500` — each skip reason is recorded with
+  the expected substring (operator-actionable).
+- `invoke_forwards_call_and_returns_content` — `tools/call`
+  round-trips through the mock upstream and the agent sees the
+  upstream-provided content unchanged.
+- `invoke_unknown_tool_returns_unknown_tool` — three negative
+  branches (wrong prefix, unknown suffix, no `.` at all).
+- `invoke_surfaces_upstream_json_rpc_error_as_is_error` — JSON-RPC
+  errors collapse into `ToolCallOutput { is_error: true, ... }`
+  (per MCP spec: protocol errors vs. semantic errors).
+- `invoke_returns_execution_failed_on_upstream_5xx` — HTTP 5xx
+  surfaces as `DispatchError::ExecutionFailed` with the status in
+  the reason string.
+- `multi_server_namespaces_dispatch_correctly` — two mock upstreams,
+  the dispatcher routes each invocation to its own server's URL.
+
+Backward compatibility:
+
+- Registries with no `meta.json` files or no `url` fields fall
+  through to the existing `EchoDispatcher`, preserving the Slice 4d.3
+  / 4d.1 dev surface.
+- The single-issuer `MCP_JWKS_PATH` legacy path remains the third
+  fallback for production mode without a registry.
+
+Files touched:
+
+- `controller/src/mcp_server_reconciler.rs` — `McpServerMeta` gains
+  `url` + `allowed_tools`.
+- `inference-router/src/mcp/registry.rs` — `DiscoveredMcpServerMeta`
+  gains matching fields + `Default` derive.
+- `inference-router/src/mcp/forwarder.rs` — new module.
+- `inference-router/src/mcp/mod.rs` — wire module.
+- `inference-router/src/mcp/oauth.rs` — 4 test fixtures updated for
+  forward-compat with the new meta fields.
+- `inference-router/src/routes/mcp.rs` — `McpRouteState::with_tools`
+  builder; TODO comment for "future RouterToolDispatcher" deleted.
+- `inference-router/src/main.rs` — `build_mcp_router` now async,
+  discovers the forwarder catalog before mounting `/mcp`.
+
 ### Slice 4d.3 — multi-issuer OAuth verification (DoD #3 — OAuth half)
 
 Closes the OAuth half of Slice 4 DoD #3 (*"each McpServer has its own

--- a/controller/src/mcp_server_reconciler.rs
+++ b/controller/src/mcp_server_reconciler.rs
@@ -595,6 +595,20 @@ pub struct McpServerMeta {
     /// in ToolPolicy).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scopes: Vec<String>,
+    /// Slice 4d.4 — upstream MCP server URL the router forwards
+    /// `tools/call` requests to. Empty when the source `McpServerSpec`
+    /// has no `url` (defensive — admission CEL rejects empty URL but
+    /// be conservative). The router's forwarder skips servers with an
+    /// empty URL.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub url: String,
+    /// Slice 4d.4 — allowed-tools allowlist mirrored from
+    /// `McpServerSpec.allowedTools`. Empty list = no tools allowed
+    /// (fail-closed); `["*"]` = all tools the upstream advertises.
+    /// The router's forwarder filters its discovered catalog through
+    /// this list before exposing tools to the agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_tools: Vec<String>,
 }
 
 impl McpServerMeta {
@@ -611,6 +625,8 @@ impl McpServerMeta {
             issuer,
             audience,
             scopes: spec.scopes.clone(),
+            url: spec.url.clone(),
+            allowed_tools: spec.allowed_tools.clone(),
         }
     }
 }

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -339,7 +339,7 @@ async fn main() -> Result<()> {
             .merge(handoff_mutations)
             .merge(handoff_status)
             .with_state(state)
-            .merge(build_mcp_router())
+            .merge(build_mcp_router().await)
             .merge(build_platform_mcp_router(
                 Some(memory_binding_for_platform),
                 Some(policy_status_for_platform),
@@ -485,9 +485,11 @@ async fn main() -> Result<()> {
 /// falling back to the unauthenticated dev route. Operators see a clear
 /// startup-time error instead of a route that quietly serves
 /// unauthenticated MCP traffic.
-fn build_mcp_router() -> Router {
+async fn build_mcp_router() -> Router {
+    use azureclaw_inference_router::mcp::forwarder::RouterToolDispatcher;
     use azureclaw_inference_router::mcp::oauth::OAuthVerifierConfig;
     use azureclaw_inference_router::mcp::registry;
+    use std::time::Duration;
 
     let production = std::env::var("MCP_PRODUCTION_MODE")
         .map(|v| matches!(v.as_str(), "true" | "1" | "yes"))
@@ -495,45 +497,85 @@ fn build_mcp_router() -> Router {
     let jwks_path = std::env::var("MCP_JWKS_PATH").ok();
     let audience = std::env::var("MCP_OAUTH_AUDIENCE").ok();
 
-    let state = routes::McpRouteState::standard();
+    let registry_arc = Arc::new(registry::discover_from_env());
+
+    // Slice 4d.4 — when the registry advertises at least one server
+    // with a usable upstream URL, replace the in-tree EchoDispatcher
+    // with the namespaced forwarder. Discovery is best-effort: per-
+    // server failures are recorded and logged, the router still
+    // starts. If *catalog construction* itself fails (duplicate
+    // namespaced tool names across servers) we honor §3 and refuse
+    // to mount /mcp.
+    let dispatcher_arc: Option<
+        Arc<dyn azureclaw_inference_router::mcp::tools::AsyncToolDispatcher>,
+    > = if !registry_arc.is_empty() {
+        let timeout = std::env::var("MCP_FORWARDER_DISCOVERY_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(5);
+        match RouterToolDispatcher::discover(registry_arc.clone(), Duration::from_secs(timeout))
+            .await
+        {
+            Ok(dispatcher) => {
+                tracing::info!(
+                    servers = registry_arc.len(),
+                    tools = dispatcher.len(),
+                    skipped = dispatcher.skipped().len(),
+                    "Mounted /mcp upstream forwarder (Slice 4d.4)"
+                );
+                for (server, reason) in dispatcher.skipped() {
+                    tracing::warn!(server = %server, reason = %reason, "McpServer skipped by forwarder");
+                }
+                Some(Arc::new(dispatcher))
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Forwarder catalog construction failed; refusing to mount /mcp");
+                return Router::new();
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut state = routes::McpRouteState::standard();
+    if let Some(d) = dispatcher_arc {
+        state = state.with_tools(d);
+    }
 
     // Slice 4d.3 — prefer the multi-issuer path when MCP_JWKS_DIR is
     // populated and at least one server contributes `meta.json`. Falls
     // back to legacy single-JWKS path on empty/absent registry.
-    if production {
-        let registry = registry::discover_from_env();
-        if !registry.is_empty() {
-            let default_audience = audience.clone().unwrap_or_default();
-            let required_scopes = std::env::var("MCP_OAUTH_REQUIRED_SCOPES")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .map(|s| s.split_whitespace().map(|t| t.to_string()).collect())
-                .unwrap_or_default();
-            match OAuthVerifierConfig::from_registry(
-                &registry,
-                &default_audience,
-                required_scopes,
-                60,
-            ) {
-                Ok(Some(cfg)) => {
-                    let issuers: Vec<&String> = cfg.trusted_issuers.keys().collect();
-                    tracing::info!(
-                        servers = registry.len(),
-                        issuers = ?issuers,
-                        "Mounting /mcp with multi-issuer OAuth 2.1 verification (Slice 4d.3)"
-                    );
-                    return routes::protected_mcp_route(state, Arc::new(cfg));
-                }
-                Ok(None) => {
-                    tracing::warn!(
-                        "MCP_JWKS_DIR populated but no servers carry meta.json — \
-                         falling back to legacy single-issuer MCP_JWKS_PATH path"
-                    );
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "Multi-issuer OAuth config build failed; refusing to mount /mcp");
-                    return Router::new();
-                }
+    if production && !registry_arc.is_empty() {
+        let default_audience = audience.clone().unwrap_or_default();
+        let required_scopes = std::env::var("MCP_OAUTH_REQUIRED_SCOPES")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| s.split_whitespace().map(|t| t.to_string()).collect())
+            .unwrap_or_default();
+        match OAuthVerifierConfig::from_registry(
+            &registry_arc,
+            &default_audience,
+            required_scopes,
+            60,
+        ) {
+            Ok(Some(cfg)) => {
+                let issuers: Vec<&String> = cfg.trusted_issuers.keys().collect();
+                tracing::info!(
+                    servers = registry_arc.len(),
+                    issuers = ?issuers,
+                    "Mounting /mcp with multi-issuer OAuth 2.1 verification (Slice 4d.3)"
+                );
+                return routes::protected_mcp_route(state, Arc::new(cfg));
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    "MCP_JWKS_DIR populated but no servers carry meta.json — \
+                     falling back to legacy single-issuer MCP_JWKS_PATH path"
+                );
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Multi-issuer OAuth config build failed; refusing to mount /mcp");
+                return Router::new();
             }
         }
     }

--- a/inference-router/src/mcp/forwarder.rs
+++ b/inference-router/src/mcp/forwarder.rs
@@ -1,0 +1,923 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Slice 4d.4 — namespaced MCP tool forwarder.
+//!
+//! Closes Slice 4 DoD #3 (second half): `/mcp` no longer serves only
+//! the in-tree [`super::tools::EchoDispatcher`]. Instead, an
+//! [`AsyncToolDispatcher`] driven by the [`McpServerRegistry`]
+//! exposes every upstream McpServer's tools under a per-server
+//! namespace and forwards `tools/call` requests to the corresponding
+//! upstream URL.
+//!
+//! # Catalog construction (startup-time)
+//!
+//! 1. For each `DiscoveredMcpServer` with a non-empty `meta.url`:
+//!    - POST a JSON-RPC `tools/list` to the upstream.
+//!    - On 2xx, parse the result into `[ToolDefinition]`.
+//!    - Filter through `meta.allowed_tools`:
+//!       - empty → no tools advertised (fail-closed, recorded as skip).
+//!       - `["*"]` → expose every tool the upstream advertises.
+//!       - otherwise → expose only the named subset.
+//!    - Prefix each name with `{server_snake_case}.` (so server
+//!      `github-mcp` exposing tool `search` becomes `github_mcp.search`).
+//! 2. Servers whose discovery fails (network error, non-2xx, parse
+//!    failure, or empty allow-list) are recorded in `skipped` with a
+//!    human-readable reason. The router still starts — the agent sees
+//!    a partial catalog and the operator sees the gap on
+//!    `/internal/policy-status` / startup logs.
+//!
+//! # Dispatch (per `tools/call`)
+//!
+//! 1. Split the tool name on the first `.` — `prefix = server_snake_case`,
+//!    `suffix = upstream_tool_name`.
+//! 2. Look up `prefix` in the per-server index.
+//! 3. Forward a JSON-RPC `tools/call` envelope (with `name = suffix`)
+//!    to the upstream's URL.
+//! 4. Return the upstream's content array verbatim.
+//!
+//! Failures map to either `DispatchError::UnknownTool` (no namespace
+//! match), `DispatchError::ExecutionFailed` (network / non-2xx /
+//! parse), or `ToolCallOutput { is_error: true, ... }` (upstream
+//! reported a per-call error). The router's audit layer wraps the
+//! whole call — see Slice 4a/4c.
+//!
+//! # Outbound auth (Slice 4d.4 scope)
+//!
+//! **Unauthenticated only.** This slice forwards without an
+//! `Authorization` header. That covers:
+//!
+//! - In-cluster MCP servers exposed on a private network with
+//!   `productionMode: false` (developer / staging fleet).
+//! - Public unauthenticated read-only catalogs.
+//!
+//! Outbound OAuth (client-credentials, on-behalf-of for the agent's
+//! incoming bearer, or sandbox-mounted secret) is **Slice 4d.5**.
+//! Until then, the forwarder refuses to advertise servers with a
+//! non-empty `oauth.issuer` in their meta — those servers are
+//! recorded in `skipped` with reason `outbound_oauth_unsupported`
+//! so the operator sees the gap honestly (principles §3). This is
+//! the §5 anti-scaffolding boundary: only ship the consumer that we
+//! can actually drive end-to-end.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::registry::{DiscoveredMcpServer, McpServerRegistry};
+use super::tools::{
+    AsyncToolDispatcher, DispatchError, ToolCallOutput, ToolCatalog, ToolContent, ToolDefinition,
+};
+
+/// One server's entry in the forwarder's runtime index.
+#[derive(Debug, Clone)]
+struct ForwarderEntry {
+    /// Source server name (DNS-1123).
+    name: String,
+    /// Snake-cased prefix used in the agent-facing namespaced tool
+    /// name. Computed once at construction.
+    prefix: String,
+    /// Upstream URL — POST destination for `tools/call`.
+    upstream_url: String,
+    /// Map from upstream-tool-name → upstream `ToolDefinition`. Used
+    /// during dispatch to confirm the tool is in this server's
+    /// allow-list (defence-in-depth against catalog drift).
+    tools: BTreeMap<String, ToolDefinition>,
+}
+
+/// Namespaced MCP forwarder — the production-mode `AsyncToolDispatcher`
+/// mounted at `/mcp` whenever the registry advertises at least one
+/// server with a usable upstream URL.
+///
+/// Construct via [`RouterToolDispatcher::discover`]. The catalog is
+/// fixed at construction — refresh requires a rebuild (mirrors the
+/// other registry-driven router state; pod rolling-restart is the
+/// supported reload path until inotify-watch lands).
+pub struct RouterToolDispatcher {
+    catalog: ToolCatalog,
+    /// Keyed by snake_case server prefix.
+    entries: BTreeMap<String, ForwarderEntry>,
+    /// Reasons why a discovered server was not promoted. Surfaced via
+    /// `tracing::warn!` at construction and held here for observability
+    /// hooks (e.g. `/internal/policy-status` extension in 4e).
+    skipped: Vec<(String, String)>,
+    http: reqwest::Client,
+}
+
+impl std::fmt::Debug for RouterToolDispatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let servers: Vec<&str> = self.entries.values().map(|e| e.name.as_str()).collect();
+        f.debug_struct("RouterToolDispatcher")
+            .field("tools_total", &self.catalog.tools().len())
+            .field("servers", &servers)
+            .field("skipped", &self.skipped)
+            .finish()
+    }
+}
+
+impl RouterToolDispatcher {
+    /// How many namespaced tools the dispatcher advertises.
+    pub fn len(&self) -> usize {
+        self.catalog.tools().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.catalog.tools().is_empty()
+    }
+
+    /// Reasons servers were skipped during discovery. Stable shape:
+    /// `(server_name, human_readable_reason)`.
+    pub fn skipped(&self) -> &[(String, String)] {
+        &self.skipped
+    }
+
+    /// Run startup discovery against every server in `registry`. POSTs
+    /// `tools/list` to each upstream with a per-call timeout. Returns
+    /// a dispatcher with the discovered catalog. Servers whose
+    /// discovery fails are recorded in `skipped` and excluded from
+    /// the catalog.
+    ///
+    /// Catalog construction errors that affect the *aggregate* (duplicate
+    /// namespaced tool names across servers, schema validation) bubble
+    /// up as a top-level `Err` — the caller (typically `main`) refuses
+    /// to mount `/mcp` in that case (principles §3, no silent failure).
+    pub async fn discover(
+        registry: Arc<McpServerRegistry>,
+        per_call_timeout: Duration,
+    ) -> Result<Self, String> {
+        let http = reqwest::Client::builder()
+            .timeout(per_call_timeout)
+            .build()
+            .map_err(|e| format!("reqwest client init: {e}"))?;
+        Self::discover_with_client(registry, http).await
+    }
+
+    /// Same as [`discover`] but uses the provided HTTP client. Lets
+    /// tests inject a client whose connector points at a local mock
+    /// server.
+    pub async fn discover_with_client(
+        registry: Arc<McpServerRegistry>,
+        http: reqwest::Client,
+    ) -> Result<Self, String> {
+        let mut entries: BTreeMap<String, ForwarderEntry> = BTreeMap::new();
+        let mut skipped: Vec<(String, String)> = Vec::new();
+        let mut namespaced_tools: Vec<ToolDefinition> = Vec::new();
+
+        for (name, server) in &registry.servers {
+            match build_entry_for(name, server, &http).await {
+                Ok((entry, defs)) => {
+                    entries.insert(entry.prefix.clone(), entry);
+                    namespaced_tools.extend(defs);
+                }
+                Err(reason) => {
+                    tracing::warn!(server = %name, reason = %reason, "Skipping McpServer during forwarder discovery");
+                    skipped.push((name.clone(), reason));
+                }
+            }
+        }
+
+        let catalog = ToolCatalog::new(namespaced_tools)
+            .map_err(|e| format!("forwarder catalog construction failed: {e}"))?;
+
+        Ok(Self {
+            catalog,
+            entries,
+            skipped,
+            http,
+        })
+    }
+}
+
+#[async_trait]
+impl AsyncToolDispatcher for RouterToolDispatcher {
+    fn catalog(&self) -> &ToolCatalog {
+        &self.catalog
+    }
+
+    async fn invoke(&self, name: &str, arguments: &Value) -> Result<ToolCallOutput, DispatchError> {
+        let (prefix, suffix) = split_namespaced_name(name)
+            .ok_or_else(|| DispatchError::UnknownTool(name.to_string()))?;
+        let entry = self
+            .entries
+            .get(prefix)
+            .ok_or_else(|| DispatchError::UnknownTool(name.to_string()))?;
+        if !entry.tools.contains_key(suffix) {
+            return Err(DispatchError::UnknownTool(name.to_string()));
+        }
+        forward_tools_call(&self.http, entry, suffix, arguments).await
+    }
+}
+
+/// Convert a `name-with-hyphens` server name to `name_with_underscores`
+/// so the agent-facing namespaced tool name is a valid identifier in
+/// JSON Schema `properties` lookups (`.` separator). DNS-1123 names
+/// already exclude `_`, so the mapping is injective in one direction.
+pub fn server_name_to_prefix(name: &str) -> String {
+    name.replace('-', "_")
+}
+
+fn split_namespaced_name(name: &str) -> Option<(&str, &str)> {
+    let (prefix, suffix) = name.split_once('.')?;
+    if prefix.is_empty() || suffix.is_empty() {
+        return None;
+    }
+    Some((prefix, suffix))
+}
+
+/// Discover one server: POST `tools/list`, filter through allow-list,
+/// build a `ForwarderEntry` + the namespaced `ToolDefinition`s.
+async fn build_entry_for(
+    name: &str,
+    server: &DiscoveredMcpServer,
+    http: &reqwest::Client,
+) -> Result<(ForwarderEntry, Vec<ToolDefinition>), String> {
+    let meta = server
+        .meta
+        .as_ref()
+        .ok_or_else(|| "no meta.json — pre-4d.4 mirror".to_string())?;
+
+    if meta.url.is_empty() {
+        return Err("meta.url is empty — controller did not publish upstream URL".to_string());
+    }
+
+    // Slice 4d.4 anti-scaffolding boundary: refuse to expose servers
+    // that require outbound OAuth until 4d.5 wires the credential
+    // source. The router would otherwise call them anonymously and
+    // 401 every request.
+    if !meta.issuer.is_empty() {
+        return Err(
+            "outbound OAuth unsupported in 4d.4 — server requires bearer credentials (defer to 4d.5)"
+                .to_string(),
+        );
+    }
+
+    if meta.allowed_tools.is_empty() {
+        return Err(
+            "allowedTools is empty — fail-closed (use `[\"*\"]` to expose every upstream tool)"
+                .to_string(),
+        );
+    }
+
+    let upstream_tools = fetch_upstream_tools(http, &meta.url).await?;
+
+    let filtered = filter_by_allowlist(&upstream_tools, &meta.allowed_tools);
+    if filtered.is_empty() {
+        return Err(format!(
+            "no upstream tools matched allowedTools={:?}",
+            meta.allowed_tools
+        ));
+    }
+
+    let prefix = server_name_to_prefix(name);
+    let mut tools_map: BTreeMap<String, ToolDefinition> = BTreeMap::new();
+    let mut namespaced_defs: Vec<ToolDefinition> = Vec::with_capacity(filtered.len());
+
+    for def in filtered {
+        tools_map.insert(def.name.clone(), def.clone());
+        namespaced_defs.push(ToolDefinition {
+            name: format!("{prefix}.{}", def.name),
+            description: def.description.clone(),
+            input_schema: def.input_schema.clone(),
+        });
+    }
+
+    Ok((
+        ForwarderEntry {
+            name: name.to_string(),
+            prefix,
+            upstream_url: meta.url.clone(),
+            tools: tools_map,
+        },
+        namespaced_defs,
+    ))
+}
+
+/// POST a JSON-RPC `tools/list` to `url` and parse the result. No
+/// pagination — Slice 4d.4 caps at one page; multi-page upstreams are
+/// truncated with a recorded warning. Multi-page support lands when
+/// we have a real consumer that hits the cap (principles §5).
+async fn fetch_upstream_tools(
+    http: &reqwest::Client,
+    url: &str,
+) -> Result<Vec<ToolDefinition>, String> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+    });
+
+    let resp = http
+        .post(url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("tools/list POST failed: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "tools/list non-2xx: {} (body trimmed: {})",
+            status,
+            text.chars().take(120).collect::<String>()
+        ));
+    }
+
+    let parsed: ToolsListResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("tools/list parse failed: {e}"))?;
+
+    if let Some(err) = parsed.error {
+        return Err(format!(
+            "tools/list returned JSON-RPC error: code={} message={}",
+            err.code, err.message
+        ));
+    }
+
+    let result = parsed
+        .result
+        .ok_or_else(|| "tools/list missing result".to_string())?;
+
+    if result.next_cursor.is_some() {
+        tracing::warn!(
+            url = %url,
+            "Upstream advertised tools/list pagination (nextCursor present); \
+             Slice 4d.4 only consumes the first page — additional tools will \
+             not be advertised until pagination support lands"
+        );
+    }
+
+    Ok(result.tools)
+}
+
+fn filter_by_allowlist(upstream: &[ToolDefinition], allow: &[String]) -> Vec<ToolDefinition> {
+    if allow.iter().any(|t| t == "*") {
+        return upstream.to_vec();
+    }
+    let set: std::collections::HashSet<&str> = allow.iter().map(|s| s.as_str()).collect();
+    upstream
+        .iter()
+        .filter(|t| set.contains(t.name.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Forward one `tools/call` invocation to `entry.upstream_url`.
+async fn forward_tools_call(
+    http: &reqwest::Client,
+    entry: &ForwarderEntry,
+    upstream_name: &str,
+    arguments: &Value,
+) -> Result<ToolCallOutput, DispatchError> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": upstream_name,
+            "arguments": arguments,
+        },
+    });
+
+    let resp = http
+        .post(&entry.upstream_url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| DispatchError::ExecutionFailed {
+            tool: format!("{}.{}", entry.prefix, upstream_name),
+            reason: format!("upstream POST failed: {e}"),
+        })?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(DispatchError::ExecutionFailed {
+            tool: format!("{}.{}", entry.prefix, upstream_name),
+            reason: format!(
+                "upstream non-2xx: {} (body trimmed: {})",
+                status,
+                text.chars().take(120).collect::<String>()
+            ),
+        });
+    }
+
+    let parsed: ToolsCallResponse =
+        resp.json()
+            .await
+            .map_err(|e| DispatchError::ExecutionFailed {
+                tool: format!("{}.{}", entry.prefix, upstream_name),
+                reason: format!("upstream tools/call parse failed: {e}"),
+            })?;
+
+    if let Some(err) = parsed.error {
+        // Upstream protocol error → surface as an isError content
+        // entry, not a DispatchError. Per MCP spec, JSON-RPC errors
+        // from `tools/call` indicate the *protocol* failed; the
+        // semantic "tool ran but errored" path uses isError:true.
+        // We collapse them here because the agent-facing surface
+        // shouldn't distinguish (the audit layer can see both).
+        return Ok(ToolCallOutput {
+            content: vec![ToolContent::Text {
+                text: format!(
+                    "upstream JSON-RPC error code={} message={}",
+                    err.code, err.message
+                ),
+            }],
+            is_error: true,
+        });
+    }
+
+    let result = parsed
+        .result
+        .ok_or_else(|| DispatchError::ExecutionFailed {
+            tool: format!("{}.{}", entry.prefix, upstream_name),
+            reason: "tools/call missing result".to_string(),
+        })?;
+
+    Ok(ToolCallOutput {
+        content: result.content,
+        is_error: result.is_error.unwrap_or(false),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolsListResponse {
+    #[serde(default)]
+    result: Option<ToolsListResult>,
+    #[serde(default)]
+    error: Option<JsonRpcWireError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolsListResult {
+    #[serde(default)]
+    tools: Vec<ToolDefinition>,
+    #[serde(default, rename = "nextCursor")]
+    next_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolsCallResponse {
+    #[serde(default)]
+    result: Option<ToolsCallResult>,
+    #[serde(default)]
+    error: Option<JsonRpcWireError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolsCallResult {
+    #[serde(default)]
+    content: Vec<ToolContent>,
+    #[serde(default, rename = "isError")]
+    is_error: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcWireError {
+    code: i64,
+    message: String,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::registry::{DiscoveredMcpServer, DiscoveredMcpServerMeta, McpServerRegistry};
+    use axum::{
+        Json, Router,
+        extract::State,
+        http::StatusCode,
+        routing::{any, post},
+    };
+    use std::collections::BTreeMap;
+    use std::sync::Arc as StdArc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::net::TcpListener;
+
+    fn tool_def(name: &str, desc: &str) -> ToolDefinition {
+        ToolDefinition {
+            name: name.to_string(),
+            description: desc.to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }
+    }
+
+    fn discovered(name: &str, url: &str, allowed: Vec<&str>) -> DiscoveredMcpServer {
+        DiscoveredMcpServer {
+            name: name.to_string(),
+            jwks_path: std::path::PathBuf::from("/dev/null"),
+            meta: Some(DiscoveredMcpServerMeta {
+                issuer: String::new(),
+                audience: None,
+                scopes: vec![],
+                url: url.to_string(),
+                allowed_tools: allowed.into_iter().map(String::from).collect(),
+            }),
+        }
+    }
+
+    fn registry_with(servers: Vec<DiscoveredMcpServer>) -> Arc<McpServerRegistry> {
+        let mut map = BTreeMap::new();
+        for s in servers {
+            map.insert(s.name.clone(), s);
+        }
+        Arc::new(McpServerRegistry {
+            servers: map,
+            skipped: vec![],
+        })
+    }
+
+    /// State for the mock upstream server.
+    #[derive(Clone, Default)]
+    struct MockState {
+        tools: Vec<ToolDefinition>,
+        call_count: StdArc<AtomicUsize>,
+        /// If set, the upstream returns this JSON-RPC error for tools/call.
+        force_call_error: Option<(i64, String)>,
+        /// If set, the upstream returns this HTTP status for tools/call.
+        force_call_http_status: Option<u16>,
+    }
+
+    async fn mock_upstream(state: MockState) -> String {
+        let app = Router::new()
+            .route("/", post(mock_handler))
+            .route("/", any(method_block))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/")
+    }
+
+    async fn method_block() -> StatusCode {
+        StatusCode::METHOD_NOT_ALLOWED
+    }
+
+    async fn mock_handler(
+        State(state): State<MockState>,
+        Json(body): Json<serde_json::Value>,
+    ) -> (StatusCode, Json<serde_json::Value>) {
+        let method = body.get("method").and_then(|v| v.as_str()).unwrap_or("");
+        let id = body.get("id").cloned().unwrap_or(serde_json::json!(1));
+        match method {
+            "tools/list" => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "tools": state.tools,
+                    }
+                })),
+            ),
+            "tools/call" => {
+                state.call_count.fetch_add(1, Ordering::SeqCst);
+                if let Some(status) = state.force_call_http_status {
+                    return (
+                        StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                        Json(serde_json::json!({})),
+                    );
+                }
+                if let Some((code, msg)) = state.force_call_error {
+                    return (
+                        StatusCode::OK,
+                        Json(serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "error": {"code": code, "message": msg}
+                        })),
+                    );
+                }
+                let upstream_tool = body
+                    .pointer("/params/name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let args = body
+                    .pointer("/params/arguments")
+                    .cloned()
+                    .unwrap_or(serde_json::json!({}));
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "content": [
+                                {"type": "text", "text": format!("called {upstream_tool} with {args}")}
+                            ],
+                            "isError": false,
+                        }
+                    })),
+                )
+            }
+            _ => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {"code": -32601, "message": "method not found"}
+                })),
+            ),
+        }
+    }
+
+    #[test]
+    fn server_name_to_prefix_converts_hyphens() {
+        assert_eq!(server_name_to_prefix("github-mcp"), "github_mcp");
+        assert_eq!(server_name_to_prefix("plain"), "plain");
+        assert_eq!(
+            server_name_to_prefix("internal-knowledge-base"),
+            "internal_knowledge_base"
+        );
+    }
+
+    #[test]
+    fn split_namespaced_name_happy_and_edge() {
+        assert_eq!(
+            split_namespaced_name("github_mcp.search"),
+            Some(("github_mcp", "search"))
+        );
+        // Multi-dot — only split on first.
+        assert_eq!(
+            split_namespaced_name("foundry.memory.update"),
+            Some(("foundry", "memory.update"))
+        );
+        assert_eq!(split_namespaced_name("noprefix"), None);
+        assert_eq!(split_namespaced_name(".empty"), None);
+        assert_eq!(split_namespaced_name("empty."), None);
+    }
+
+    #[test]
+    fn filter_by_allowlist_star_returns_all() {
+        let upstream = vec![tool_def("a", ""), tool_def("b", "")];
+        let allow = vec!["*".to_string()];
+        let got = filter_by_allowlist(&upstream, &allow);
+        assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn filter_by_allowlist_named_subset() {
+        let upstream = vec![tool_def("a", ""), tool_def("b", ""), tool_def("c", "")];
+        let allow = vec!["a".to_string(), "c".to_string()];
+        let got = filter_by_allowlist(&upstream, &allow);
+        assert_eq!(got.len(), 2);
+        assert!(got.iter().any(|t| t.name == "a"));
+        assert!(got.iter().any(|t| t.name == "c"));
+    }
+
+    #[tokio::test]
+    async fn discover_happy_path_builds_namespaced_catalog() {
+        let state = MockState {
+            tools: vec![
+                tool_def("search", "search docs"),
+                tool_def("fetch", "fetch by id"),
+            ],
+            ..Default::default()
+        };
+        let url = mock_upstream(state).await;
+        let registry = registry_with(vec![discovered("github-mcp", &url, vec!["*"])]);
+
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .expect("discover");
+
+        assert_eq!(dispatcher.len(), 2);
+        assert!(dispatcher.skipped().is_empty());
+        let names: Vec<&str> = dispatcher
+            .catalog()
+            .tools()
+            .iter()
+            .map(|t| t.name.as_str())
+            .collect();
+        assert!(names.contains(&"github_mcp.search"));
+        assert!(names.contains(&"github_mcp.fetch"));
+    }
+
+    #[tokio::test]
+    async fn discover_filters_by_allow_list() {
+        let state = MockState {
+            tools: vec![tool_def("search", ""), tool_def("dangerous", "")],
+            ..Default::default()
+        };
+        let url = mock_upstream(state).await;
+        let registry = registry_with(vec![discovered("github-mcp", &url, vec!["search"])]);
+
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .expect("discover");
+
+        assert_eq!(dispatcher.len(), 1);
+        assert_eq!(dispatcher.catalog().tools()[0].name, "github_mcp.search");
+    }
+
+    #[tokio::test]
+    async fn discover_skips_servers_with_empty_url() {
+        let mut server = discovered("svc", "http://placeholder/", vec!["*"]);
+        server.meta.as_mut().unwrap().url = String::new();
+        let registry = registry_with(vec![server]);
+
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .expect("discover");
+        assert!(dispatcher.is_empty());
+        assert_eq!(dispatcher.skipped().len(), 1);
+        assert!(dispatcher.skipped()[0].1.contains("meta.url is empty"));
+    }
+
+    #[tokio::test]
+    async fn discover_skips_servers_requiring_outbound_oauth() {
+        let mut server = discovered("svc", "http://placeholder/", vec!["*"]);
+        server.meta.as_mut().unwrap().issuer = "https://idp.example".to_string();
+        let registry = registry_with(vec![server]);
+
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .expect("discover");
+        assert!(dispatcher.is_empty());
+        assert_eq!(dispatcher.skipped().len(), 1);
+        assert!(
+            dispatcher.skipped()[0]
+                .1
+                .contains("outbound OAuth unsupported")
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_skips_servers_with_empty_allow_list() {
+        let registry = registry_with(vec![discovered("svc", "http://placeholder/", vec![])]);
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .expect("discover");
+        assert!(dispatcher.is_empty());
+        assert!(dispatcher.skipped()[0].1.contains("allowedTools is empty"));
+    }
+
+    #[tokio::test]
+    async fn discover_skips_servers_whose_upstream_returns_500() {
+        // Bind a port but never serve → connection-refused-like.
+        // Easiest is point at 127.0.0.1:1 which kernels close fast.
+        let registry = registry_with(vec![discovered("dead", "http://127.0.0.1:1/", vec!["*"])]);
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_millis(500))
+            .await
+            .expect("discover should not propagate per-server errors");
+        assert!(dispatcher.is_empty());
+        assert!(!dispatcher.skipped().is_empty());
+    }
+
+    #[tokio::test]
+    async fn invoke_forwards_call_and_returns_content() {
+        let state = MockState {
+            tools: vec![tool_def("search", "")],
+            ..Default::default()
+        };
+        let url = mock_upstream(state.clone()).await;
+        let registry = registry_with(vec![discovered("github-mcp", &url, vec!["*"])]);
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let out = dispatcher
+            .invoke("github_mcp.search", &serde_json::json!({"query": "azure"}))
+            .await
+            .expect("invoke");
+        assert!(!out.is_error);
+        assert_eq!(out.content.len(), 1);
+        let ToolContent::Text { text } = &out.content[0];
+        assert!(text.contains("called search"));
+        assert!(text.contains("azure"));
+    }
+
+    #[tokio::test]
+    async fn invoke_unknown_tool_returns_unknown_tool() {
+        let state = MockState {
+            tools: vec![tool_def("search", "")],
+            ..Default::default()
+        };
+        let url = mock_upstream(state).await;
+        let registry = registry_with(vec![discovered("github-mcp", &url, vec!["*"])]);
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        // Wrong prefix.
+        let err = dispatcher
+            .invoke("other.search", &serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DispatchError::UnknownTool(_)));
+
+        // Right prefix, unknown suffix.
+        let err = dispatcher
+            .invoke("github_mcp.unknown", &serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DispatchError::UnknownTool(_)));
+
+        // No dot at all.
+        let err = dispatcher
+            .invoke("flat", &serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DispatchError::UnknownTool(_)));
+    }
+
+    #[tokio::test]
+    async fn invoke_surfaces_upstream_json_rpc_error_as_is_error() {
+        let state = MockState {
+            tools: vec![tool_def("flaky", "")],
+            force_call_error: Some((-32000, "boom".to_string())),
+            ..Default::default()
+        };
+        let url = mock_upstream(state).await;
+        let registry = registry_with(vec![discovered("svc", &url, vec!["*"])]);
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let out = dispatcher
+            .invoke("svc.flaky", &serde_json::json!({}))
+            .await
+            .expect("invoke");
+        assert!(out.is_error);
+        let ToolContent::Text { text } = &out.content[0];
+        assert!(text.contains("code=-32000"));
+        assert!(text.contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn invoke_returns_execution_failed_on_upstream_5xx() {
+        let state = MockState {
+            tools: vec![tool_def("flaky", "")],
+            force_call_http_status: Some(503),
+            ..Default::default()
+        };
+        let url = mock_upstream(state).await;
+        let registry = registry_with(vec![discovered("svc", &url, vec!["*"])]);
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let err = dispatcher
+            .invoke("svc.flaky", &serde_json::json!({}))
+            .await
+            .unwrap_err();
+        match err {
+            DispatchError::ExecutionFailed { tool, reason } => {
+                assert_eq!(tool, "svc.flaky");
+                assert!(reason.contains("503"));
+            }
+            other => panic!("expected ExecutionFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn multi_server_namespaces_dispatch_correctly() {
+        let s1 = MockState {
+            tools: vec![tool_def("search", "")],
+            ..Default::default()
+        };
+        let s2 = MockState {
+            tools: vec![tool_def("query", "")],
+            ..Default::default()
+        };
+        let url1 = mock_upstream(s1).await;
+        let url2 = mock_upstream(s2).await;
+        let registry = registry_with(vec![
+            discovered("github-mcp", &url1, vec!["*"]),
+            discovered("kb-search", &url2, vec!["*"]),
+        ]);
+        let dispatcher = RouterToolDispatcher::discover(registry, Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(dispatcher.len(), 2);
+
+        // Each tool routes to its own upstream.
+        let out1 = dispatcher
+            .invoke("github_mcp.search", &serde_json::json!({"q": "a"}))
+            .await
+            .unwrap();
+        let ToolContent::Text { text: t1 } = &out1.content[0];
+        assert!(t1.contains("called search"));
+
+        let out2 = dispatcher
+            .invoke("kb_search.query", &serde_json::json!({"q": "b"}))
+            .await
+            .unwrap();
+        let ToolContent::Text { text: t2 } = &out2.content[0];
+        assert!(t2.contains("called query"));
+    }
+}

--- a/inference-router/src/mcp/mod.rs
+++ b/inference-router/src/mcp/mod.rs
@@ -46,6 +46,7 @@
 //! confusion, kid mismatch, expired token, replayed token.
 
 pub mod error;
+pub mod forwarder;
 pub mod initialize;
 pub mod jsonrpc;
 pub mod oauth;

--- a/inference-router/src/mcp/oauth.rs
+++ b/inference-router/src/mcp/oauth.rs
@@ -1200,6 +1200,7 @@ mod tests {
                     issuer: "https://idp-a.example".to_string(),
                     audience: Some("api://server-a".to_string()),
                     scopes: vec!["tools.invoke".to_string()],
+                    ..Default::default()
                 }),
             },
         );
@@ -1212,6 +1213,7 @@ mod tests {
                     issuer: "https://idp-b.example".to_string(),
                     audience: Some("api://server-b".to_string()),
                     scopes: vec![],
+                    ..Default::default()
                 }),
             },
         );
@@ -1273,6 +1275,7 @@ mod tests {
                     issuer: issuer.clone(),
                     audience: Some("api://a".to_string()),
                     scopes: vec![],
+                    ..Default::default()
                 }),
             },
         );
@@ -1285,6 +1288,7 @@ mod tests {
                     issuer: issuer.clone(),
                     audience: Some("api://b".to_string()),
                     scopes: vec![],
+                    ..Default::default()
                 }),
             },
         );

--- a/inference-router/src/mcp/registry.rs
+++ b/inference-router/src/mcp/registry.rs
@@ -40,7 +40,7 @@ use std::path::{Path, PathBuf};
 /// `OAuthVerifierConfig` — `trusted_issuers` keyed by `issuer`,
 /// `expected_audiences` aggregated from all servers' optional
 /// audience fields.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiscoveredMcpServerMeta {
     pub issuer: String,
@@ -48,6 +48,20 @@ pub struct DiscoveredMcpServerMeta {
     pub audience: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scopes: Vec<String>,
+    /// Slice 4d.4 — upstream MCP server URL the router's
+    /// [`crate::mcp::forwarder::RouterToolDispatcher`] forwards
+    /// `tools/call` requests to. Empty string when missing in
+    /// `meta.json` (pre-4d.4 mirrors) — the forwarder skips such
+    /// entries with a recorded reason.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub url: String,
+    /// Slice 4d.4 — allowed-tools allowlist mirrored from
+    /// `McpServerSpec.allowedTools`. Empty list = no tools advertised
+    /// to the agent (fail-closed); `["*"]` = expose every tool the
+    /// upstream advertises. Filtered against discovered upstream
+    /// catalog at startup.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_tools: Vec<String>,
 }
 
 /// A single McpServer discovered under `MCP_JWKS_DIR`.

--- a/inference-router/src/routes/mcp.rs
+++ b/inference-router/src/routes/mcp.rs
@@ -70,14 +70,23 @@ pub struct McpRouteState {
 impl McpRouteState {
     /// Default production state: stock `InitializeConfig`, `OsRng`
     /// session ids, in-tree `EchoDispatcher` (real ping/echo tool).
-    /// Real upstream tools land via a future `RouterToolDispatcher`
-    /// implementation that proxies into `McpServer` CRs.
+    ///
+    /// Slice 4d.4 replaces this dispatcher with [`crate::mcp::forwarder::RouterToolDispatcher`]
+    /// at mount time when the registry advertises at least one usable
+    /// `McpServer.spec.url`; see [`with_tools`].
     pub fn standard() -> Self {
         Self {
             config: Arc::new(InitializeConfig::default()),
             minter: Arc::new(OsRngSessionMinter),
             tools: Arc::new(SyncToAsync::new(EchoDispatcher::standard())),
         }
+    }
+
+    /// Swap the dispatcher (used by Slice 4d.4 to mount the
+    /// namespaced upstream forwarder when the registry is non-empty).
+    pub fn with_tools(mut self, tools: Arc<dyn AsyncToolDispatcher>) -> Self {
+        self.tools = tools;
+        self
     }
 
     /// State for the **platform MCP server** mounted at `/platform/mcp`.


### PR DESCRIPTION
## Summary

Closes the **dispatch half** of Slice 4 DoD #3 (*"per-server JWKS + namespaced tools"*). The OAuth half landed in PR #293 (Slice 4d.3); this PR wires the actual upstream forwarder so `/mcp` no longer ships only the in-tree `EchoDispatcher`.

When the registry advertises at least one `McpServer` with a usable upstream URL, `RouterToolDispatcher` discovers each upstream's `tools/list` at startup, filters through `spec.allowedTools`, and exposes the surviving tools under a `{server_snake_case}.{tool}` namespace. Tool calls are then forwarded to the matching upstream URL.

## Wire contract — what the controller emits

`meta.json` (per-server ConfigMap) gains two fields alongside Slice 4d.3's OAuth metadata:

| Field | Source | Purpose |
|-------|--------|---------|
| `url` | `McpServer.spec.url` | Upstream MCP server URL (POST destination) |
| `allowedTools` | `McpServer.spec.allowedTools` | Per-server allow-list (`[\"*\"]` exposes all) |

## Wire contract — what the router consumes

\`mcp::registry::DiscoveredMcpServerMeta\` matches the producer shape, and the new \`mcp::forwarder::RouterToolDispatcher\`:

1. Discovers each upstream's tool catalog at router startup.
2. Filters through \`allowedTools\` (\`[\"*\"]\` exposes all; explicit list selects subset; empty fails closed).
3. Builds a namespaced catalog: \`github-mcp\` exposing \`search\` becomes \`github_mcp.search\` agent-side.
4. Skips (with structured logs) any server with empty URL, outbound-OAuth requirement, unreachable upstream, or HTTP/JSON-RPC errors. Router still starts.

## Out-of-scope (Slice 4d.5)

- Outbound OAuth (client-credentials / OBO). Servers whose meta carries an \`issuer\` are deliberately skipped with a clear reason. This is the §5 anti-scaffolding boundary: we only ship the consumer we can drive end-to-end today.

## Test coverage (15 new unit tests)

Every skip reason is asserted with the expected substring (operator-actionable). The happy path runs against a real \`axum::Router\` mock upstream — full JSON-RPC \`tools/list\` → \`tools/call\` round-trip through the dispatcher.

Negative branches:
- Unknown tool (wrong prefix / unknown suffix / no \`.\` at all) → \`UnknownTool\`.
- Upstream JSON-RPC error → \`is_error: true\` content (per MCP spec).
- Upstream HTTP 5xx → \`ExecutionFailed\`.

Multi-server dispatch is asserted with two distinct mock upstreams — each invocation lands at the correct URL.

## Backward compatibility

Registries without \`meta.json\` files or with empty \`url\` fall through to the existing \`EchoDispatcher\`. The single-issuer \`MCP_JWKS_PATH\` legacy path remains as the third fallback.

## Verification

- \`cargo test --package azureclaw-inference-router\` → 835 lib tests (+15)
- \`cargo test --package azureclaw-controller\` → 559 (unchanged shape, +1 from struct field addition)
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo fmt --all --check\` clean

## Slice 4 DoD scoreboard after this PR

| # | Item | State |
|---|------|-------|
| 1 | plural ≥ 3 servers e2e | ✅ #292 |
| 2 | singular alias deprecation | ✅ #291 |
| 3 | per-server JWKS + namespaced tools | ✅ (OAuth #293, dispatch this PR) |
| 4 | audit persistence | ✅ #287 |
| 5 | remote audit sink | ✅ #290 |
| 6 | stale-file sweep | ✅ #292 |
| 7 | \`azureclaw audit tail\` CLI | ✅ #289 |
| 8 | CHANGELOG + docs | 🟡 Slice 4e queued |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>