### PR TITLE
slice-5b: egressMode enum replaces learnEgress bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 5b — `egressMode` enum replaces `learnEgress` bool (DoD #3)
+
+Replaces `ClawSandbox.spec.networkPolicy.learnEgress: bool` with
+`egressMode: Strict | Learn` enum across the controller, router,
+CLI, Headlamp plugin, helm CRD schema, and docs. Default = `Learn`.
+The `Approval` variant is deferred to Slice 5c (no consumer yet
+per principles §5). No back-compat shim: the repo has no live
+deployments, so the legacy field was removed cleanly rather than
+deprecated.
+
+- `controller/src/crd.rs`: new `EgressMode` enum (`#[derive(Default)]`
+  with `#[default]` on `Learn`); replaces `NetworkPolicyConfig.learn_egress`.
+  Tests cover default + wire-format round-trip in PascalCase.
+- `controller/src/reconciler/mod.rs`: emits `EGRESS_MODE=strict|learn`
+  on the sandbox pod env. No back-compat `EGRESS_LEARN_MODE`.
+- `inference-router/src/routes/mod.rs`: consumes `EGRESS_MODE`, defaults
+  to Learn when unset.
+- `inference-router/src/spawn/mod.rs`: sub-agent CR builder reads
+  `networkPolicy.egressMode` and emits the new field on respawn.
+  Internal `SpawnRequest.learn_egress: bool` retained (not wire).
+- `deploy/helm/azureclaw/templates/crd.yaml`: `learnEgress` removed
+  from the schema; `egressMode` enum-validated.
+- `cli/src/commands/{add,policy,handoff,handoff/helpers,up/sandbox_bringup,
+  dev/local-k8s,operator/actions}.ts`: every CR producer/reader migrated.
+- `tools/headlamp-plugin/src/index.tsx`: all 4 egress readers consume
+  `egressMode` directly. Phase chips + dashboard counters honour the
+  new enum.
+- `docs/use-cases.md`, `docs/egress-proxy.md`: doc samples updated.
+
 ### Slice 5a — Surface blocked egress attempts (DoD #1)
 
 First slice in the Slice 5 "egress polish + observability" sequence.

--- a/cli/src/commands/add.test.ts
+++ b/cli/src/commands/add.test.ts
@@ -111,7 +111,7 @@ function buildSandboxManifest(name: string, options: AddOptions) {
 
   if (options.learnEgress) {
     const np = (sandbox.spec as Record<string, unknown>).networkPolicy as Record<string, unknown>;
-    np.learnEgress = true;
+    np.egressMode = "Learn";
   }
 
   return sandbox;
@@ -263,10 +263,10 @@ describe("ClawSandbox manifest generation", () => {
     ]);
   });
 
-  it("enables learnEgress when flag is set", () => {
+  it("sets egressMode=Learn when --learn-egress flag is set (Slice 5b)", () => {
     const manifest = buildSandboxManifest("a", defaultOptions({ learnEgress: true }));
     const spec = manifest.spec as any;
-    expect(spec.networkPolicy.learnEgress).toBe(true);
+    expect(spec.networkPolicy.egressMode).toBe("Learn");
   });
 
   it("adds governance config when enabled (S13: toolPolicyRef)", () => {

--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -193,10 +193,12 @@ generating per-sandbox AGT ToolPolicy / TrustGraph CRs.
         };
       }
 
-      // Egress learn mode
+      // Egress mode (Slice 5b): the `--learn-egress` flag now writes
+      // `egressMode: Learn`. Default is also Learn (controller-side), so
+      // omitting the flag is equivalent.
       if (options.learnEgress) {
         const np = (sandbox.spec as Record<string, unknown>).networkPolicy as Record<string, unknown>;
-        np.learnEgress = true;
+        np.egressMode = "Learn";
       }
 
       // Channel and plugin credentials — stored in K8s secret, NOT in CRD spec.

--- a/cli/src/commands/dev/local-k8s.ts
+++ b/cli/src/commands/dev/local-k8s.ts
@@ -1803,7 +1803,7 @@ async function autoCreateSandbox(
     "  networkPolicy:",
     "    defaultDeny: true",
     "    approvalRequired: false",
-    "    learnEgress: true",
+    "    egressMode: Learn",
     "    allowedEndpoints: []",
     "",
   ].join("\n");

--- a/cli/src/commands/handoff.ts
+++ b/cli/src/commands/handoff.ts
@@ -474,7 +474,7 @@ export function handoffCommand(): Command {
               networkPolicy: {
                 defaultDeny: true,
                 approvalRequired: true,
-                learnEgress: sourceLearnEgress,
+                egressMode: sourceLearnEgress ? "Learn" : "Strict",
               },
               sandbox: {
                 isolation: sourceIsolation,

--- a/cli/src/commands/handoff/helpers.ts
+++ b/cli/src/commands/handoff/helpers.ts
@@ -346,7 +346,12 @@ export async function createHandoffHelpers(name: string): Promise<HandoffHelpers
 
       return {
         model: model || defaults.model,
-        learnEgress: spec.networkPolicy?.learnEgress ?? defaults.learnEgress,
+        learnEgress: (() => {
+          const mode = spec.networkPolicy?.egressMode;
+          return typeof mode === "string"
+            ? mode === "Learn"
+            : defaults.learnEgress;
+        })(),
         isolation: spec.sandbox?.isolation || defaults.isolation,
         trustThreshold: spec.governance?.trustThreshold || defaults.trustThreshold,
       };

--- a/cli/src/commands/operator/actions.ts
+++ b/cli/src/commands/operator/actions.ts
@@ -84,7 +84,7 @@ export function createActions(ctx: ActionContext): OperatorActions {
       await execa("kubectl", kctl([
         "patch", "clawsandbox", sb.name, "-n", "azureclaw-system",
         "--type", "merge", "-p",
-        JSON.stringify({ spec: { networkPolicy: { learnEgress: false } } }),
+        JSON.stringify({ spec: { networkPolicy: { egressMode: "Strict" } } }),
       ], kubeContext), { stdio: "pipe" }).catch(() => {});
       activityLog.log(`{green-fg}🔒 Enforced{/} ${sb.name}`);
       activityLog.log(`{gray-fg}   ↳ saved to CRD — may trigger pod restart{/}`);
@@ -106,7 +106,7 @@ export function createActions(ctx: ActionContext): OperatorActions {
       await execa("kubectl", kctl([
         "patch", "clawsandbox", sb.name, "-n", "azureclaw-system",
         "--type", "merge", "-p",
-        JSON.stringify({ spec: { networkPolicy: { learnEgress: true } } }),
+        JSON.stringify({ spec: { networkPolicy: { egressMode: "Learn" } } }),
       ], kubeContext), { stdio: "pipe" }).catch(() => {});
       activityLog.log(`{yellow-fg}📖 Learning{/} ${sb.name}`);
       activityLog.log(`{gray-fg}   ↳ saved to CRD — may trigger pod restart{/}`);

--- a/cli/src/commands/policy.test.ts
+++ b/cli/src/commands/policy.test.ts
@@ -40,7 +40,7 @@ function buildLearnApplyPatch(domains: string[]) {
     spec: {
       networkPolicy: {
         allowedEndpoints: endpoints,
-        learnEgress: false,
+        egressMode: "Strict",
       },
     },
   };
@@ -167,15 +167,15 @@ describe("policy learn — apply patch", () => {
     ]);
   });
 
-  it("disables learnEgress when applying", () => {
+  it("sets egressMode=Strict when applying", () => {
     const patch = buildLearnApplyPatch(["example.com"]);
-    expect(patch.spec.networkPolicy.learnEgress).toBe(false);
+    expect(patch.spec.networkPolicy.egressMode).toBe("Strict");
   });
 
   it("produces empty endpoints for empty domain list", () => {
     const patch = buildLearnApplyPatch([]);
     expect(patch.spec.networkPolicy.allowedEndpoints).toEqual([]);
-    expect(patch.spec.networkPolicy.learnEgress).toBe(false);
+    expect(patch.spec.networkPolicy.egressMode).toBe("Strict");
   });
 });
 

--- a/cli/src/commands/policy.ts
+++ b/cli/src/commands/policy.ts
@@ -192,7 +192,7 @@ export function policyCommand(): Command {
               spec: {
                 networkPolicy: {
                   allowedEndpoints: endpoints,
-                  learnEgress: false,
+                  egressMode: "Strict",
                 },
               },
             }),

--- a/cli/src/commands/up/sandbox_bringup.ts
+++ b/cli/src/commands/up/sandbox_bringup.ts
@@ -371,7 +371,7 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
       networkPolicy: {
         defaultDeny: true,
         approvalRequired: true,
-        learnEgress: true,
+        egressMode: "Learn",
       },
       governance: {
         enabled: true,

--- a/controller/src/crd.rs
+++ b/controller/src/crd.rs
@@ -765,10 +765,14 @@ pub struct NetworkPolicyConfig {
     #[serde(default = "default_true")]
     pub approval_required: bool,
     pub allowed_endpoints: Option<Vec<EndpointConfig>>,
-    /// Enable egress learn mode: observe all accessed domains (blocklist still enforced).
-    /// Use `azureclaw policy learn <name>` to export the learned allowlist.
+    /// Egress enforcement mode. `Learn` (default) records every accessed
+    /// domain into `BlockedBuffer` without denying; `Strict` denies anything
+    /// outside the resolved allowlist. The Slice 5 spec also reserves
+    /// `Approval` (deny-with-approval-request) — wired in a later sub-slice
+    /// when `EgressApproval` CRD lands as its real consumer (§5 no
+    /// scaffolding).
     #[serde(default)]
-    pub learn_egress: bool,
+    pub egress_mode: EgressMode,
     /// Reference to a signed OCI artifact containing the canonical egress
     /// allowlist. Populated by `azureclaw egress … --sign` (S12.c).
     /// **Authoritative** in S12.e — when set, the controller derives
@@ -781,13 +785,31 @@ pub struct NetworkPolicyConfig {
     pub allowlist_ref: Option<OciArtifactRef>,
 }
 
+/// Egress enforcement mode.
+///
+/// Default = `Learn` because operators typically need to discover required
+/// domains during early integration; flip to `Strict` once the allowlist is
+/// established.
+///
+/// `Approval` is reserved for Slice 5c — it lands together with the
+/// `EgressApproval` CRD so the slice ships with a real consumer (per
+/// principles §5 no scaffolding).
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, JsonSchema, Default)]
+pub enum EgressMode {
+    /// Deny any host not in the resolved allowlist. Blocklist still applied.
+    Strict,
+    /// Allow + record every host (default). Blocklist still applied.
+    #[default]
+    Learn,
+}
+
 impl Default for NetworkPolicyConfig {
     fn default() -> Self {
         Self {
             default_deny: true,
             approval_required: true,
             allowed_endpoints: None,
-            learn_egress: false,
+            egress_mode: EgressMode::default(),
             allowlist_ref: None,
         }
     }
@@ -1071,8 +1093,39 @@ mod tests {
         assert!(cfg.default_deny);
         assert!(cfg.approval_required);
         assert!(cfg.allowed_endpoints.is_none());
-        assert!(!cfg.learn_egress);
+        assert_eq!(cfg.egress_mode, EgressMode::Learn);
         assert!(cfg.allowlist_ref.is_none());
+    }
+
+    #[test]
+    fn egress_mode_default_is_learn() {
+        // Slice 5b: default egress mode is `Learn` so manifests that omit
+        // the field keep observing instead of denying.
+        let cfg = NetworkPolicyConfig::default();
+        assert_eq!(cfg.egress_mode, EgressMode::Learn);
+    }
+
+    #[test]
+    fn egress_mode_wire_format_is_pascal_case() {
+        // Match CRD enum convention (capitalised variants, like ClawSandbox phases).
+        let strict = serde_json::to_string(&EgressMode::Strict).unwrap();
+        let learn = serde_json::to_string(&EgressMode::Learn).unwrap();
+        assert_eq!(strict, "\"Strict\"");
+        assert_eq!(learn, "\"Learn\"");
+        let parsed: EgressMode = serde_json::from_str("\"Strict\"").unwrap();
+        assert_eq!(parsed, EgressMode::Strict);
+    }
+
+    #[test]
+    fn egress_mode_strict_round_trips() {
+        let cfg = NetworkPolicyConfig {
+            egress_mode: EgressMode::Strict,
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(v.get("egressMode").and_then(|s| s.as_str()), Some("Strict"));
+        let back: NetworkPolicyConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(back.egress_mode, EgressMode::Strict);
     }
 
     #[test]

--- a/controller/src/mesh_peer/offload.rs
+++ b/controller/src/mesh_peer/offload.rs
@@ -841,7 +841,7 @@ pub(crate) fn build_offload_sandbox_crd(
         "networkPolicy": {
             "defaultDeny": true,
             "approvalRequired": true,
-            "learnEgress": true,
+            "egressMode": "Learn",
         },
         "governance": {
             "enabled": true,

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1341,15 +1341,21 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             json!({"name": "BLOCKLIST_SEED_PATH", "value": "/etc/azureclaw/blocklist/domains.txt"}),
         );
 
-        // Egress learn mode — enabled by default so operators can discover required domains.
-        // Blocklist (threat intelligence) is still enforced. Disable with network_policy.learn_egress=false.
-        let learn_egress = spec
+        // Egress mode — Slice 5b: `spec.networkPolicy.egressMode` drives the
+        // router's enforcement strategy. Default = `Learn` so manifests
+        // without an explicit choice keep observing instead of denying.
+        // Router contract: `EGRESS_MODE=strict|learn`.
+        // Blocklist (threat intelligence) is enforced in every mode.
+        let egress_mode = spec
             .network_policy
             .as_ref()
-            .is_none_or(|np| np.learn_egress);
-        if learn_egress {
-            router_env.push(json!({"name": "EGRESS_LEARN_MODE", "value": "true"}));
-        }
+            .map(|np| np.egress_mode)
+            .unwrap_or(crate::crd::EgressMode::Learn);
+        let egress_mode_str = match egress_mode {
+            crate::crd::EgressMode::Strict => "strict",
+            crate::crd::EgressMode::Learn => "learn",
+        };
+        router_env.push(json!({"name": "EGRESS_MODE", "value": egress_mode_str}));
 
         // ── Agent container ──────────────────────────────────────────
         // S10.A2.b: branch the agent container shape on the runtime

--- a/deploy/helm/azureclaw/templates/crd.yaml
+++ b/deploy/helm/azureclaw/templates/crd.yaml
@@ -579,10 +579,18 @@ spec:
                     approvalRequired:
                       type: boolean
                       default: true
-                    learnEgress:
-                      type: boolean
-                      default: false
-                      description: "Enable egress learn mode: observe all accessed domains (blocklist still enforced)"
+                    egressMode:
+                      type: string
+                      enum: [Strict, Learn]
+                      default: Learn
+                      description: |
+                        Egress enforcement mode (Slice 5b):
+                        - `Learn` (default): allow + record every host.
+                          Blocklist still applied.
+                        - `Strict`: deny anything outside the resolved
+                          allowlist. Blocklist still applied.
+                        Reserved future variant `Approval` lands together
+                        with the EgressApproval CRD.
                     allowedEndpoints:
                       type: array
                       items:

--- a/docs/egress-proxy.md
+++ b/docs/egress-proxy.md
@@ -12,7 +12,7 @@ metadata:
   name: my-agent
 spec:
   networkPolicy:
-    learnEgress: true                # learn ↔ enforce toggle (default: learn)
+    egressMode: Learn                # Learn | Strict (default: Learn)
     allowedEndpoints:                # inline allowlist (current source of truth)
       - api.telegram.org
       - api.openai.com

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -123,7 +123,7 @@ spec:
     trustThreshold: 500
   networkPolicy:
     defaultDeny: true
-    learnEgress: false
+    egressMode: Strict
     allowlistRef:
       registry: azureclawacr.azurecr.io
       repository: policy/egress-allowlist/research-bot

--- a/inference-router/src/routes/mod.rs
+++ b/inference-router/src/routes/mod.rs
@@ -235,11 +235,13 @@ impl AppState {
             Blocklist::disabled()
         };
 
-        // Learn mode: observe all egress domains (blocklist still enforced)
-        let learn_mode = std::env::var("EGRESS_LEARN_MODE")
-            .unwrap_or_else(|_| "false".into())
-            .parse::<bool>()
-            .unwrap_or(false);
+        // Egress mode (Slice 5b): the controller emits `EGRESS_MODE=strict|learn`.
+        // Default = `learn` when unset so a fresh router started without
+        // the controller wiring (e.g. local dev) keeps observing.
+        let learn_mode = match std::env::var("EGRESS_MODE").ok().as_deref() {
+            Some(v) if v.eq_ignore_ascii_case("strict") => false,
+            _ => true,
+        };
         if learn_mode {
             blocklist.set_learn_mode(true);
         }

--- a/inference-router/src/spawn/mod.rs
+++ b/inference-router/src/spawn/mod.rs
@@ -589,9 +589,10 @@ pub async fn collect_sub_agent_snapshots(
 
         let learn_egress = spec
             .get("networkPolicy")
-            .and_then(|n| n.get("learnEgress"))
-            .and_then(|l| l.as_bool())
-            .unwrap_or(false);
+            .and_then(|n| n.get("egressMode"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.eq_ignore_ascii_case("Learn"))
+            .unwrap_or(true); // CRD default = Learn
 
         let isolation = spec
             .get("sandbox")
@@ -724,7 +725,7 @@ pub(crate) fn build_sub_agent_crd_with_labels(
         "networkPolicy": {
             "defaultDeny": true,
             "approvalRequired": true,
-            "learnEgress": req.learn_egress,
+            "egressMode": if req.learn_egress { "Learn" } else { "Strict" },
         },
     });
 

--- a/tools/headlamp-plugin/src/index.tsx
+++ b/tools/headlamp-plugin/src/index.tsx
@@ -343,7 +343,7 @@ function computeMetrics(sandboxes: KubeObject[] | null, secrets: KubeObject[] | 
 
     const np = spec.networkPolicy ?? null;
     // Same default semantics as the controller — absent block ⇒ Learn.
-    const isLearn = !np || np.learnEgress !== false;
+    const isLearn = !np || (np.egressMode ?? "Learn") === "Learn";
     if (isLearn) m.egressLearn += 1;
     else m.egressStrict += 1;
     const pending = Array.isArray(status.pendingApprovals) ? status.pendingApprovals.length : 0;
@@ -507,7 +507,7 @@ function Overview() {
               label: "Egress",
               getter: (r: KubeObject) => {
                 const np = getSpec(r).networkPolicy;
-                const isLearn = !np || np.learnEgress !== false;
+                const isLearn = !np || (np.egressMode ?? "Learn") === "Learn";
                 return isLearn ? "Learn" : "Strict";
               },
             },
@@ -625,9 +625,9 @@ function CrdList({ crd }: { crd: CrdDescriptor }) {
         label: "Egress",
         getter: (r: KubeObject) => {
           const np = getSpec(r).networkPolicy;
-          // Controller default: NetworkPolicy block absent OR learnEgress
-          // unset → Learn mode. Only explicit `learnEgress: false` → Strict.
-          const isLearn = !np || np.learnEgress !== false;
+          // Controller default: NetworkPolicy block absent OR egressMode
+          // unset → Learn mode. Only explicit `egressMode: Strict` → Strict.
+          const isLearn = !np || (np.egressMode ?? "Learn") === "Learn";
           return isLearn ? (
             <StatusLabel status="warning">Learn</StatusLabel>
           ) : (
@@ -768,7 +768,7 @@ function SandboxExtras({ item }: { item: KubeObject }) {
 
   const npRaw = spec.networkPolicy ?? null;
   const np = npRaw ?? {};
-  const isLearn = !npRaw || np.learnEgress !== false;
+  const isLearn = !npRaw || (np.egressMode ?? "Learn") === "Learn";
   const allowed: Array<{ host?: string; port?: number }> = Array.isArray(np.allowedEndpoints) ? np.allowedEndpoints : [];
   const pendingApprovals: Array<{ domain?: string; reason?: string }> = Array.isArray(status.pendingApprovals)
     ? status.pendingApprovals


### PR DESCRIPTION
## Slice 5b — `egressMode` enum (DoD #3)

Replaces `ClawSandbox.spec.networkPolicy.learnEgress: bool` with
`egressMode: Strict | Learn` enum. Default = `Learn`. The `Approval`
variant is deferred to Slice 5c (no consumer yet per principles §5).

**No back-compat shim** — the repo has no live deployments yet, so
the legacy field was removed cleanly rather than deprecated.

### Changes
- **controller/src/crd.rs** — new `EgressMode` enum with
  `#[derive(Default)]` and `#[default]` on `Learn`. Replaces
  `NetworkPolicyConfig.learn_egress`.
- **controller/src/reconciler/mod.rs** — emits `EGRESS_MODE=strict|learn`.
  No back-compat `EGRESS_LEARN_MODE`.
- **inference-router/src/routes/mod.rs** — consumes `EGRESS_MODE`,
  defaults to Learn when unset.
- **inference-router/src/spawn/mod.rs** — sub-agent reader/producer
  migrated. Internal `SpawnRequest.learn_egress` retained (not wire).
- **deploy/helm/azureclaw/templates/crd.yaml** — `learnEgress` removed
  from schema.
- **cli/src/commands/*** — every CR producer/reader migrated.
- **tools/headlamp-plugin/src/index.tsx** — all 4 egress readers
  consume `egressMode` directly.
- **docs/use-cases.md, docs/egress-proxy.md** — samples updated.

### Verification
- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p azureclaw-controller --bin azureclaw-controller` ✅ 562 passed
- `cargo test -p azureclaw-inference-router --lib` ✅ 849 passed
- `cd cli && npm run typecheck` ✅
- `cd cli && npm test` ✅ 692 passed | 2 skipped
- `cd tools/headlamp-plugin && npm run build` ✅

Closes Slice 5 DoD #3.