### PR TITLE
Slice 4e: docs consolidation — Slice 4 DoD #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 4e — Slice 4 docs consolidation (DoD #8)
+
+Closes Slice 4 DoD #8 (*"CHANGELOG + `docs/api/mcpserver.md` updated"*).
+Per-CRD doc pages have been consolidated into
+[`docs/api/crd-reference.md`](docs/api/crd-reference.md) +
+[`docs/api/lifecycle.md`](docs/api/lifecycle.md) since Slice 1; the
+remaining gap was stale singular-form prose:
+
+- `docs/api/crd-reference.md`: `spec.mcpRefs` corrected to
+  `spec.mcpServerRefs`; `McpServer` section rewritten to reflect the
+  Slice 4 plural model — per-server `/etc/azureclaw/mcp/<name>/`
+  volumes, multi-issuer `OAuthVerifier`, namespaced
+  `{server}.{tool}` dispatch, `allowed_tools` semantics
+  (`["*"]` vs explicit subset vs empty = fail-closed).
+- `docs/api/lifecycle.md`: `/v1/mcp/*` proxy reference updated to
+  `/mcp` (the actual route); new "Plural binding (`mcpServerRefs`,
+  Slice 4)" subsection documents the per-server volume layout,
+  OAuth verifier population (4d.3), and namespaced forwarder
+  catalog (4d.4); `Ready` row gains plural-McpServer + ClawMemory
+  echo coverage. Stale-file sweep (DoD #6) explicitly documented
+  as producer-side: each reconcile rewrites the current ref set,
+  removed-server volumes disappear on next kubelet pod sync.
+
+No code changes. Closes Slice 4.
+
 ### Slice 4d.4 — namespaced MCP tool forwarder (DoD #3 — dispatch half)
 
 Closes the dispatch half of Slice 4 DoD #3 (*"…with namespaced tool

--- a/docs/api/crd-reference.md
+++ b/docs/api/crd-reference.md
@@ -72,7 +72,7 @@ status:
 | `spec.inferenceRef.name` | LocalObjectReference | Bind to an `InferencePolicy` (model, tokens, region). If unset, the cluster default applies. |
 | `spec.policyRef.name` | LocalObjectReference | Bind to a `ToolPolicy`. If unset, the runtime ships with a deny-all default. |
 | `spec.memoryRef.name` | LocalObjectReference | Bind to a `ClawMemory`. |
-| `spec.mcpRefs` | `[]LocalObjectReference` | List of `McpServer` resources the agent may call. |
+| `spec.mcpServerRefs` | `[]LocalObjectReference` | List of `McpServer` resources the agent may call. The controller mirrors each referenced server's JWKS + signing keys into per-server volumes under `/etc/azureclaw/mcp/<name>/` (Slice 4d.2); the inference router builds a multi-issuer OAuth verifier and a namespaced tool catalog (`{server}.{tool}` — Slice 4d.3 / 4d.4) over those mounts. Up to 8 entries; unique by `name`. The deprecated singular `spec.mcpServerRef` (singular form) is still accepted as input but emits a `Warning` event and is folded into `mcpServerRefs` on reconcile. |
 | `spec.mesh.enabled` | bool | Register with AgentMesh. Defaults `false`. |
 | `spec.mesh.trustRef.name` | LocalObjectReference | Bind to a `TrustGraph` (cluster-scoped). |
 | `spec.governance.profile` | string | Name of a profile under `policy-engine/profiles/`. Defaults to `standard`. |
@@ -115,7 +115,7 @@ The `agentCard.trustAnchorRef` configures which signers' AgentCards the gateway 
 
 ## `McpServer` — declared MCP backend
 
-Declares an MCP server the sandbox may call. The router enforces — calls to an MCP host that is not declared are denied.
+Declares an MCP server the sandbox may call. The router enforces — calls to an MCP host that is not declared are denied. As of Slice 4, a `ClawSandbox` may bind up to 8 `McpServer`s via `spec.mcpServerRefs`; the controller mirrors per-server JWKS + signing keys into `/etc/azureclaw/mcp/<name>/{jwks.json,meta.json}` and the router exposes tools under the namespaced name `{server}.{tool}` (e.g. `github_mcp.repo_search`). Inbound MCP requests are verified against a multi-issuer `OAuthVerifier` keyed by `oauth.issuer`.
 
 ```yaml
 apiVersion: azureclaw.azure.com/v1alpha1
@@ -124,12 +124,20 @@ metadata:
   name: github-mcp
 spec:
   url: https://api.githubcopilot.com/mcp
-  auth:
-    kind: OAuth                    # or ApiKey | ServiceAccount | None
-    secretRef: { name: github-mcp-creds }
-  scopes: ["read:repo"]
-  contentSafety: required          # or optional | off
+  oauth:
+    issuer: https://github.com/login/oauth
+    audience: azureclaw-mcp
+  allowedTools: ["*"]                # or explicit list; empty list fails closed
+  contentSafety: required            # or optional | off
 ```
+
+| Field | Purpose |
+|---|---|
+| `spec.url` | Upstream MCP endpoint. The router proxies `tools/list` + `tools/call` over JSON-RPC. |
+| `spec.oauth.issuer` | OAuth 2.1 issuer URL. The controller fetches the JWKS and mirrors it to the sandbox; the router verifies inbound MCP-host bearer tokens against it. |
+| `spec.oauth.audience` | Optional. When set, the router enforces the `aud` claim. |
+| `spec.allowedTools` | Allow-list of tool names exposed to the agent. `["*"]` exposes the entire upstream catalog; an explicit list selects a subset; an **empty** list fails closed and the server is skipped with reason `allowed_tools is empty` on the registry. |
+| `spec.contentSafety` | `required` \| `optional` \| `off` — content-safety floor applied to MCP responses. |
 
 ---
 

--- a/docs/api/lifecycle.md
+++ b/docs/api/lifecycle.md
@@ -125,7 +125,7 @@ Every CLI command is a thin wrapper around `kubectl apply`. The CLI does no orch
 | `azureclaw destroy <name>` | Deletes `ClawSandbox` | Cascades via finalizer to delete the namespace + federated credential | — |
 | `azureclaw inferencepolicy apply` | `InferencePolicy` | `ConfigMap` `inferencepolicy-<name>-profile` | Inference router (`/v1/chat`, `/v1/responses`) |
 | `azureclaw toolpolicy apply` | `ToolPolicy` | `ConfigMap` `toolpolicy-<name>-profile` | Inference router (every tool dispatch) |
-| `azureclaw mcp add` | `McpServer` | `Secret` `mcp-<name>-signing` (Ed25519 keypair) <br/> `ConfigMap` `mcp-<name>-jwks` (when `productionMode=true`) | Inference router (`/v1/mcp/*` proxy) |
+| `azureclaw mcp add` | `McpServer` | `Secret` `mcp-<name>-signing` (Ed25519 keypair) <br/> `ConfigMap` `mcp-<name>-jwks` (when `productionMode=true`) | Inference router (`/mcp` proxy — multi-issuer OAuth verifier + namespaced `{server}.{tool}` dispatch since Slice 4d.3 / 4d.4) |
 | `azureclaw a2a-agent apply` | `A2AAgent` | `ConfigMap` `a2aagent-<name>-card` (signed AgentCard) | A2A gateway (inbound JWS verification) |
 | `azureclaw eval` | `ClawEval` | `ConfigMap` `claweval-<name>-spec` <br/> `Job` (when run-now) | Eval harness |
 | `azureclaw mesh ...` | `TrustGraph` | `ConfigMap` `trustgraph-<name>-graph` | Inference router (KNOCK accept/deny + AGT trust score) |
@@ -251,6 +251,27 @@ Two artifacts, two purposes:
 
 If JWKS fetch fails the CR is stamped `Degraded / JwksFetchFailed` and the controller requeues with backoff. The router's tool dispatch path treats this as fail-closed for that MCP server.
 
+### Plural binding (`mcpServerRefs`, Slice 4)
+
+A `ClawSandbox` may bind up to **8** `McpServer`s via `spec.mcpServerRefs: []LocalObjectReference`. The legacy singular form `spec.mcpServerRef` is accepted on input and folded into the plural list on reconcile (a `Warning` event is emitted to nudge migration). For every referenced server the controller mirrors a per-server volume into the sandbox pod:
+
+```
+/etc/azureclaw/mcp/
+  ├── <name-a>/
+  │   ├── jwks.json   ← mirrored issuer JWKS
+  │   └── meta.json   ← { url, issuer, audience, allowed_tools }
+  └── <name-b>/
+      ├── jwks.json
+      └── meta.json
+```
+
+The inference router walks `MCP_JWKS_DIR` at startup, builds an `McpServerRegistry` keyed by name, and:
+
+1. **OAuth (Slice 4d.3):** registers each `meta.issuer` as a trusted issuer in the multi-issuer `OAuthVerifier`. Inbound MCP-host requests are routed to the matching JWKS by `iss` claim.
+2. **Tool dispatch (Slice 4d.4):** for each unauthenticated server (servers requiring outbound OAuth are skipped until Slice 4d.5), the router calls `tools/list` upstream and registers each tool under the namespaced name `{server_snake_case}.{tool}`. `allowed_tools` filters the catalog (`["*"]` = full passthrough; explicit list = subset; empty = fail-closed with reason recorded).
+
+Stale-file sweep (DoD #6) is producer-side: each reconcile rewrites the full current ref set, so removed servers' volumes disappear naturally on the next kubelet pod sync.
+
 ---
 
 ## `A2AAgent` — public-ingress endpoint
@@ -319,7 +340,7 @@ The `status.phase` string is part of the public contract: `azureclaw connect`, `
 |---|---|---|---|
 | `Pending` | Controller accepted the CR but has not yet produced a compiled artifact (waiting on an admit step or finalizer cleanup). | `False` | Reserved for async admission flows; not stamped by Slice 0 reconcilers. |
 | `Compiled` | Spec parsed, `ConfigMap` written, but the **router has not yet echoed back the loaded digest**. The artifact exists; the data plane is not yet enforcing it. | `False` (reason `AwaitingRouterEnforcement` or `NoSandboxesReferencing`) | Slice 0 — `ClawMemory`. Slice 1c — `ToolPolicy` with `spec.agtProfile.inline` while the controller-side poller is awaiting confirmation from at least one referencing `ClawSandbox`'s `inference-router /internal/policy-status` endpoint, or while no `ClawSandbox` references the policy yet. Slice 2a/2b/2c/2d.1 — `InferencePolicy` while the same digest-echo loop awaits confirmation for `tokenBudget.{perRequestTokens, dailyTokens, monthlyTokens}` + `contentSafety.{hate, selfHarm, sexual, violence}` floors + `requirePromptShields` fail-closed + `modelPreference.primary.deployment` override (the remaining `modelPreference.fallback` health-aware failover keeps `InferencePolicy` in `Compiled` only when an operator explicitly relies on it — Slice 2d.2 deliverable). A `Warning` Event with reason `PolicyNotEnforced` is emitted on every reconcile in this state so operators see the gap in `kubectl describe`. |
-| `Ready` | Spec compiled **and** the consuming component (router, runtime, etc.) has confirmed it is enforcing the artifact. `kubectl wait --for=condition=Ready` must only return at this point. | `True` | `ToolPolicy` **without** `spec.agtProfile` (runtime-side enforcement of commerce / rate-limit / approval is co-located in the in-process AGT plugin); `ToolPolicy` with `spec.agtProfile.inline` after every referencing `ClawSandbox`'s router echoes the published digest on `/internal/policy-status` (reason `RouterEnforcing` — Slice 1c); `InferencePolicy` after every referencing `ClawSandbox`'s router echoes the inference-policy digest on the same endpoint (reason `RouterEnforcing` — Slice 2a); `McpServer` (singular today; see Slice 4), `A2AAgent`, `ClawSandbox`, `TrustGraph`. |
+| `Ready` | Spec compiled **and** the consuming component (router, runtime, etc.) has confirmed it is enforcing the artifact. `kubectl wait --for=condition=Ready` must only return at this point. | `True` | `ToolPolicy` **without** `spec.agtProfile` (runtime-side enforcement of commerce / rate-limit / approval is co-located in the in-process AGT plugin); `ToolPolicy` with `spec.agtProfile.inline` after every referencing `ClawSandbox`'s router echoes the published digest on `/internal/policy-status` (reason `RouterEnforcing` — Slice 1c); `InferencePolicy` after every referencing `ClawSandbox`'s router echoes the inference-policy digest on the same endpoint (reason `RouterEnforcing` — Slice 2a); `ClawMemory` after the binding digest is echoed (reason `RouterEnforcing` — Slice 3a); `McpServer` (plural since Slice 4 — `ClawSandbox.spec.mcpServerRefs` mirrors up to 8 servers; the singular `spec.mcpServerRef` remains an accepted alias with deprecation warning); `A2AAgent`, `ClawSandbox`, `TrustGraph`. |
 | `Degraded` | Spec is valid but a dependency is failing (Foundry 5xx, JWKS fetch timeout, etc.). Retry will help — the reconciler requeues at `REQUEUE_FAIL`. | `False` (reason describes the dependency) | Any reconciler on transient failure. |
 | `Failed` | Spec is invalid and will not converge without user editing the CR (validation, signature mismatch, malformed reference). | `False` | Any reconciler on permanent failure. |
 


### PR DESCRIPTION
Closes Slice 4 DoD #8 (*CHANGELOG + docs/api/mcpserver.md updated*).

Per-CRD doc pages were consolidated into \`docs/api/crd-reference.md\` + \`docs/api/lifecycle.md\` since Slice 1; the remaining gap was stale singular-form McpServer prose.

## Changes
- \`docs/api/crd-reference.md\`: \`spec.mcpRefs\` → \`spec.mcpServerRefs\`; \`McpServer\` section rewritten for the Slice 4 plural model (per-server \`/etc/azureclaw/mcp/<name>/\` volumes, multi-issuer \`OAuthVerifier\`, namespaced \`{server}.{tool}\` dispatch, \`allowed_tools\` semantics).
- \`docs/api/lifecycle.md\`: \`/v1/mcp/*\` → \`/mcp\`; new "Plural binding (\`mcpServerRefs\`, Slice 4)" subsection; \`Ready\` row updated for plural McpServer + ClawMemory echo coverage; stale-file sweep producer-side semantics documented.
- CHANGELOG entry under [Unreleased] crd-well-oiled-machine.

No code changes — pure docs.

## Slice 4 status post-merge
| # | Item | State |
|---|------|-------|
| 1 | plural ≥ 3 servers e2e | ✅ Slice 4d.2 |
| 2 | singular alias deprecation | ✅ Slice 4d.1 |
| 3 | per-server JWKS + namespaced tools | ✅ Slices 4d.2/4d.3/4d.4 |
| 4 | audit persistence across restart | ✅ Slice 4a |
| 5 | remote audit sink | ✅ Slice 4c |
| 6 | stale-file sweep | ✅ (kubelet sync, producer-side) |
| 7 | \`azureclaw audit tail\` | ✅ Slice 4b |
| 8 | CHANGELOG + docs | ✅ (this PR) |

Slice 4 closed. Next up: Slice 5 (egress polish + observability).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>