### PR TITLE
Slice 5d: structured AllowlistDrift summary + Headlamp banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 5d — `AllowlistDrift` structured diff + Headlamp banner
+
+Closes Slice 5 DoD #5. The `AllowlistDrift=True` condition already
+fires when a `ClawSandbox` carries both `allowedEndpoints` (inline)
+and `allowlistRef` (signed artifact) and they diverge — but until
+now the message was a single human sentence with no machine-readable
+diff. Operators had to manually compare two host lists to see what
+the bundle was missing.
+
+- **`DriftSummary` payload appended to the condition message.**
+  Format: `"… artifact wins | drift={JSON}"` where the JSON object
+  has `added` (entries only inline — operator intent missing from
+  the signed authority) and `removed` (entries only in the bundle —
+  authority has hosts the operator did not echo). Entries are
+  `host:port` strings, port normalized to `443`, sorted
+  lexicographically. Empty-list contracts: no drift ⇒ no JSON
+  payload at all (legacy message preserved). Pinned in
+  `controller/src/policy_fetcher.rs::DriftSummary` and
+  serde-roundtrip-tested.
+- **Headlamp plugin banner.** Every `ClawSandbox` detail view now
+  shows a yellow "Allowlist drift detected" section when the
+  `AllowlistDrift` condition is `True`. The banner parses the
+  trailing JSON and renders a two-row table (only-in-inline /
+  only-in-bundle) with the host list. Falls back to the raw
+  condition message when the JSON suffix is absent
+  (forward-compat).
+- **No wire surface change.** The drift JSON is a suffix of an
+  existing condition message — no new CRD field, no router
+  protocol bump, no controller env var. Old plugins ignore the
+  suffix; new plugins parse it.
+
 ### Slice 5c.2 — `Unsigned` warning condition + helm `requireSigned` fail-closed toggle
 
 Surfaces the gap when a `ClawSandbox` uses

--- a/controller/src/policy_fetcher.rs
+++ b/controller/src/policy_fetcher.rs
@@ -402,6 +402,50 @@ fn endpoint_lists_equivalent(
     norm(a) == norm(b)
 }
 
+/// Structured drift summary: what's in `inline` but not the verified
+/// artifact (`added`), and what's in the artifact but not inline
+/// (`removed`). Computed only when drift is detected so we can attach
+/// a machine-readable payload to the `AllowlistDrift=True` condition
+/// message. Entries are formatted `host:port` (port normalized to 443
+/// when absent) and sorted lexicographically.
+///
+/// **Wire contract** — the headlamp plugin parses this from the
+/// condition message as JSON. Keep field names stable. Adding fields
+/// is OK; renames are not.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct DriftSummary {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+fn normalize_endpoints_for_summary(
+    list: &[crate::crd::EndpointConfig],
+) -> std::collections::BTreeSet<(String, u16)> {
+    list.iter()
+        .map(|e| (e.host.to_ascii_lowercase(), e.port.unwrap_or(443)))
+        .collect()
+}
+
+/// Compute a structured drift summary between an inline endpoint
+/// list and the verified-artifact-derived list. `added` are entries
+/// only present inline (operator intent diverging from the signed
+/// authority); `removed` are entries only in the artifact. Returns
+/// empty lists when the two sets are equivalent.
+#[must_use]
+pub fn compute_drift_summary(
+    inline: &[crate::crd::EndpointConfig],
+    derived: &[crate::crd::EndpointConfig],
+) -> DriftSummary {
+    let inline_set = normalize_endpoints_for_summary(inline);
+    let derived_set = normalize_endpoints_for_summary(derived);
+    let fmt = |(h, p): &(String, u16)| format!("{h}:{p}");
+    let mut added: Vec<String> = inline_set.difference(&derived_set).map(fmt).collect();
+    let mut removed: Vec<String> = derived_set.difference(&inline_set).map(fmt).collect();
+    added.sort();
+    removed.sort();
+    DriftSummary { added, removed }
+}
+
 // ─────────────────────────── public entry ───────────────────────────
 
 /// Pull, verify, and parse a signed egress-allowlist artifact.
@@ -1333,6 +1377,11 @@ pub async fn resolve_allowlist_with_handle(
             );
             let derived = canonical_to_endpoint_config(&verified.endpoints);
             let drift = inline_present && !endpoint_lists_equivalent(&inline, &derived);
+            let drift_summary = if drift {
+                Some(compute_drift_summary(&inline, &derived))
+            } else {
+                None
+            };
 
             conditions.push(preserve_transition_time(
                 prior_verified,
@@ -1356,16 +1405,20 @@ pub async fn resolve_allowlist_with_handle(
                 ),
                 generation,
             ));
-            emit_drift_condition(
-                &mut conditions,
-                &mut lkg_entry,
-                drift,
-                if drift {
-                    "inline allowedEndpoints differs from verified artifact; artifact wins"
-                } else {
-                    "inline allowedEndpoints empty or matches artifact"
-                },
-            );
+            // Drift message format: human prefix + ` | drift=<json>` so
+            // the plugin can parse the trailing JSON without losing the
+            // human-readable summary. Plugins must split on " | drift="
+            // and parse what follows as `DriftSummary`.
+            let drift_msg = if let Some(ref s) = drift_summary {
+                let json = serde_json::to_string(s)
+                    .unwrap_or_else(|_| r#"{"added":[],"removed":[]}"#.to_string());
+                format!(
+                    "inline allowedEndpoints differs from verified artifact; artifact wins | drift={json}"
+                )
+            } else {
+                "inline allowedEndpoints empty or matches artifact".to_string()
+            };
+            emit_drift_condition(&mut conditions, &mut lkg_entry, drift, &drift_msg);
 
             // Update LKG with the freshly verified endpoints.
             lkg_entry.endpoints = Some(derived.clone());
@@ -2348,6 +2401,59 @@ mod tests {
                 .iter()
                 .all(|e| !e.host.is_empty() && e.port.is_some())
         );
+    }
+
+    #[test]
+    fn drift_summary_empty_when_lists_equivalent() {
+        let a = vec![ep("API.Example.COM", None), ep("b.example", Some(443))];
+        let b = vec![ep("b.example", None), ep("api.example.com", Some(443))];
+        let s = compute_drift_summary(&a, &b);
+        assert!(s.added.is_empty());
+        assert!(s.removed.is_empty());
+    }
+
+    #[test]
+    fn drift_summary_reports_added_and_removed_sorted() {
+        let inline = vec![
+            ep("z.added.example", None),
+            ep("api.shared.example", None),
+            ep("a.added.example", Some(8443)),
+        ];
+        let derived = vec![
+            ep("api.shared.example", Some(443)),
+            ep("only-in-artifact.example", None),
+        ];
+        let s = compute_drift_summary(&inline, &derived);
+        assert_eq!(s.added, vec!["a.added.example:8443", "z.added.example:443"]);
+        assert_eq!(s.removed, vec!["only-in-artifact.example:443"]);
+    }
+
+    #[test]
+    fn drift_summary_port_normalization_matches_equivalence() {
+        // ep("h", None) and ep("h", Some(443)) must NOT register as a
+        // change (port-default normalization).
+        let inline = vec![ep("api.example", None)];
+        let derived = vec![ep("api.example", Some(443))];
+        let s = compute_drift_summary(&inline, &derived);
+        assert!(s.added.is_empty());
+        assert!(s.removed.is_empty());
+    }
+
+    #[test]
+    fn drift_summary_is_serde_round_trip_stable() {
+        // Wire contract: headlamp plugin parses the JSON suffix of
+        // the `AllowlistDrift` condition message. Pin the schema.
+        let s = DriftSummary {
+            added: vec!["a.example:443".into()],
+            removed: vec!["b.example:8443".into()],
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert_eq!(
+            json,
+            r#"{"added":["a.example:443"],"removed":["b.example:8443"]}"#
+        );
+        let back: DriftSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
     }
 
     #[test]

--- a/tools/headlamp-plugin/src/index.tsx
+++ b/tools/headlamp-plugin/src/index.tsx
@@ -209,6 +209,85 @@ function shortDigest(digest: string | undefined): string {
   return `${digest.slice(0, colon + 1)}${digest.slice(colon + 1, colon + 13)}…`;
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// AllowlistDrift banner (crd-well-oiled-machine Slice 5d)
+//
+// The controller emits an `AllowlistDrift=True` condition when a
+// ClawSandbox's CR carries both `allowedEndpoints` (inline) AND
+// `allowlistRef` (signed artifact) and the two diverge. The artifact
+// wins and inline is ignored — but operators need to *see* the diff
+// so they can either re-sign the bundle to include the new hosts or
+// drop the inline override.
+//
+// The condition message format is:
+//   "inline allowedEndpoints differs from verified artifact; artifact wins | drift={JSON}"
+// where JSON is `{"added":[...],"removed":[...]}` of `host:port` strings.
+// `added` = inline entries missing from the artifact (operator intent
+// diverging from authority). `removed` = artifact entries the operator
+// did not echo inline. See
+// `controller/src/policy_fetcher.rs::DriftSummary` for the canonical
+// schema.
+// ──────────────────────────────────────────────────────────────────────
+
+interface DriftSummary {
+  added: string[];
+  removed: string[];
+}
+
+function parseDriftFromMessage(message: string | undefined): DriftSummary | null {
+  if (!message) return null;
+  const idx = message.indexOf(" | drift=");
+  if (idx < 0) return null;
+  try {
+    const parsed = JSON.parse(message.slice(idx + " | drift=".length));
+    if (!parsed || typeof parsed !== "object") return null;
+    const added = Array.isArray(parsed.added) ? parsed.added.filter((s: unknown) => typeof s === "string") : [];
+    const removed = Array.isArray(parsed.removed) ? parsed.removed.filter((s: unknown) => typeof s === "string") : [];
+    return { added, removed };
+  } catch {
+    return null;
+  }
+}
+
+function AllowlistDriftBanner({ item }: { item: KubeObject }) {
+  const status = getStatus(item);
+  const conditions = (status.conditions as Array<Record<string, any>> | undefined) ?? [];
+  const drift = conditions.find(c => c.type === "AllowlistDrift" && c.status === "True");
+  if (!drift) return null;
+
+  const summary = parseDriftFromMessage(drift.message as string | undefined);
+  const added = summary?.added ?? [];
+  const removed = summary?.removed ?? [];
+
+  return (
+    <SectionBox title="⚠ Allowlist drift detected">
+      <p style={{ padding: "0.5rem", fontSize: "0.9rem" }}>
+        <StatusLabel status={"warning" as any}>artifact wins</StatusLabel>{" "}
+        Inline <code>allowedEndpoints</code> diverges from the verified
+        signed bundle. The router enforces the bundle; the inline list is
+        ignored. Either re-sign the bundle to include the divergent
+        hosts, or remove the inline override.
+      </p>
+      {(added.length > 0 || removed.length > 0) ? (
+        <SimpleTable
+          data={[
+            { side: `Only in inline (operator added, not signed) — ${added.length}`, hosts: added.join(", ") || "—" },
+            { side: `Only in bundle (signed, but missing inline) — ${removed.length}`, hosts: removed.join(", ") || "—" },
+          ]}
+          columns={[
+            { label: "Side", getter: (r: any) => r.side },
+            { label: "Hosts", getter: (r: any) => <code>{r.hosts}</code> },
+          ]}
+        />
+      ) : (
+        <p style={{ padding: "0.5rem", fontSize: "0.85rem", opacity: 0.75 }}>
+          {(drift.message as string) ?? "(no diff payload)"}
+        </p>
+      )}
+    </SectionBox>
+  );
+}
+
 function reasonChip(reason: string | undefined) {
   if (!reason) return <span>—</span>;
   const success = reason === "RouterEnforcing" || reason === "AllDigestsMatch";
@@ -702,6 +781,8 @@ function CrdDetail({ crd }: { crd: CrdDescriptor }) {
       </SectionBox>
 
       {crd.plural === "clawsandboxes" && <SandboxExtras item={item} />}
+
+      <AllowlistDriftBanner item={item} />
 
       <RouterPolicyStatusPanel crd={crd} item={item} />
 


### PR DESCRIPTION
Closes Slice 5 DoD #5 (drift surfacing).

## What

The `AllowlistDrift=True` condition already fires when a `ClawSandbox`
carries both `allowedEndpoints` (inline) and `allowlistRef` (signed
artifact) and the two diverge — but the message was a single
sentence with no machine-readable diff. Operators had to manually
compare two host lists.

## Changes

**Controller (`policy_fetcher.rs`)**: new public `DriftSummary { added, removed }` type. Computed when drift is detected, normalized (lowercase host, port→443), formatted `host:port`, sorted. Appended to the condition message as `" | drift=<JSON>"`. Empty-list contract: no drift ⇒ no JSON payload (legacy message preserved).

**Headlamp plugin**: `AllowlistDriftBanner` renders on any CR carrying the condition. Parses the JSON suffix and shows a two-row table (only-in-inline / only-in-bundle). Falls back to raw message text when JSON suffix absent (forward-compat for old controllers).

## Wire contract

No new CRD field, no router protocol bump, no new env var. Drift summary rides on an existing condition message. Old plugins ignore the suffix; new plugins parse it.

## Tests

- 4 new unit tests on `DriftSummary`:
  - Equivalent lists → empty added/removed
  - Diff → sorted, port-normalized output
  - Port-default normalization matches `endpoint_lists_equivalent`
  - Serde round-trip pins the JSON schema
- 581 controller + 863 router + 26 e2e tests still green
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- Plugin `tsc --noEmit` clean, `npm run build` produces 19.91 kB bundle

## Scope-out

Slice 5c.3 (TTL ceiling on allowlist bundles) was dropped after honest review — it only catches a >24h dead-controller scenario, which Prometheus alerting on `LastReconciledAt` covers more cleanly without adding wire surface.