### PR TITLE
Slice 5c.2: AllowlistVerified=Unsigned warning + helm requireSigned fail-closed toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 5c.2 — `Unsigned` warning condition + helm `requireSigned` fail-closed toggle
+
+Surfaces the gap when a `ClawSandbox` uses
+`spec.networkPolicy.allowedEndpoints` (inline) without a signed
+`spec.networkPolicy.allowlistRef`, and gives operators a single
+helm switch to flip the policy from *allow with warning* to
+*fail-closed*.
+
+- **Default behaviour (no change to working sandboxes):** inline
+  allowlists keep reconciling. The controller now additionally
+  stamps `AllowlistVerified=False / reason=Unsigned` so operators
+  see the missing attestation in `kubectl describe clawsandbox` and
+  in the Headlamp panel. The L4 NetworkPolicy and the L7 router
+  allowlist mount are still programmed from the inline list — no
+  egress regression.
+- **`egress.requireSigned: true`** (new helm value, default
+  `false`): when set, the controller refuses to program user egress
+  for inline-only allowlists. `endpoints` is dropped, the L7 mount
+  is published empty (router rejects every L7 attempt), and the
+  sandbox stamps `Degraded=True / reason=Unsigned` with an
+  actionable message pointing operators to either sign the bundle
+  via `allowlistRef` or relax the helm value.
+- Threaded through `controller-deployment.yaml` as the
+  `REQUIRE_SIGNED_ALLOWLIST` env var. `policy_fetcher`'s
+  `require_signed_allowlist()` reads it on every reconcile so
+  operators can toggle without a controller restart.
+- New `reason::UNSIGNED` constant in `status::conditions`. Existing
+  cosign verify path (`allowlistRef` set) is unchanged — it already
+  emits `AllowlistVerified=True / reason=Verified` on success and
+  the appropriate verify-fail reasons otherwise.
+- Reconciler's `fail_closed_no_lkg` short-circuit now distinguishes
+  *verify-fail-no-LKG* (`reason=FailedClosed`) from the new
+  *require-signed-rejection* path (`reason=Unsigned`) so the
+  Degraded message is actionable in either case.
+- Tests: 3 new + 1 updated unit tests in `policy_fetcher::tests`
+  (`resolve_inline_only_with_require_signed_fails_closed`,
+  `resolve_inline_empty_with_require_signed_is_noop`,
+  `require_signed_allowlist_parses_truthy_values`, plus the
+  existing `resolve_inline_only_emits_authoritative_inline` now
+  asserts the `Unsigned` warning).
+- Closes Slice 5 DoD #7 (attestation surface) — note: full signed
+  *bundleRef path was always-on since S12.e; Slice 5c.2 closes the
+  loop on the *unsigned* side so the cosign infra is no longer
+  silent for inline-only sandboxes.
+
 ### Slice 5c.1 — Egress allowlist mount + router echo (DoD #2 wire)
 
 Wires the controller-published signed egress allowlist into the

--- a/controller/src/policy_fetcher.rs
+++ b/controller/src/policy_fetcher.rs
@@ -214,6 +214,25 @@ fn split_csv_env(name: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Slice 5c.2: `REQUIRE_SIGNED_ALLOWLIST=true` flips the inline-only
+/// (no `allowlistRef`) path from *allow with `Unsigned` warning* to
+/// fail-closed. Default `false`. Sourced via helm value
+/// `egress.requireSigned` → controller deployment env.
+///
+/// Accepts `true|1|yes|on` (case-insensitive) as truthy; anything else
+/// is falsy. Read on every reconcile so operators can toggle without a
+/// controller restart by editing the Deployment env.
+pub(crate) fn require_signed_allowlist() -> bool {
+    matches!(
+        std::env::var("REQUIRE_SIGNED_ALLOWLIST")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "true" | "1" | "yes" | "on"
+    )
+}
+
 // ─────────────────────────── cache ───────────────────────────
 
 #[derive(Debug, Clone)]
@@ -1188,6 +1207,49 @@ pub async fn resolve_allowlist_with_handle(
                 "no allowlistRef set; using inline allowedEndpoints",
                 generation,
             ));
+            // Slice 5c.2: surface inline-only as `AllowlistVerified=False/Unsigned`.
+            // Default behaviour is *allow with warning* — leave
+            // `endpoints` set and let the reconciler still program the
+            // L4 NetworkPolicy + L7 router mount. Operators flip
+            // `egress.requireSigned: true` (helm) to fail-closed; see
+            // below.
+            conditions.push(preserve_transition_time(
+                prior_verified,
+                TYPE_ALLOWLIST_VERIFIED,
+                cond_status::FALSE,
+                cond_reason::UNSIGNED,
+                "inline allowedEndpoints have no cosign attestation \
+                 (set spec.networkPolicy.allowlistRef to sign the bundle)",
+                generation,
+            ));
+        }
+        let require_signed = require_signed_allowlist();
+        if require_signed && inline_present {
+            // Fail-closed: drop the endpoints + flip authoritative to
+            // FailedClosed so the reconciler stamps Degraded.
+            return AllowlistResolution {
+                endpoints: None,
+                conditions: vec![
+                    preserve_transition_time(
+                        prior_authoritative,
+                        TYPE_ALLOWLIST_AUTHORITATIVE,
+                        cond_status::FALSE,
+                        cond_reason::FAILED_CLOSED,
+                        "REQUIRE_SIGNED_ALLOWLIST=true and inline allowedEndpoints \
+                         have no allowlistRef; refusing to program user egress",
+                        generation,
+                    ),
+                    preserve_transition_time(
+                        prior_verified,
+                        TYPE_ALLOWLIST_VERIFIED,
+                        cond_status::FALSE,
+                        cond_reason::UNSIGNED,
+                        "REQUIRE_SIGNED_ALLOWLIST=true: inline allowedEndpoints rejected",
+                        generation,
+                    ),
+                ],
+                fail_closed_no_lkg: true,
+            };
         }
         return AllowlistResolution {
             endpoints: if inline_present { Some(inline) } else { None },
@@ -2057,6 +2119,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_inline_only_emits_authoritative_inline() {
         let _g = env_lock().lock().unwrap();
+        let _r = EnvGuard::unset("REQUIRE_SIGNED_ALLOWLIST");
         let sb = sandbox_with_inline_only(vec![ep("api.example.com", None)]);
         let h = SharedSignerPolicy::from_state(SignerPolicyState::Absent);
         let res = resolve_allowlist_with_handle(&sb, &h).await;
@@ -2066,9 +2129,74 @@ mod tests {
             .expect("AllowlistAuthoritative emitted");
         assert_eq!(auth.status, "False");
         assert_eq!(auth.reason, "Inline");
-        assert!(cond_by_type(&res.conditions, "AllowlistVerified").is_none());
+        // Slice 5c.2: inline-only now also surfaces an Unsigned
+        // warning condition so operators see the gap.
+        let verified = cond_by_type(&res.conditions, "AllowlistVerified")
+            .expect("AllowlistVerified emitted with Unsigned reason");
+        assert_eq!(verified.status, "False");
+        assert_eq!(verified.reason, "Unsigned");
         assert!(cond_by_type(&res.conditions, "AllowlistDrift").is_none());
         assert!(!res.fail_closed_no_lkg);
+    }
+
+    /// Slice 5c.2: with `REQUIRE_SIGNED_ALLOWLIST=true`, inline-only
+    /// allowlists fail-closed (endpoints=None, fail_closed_no_lkg=true,
+    /// Authoritative=False/FailedClosed, Verified=False/Unsigned).
+    #[tokio::test]
+    async fn resolve_inline_only_with_require_signed_fails_closed() {
+        let _g = env_lock().lock().unwrap();
+        let _r = EnvGuard::set("REQUIRE_SIGNED_ALLOWLIST", "true");
+        let sb = sandbox_with_inline_only(vec![ep("api.example.com", None)]);
+        let h = SharedSignerPolicy::from_state(SignerPolicyState::Absent);
+        let res = resolve_allowlist_with_handle(&sb, &h).await;
+        assert!(
+            res.endpoints.is_none(),
+            "require-signed must drop inline endpoints"
+        );
+        assert!(res.fail_closed_no_lkg, "must signal fail-closed");
+        let auth =
+            cond_by_type(&res.conditions, "AllowlistAuthoritative").expect("Authoritative emitted");
+        assert_eq!(auth.status, "False");
+        assert_eq!(auth.reason, "FailedClosed");
+        let verified =
+            cond_by_type(&res.conditions, "AllowlistVerified").expect("Verified emitted");
+        assert_eq!(verified.status, "False");
+        assert_eq!(verified.reason, "Unsigned");
+    }
+
+    /// Slice 5c.2: `REQUIRE_SIGNED_ALLOWLIST=true` with an EMPTY inline
+    /// list is a no-op (nothing to reject) — still no conditions, no
+    /// fail-closed marker.
+    #[tokio::test]
+    async fn resolve_inline_empty_with_require_signed_is_noop() {
+        let _g = env_lock().lock().unwrap();
+        let _r = EnvGuard::set("REQUIRE_SIGNED_ALLOWLIST", "true");
+        let sb = sandbox_with_inline_only(vec![]);
+        let h = SharedSignerPolicy::from_state(SignerPolicyState::Absent);
+        let res = resolve_allowlist_with_handle(&sb, &h).await;
+        assert!(res.endpoints.is_none());
+        assert!(res.conditions.is_empty());
+        assert!(!res.fail_closed_no_lkg);
+    }
+
+    /// Slice 5c.2: `require_signed_allowlist()` parses common truthy
+    /// values + treats anything else as `false`.
+    #[test]
+    fn require_signed_allowlist_parses_truthy_values() {
+        let _g = env_lock().lock().unwrap();
+        for v in ["true", "TRUE", "1", "yes", "on", "On"] {
+            let _e = EnvGuard::set("REQUIRE_SIGNED_ALLOWLIST", v);
+            assert!(require_signed_allowlist(), "expected truthy: {v}");
+        }
+        for v in ["false", "0", "no", "off", "", "garbage"] {
+            let _e = EnvGuard::set("REQUIRE_SIGNED_ALLOWLIST", v);
+            assert!(!require_signed_allowlist(), "expected falsy: {v}");
+        }
+        let _u = EnvGuard::unset("REQUIRE_SIGNED_ALLOWLIST");
+        assert!(
+            !require_signed_allowlist(),
+            "unset env defaults to falsy / allow-with-warning"
+        );
     }
 
     #[tokio::test]

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -1017,19 +1017,39 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     // failure mode that should be visible to operators, not papered
     // over.
     if allowlist_resolution.fail_closed_no_lkg {
+        // Distinguish the two fail-closed reasons so the Degraded
+        // condition is actionable: verify-fail + no-LKG vs.
+        // Slice 5c.2 unsigned-rejection (REQUIRE_SIGNED_ALLOWLIST=true
+        // and inline-only allowlist).
+        let unsigned_rejected = allowlist_resolution.conditions.iter().any(|c| {
+            c.type_ == crate::status::conditions::TYPE_ALLOWLIST_VERIFIED
+                && c.reason == crate::status::conditions::reason::UNSIGNED
+        });
+        let (deg_reason, deg_msg): (&str, &str) = if unsigned_rejected {
+            (
+                crate::status::conditions::reason::UNSIGNED,
+                "REQUIRE_SIGNED_ALLOWLIST=true and inline allowedEndpoints \
+                 have no allowlistRef; refusing to broaden egress (fail-closed). \
+                 Either set spec.networkPolicy.allowlistRef to a signed OCI \
+                 artifact, or set helm value egress.requireSigned=false.",
+            )
+        } else {
+            (
+                crate::status::conditions::reason::FAILED_CLOSED,
+                "egress allowlist verify failed and no last-known-good cached; \
+                 refusing to broaden egress (fail-closed)",
+            )
+        };
         tracing::warn!(
             sandbox = %name,
-            "AllowlistAuthoritative=False/FailedClosed: verify failed and no last-known-good; \
-             refusing to deploy sandbox pod with broad egress"
+            unsigned_rejected,
+            "AllowlistAuthoritative=False/FailedClosed: {}",
+            deg_reason,
         );
         let sandbox_api: Api<ClawSandbox> =
             Api::namespaced(client.clone(), &sandbox.namespace().unwrap_or_default());
-        let mut status_obj = crate::status::build_degraded_status_patch(
-            &sandbox,
-            crate::status::conditions::reason::FAILED_CLOSED,
-            "egress allowlist verify failed and no last-known-good cached; \
-             refusing to broaden egress (fail-closed)",
-        );
+        let mut status_obj =
+            crate::status::build_degraded_status_patch(&sandbox, deg_reason, deg_msg);
         // Preserve the resolution's three conditions so operators see
         // the verify-fail reason alongside the Degraded marker.
         if let Some(arr) = status_obj["status"]["conditions"].as_array_mut() {

--- a/controller/src/status/conditions.rs
+++ b/controller/src/status/conditions.rs
@@ -272,6 +272,21 @@ pub mod reason {
     /// to Ready. Slice 4d.2 wires the per-server file scheme that the
     /// plural form unlocks; Slice 4-final removes the singular field.
     pub const MCP_SINGULAR_DEPRECATED: &str = "McpSingularDeprecated";
+
+    /// `crd-well-oiled-machine` Slice 5c.2 — `Unsigned`:
+    /// `AllowlistVerified=False` reason for sandboxes that use
+    /// `spec.networkPolicy.allowedEndpoints` (inline) without a
+    /// signed `spec.networkPolicy.allowlistRef`. Default behaviour
+    /// is *allow with warning* — the sandbox still reconciles to
+    /// `Ready=True` and the inline endpoints are programmed into the
+    /// L4 NetworkPolicy and the L7 router allowlist mount. When the
+    /// controller is configured with `REQUIRE_SIGNED_ALLOWLIST=true`
+    /// (helm value `egress.requireSigned: true`), the resolver
+    /// fail-closes instead: endpoints = None,
+    /// `AllowlistAuthoritative=False/FailedClosed`,
+    /// `fail_closed_no_lkg = true`, and the reconciler elevates
+    /// `Degraded=True/Unsigned`.
+    pub const UNSIGNED: &str = "Unsigned";
 }
 
 /// Slice 3b.4 wire-contract prefix routers attach to

--- a/deploy/helm/azureclaw/templates/controller-deployment.yaml
+++ b/deploy/helm/azureclaw/templates/controller-deployment.yaml
@@ -51,6 +51,15 @@ spec:
             - name: BYO_STRICT_MODE
               value: "1"
             {{- end }}
+            {{- if .Values.egress.requireSigned }}
+            # Slice 5c.2: when true, the controller rejects sandboxes
+            # whose `spec.networkPolicy.allowedEndpoints` is set without
+            # a signed `spec.networkPolicy.allowlistRef`. Default
+            # `false` — inline-only allowlists are allowed but stamped
+            # `AllowlistVerified=False/Unsigned` as a warning.
+            - name: REQUIRE_SIGNED_ALLOWLIST
+              value: "true"
+            {{- end }}
             - name: INFERENCE_ROUTER_IMAGE
               value: "{{ .Values.inferenceRouter.image.repository }}:{{ .Values.inferenceRouter.image.tag }}"
             - name: SANDBOX_IMAGE

--- a/deploy/helm/azureclaw/values.yaml
+++ b/deploy/helm/azureclaw/values.yaml
@@ -355,3 +355,16 @@ a2aGateway:
     limits:
       cpu: "500m"
       memory: "256Mi"
+
+# Egress allowlist policy (Slice 5c.2).
+egress:
+  # When `true`, ClawSandboxes that set
+  # `spec.networkPolicy.allowedEndpoints` without a signed
+  # `spec.networkPolicy.allowlistRef` fail-closed: the controller
+  # publishes an empty L7 allowlist mount, refuses to broaden L4
+  # egress beyond the always-allowed baseline (DNS / inference router
+  # / mesh), and stamps `Degraded=True / reason=Unsigned`. Default
+  # `false` — inline allowlists are allowed but surfaced as
+  # `AllowlistVerified=False / reason=Unsigned` warnings so operators
+  # can migrate to signed bundles at their own pace.
+  requireSigned: false


### PR DESCRIPTION
## Summary

Closes Slice 5 DoD #7 (attestation surface) for the **inline** allowlist path.

Today the controller cosign-verifies \`spec.networkPolicy.allowlistRef\` and emits \`AllowlistVerified=True/reason=Verified\` when set, but if the operator only uses inline \`allowedEndpoints\` the cosign infrastructure is silent — there's no visible signal that the bundle is unsigned.

This PR fixes that and gives operators a single helm switch to flip the policy from *allow-with-warning* (default, current behaviour) to *fail-closed*.

## What changes

### Default behaviour (no change to working sandboxes)
- Inline allowlists keep reconciling normally.
- Controller now **additionally** stamps \`AllowlistVerified=False / reason=Unsigned\` so operators see the missing cosign attestation in \`kubectl describe clawsandbox\` and in the Headlamp router-enforcement panel.
- L4 NetworkPolicy and L7 router allowlist mount are still programmed from the inline list — no egress regression.

### Opt-in fail-closed
- New helm value \`egress.requireSigned\` (default \`false\`).
- When \`true\`, sets env \`REQUIRE_SIGNED_ALLOWLIST=true\` on the controller Deployment.
- The resolver in \`policy_fetcher\` then refuses to program user egress for inline-only allowlists: \`endpoints\` is dropped, the L7 mount is published empty (router rejects every L7 attempt at host level), and the sandbox stamps \`Degraded=True / reason=Unsigned\` with an actionable message pointing the operator to either sign the bundle via \`allowlistRef\` or relax the helm value.
- Read on every reconcile so operators can toggle without a controller restart.

### Reconciler distinguishes two fail-closed reasons
The existing \`fail_closed_no_lkg\` short-circuit path now distinguishes:
- **verify-fail + no-LKG** → \`Degraded=True / reason=FailedClosed\` (unchanged).
- **require-signed-rejection** → \`Degraded=True / reason=Unsigned\` (new), with a message pointing at both remediations.

### Wiring
- New \`reason::UNSIGNED\` constant in \`status::conditions\`.
- \`policy_fetcher::require_signed_allowlist()\` parses env truthy values (\`true\`/\`1\`/\`yes\`/\`on\`, case-insensitive); anything else is false.
- \`deploy/helm/azureclaw/templates/controller-deployment.yaml\` passes through \`REQUIRE_SIGNED_ALLOWLIST\` when \`.Values.egress.requireSigned\` is truthy.
- \`deploy/helm/azureclaw/values.yaml\` documents the new value.

## Tests

- 3 new + 1 updated unit test in \`policy_fetcher::tests\`:
  - \`resolve_inline_only_with_require_signed_fails_closed\`
  - \`resolve_inline_empty_with_require_signed_is_noop\`
  - \`require_signed_allowlist_parses_truthy_values\`
  - \`resolve_inline_only_emits_authoritative_inline\` (updated to also assert the new \`Unsigned\` warning)
- \`cargo test --workspace\` green: **577 controller** (+3) + **863 router** + 26 integration.
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- \`cargo fmt --all -- --check\` clean.
- \`helm template\` verified both code paths (default off; \`--set egress.requireSigned=true\` renders the env var).

## Out of scope (queued)

- **Slice 5c.3** — TTL ceiling (default 24h, helm-configurable) on the signed bundle.
- **Slice 5d** — \`AllowlistDrift\` summary enrichment + Headlamp banner.
- **Slice 5e** — \`azureclaw egress allow-extra\` CLI (depends on this slice).