### PR TITLE
Slice 5a: surface blocked egress attempts (DoD #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 5a — Surface blocked egress attempts (DoD #1)
+
+First slice in the Slice 5 "egress polish + observability" sequence.
+Closes Slice 5 DoD #1 (*"`azureclaw egress blocked` lists every host the
+agent attempted that the enforcement layer refused"*) by exposing the
+existing in-process `BlockedBuffer` over operator-facing surfaces.
+
+- `inference-router/src/egress_blocked.rs`: new `snapshot_since` +
+  `top_hosts` methods on `BlockedBuffer`. Newest-first ordering by
+  `last_seen_unix`; `top_hosts` aggregates across `(sandbox, port)` by
+  hostname with a deterministic secondary sort for tied counts. 7
+  unit tests cover filter cutoffs, dedup count carry-through,
+  aggregation across sandboxes/ports, `n=0` early return, and the
+  100-cap truncation.
+- `inference-router/src/routes/internal.rs`: two new endpoints
+  mounted on the admin-gated `protected` router:
+  - `GET /internal/egress/blocked?since=<rfc3339|unix|-Nm>` — full list.
+  - `GET /internal/egress/blocked/top?window=<duration>&n=<int>` —
+    top-N rolling-window aggregate.
+  Both emit `schema_version: 1` envelopes carrying RFC 3339 strings
+  alongside raw Unix seconds for downstream parsers. Hand-rolled
+  duration + RFC 3339 parsers (no `chrono` dep) with 7 unit + 6
+  integration tests covering bare seconds, `s/m/h/d` suffixes,
+  relative `-Nm` form, malformed input → `0`, the `n ≤ 100` cap, and
+  the `window` default of 5m.
+- `cli/src/commands/egress/blocked.ts`: new
+  `azureclaw egress blocked <sandbox> [--since 10m] [--top]
+  [--window 1h] [--n 20] [--watch] [--json]` subcommand. Mirrors
+  the `azureclaw inspect` token-resolution path
+  (`router-admin-token` secret first, in-pod `admin-token` file
+  fallback) and uses in-pod `kubectl exec curl` to avoid
+  port-forward collisions. `--watch` re-renders every 5s with VT
+  clear; `--top` overrides `--since` (window is its own filter).
+  13 vitest unit tests cover query-string composition, the renderer
+  surface (HOST/PORT/SANDBOX/LAST_SEEN/COUNT columns, empty-state
+  message, since-filter line, top-N window line) and the
+  `unixToIso(0) === "epoch"` sentinel.
+
+Producer→consumer loop is real and complete: the router has been
+populating `BlockedBuffer` from the forward proxy since S12.f; this
+slice just makes that surface visible to operators without giving
+the agent any new wire access.
+
 ### Slice 4e — Slice 4 docs consolidation (DoD #8)
 
 Closes Slice 4 DoD #8 (*"CHANGELOG + `docs/api/mcpserver.md` updated"*).

--- a/cli/src/commands/egress.ts
+++ b/cli/src/commands/egress.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getAdminToken, withAdminAuth } from "../router-admin.js";
+import { blockedCommand } from "./egress/blocked.js";
 import {
   EGRESS_ALLOWLIST_MEDIA_TYPE,
   autoDetectSignMode,
@@ -20,6 +21,11 @@ import {
 
 export function egressCommand(): Command {
   const cmd = new Command("egress");
+  // Slice 5a — `azureclaw egress blocked <sandbox>` subcommand surfaces
+  // the router's /internal/egress/blocked view. Kept as a subcommand
+  // rather than another top-level flag so --watch/--top/--since don't
+  // collide with the existing flat-options surface.
+  cmd.addCommand(blockedCommand());
 
   cmd
     .description("Manage network egress: allowlist, approvals, and learn mode")

--- a/cli/src/commands/egress/blocked.test.ts
+++ b/cli/src/commands/egress/blocked.test.ts
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildPath,
+  renderList,
+  renderTop,
+  unixToIso,
+  type BlockedResponse,
+  type BlockedTopResponse,
+} from "./blocked.js";
+
+describe("egress blocked CLI — buildPath", () => {
+  it("returns the bare list path with no options", () => {
+    expect(buildPath({})).toBe("/internal/egress/blocked");
+  });
+
+  it("encodes --since", () => {
+    expect(buildPath({ since: "-10m" })).toBe(
+      "/internal/egress/blocked?since=-10m"
+    );
+  });
+
+  it("encodes --since with RFC 3339 (URL-safe)", () => {
+    const got = buildPath({ since: "2024-01-15T10:30:45Z" });
+    // URLSearchParams percent-encodes the colons; both forms acceptable.
+    expect(got).toContain("/internal/egress/blocked?since=");
+    expect(decodeURIComponent(got.split("=")[1])).toBe("2024-01-15T10:30:45Z");
+  });
+
+  it("returns the bare top path with no options", () => {
+    expect(buildPath({ top: true })).toBe("/internal/egress/blocked/top");
+  });
+
+  it("encodes --top --window --n", () => {
+    expect(buildPath({ top: true, window: "1h", n: "20" })).toBe(
+      "/internal/egress/blocked/top?window=1h&n=20"
+    );
+  });
+
+  it("--top overrides --since (since is list-only)", () => {
+    // since is documented as list-only; top uses window. Confirm builder
+    // does NOT leak `since` into the top path.
+    expect(buildPath({ top: true, since: "-10m" })).toBe(
+      "/internal/egress/blocked/top"
+    );
+  });
+});
+
+describe("egress blocked CLI — unixToIso", () => {
+  it("0 → 'epoch'", () => {
+    expect(unixToIso(0)).toBe("epoch");
+  });
+
+  it("known timestamp formats with .000Z suffix", () => {
+    // 2024-01-15T10:30:45Z
+    expect(unixToIso(1_705_314_645)).toBe("2024-01-15T10:30:45.000Z");
+  });
+});
+
+describe("egress blocked CLI — renderers", () => {
+  it("renderList prints 'No blocked attempts' on empty response", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const resp: BlockedResponse = {
+      schema_version: 1,
+      total: 0,
+      count: 0,
+      since_unix: 0,
+      entries: [],
+    };
+    renderList("sb1", "azureclaw-sb1", resp);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("No blocked attempts");
+    spy.mockRestore();
+  });
+
+  it("renderList prints HOST/PORT/SANDBOX/LAST_SEEN/COUNT header", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const resp: BlockedResponse = {
+      schema_version: 1,
+      total: 1,
+      count: 1,
+      since_unix: 0,
+      entries: [
+        {
+          host: "evil.example.com",
+          port: 443,
+          source_sandbox: "sb1",
+          count: 3,
+          first_seen_unix: 1_705_314_645,
+          last_seen_unix: 1_705_314_700,
+          first_seen: "2024-01-15T10:30:45.000Z",
+          last_seen: "2024-01-15T10:31:40.000Z",
+        },
+      ],
+    };
+    renderList("sb1", "azureclaw-sb1", resp);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("HOST");
+    expect(out).toContain("PORT");
+    expect(out).toContain("SANDBOX");
+    expect(out).toContain("LAST_SEEN");
+    expect(out).toContain("COUNT");
+    expect(out).toContain("evil.example.com");
+    expect(out).toContain("443");
+    expect(out).toContain("sb1");
+    expect(out).toContain("2024-01-15T10:31:40.000Z");
+    expect(out).toContain(" 3"); // count column
+    spy.mockRestore();
+  });
+
+  it("renderList includes since-filter line when since_unix > 0", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const resp: BlockedResponse = {
+      schema_version: 1,
+      total: 0,
+      count: 0,
+      since_unix: 1_705_314_645,
+      entries: [],
+    };
+    renderList("sb1", "azureclaw-sb1", resp);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Filter: since 2024-01-15T10:30:45.000Z");
+    spy.mockRestore();
+  });
+
+  it("renderTop prints HOST/COUNT header with window line", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const resp: BlockedTopResponse = {
+      schema_version: 1,
+      since_unix: 1_705_314_645,
+      window: "5m",
+      n: 10,
+      top: [
+        { host: "a.example.com", count: 5 },
+        { host: "b.example.com", count: 2 },
+      ],
+    };
+    renderTop("sb1", "azureclaw-sb1", resp);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Window: 5m");
+    expect(out).toContain("top 10");
+    expect(out).toContain("HOST");
+    expect(out).toContain("COUNT");
+    expect(out).toContain("a.example.com");
+    expect(out).toContain(" 5");
+    expect(out).toContain("b.example.com");
+    spy.mockRestore();
+  });
+
+  it("renderTop prints 'No blocked attempts' on empty top", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const resp: BlockedTopResponse = {
+      schema_version: 1,
+      since_unix: 0,
+      window: "5m",
+      n: 10,
+      top: [],
+    };
+    renderTop("sb1", "azureclaw-sb1", resp);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("No blocked attempts");
+    spy.mockRestore();
+  });
+});

--- a/cli/src/commands/egress/blocked.ts
+++ b/cli/src/commands/egress/blocked.ts
@@ -1,0 +1,342 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `azureclaw egress blocked <sandbox> [--since 10m] [--top] [--watch]`
+//! — surface the router's `/internal/egress/blocked` view of every
+//! egress attempt that was denied by the enforcement layer.
+//!
+//! Slice 5a in
+//! `docs/internal/crd-well-oiled-machine/slice-5-egress-polish-and-observability.md`.
+//! Mirrors the in-pod curl approach used by `azureclaw inspect` so we
+//! avoid `kubectl port-forward` port-collision footguns.
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { execa } from "execa";
+
+// --- Wire DTOs (must mirror `inference-router/src/routes/internal.rs`) ----
+
+export interface BlockedEntry {
+  host: string;
+  port: number;
+  source_sandbox: string;
+  count: number;
+  first_seen_unix: number;
+  last_seen_unix: number;
+  first_seen: string;
+  last_seen: string;
+}
+
+export interface BlockedResponse {
+  schema_version: number;
+  total: number;
+  count: number;
+  since_unix: number;
+  entries: BlockedEntry[];
+}
+
+export interface TopHost {
+  host: string;
+  count: number;
+}
+
+export interface BlockedTopResponse {
+  schema_version: number;
+  since_unix: number;
+  window: string;
+  n: number;
+  top: TopHost[];
+}
+
+interface BlockedOptions {
+  namespace?: string;
+  since?: string;
+  top?: boolean;
+  window?: string;
+  n?: string;
+  watch?: boolean;
+  json?: boolean;
+}
+
+export function blockedCommand(): Command {
+  return new Command("blocked")
+    .description(
+      "Show egress attempts the router's enforcement layer denied (Slice 5a)"
+    )
+    .argument("<sandbox>", "Sandbox name (the `metadata.name` of the ClawSandbox)")
+    .option(
+      "-n, --namespace <ns>",
+      "Sandbox pod namespace (default: 'azureclaw-<sandbox>')"
+    )
+    .option(
+      "--since <duration>",
+      "Only show attempts newer than this. Accepts RFC 3339, Unix seconds, or '-Nm'/'-Nh'/'-Nd' (default: all-time)"
+    )
+    .option(
+      "--top",
+      "Show top-N most-attempted blocked hosts in a rolling window instead of the full list"
+    )
+    .option(
+      "--window <duration>",
+      "With --top: rolling window for the top-N aggregate. Examples: 5m, 1h, 24h (default: 5m)"
+    )
+    .option(
+      "--n <count>",
+      "With --top: how many hosts to surface (default: 10, max: 100)"
+    )
+    .option(
+      "--watch",
+      "Poll every 5s and re-render. Press Ctrl-C to exit."
+    )
+    .option("--json", "Emit raw JSON instead of the formatted table")
+    .action(async (sandbox: string, opts: BlockedOptions) => {
+      try {
+        await runBlocked(sandbox, opts);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(chalk.red(`\n  egress blocked failed: ${msg}\n`));
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runBlocked(sandbox: string, opts: BlockedOptions): Promise<void> {
+  const ns = opts.namespace ?? `azureclaw-${sandbox}`;
+  const token = await readAdminToken(sandbox, ns);
+  if (!token) {
+    throw new Error(
+      `Could not read admin token from secret 'router-admin-token' in '${ns}'.\n` +
+        `  The sandbox may not be fully provisioned yet. Try 'azureclaw status ${sandbox}'.`
+    );
+  }
+
+  const renderOnce = async () => {
+    const path = buildPath(opts);
+    const raw = await fetchInternal(sandbox, ns, token, path);
+    if (opts.json) {
+      console.log(raw);
+      return;
+    }
+    if (opts.top) {
+      const resp = JSON.parse(raw) as BlockedTopResponse;
+      renderTop(sandbox, ns, resp);
+    } else {
+      const resp = JSON.parse(raw) as BlockedResponse;
+      renderList(sandbox, ns, resp);
+    }
+  };
+
+  if (!opts.watch) {
+    await renderOnce();
+    return;
+  }
+
+  // Render-loop: clear screen + redraw every 5s until SIGINT.
+  // We don't use `setInterval` so a slow render can't double-stack.
+  let stop = false;
+  process.on("SIGINT", () => {
+    stop = true;
+  });
+  while (!stop) {
+    process.stdout.write("\x1Bc"); // VT clear
+    try {
+      await renderOnce();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(chalk.yellow(`  fetch failed: ${msg} (retrying)`));
+    }
+    await sleep(5_000);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/// Compose the `/internal/egress/blocked[/top]` URL with the right query
+/// string for the current invocation.
+export function buildPath(opts: BlockedOptions): string {
+  if (opts.top) {
+    const params = new URLSearchParams();
+    if (opts.window) params.set("window", opts.window);
+    if (opts.n) params.set("n", opts.n);
+    const qs = params.toString();
+    return qs
+      ? `/internal/egress/blocked/top?${qs}`
+      : "/internal/egress/blocked/top";
+  }
+  const params = new URLSearchParams();
+  if (opts.since) params.set("since", opts.since);
+  const qs = params.toString();
+  return qs ? `/internal/egress/blocked?${qs}` : "/internal/egress/blocked";
+}
+
+async function readAdminToken(
+  sandbox: string,
+  ns: string
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await execa(
+      "kubectl",
+      [
+        "get",
+        "secret",
+        "router-admin-token",
+        "-n",
+        ns,
+        "-o",
+        "jsonpath={.data.token}",
+      ],
+      { stdio: "pipe", reject: false }
+    );
+    if (stdout.trim()) {
+      return Buffer.from(stdout.trim(), "base64").toString("utf8").trim();
+    }
+  } catch {
+    /* fall through */
+  }
+  for (const container of ["inference-router", "openclaw"]) {
+    try {
+      const { stdout } = await execa(
+        "kubectl",
+        [
+          "exec",
+          "-n",
+          ns,
+          `deploy/${sandbox}`,
+          "-c",
+          container,
+          "--",
+          "cat",
+          "/etc/azureclaw/secrets/admin-token",
+        ],
+        { stdio: "pipe", reject: false }
+      );
+      if (stdout.trim()) return stdout.trim();
+    } catch {
+      /* try next */
+    }
+  }
+  return undefined;
+}
+
+/// In-pod curl, token via stdin (no argv leak).
+async function fetchInternal(
+  sandbox: string,
+  ns: string,
+  token: string,
+  path: string
+): Promise<string> {
+  const script =
+    "read -r AZURECLAW_ADMIN_TOKEN <&0 && " +
+    "curl --silent --show-error --fail --max-time 10 " +
+    '-H "Authorization: Bearer $AZURECLAW_ADMIN_TOKEN" ' +
+    `http://127.0.0.1:8443${path}`;
+
+  const result = await execa(
+    "kubectl",
+    [
+      "exec",
+      "-i",
+      "-n",
+      ns,
+      `deploy/${sandbox}`,
+      "-c",
+      "openclaw",
+      "--",
+      "bash",
+      "-c",
+      script,
+    ],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+      input: `${token}\n`,
+      reject: false,
+    }
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Router ${path} fetch failed (exit ${result.exitCode}). ` +
+        `stderr: ${result.stderr?.toString().trim() ?? "<empty>"}`
+    );
+  }
+  return result.stdout;
+}
+
+// --- Renderers ------------------------------------------------------------
+
+export function renderList(
+  sandbox: string,
+  ns: string,
+  resp: BlockedResponse
+): void {
+  console.log("");
+  console.log(
+    chalk.bold(`  Blocked egress attempts — ${sandbox}`) +
+      chalk.dim(` (namespace: ${ns})`)
+  );
+  if (resp.since_unix > 0) {
+    console.log(chalk.dim(`  Filter: since ${unixToIso(resp.since_unix)}`));
+  }
+  console.log(
+    chalk.dim(`  ${resp.count} of ${resp.total} buffered entries shown\n`)
+  );
+  if (resp.entries.length === 0) {
+    console.log(chalk.green("  ✓ No blocked attempts in the window.\n"));
+    return;
+  }
+  const rows = resp.entries.map((e) => [
+    e.host,
+    String(e.port),
+    e.source_sandbox,
+    e.last_seen,
+    String(e.count),
+  ]);
+  printTable(["HOST", "PORT", "SANDBOX", "LAST_SEEN", "COUNT"], rows);
+  console.log("");
+}
+
+export function renderTop(
+  sandbox: string,
+  ns: string,
+  resp: BlockedTopResponse
+): void {
+  console.log("");
+  console.log(
+    chalk.bold(`  Top blocked hosts — ${sandbox}`) +
+      chalk.dim(` (namespace: ${ns})`)
+  );
+  console.log(
+    chalk.dim(
+      `  Window: ${resp.window} (since ${unixToIso(resp.since_unix)}), top ${resp.n}\n`
+    )
+  );
+  if (resp.top.length === 0) {
+    console.log(chalk.green("  ✓ No blocked attempts in the window.\n"));
+    return;
+  }
+  const rows = resp.top.map((t) => [t.host, String(t.count)]);
+  printTable(["HOST", "COUNT"], rows);
+  console.log("");
+}
+
+export function printTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length))
+  );
+  const sep = "  ";
+  const header = headers
+    .map((h, i) => h.padEnd(widths[i]))
+    .join(sep);
+  console.log("  " + chalk.bold(header));
+  for (const row of rows) {
+    console.log("  " + row.map((c, i) => c.padEnd(widths[i])).join(sep));
+  }
+}
+
+export function unixToIso(unix: number): string {
+  if (unix === 0) return "epoch";
+  // Slice 5a router emits `.000Z`; mirror that for consistency.
+  return new Date(unix * 1000).toISOString().replace(/\.\d{3}Z$/, ".000Z");
+}

--- a/inference-router/src/egress_blocked.rs
+++ b/inference-router/src/egress_blocked.rs
@@ -187,6 +187,57 @@ impl BlockedBuffer {
             .collect()
     }
 
+    /// Snapshot of every entry whose `last_seen_unix >= since_unix`, newest
+    /// first by last-seen. Used by `/internal/egress/blocked?since=…` to
+    /// support the CLI's `--since` filter.
+    ///
+    /// The buffer doesn't index by time, so this performs a full scan over
+    /// the deduplicated entry set. Bounded by `capacity` (1024 by default).
+    pub fn snapshot_since(&self, since_unix: u64) -> Vec<BlockedEntry> {
+        let inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut out: Vec<BlockedEntry> = inner
+            .by_key
+            .values()
+            .filter(|e| e.last_seen_unix >= since_unix)
+            .cloned()
+            .collect();
+        out.sort_by_key(|e| std::cmp::Reverse(e.last_seen_unix));
+        out
+    }
+
+    /// Top-N most-attempted hosts whose `last_seen_unix >= since_unix`,
+    /// aggregated across sandboxes + ports by hostname. Returns
+    /// `(host, total_attempts)` pairs, descending by attempt count.
+    ///
+    /// Used by the periodic `EgressBlockedSeen` event (Slice 5b) and the
+    /// `/internal/egress/blocked/top` endpoint surfaced to the plugin.
+    pub fn top_hosts(&self, since_unix: u64, n: usize) -> Vec<(String, u32)> {
+        if n == 0 {
+            return Vec::new();
+        }
+        let inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut by_host: HashMap<String, u32> = HashMap::new();
+        for e in inner.by_key.values() {
+            if e.last_seen_unix < since_unix {
+                continue;
+            }
+            let slot = by_host.entry(e.host.clone()).or_insert(0);
+            *slot = slot.saturating_add(e.count);
+        }
+        let mut out: Vec<(String, u32)> = by_host.into_iter().collect();
+        // Stable secondary sort by host name so equal counts produce
+        // deterministic output for tests + UI.
+        out.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        out.truncate(n);
+        out
+    }
+
     pub fn len(&self) -> usize {
         self.inner.lock().map(|g| g.by_key.len()).unwrap_or(0)
     }
@@ -443,5 +494,97 @@ mod tests {
         b.clear();
         assert_eq!(b.len(), 0);
         assert!(b.snapshot(10).is_empty());
+    }
+
+    // ---- Slice 5a: snapshot_since + top_hosts ----------------------------
+
+    /// Use `record_at` to inject known timestamps so the since-filter is
+    /// deterministic. The instant clock value (`now`) is unused for the
+    /// filter assertions — the test only inspects `last_seen_unix`.
+    fn rec_at(b: &BlockedBuffer, ts_unix: u64, sandbox: &str, host: &str, port: u16) {
+        b.record_at(Instant::now(), ts_unix, sandbox, host, port);
+    }
+
+    #[test]
+    fn snapshot_since_filters_by_last_seen_and_sorts_desc() {
+        let b = buf();
+        rec_at(&b, 100, "sb1", "old.example.com", 443);
+        rec_at(&b, 200, "sb1", "mid.example.com", 443);
+        rec_at(&b, 300, "sb1", "new.example.com", 443);
+
+        // since=150 → drops old.example.com
+        let snap = b.snapshot_since(150);
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].host, "new.example.com"); // newest first
+        assert_eq!(snap[1].host, "mid.example.com");
+
+        // since=0 → all three
+        assert_eq!(b.snapshot_since(0).len(), 3);
+
+        // since=>max ts → none
+        assert!(b.snapshot_since(9999).is_empty());
+    }
+
+    #[test]
+    fn snapshot_since_returns_dedup_count_for_repeats() {
+        let b = buf();
+        rec_at(&b, 100, "sb1", "h.example.com", 443);
+        rec_at(&b, 200, "sb1", "h.example.com", 443); // dedup; bumps last_seen
+        rec_at(&b, 300, "sb1", "h.example.com", 443); // dedup again
+
+        let snap = b.snapshot_since(0);
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].count, 3);
+        assert_eq!(snap[0].last_seen_unix, 300);
+    }
+
+    #[test]
+    fn top_hosts_aggregates_across_sandboxes_and_ports() {
+        let b = buf();
+        // a.example.com from two sandboxes; total count = 1 + 1 = 2.
+        rec_at(&b, 100, "sb1", "a.example.com", 443);
+        rec_at(&b, 110, "sb2", "a.example.com", 443);
+        // b.example.com on two ports; total count = 1 + 1 = 2.
+        rec_at(&b, 120, "sb1", "b.example.com", 443);
+        rec_at(&b, 130, "sb1", "b.example.com", 80);
+        // c.example.com seen 3 times from one sandbox.
+        rec_at(&b, 140, "sb1", "c.example.com", 443);
+        rec_at(&b, 141, "sb1", "c.example.com", 443);
+        rec_at(&b, 142, "sb1", "c.example.com", 443);
+
+        let top = b.top_hosts(0, 3);
+        // c (count 3) > a (2) = b (2); a sorts before b alphabetically.
+        assert_eq!(top.len(), 3);
+        assert_eq!(top[0], ("c.example.com".to_string(), 3));
+        assert_eq!(top[1], ("a.example.com".to_string(), 2));
+        assert_eq!(top[2], ("b.example.com".to_string(), 2));
+    }
+
+    #[test]
+    fn top_hosts_respects_since_filter() {
+        let b = buf();
+        rec_at(&b, 100, "sb1", "old.example.com", 443);
+        rec_at(&b, 200, "sb1", "new.example.com", 443);
+
+        let top = b.top_hosts(150, 10);
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].0, "new.example.com");
+    }
+
+    #[test]
+    fn top_hosts_truncates_to_n() {
+        let b = BlockedBuffer::new(64, Duration::from_secs(60), 100);
+        for i in 0..5 {
+            rec_at(&b, 100 + i as u64, "sb1", &format!("h{i}.example.com"), 443);
+        }
+        assert_eq!(b.top_hosts(0, 3).len(), 3);
+        assert_eq!(b.top_hosts(0, 0).len(), 0);
+        assert_eq!(b.top_hosts(0, 100).len(), 5);
+    }
+
+    #[test]
+    fn top_hosts_empty_buffer_returns_empty() {
+        let b = buf();
+        assert!(b.top_hosts(0, 10).is_empty());
     }
 }

--- a/inference-router/src/routes/internal.rs
+++ b/inference-router/src/routes/internal.rs
@@ -32,7 +32,10 @@ use crate::deployment_health::DeploymentHealthSnapshot;
 use crate::policy_status::PolicyStatusEntry;
 
 pub fn internal_routes() -> Router<AppState> {
-    Router::new().route("/internal/policy-status", get(policy_status))
+    Router::new()
+        .route("/internal/policy-status", get(policy_status))
+        .route("/internal/egress/blocked", get(egress_blocked))
+        .route("/internal/egress/blocked/top", get(egress_blocked_top))
 }
 
 /// JSON envelope returned by `GET /internal/policy-status`. Each
@@ -154,6 +157,268 @@ async fn policy_status(State(state): State<AppState>) -> impl IntoResponse {
     })
 }
 
+// ---------------------------------------------------------------------------
+// Slice 5a — surfaced egress blocked buffer
+//
+// Operator-facing companion to the existing `/egress/learned/blocked`
+// endpoint (which keeps its old shape for the
+// `azureclaw egress … --pending`/`--approve` workflow). The `/internal`
+// variants are the canonical surface the `azureclaw egress blocked` CLI
+// and the headlamp plugin consume:
+//
+//   GET /internal/egress/blocked?since=<rfc3339>
+//   GET /internal/egress/blocked/top?window=<go-duration>&n=<int>
+//
+// Both routes are mounted on the `protected` axum router (admin-token +
+// `ADMIN_ALLOW_IPS` gated), and they read from the same in-process
+// `BlockedBuffer` the forward-proxy enforcement path already populates.
+// ---------------------------------------------------------------------------
+
+/// Wire DTO for a single blocked-attempt entry. Mirrors
+/// [`crate::egress_blocked::BlockedEntry`] but renames timestamp fields
+/// to the suffix-stripped form preferred by the JSON wire surface and
+/// adds RFC 3339 strings alongside the raw Unix seconds for human eyes
+/// (controller / CLI parses both).
+#[derive(Debug, Serialize)]
+struct BlockedEntryDto {
+    host: String,
+    port: u16,
+    source_sandbox: String,
+    count: u32,
+    first_seen_unix: u64,
+    last_seen_unix: u64,
+    first_seen: String,
+    last_seen: String,
+}
+
+impl From<crate::egress_blocked::BlockedEntry> for BlockedEntryDto {
+    fn from(e: crate::egress_blocked::BlockedEntry) -> Self {
+        let first_seen = format_rfc3339_unix(e.first_seen_unix);
+        let last_seen = format_rfc3339_unix(e.last_seen_unix);
+        Self {
+            host: e.host,
+            port: e.port,
+            source_sandbox: e.source_sandbox,
+            count: e.count,
+            first_seen_unix: e.first_seen_unix,
+            last_seen_unix: e.last_seen_unix,
+            first_seen,
+            last_seen,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct BlockedResponse {
+    schema_version: u32,
+    total: usize,
+    count: usize,
+    /// Echo of the resolved `since` filter as Unix seconds. `0` when the
+    /// caller passed no filter or the input parsed as the epoch.
+    since_unix: u64,
+    entries: Vec<BlockedEntryDto>,
+}
+
+#[derive(Debug, Serialize)]
+struct TopHost {
+    host: String,
+    count: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct BlockedTopResponse {
+    schema_version: u32,
+    /// Echo of the resolved window start as Unix seconds.
+    since_unix: u64,
+    /// Original window string from the request, normalized lowercase.
+    window: String,
+    n: usize,
+    top: Vec<TopHost>,
+}
+
+/// `GET /internal/egress/blocked?since=<rfc3339>` — list of every blocked
+/// host the router has observed whose `last_seen_unix >= since`. Newest
+/// first. The buffer is bounded (default 1024 distinct keys) so this is
+/// safe to call frequently from the CLI's `--watch` loop.
+///
+/// Missing or unparseable `since` collapses to `0` (return everything).
+async fn egress_blocked(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let since_unix = params
+        .get("since")
+        .map(|s| s.as_str())
+        .map(parse_since_or_zero)
+        .unwrap_or(0);
+    let entries: Vec<BlockedEntryDto> = state
+        .blocked_egress
+        .snapshot_since(since_unix)
+        .into_iter()
+        .map(BlockedEntryDto::from)
+        .collect();
+    Json(BlockedResponse {
+        schema_version: 1,
+        total: state.blocked_egress.len(),
+        count: entries.len(),
+        since_unix,
+        entries,
+    })
+}
+
+/// `GET /internal/egress/blocked/top?window=5m&n=10` — top-N
+/// most-attempted blocked hosts in the rolling window. Aggregates across
+/// source sandboxes + ports by hostname. Used by the plugin sidebar and
+/// the rate-limited `EgressBlockedSeen` k8s event (planned for Slice 5b).
+///
+/// Accepted `window` formats: bare seconds (`300`), or Go-style duration
+/// (`5m`, `1h`, `30s`). Default 5m. `n` defaults to 10, capped at 100.
+async fn egress_blocked_top(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let window_raw = params
+        .get("window")
+        .cloned()
+        .unwrap_or_else(|| "5m".to_string());
+    let window_secs = parse_duration_secs(&window_raw).unwrap_or(300);
+    let n: usize = params
+        .get("n")
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(10)
+        .min(100);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let since_unix = now.saturating_sub(window_secs);
+    let top: Vec<TopHost> = state
+        .blocked_egress
+        .top_hosts(since_unix, n)
+        .into_iter()
+        .map(|(host, count)| TopHost { host, count })
+        .collect();
+    Json(BlockedTopResponse {
+        schema_version: 1,
+        since_unix,
+        window: window_raw.to_lowercase(),
+        n,
+        top,
+    })
+}
+
+/// Parse a Go-style duration string into seconds. Accepts integer
+/// seconds (`"300"`), or `Nm` / `Nh` / `Ns` (single-unit suffix). Returns
+/// `None` on parse failure so the caller can supply a default.
+///
+/// Intentionally narrow — operators paste these strings into URLs; we
+/// don't want surprises from compound forms like `1h30m`.
+fn parse_duration_secs(raw: &str) -> Option<u64> {
+    let s = raw.trim().to_lowercase();
+    if s.is_empty() {
+        return None;
+    }
+    if let Ok(n) = s.parse::<u64>() {
+        return Some(n);
+    }
+    let (num, mul) = if let Some(rest) = s.strip_suffix("ms") {
+        // milliseconds — round to a 1-second floor so we never accept
+        // a window that would inflate to "everything" via underflow.
+        (rest, 0u64)
+    } else if let Some(rest) = s.strip_suffix('s') {
+        (rest, 1)
+    } else if let Some(rest) = s.strip_suffix('m') {
+        (rest, 60)
+    } else if let Some(rest) = s.strip_suffix('h') {
+        (rest, 3_600)
+    } else if let Some(rest) = s.strip_suffix('d') {
+        (rest, 86_400)
+    } else {
+        return None;
+    };
+    let n: u64 = num.trim().parse().ok()?;
+    Some(n.saturating_mul(mul).max(if mul == 0 { 0 } else { 1 }))
+}
+
+/// Parse the `since` query parameter. Accepts:
+/// - integer Unix seconds (`"1705314645"`)
+/// - RFC 3339 / ISO 8601 (`"2024-01-15T10:30:45Z"`)
+/// - Go-style relative duration prefixed with `-` (`"-10m"`)
+///
+/// On failure → `0` (return everything). Loud failure isn't useful here
+/// because the CLI does its own parsing; the router is the second line.
+fn parse_since_or_zero(raw: &str) -> u64 {
+    let s = raw.trim();
+    if s.is_empty() {
+        return 0;
+    }
+    if let Ok(n) = s.parse::<u64>() {
+        return n;
+    }
+    // Relative `-Nm` form → "now minus duration".
+    if let Some(stripped) = s.strip_prefix('-') {
+        if let Some(secs) = parse_duration_secs(stripped) {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            return now.saturating_sub(secs);
+        }
+    }
+    parse_rfc3339_to_unix(s).unwrap_or(0)
+}
+
+/// RFC 3339 → Unix seconds. Hand-rolled to avoid pulling in `chrono`
+/// just for the inverse of [`format_rfc3339`]. Accepts the
+/// `YYYY-MM-DDTHH:MM:SS(.fff)?(Z|±HH:MM)` shape produced by the rest of
+/// the router. Returns `None` on malformed input — callers fall back to
+/// `0` (return-everything).
+fn parse_rfc3339_to_unix(s: &str) -> Option<u64> {
+    // Strip trailing `Z` or `+00:00`/`-00:00` offsets. We don't support
+    // non-zero offsets — every callsite in the router emits UTC.
+    let body = s
+        .strip_suffix('Z')
+        .or_else(|| s.strip_suffix("+00:00"))
+        .or_else(|| s.strip_suffix("-00:00"))
+        .unwrap_or(s);
+    // Drop any subsecond suffix.
+    let body = body.split('.').next()?;
+    // Expect `YYYY-MM-DDTHH:MM:SS`.
+    let (date, time) = body.split_once('T')?;
+    let mut date_parts = date.split('-');
+    let y: i32 = date_parts.next()?.parse().ok()?;
+    let mo: u32 = date_parts.next()?.parse().ok()?;
+    let d: u32 = date_parts.next()?.parse().ok()?;
+    let mut time_parts = time.split(':');
+    let h: u32 = time_parts.next()?.parse().ok()?;
+    let mi: u32 = time_parts.next()?.parse().ok()?;
+    let se: u32 = time_parts.next()?.parse().ok()?;
+    // Civil → days-from-epoch using the inverse of `days_to_ymd`.
+    let yp = if mo <= 2 { y - 1 } else { y };
+    let era = if yp >= 0 { yp } else { yp - 399 } / 400;
+    let yoe = (yp - era * 400) as u64;
+    let mp = if mo > 2 { mo - 3 } else { mo + 9 };
+    let doy = (153 * mp as u64 + 2) / 5 + d as u64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era as i64 * 146_097 + doe as i64 - 719_468;
+    let secs = days
+        .checked_mul(86_400)?
+        .checked_add(h as i64 * 3_600)?
+        .checked_add(mi as i64 * 60)?
+        .checked_add(se as i64)?;
+    if secs < 0 {
+        return None;
+    }
+    Some(secs as u64)
+}
+
+/// Render Unix seconds in the same `format_rfc3339` shape used by
+/// `policy-status`. The blocked-buffer entries are stored as `u64`
+/// epoch seconds (no nanosecond precision) so we always emit `.000`.
+fn format_rfc3339_unix(unix_secs: u64) -> String {
+    format_rfc3339(std::time::UNIX_EPOCH + std::time::Duration::from_secs(unix_secs))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,5 +498,78 @@ mod tests {
         assert_eq!(json["count"].as_u64(), Some(0));
         assert_eq!(json["entries"].as_array().unwrap().len(), 0);
         assert_eq!(json["deployment_health"].as_array().unwrap().len(), 0);
+    }
+
+    // ---- Slice 5a helpers ------------------------------------------------
+
+    #[test]
+    fn parse_duration_secs_bare_seconds() {
+        assert_eq!(parse_duration_secs("300"), Some(300));
+        assert_eq!(parse_duration_secs("0"), Some(0));
+    }
+
+    #[test]
+    fn parse_duration_secs_suffixes() {
+        assert_eq!(parse_duration_secs("5s"), Some(5));
+        assert_eq!(parse_duration_secs("5m"), Some(300));
+        assert_eq!(parse_duration_secs("1h"), Some(3_600));
+        assert_eq!(parse_duration_secs("2d"), Some(172_800));
+        // Case-insensitive.
+        assert_eq!(parse_duration_secs("5M"), Some(300));
+    }
+
+    #[test]
+    fn parse_duration_secs_invalid() {
+        assert_eq!(parse_duration_secs(""), None);
+        assert_eq!(parse_duration_secs("abc"), None);
+        assert_eq!(parse_duration_secs("5y"), None);
+        // Compound forms intentionally not supported.
+        assert_eq!(parse_duration_secs("1h30m"), None);
+    }
+
+    #[test]
+    fn parse_since_or_zero_unix_integer() {
+        assert_eq!(parse_since_or_zero("1705314645"), 1_705_314_645);
+        assert_eq!(parse_since_or_zero(""), 0);
+        assert_eq!(parse_since_or_zero("garbage"), 0);
+    }
+
+    #[test]
+    fn parse_since_or_zero_rfc3339_roundtrips_with_formatter() {
+        // 2024-01-15T10:30:45Z = 1705314645.
+        let n = parse_since_or_zero("2024-01-15T10:30:45Z");
+        assert_eq!(n, 1_705_314_645);
+        // Subseconds dropped (we round down to nearest second).
+        let n2 = parse_since_or_zero("2024-01-15T10:30:45.500Z");
+        assert_eq!(n2, 1_705_314_645);
+    }
+
+    #[test]
+    fn parse_since_relative_minus_form() {
+        // -1h should be roughly `now - 3600`. We can't assert exact value
+        // without freezing the clock; just check it's monotonically less
+        // than the current epoch and within 5s of the expected delta.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let result = parse_since_or_zero("-1h");
+        let expected = now.saturating_sub(3600);
+        assert!(result <= now);
+        assert!(result.abs_diff(expected) <= 5);
+    }
+
+    #[test]
+    fn format_rfc3339_unix_zero_is_epoch() {
+        assert_eq!(format_rfc3339_unix(0), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn format_rfc3339_unix_known_timestamp() {
+        // 2024-01-15T10:30:45Z
+        assert_eq!(
+            format_rfc3339_unix(1_705_314_645),
+            "2024-01-15T10:30:45.000Z"
+        );
     }
 }

--- a/inference-router/tests/egress_blocked_endpoint.rs
+++ b/inference-router/tests/egress_blocked_endpoint.rs
@@ -137,3 +137,112 @@ async fn endpoint_returns_recorded_blocks() {
     assert_eq!(entries[1]["count"], 2);
     assert_eq!(entries[1]["source_sandbox"], "sb-test");
 }
+
+// ---------------------------------------------------------------------------
+// Slice 5a — `/internal/egress/blocked` + `/internal/egress/blocked/top`
+// ---------------------------------------------------------------------------
+
+fn internal_app(state: AppState) -> Router {
+    Router::new()
+        .merge(azureclaw_inference_router::routes::internal_routes())
+        .with_state(state)
+}
+
+#[tokio::test]
+async fn internal_blocked_returns_empty_when_no_blocks() {
+    let state = test_state();
+    let app = internal_app(state);
+    let (status, body) = get_json(&app, "/internal/egress/blocked").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["schema_version"], 1);
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["count"], 0);
+    assert_eq!(body["since_unix"], 0);
+    assert!(body["entries"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn internal_blocked_returns_entries_with_rfc3339_strings() {
+    let state = test_state();
+    state
+        .blocked_egress
+        .record("sb-test", "evil.example.com", 443);
+
+    let app = internal_app(state);
+    let (status, body) = get_json(&app, "/internal/egress/blocked").await;
+    assert_eq!(status, StatusCode::OK);
+    let entries = body["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    let e = &entries[0];
+    assert_eq!(e["host"], "evil.example.com");
+    assert_eq!(e["port"], 443);
+    assert_eq!(e["count"], 1);
+    // RFC 3339 strings present alongside raw Unix seconds.
+    let first = e["first_seen"].as_str().unwrap();
+    assert!(first.ends_with('Z'), "first_seen should be RFC 3339 UTC");
+    assert!(e["last_seen"].as_str().unwrap().ends_with('Z'));
+    assert!(e["first_seen_unix"].as_u64().is_some());
+    assert!(e["last_seen_unix"].as_u64().is_some());
+}
+
+#[tokio::test]
+async fn internal_blocked_since_relative_filter() {
+    let state = test_state();
+    state
+        .blocked_egress
+        .record("sb-test", "old.example.com", 443);
+    state
+        .blocked_egress
+        .record("sb-test", "new.example.com", 443);
+
+    let app = internal_app(state);
+    // -1h relative: both records are <1h old → both returned.
+    let (status, body) = get_json(&app, "/internal/egress/blocked?since=-1h").await;
+    assert_eq!(status, StatusCode::OK);
+    let entries = body["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 2);
+    // since_unix is echoed and non-zero (now - 1h).
+    assert!(body["since_unix"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn internal_blocked_top_aggregates_and_truncates() {
+    let state = test_state();
+    state.blocked_egress.record("sb1", "a.example.com", 443);
+    state.blocked_egress.record("sb2", "a.example.com", 443);
+    state.blocked_egress.record("sb1", "b.example.com", 443);
+
+    let app = internal_app(state);
+    let (status, body) = get_json(&app, "/internal/egress/blocked/top?window=1h&n=10").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["schema_version"], 1);
+    assert_eq!(body["window"], "1h");
+    let top = body["top"].as_array().unwrap();
+    assert_eq!(top.len(), 2);
+    // a.example.com has count 2 across two sandboxes → first.
+    assert_eq!(top[0]["host"], "a.example.com");
+    assert_eq!(top[0]["count"], 2);
+    assert_eq!(top[1]["host"], "b.example.com");
+    assert_eq!(top[1]["count"], 1);
+}
+
+#[tokio::test]
+async fn internal_blocked_top_defaults_n_and_window() {
+    let state = test_state();
+    state.blocked_egress.record("sb1", "h.example.com", 443);
+    let app = internal_app(state);
+    let (status, body) = get_json(&app, "/internal/egress/blocked/top").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["n"], 10);
+    assert_eq!(body["window"], "5m");
+    assert_eq!(body["top"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn internal_blocked_top_caps_n_at_100() {
+    let state = test_state();
+    let app = internal_app(state);
+    let (status, body) = get_json(&app, "/internal/egress/blocked/top?n=9999").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["n"], 100);
+}


### PR DESCRIPTION
First slice in the Slice 5 *egress polish + observability* sequence. Closes Slice 5 DoD #1 (*\"\`azureclaw egress blocked\` lists every host the agent attempted that the enforcement layer refused\"*).

The router has been populating an in-process \`BlockedBuffer\` from the forward proxy since S12.f — this slice exposes that buffer to operators without giving the agent any new wire access.

## Producer (router)

- New \`BlockedBuffer::snapshot_since(since_unix)\` + \`top_hosts(since, n)\` methods. \`snapshot_since\` is newest-first by \`last_seen_unix\`; \`top_hosts\` aggregates across \`(sandbox, port)\` by hostname with a deterministic secondary sort for tied counts.
- 7 unit tests in \`egress_blocked.rs\` cover filter cutoffs, dedup count carry-through, multi-sandbox/multi-port aggregation, \`n=0\` early-return, and the \`truncate(n)\` contract.

## Wire surface

\`\`\`
GET /internal/egress/blocked?since=<rfc3339|unix|-Nm>
GET /internal/egress/blocked/top?window=<duration>&n=<int>
\`\`\`

Both mounted on the admin-gated \`protected\` router. JSON envelopes carry \`schema_version: 1\` and RFC 3339 strings alongside raw Unix seconds. Hand-rolled duration + RFC 3339 parsers (no \`chrono\` dep) with 7 unit + 6 integration tests covering bare seconds, \`s/m/h/d\` suffixes, relative \`-Nm\` form, malformed input → \`0\`, the \`n ≤ 100\` cap, and the default 5m window.

## CLI

\`\`\`
azureclaw egress blocked <sandbox> [--since 10m] [--top] [--window 1h] [--n 20] [--watch] [--json]
\`\`\`

Added as a subcommand under \`egress\` so \`--watch\`/\`--top\`/\`--since\` don't collide with the existing flat-options surface. Mirrors \`azureclaw inspect\` token-resolution (\`router-admin-token\` secret first, in-pod \`admin-token\` file fallback) and uses in-pod \`kubectl exec curl\` to avoid port-forward collisions. \`--watch\` loops every 5s with VT clear; \`--top\` overrides \`--since\`; \`--json\` emits raw response.

13 vitest unit tests cover \`buildPath\`, the renderer surface (HOST/PORT/SANDBOX/LAST_SEEN/COUNT columns, empty-state message, since-filter line, top-N window line) and the \`unixToIso(0) === \"epoch\"\` sentinel.

## Verification

- \`cargo test -p azureclaw-inference-router\` → 849 lib + 8 egress_blocked integration (up from 2)
- \`cargo clippy -p azureclaw-inference-router --all-targets -- -D warnings\` clean
- \`cargo fmt --all\` clean
- \`npm test\` → 692 CLI tests (up from 679; +13 new)
- \`npm run typecheck\` / \`npm run build\` clean

## Principles compliance

- §5 no scaffolding — producer (BlockedBuffer fill from forward proxy) was already live; this PR connects consumer surfaces to it.
- §6 dev-only + test every new line — every new helper has unit coverage; every new endpoint has integration coverage; every new CLI helper has vitest coverage.