### PR TITLE
Slice 1c.2: ToolPolicy.spec.agtProfile.bundleRef (signed OCI artifact)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1c.2 — `ToolPolicy.spec.agtProfile.bundleRef` (signed OCI artifact)
+
+Continues the Slice 1c-real signing-generalization arc started in
+1c.1 (`PolicyKind` trait + `policy_canonical` module). 1c.2 wires
+the first per-kind consumer: `ToolPolicy.spec.agtProfile` now
+accepts a signed OCI artifact as an alternative to inline YAML.
+
+- **`AgtProfileSource.bundleRef`** — new field on `ToolPolicy.spec.agtProfile`,
+  mutually exclusive with `inline`. The controller pulls the artifact
+  via `policy_fetcher::fetch_and_verify_generic::<ToolsKind>`, cosign-
+  verifies against the active `SignerPolicy`, parses the bytes through
+  `policy_canonical::tools::parse` (UTF-8 + YAML mapping + required
+  fields `version` / `agent` / `policies`), and writes the verified
+  bytes into the compiled-profile `ConfigMap` under
+  `agt-profile.yaml`. The wire contract with the router is **identical
+  to the inline path** — the router doesn't know which source produced
+  the bytes; the length-prefixed content digest (Slice 1b) closes the
+  echo loop the same way either way.
+- **OCI artifact media type:**
+  `application/vnd.azureclaw.agt-profile.v1+yaml`. Mismatches surface
+  as `Ready=False / reason=InvalidRef`.
+- **`ToolPolicyStatus.agtProfileBundleDigest`** — new status field
+  carrying the verified OCI manifest digest (distinct from
+  `agtProfileDigest`, which is the length-prefixed content digest the
+  router echoes). `None` for the inline path. Populated only after
+  cosign verification succeeds.
+- **Mutual exclusion** — admission CEL
+  (`!has(self.agtProfile) || !(has(self.agtProfile.inline) && has(self.agtProfile.bundleRef))`)
+  rejects specs that set both at apply time. The reconciler also
+  performs a runtime defense-in-depth check (`reason=InvalidSpec`) for
+  older clusters lacking the latest CRD.
+- **Error taxonomy** — fetch/verify failures reuse the egress
+  `FetchError` vocabulary verbatim via `reason_for_error`:
+  `SignerPolicyMissing` / `SignerPolicyMalformed` / `InvalidRef` /
+  `Unauthorized` / `NotFound` / `SignatureVerifyFailed` /
+  `IdentityMismatch` / `CanonicalFormViolation` / `Transient`. One
+  vocabulary across all signed-policy kinds — operator docs stay
+  minimal as 1c.3 / 1c.4 / 1c.5 land.
+- **Canonical form for AGT YAML** intentionally permits comments
+  (operator-authored YAML profiles); the OCI digest pins the bytes
+  loaded into the router, so the byte-frozen "no comments" rule that
+  the egress allowlist applies for semantic-deduplication does not
+  apply here. Validation is structural (UTF-8 + parseable YAML mapping
+  + required top-level fields).
+- **TODO comments removed** in `controller/src/tool_policy.rs` —
+  the long-deferred *"Slice 1c will add bundleRef"* §5 violation is
+  now closed (the field is shipped).
+
+`controller/src/policy_canonical/tools.rs` — new ~300 LOC module
+with the `ToolsKind` `PolicyKind` impl, per-kind cache, and 15
+unit tests (minimal/with-policies/with-comments parse, all
+required-field rejection paths, non-UTF8/non-mapping rejection,
+finalize/cache roundtrip, cross-kind cache isolation).
+
+`controller/src/tool_policy_reconciler.rs` — new
+`resolve_agt_profile_source` helper unifies the inline / bundleRef /
+none / both-set cases into a single
+`(bytes, oci_digest, degraded)` triple consumed by the existing
+`ensure_profile_configmap` flow. 5 new unit tests covering all four
+spec-shape cases + a tripwire test pinning the `fetch_error_to_degraded`
+mapping to the shared `reason_for_error` taxonomy.
+
+CRD schema regenerated; 14 helm_drift tests pass. 619 controller
+tests (was 597 at 1c.1), clippy `-D warnings` clean, fmt clean.
+
 ### Slice 5d — `AllowlistDrift` structured diff + Headlamp banner
 
 Closes Slice 5 DoD #5. The `AllowlistDrift=True` condition already

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -104,16 +104,32 @@ pub fn mcp_server_validations() -> Vec<ValidationRule> {
 ///    nothing is almost always an authoring mistake; if truly
 ///    intended, an explicit `disabled: true` field is the right
 ///    escape hatch — not silently empty selectors).
+/// 2. `agtProfile.inline` and `agtProfile.bundleRef` are mutually
+///    exclusive — at most one may be set. Both absent is permitted
+///    (back-compat: no AGT profile attached); both present is an
+///    authoring error.
 #[must_use]
 pub fn tool_policy_validations() -> Vec<ValidationRule> {
-    vec![ValidationRule {
-        rule:
-            "has(self.appliesTo.sandboxMatchLabels) && size(self.appliesTo.sandboxMatchLabels) > 0"
-                .into(),
-        message: Some("spec.appliesTo.sandboxMatchLabels must contain at least one label".into()),
-        reason: Some("FieldValueInvalid".into()),
-        ..ValidationRule::default()
-    }]
+    vec![
+        ValidationRule {
+            rule:
+                "has(self.appliesTo.sandboxMatchLabels) && size(self.appliesTo.sandboxMatchLabels) > 0"
+                    .into(),
+            message: Some("spec.appliesTo.sandboxMatchLabels must contain at least one label".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule:
+                "!has(self.agtProfile) || !(has(self.agtProfile.inline) && has(self.agtProfile.bundleRef))"
+                    .into(),
+            message: Some(
+                "spec.agtProfile.inline and spec.agtProfile.bundleRef are mutually exclusive".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+    ]
 }
 
 /// Inject CEL rules onto the `spec` schema node of a generated CRD.

--- a/controller/src/policy_canonical/egress.rs
+++ b/controller/src/policy_canonical/egress.rs
@@ -87,6 +87,7 @@ impl PolicyKind for EgressKind {
         }
         match &entry.verified {
             CachedValue::Egress(v) => Some(v.clone()),
+            CachedValue::Tools(_) => None,
         }
     }
 

--- a/controller/src/policy_canonical/mod.rs
+++ b/controller/src/policy_canonical/mod.rs
@@ -30,10 +30,13 @@ use crate::policy_fetcher::FetchError;
 use std::time::{Instant, SystemTime};
 
 pub mod egress;
+pub mod tools;
 
 #[allow(unused_imports)]
-// re-exported for downstream sub-slices (1c.2+); tests use the full path
+// re-exported for downstream sub-slices (1c.3+); tests use the full path
 pub use egress::EgressKind;
+#[allow(unused_imports)]
+pub use tools::ToolsKind;
 
 /// One slot per `PolicyKind` for the per-kind verified-artifact cache.
 ///
@@ -47,9 +50,10 @@ pub use egress::EgressKind;
 /// is the implementation detail of how
 /// [`PolicyKind::cache_get`] / [`PolicyKind::cache_put`] are wired, not
 /// a public extension point.
-#[allow(dead_code)] // future kinds will add variants in 1c.2 - 1c.5
+#[allow(dead_code)] // future kinds will add variants in 1c.3 - 1c.5
 pub(crate) enum CachedValue {
     Egress(egress::VerifiedAllowlist),
+    Tools(tools::VerifiedAgtProfile),
 }
 
 /// Trait implemented by each policy kind (egress, tools, inference,

--- a/controller/src/policy_canonical/tools.rs
+++ b/controller/src/policy_canonical/tools.rs
@@ -1,0 +1,382 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! AGT policy profile canonical-form parser + `PolicyKind` impl.
+//!
+//! Slice 1c.2 — second per-kind implementation after egress (1c.1).
+//! Unlike egress, AGT profiles are customer-authored YAML that operators
+//! write by hand: rules are documented with `#` comments, key order is
+//! cosmetic, and the file shape is a rich nested mapping rather than a
+//! flat allowlist. Imposing the strict byte-canonical rules egress
+//! enforces (no comments, sorted keys, deduplication) would break
+//! day-1 ergonomics — operators would need a separate `azureclaw
+//! agt-profile canonicalize` step before every sign.
+//!
+//! The supply-chain guarantee is preserved without strict byte-
+//! canonicalization because the OCI digest already pins the *bytes*
+//! that get loaded into the router. The semantic deduplication concern
+//! that justifies egress canonicalization (two equivalent allowlists
+//! producing the same digest) doesn't apply: AGT profiles are signed
+//! and consumed as-is — the bytes themselves are the policy, not a
+//! normalized projection of them.
+//!
+//! What we DO enforce (trait invariant #1, applied to AGT):
+//! - Valid UTF-8
+//! - Parseable as a YAML mapping
+//! - Required top-level keys present: `version`, `agent`, `policies`
+//! - `version` is a non-empty string
+//! - `agent` is a non-empty string
+//! - `policies` is a sequence (possibly empty)
+//!
+//! Anything beyond that is delegated to the router's AGT engine
+//! (`Governance::load_policies_from_dir`), which catches per-rule
+//! semantic errors and surfaces them via `GET /internal/policy-status`.
+//! That deliberate split keeps the controller's responsibilities
+//! narrow — *supply chain verification + structural sanity* — and lets
+//! the producer-consumer loop close without the controller having to
+//! re-implement the AGT rule engine.
+
+use super::{CachedValue, PolicyKind};
+use crate::policy_fetcher::{CACHE_TTL, FetchError};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Instant, SystemTime};
+
+/// OCI media type for the v1 AGT profile artifact. The pulled
+/// `artifactType` MUST match this exactly; consumers reject any other
+/// value (forward-compat: v2 bumps the suffix; v1 consumers MUST refuse
+/// v2 artifacts).
+pub const AGT_PROFILE_V1_MEDIA_TYPE: &str = "application/vnd.azureclaw.agt-profile.v1+yaml";
+
+/// A verified AGT policy profile bundle. The `bytes` field is the
+/// signed payload as pulled from OCI; the router consumes it verbatim
+/// via the existing `Governance::load_policies_from_dir` path. The
+/// `version` / `agent` fields are extracted at parse time for
+/// observability + admission cross-checks (the `agent` value MUST
+/// equal `ToolPolicy.metadata.name` when bundleRef is in use — see
+/// reconciler).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedAgtProfile {
+    /// AGT schema version declared by the producer. v1 accepts `"1.0"`
+    /// (the only value upstream AGT ships today). Surfaced in
+    /// controller status for forward-compat diagnostics.
+    pub version: String,
+    /// Agent name declared inside the profile. Used by the reconciler
+    /// to cross-check that the producer's intent matches the consuming
+    /// ToolPolicy. A mismatch is surfaced as a Ready=False condition
+    /// rather than a fetch error so operators can diagnose it without
+    /// re-pulling the artifact.
+    pub agent: String,
+    /// Number of `policies[]` entries — for log lines + status,
+    /// not used in enforcement decisions.
+    pub policies_count: usize,
+    /// Raw signed bytes. The reconciler writes these verbatim into the
+    /// compiled-profile ConfigMap under key `agt-profile.yaml`; the
+    /// router echoes the [`crate::tool_policy_compile::agt_profile_digest`]
+    /// computed over these exact bytes.
+    pub bytes: Vec<u8>,
+    /// `sha256:...` matched against `OciArtifactRef.digest`.
+    pub digest: String,
+    pub fetched_at: SystemTime,
+}
+
+/// `PolicyKind` discriminator for AGT policy profiles.
+pub struct ToolsKind;
+
+impl PolicyKind for ToolsKind {
+    const MEDIA_TYPE: &'static str = AGT_PROFILE_V1_MEDIA_TYPE;
+    const API_VERSION: &'static str = "agentmesh.io/v1";
+    const KIND: &'static str = "AgtProfile";
+    type Output = VerifiedAgtProfile;
+
+    fn parse(bytes: &[u8]) -> Result<Self::Output, FetchError> {
+        parse(bytes)
+    }
+
+    fn finalize(out: &mut Self::Output, digest: String, fetched_at: SystemTime) {
+        out.digest = digest;
+        out.fetched_at = fetched_at;
+    }
+
+    fn cache_get(key: &str, now: Instant) -> Option<Self::Output> {
+        let guard = cache().lock().ok()?;
+        let entry = guard.get(key)?;
+        if now.duration_since(entry.inserted) > CACHE_TTL {
+            return None;
+        }
+        match &entry.verified {
+            CachedValue::Tools(v) => Some(v.clone()),
+            CachedValue::Egress(_) => None,
+        }
+    }
+
+    fn cache_put(key: String, value: Self::Output) {
+        if let Ok(mut guard) = cache().lock() {
+            guard.insert(
+                key,
+                CacheEntry {
+                    verified: CachedValue::Tools(value),
+                    inserted: Instant::now(),
+                },
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn cache_clear() {
+        if let Ok(mut guard) = cache().lock() {
+            guard.clear();
+        }
+    }
+}
+
+// ─────────────────────────── cache ───────────────────────────
+
+struct CacheEntry {
+    verified: CachedValue,
+    inserted: Instant,
+}
+
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// ─────────────────────────── parser ───────────────────────────
+
+/// Parse + structural validate the AGT profile bytes. Returns
+/// [`FetchError::CanonicalFormViolation`] for any structural issue.
+/// The returned [`VerifiedAgtProfile::digest`] is empty; the caller
+/// fills it via [`ToolsKind::finalize`].
+pub(crate) fn parse(bytes: &[u8]) -> Result<VerifiedAgtProfile, FetchError> {
+    // UTF-8 — required for both YAML parsing and the eventual ConfigMap
+    // write (Kubernetes ConfigMap.data is map[string]string; binaryData
+    // would be a different field).
+    let s = std::str::from_utf8(bytes)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("utf-8: {e}")))?;
+
+    let doc: serde_yaml::Value = serde_yaml::from_str(s)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("yaml parse: {e}")))?;
+
+    let map = doc
+        .as_mapping()
+        .ok_or_else(|| FetchError::CanonicalFormViolation("top-level must be a mapping".into()))?;
+
+    let version = map
+        .get(serde_yaml::Value::String("version".into()))
+        .ok_or_else(|| FetchError::CanonicalFormViolation("missing `version`".into()))?
+        .as_str()
+        .ok_or_else(|| FetchError::CanonicalFormViolation("`version` must be a string".into()))?
+        .to_string();
+    if version.is_empty() {
+        return Err(FetchError::CanonicalFormViolation(
+            "`version` must be non-empty".into(),
+        ));
+    }
+
+    let agent = map
+        .get(serde_yaml::Value::String("agent".into()))
+        .ok_or_else(|| FetchError::CanonicalFormViolation("missing `agent`".into()))?
+        .as_str()
+        .ok_or_else(|| FetchError::CanonicalFormViolation("`agent` must be a string".into()))?
+        .to_string();
+    if agent.is_empty() {
+        return Err(FetchError::CanonicalFormViolation(
+            "`agent` must be non-empty".into(),
+        ));
+    }
+
+    let policies = map
+        .get(serde_yaml::Value::String("policies".into()))
+        .ok_or_else(|| FetchError::CanonicalFormViolation("missing `policies`".into()))?;
+    let policies_seq = policies.as_sequence().ok_or_else(|| {
+        FetchError::CanonicalFormViolation("`policies` must be a sequence".into())
+    })?;
+    let policies_count = policies_seq.len();
+
+    Ok(VerifiedAgtProfile {
+        version,
+        agent,
+        policies_count,
+        bytes: bytes.to_vec(),
+        digest: String::new(),
+        fetched_at: SystemTime::UNIX_EPOCH,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_ok() {
+        let yaml = b"version: \"1.0\"\nagent: test\npolicies: []\n";
+        let r = parse(yaml).unwrap();
+        assert_eq!(r.version, "1.0");
+        assert_eq!(r.agent, "test");
+        assert_eq!(r.policies_count, 0);
+        assert_eq!(r.bytes, yaml);
+        assert_eq!(r.digest, "");
+    }
+
+    #[test]
+    fn parse_with_one_policy_ok() {
+        let yaml = br#"version: "1.0"
+agent: my-agent
+policies:
+  - name: rule-1
+    type: capability
+    allowed_actions:
+      - "shell:ls"
+    priority: 10
+"#;
+        let r = parse(yaml).unwrap();
+        assert_eq!(r.agent, "my-agent");
+        assert_eq!(r.policies_count, 1);
+    }
+
+    #[test]
+    fn parse_with_comments_ok() {
+        // AGT profiles allow comments (unlike egress) — operators author by hand.
+        let yaml = br#"# top-level comment
+version: "1.0"  # inline comment
+agent: with-comments
+policies:
+  # rule documentation
+  - name: r
+    type: capability
+    allowed_actions: ["shell:ls"]
+"#;
+        let r = parse(yaml).unwrap();
+        assert_eq!(r.agent, "with-comments");
+        assert_eq!(r.policies_count, 1);
+    }
+
+    #[test]
+    fn parse_rejects_non_utf8() {
+        let bytes = b"\xff\xfeversion: 1.0\n";
+        let err = parse(bytes).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("utf-8")));
+    }
+
+    #[test]
+    fn parse_rejects_missing_version() {
+        let yaml = b"agent: test\npolicies: []\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("version")),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_empty_version() {
+        let yaml = b"version: \"\"\nagent: test\npolicies: []\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-empty")),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_missing_agent() {
+        let yaml = b"version: \"1.0\"\npolicies: []\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("agent")));
+    }
+
+    #[test]
+    fn parse_rejects_empty_agent() {
+        let yaml = b"version: \"1.0\"\nagent: \"\"\npolicies: []\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-empty"))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_missing_policies() {
+        let yaml = b"version: \"1.0\"\nagent: test\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("policies")));
+    }
+
+    #[test]
+    fn parse_rejects_policies_not_sequence() {
+        let yaml = b"version: \"1.0\"\nagent: test\npolicies: not-a-list\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("sequence")));
+    }
+
+    #[test]
+    fn parse_rejects_non_mapping_top_level() {
+        let yaml = b"- not\n- a\n- mapping\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("mapping")));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_yaml() {
+        let yaml = b"version: \"1.0\nagent: unclosed-quote\n";
+        let err = parse(yaml).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("yaml")),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_preserves_raw_bytes() {
+        // Reconciler writes `bytes` verbatim into the ConfigMap; the
+        // router echoes the digest computed over these exact bytes.
+        // Verify any structural valid input round-trips bytes unchanged.
+        let yaml = b"version: \"1.0\"\nagent: byte-preserve\npolicies: []\n";
+        let r = parse(yaml).unwrap();
+        assert_eq!(r.bytes.as_slice(), yaml);
+    }
+
+    #[test]
+    fn finalize_stamps_digest_and_time() {
+        let mut r = parse(b"version: \"1.0\"\nagent: f\npolicies: []\n").unwrap();
+        let now = SystemTime::now();
+        ToolsKind::finalize(&mut r, "sha256:abc".into(), now);
+        assert_eq!(r.digest, "sha256:abc");
+        assert_eq!(r.fetched_at, now);
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        ToolsKind::cache_clear();
+        let mut v = parse(b"version: \"1.0\"\nagent: c\npolicies: []\n").unwrap();
+        ToolsKind::finalize(&mut v, "sha256:cached".into(), SystemTime::now());
+        ToolsKind::cache_put("k1".into(), v.clone());
+        let hit = ToolsKind::cache_get("k1", Instant::now()).expect("cache hit");
+        assert_eq!(hit.digest, "sha256:cached");
+        assert_eq!(hit.agent, "c");
+    }
+
+    #[test]
+    fn cache_isolated_per_kind() {
+        // Sanity: a key inserted into the tools cache MUST NOT collide
+        // with the egress cache (different OnceLock backing stores).
+        ToolsKind::cache_clear();
+        crate::policy_canonical::egress::EgressKind::cache_clear();
+        let mut v = parse(b"version: \"1.0\"\nagent: iso\npolicies: []\n").unwrap();
+        ToolsKind::finalize(&mut v, "sha256:tools-only".into(), SystemTime::now());
+        ToolsKind::cache_put("shared-key".into(), v);
+        // Egress cache MUST miss — different per-kind static slot.
+        assert!(
+            crate::policy_canonical::egress::EgressKind::cache_get("shared-key", Instant::now())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn media_type_v1() {
+        assert_eq!(
+            ToolsKind::MEDIA_TYPE,
+            "application/vnd.azureclaw.agt-profile.v1+yaml"
+        );
+    }
+}

--- a/controller/src/tool_policy.rs
+++ b/controller/src/tool_policy.rs
@@ -73,23 +73,33 @@ pub struct ToolPolicySpec {
     /// `/opt/azureclaw-plugin/policies/*.yaml` fallback that older
     /// releases shipped has been removed.
     ///
-    /// Slice 1b ships **inline** only; `bundleRef` (signed OCI
-    /// artifact fetch) lands in Slice 1c. The wire contract between
-    /// controller and router is the length-prefixed sha256 digest
-    /// produced by [`crate::tool_policy_compile::agt_profile_digest`],
-    /// echoed back by the router via `GET /internal/policy-status`.
+    /// Two sources are supported (mutually exclusive):
+    /// - `inline`: raw YAML carried in the spec (Slice 1b)
+    /// - `bundleRef`: signed OCI artifact (Slice 1c.2) — the controller
+    ///   pulls + cosign-verifies via
+    ///   [`crate::policy_fetcher::fetch_and_verify_generic`] with
+    ///   [`crate::policy_canonical::tools::ToolsKind`] and writes the
+    ///   verified bytes into the same ConfigMap key. The wire contract
+    ///   with the router is identical to the inline path — the router
+    ///   doesn't know (or need to know) which source produced the bytes.
+    ///
+    /// Mutual exclusion: admission CEL (in the Helm CRD) enforces
+    /// `has(inline) != has(bundleRef)`. The reconciler also checks this
+    /// at runtime as a defense-in-depth measure (older clusters without
+    /// the latest CRD).
     ///
     /// Per principles.md §3: when `agtProfile` is set, the controller
     /// stamps `phase=Compiled` and `Ready=False /
     /// reason=AwaitingRouterEnforcement` until the router-confirmation
-    /// poller (Slice 1c) closes the loop.
+    /// poller closes the loop. Fetch failures (signature, ACR, parse)
+    /// surface as `Ready=False / reason=AllowlistMissing|…` — reusing
+    /// the egress error taxonomy via [`crate::policy_fetcher::FetchError`].
     pub agt_profile: Option<AgtProfileSource>,
 }
 
-/// AGT policy profile source. Slice 1b: `inline` only — the raw YAML
-/// body is carried in the spec. Slice 1c will add `bundleRef` for OCI
-/// pull paths. The two variants are mutually exclusive (admission CEL
-/// enforces exactly-one).
+/// AGT policy profile source. Exactly one of `inline` or `bundleRef`
+/// must be set (admission CEL + runtime check enforce); both being
+/// absent is treated as "no AGT profile" (back-compat path).
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AgtProfileSource {
@@ -97,6 +107,23 @@ pub struct AgtProfileSource {
     /// it is non-empty; the router parses it at load time and surfaces
     /// any syntax error via `GET /internal/policy-status`.
     pub inline: Option<String>,
+
+    /// Signed OCI artifact reference. The controller pulls the artifact
+    /// from `<registry>/<repository>@<digest>`, verifies the cosign
+    /// signature against the active [`crate::signer_policy::SignerPolicy`],
+    /// re-validates the AGT YAML structure
+    /// ([`crate::policy_canonical::tools::ToolsKind`]), and writes the
+    /// bytes into the compiled-profile ConfigMap under
+    /// `agt-profile.yaml`. On any verification failure the controller
+    /// stamps `Ready=False / reason=AllowlistMissing|AllowlistMalformed|
+    /// AllowlistUnauthorized|AllowlistSignatureVerifyFailed` (the same
+    /// `FetchError` variants used by egress — one error taxonomy
+    /// across all signed-policy kinds).
+    ///
+    /// Artifact `artifactType` MUST be
+    /// `application/vnd.azureclaw.agt-profile.v1+yaml`; a mismatch
+    /// surfaces as `Ready=False / reason=InvalidRef`.
+    pub bundle_ref: Option<crate::crd::OciArtifactRef>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
@@ -185,11 +212,21 @@ pub struct ToolPolicyStatus {
 
     /// Length-prefixed sha256 digest (Slice 1a aggregate canonical
     /// format) of the AGT profile bytes the controller published to
-    /// the compiled ConfigMap. Set only when
-    /// `spec.agtProfile.inline` is present. The router echoes this
-    /// digest on `GET /internal/policy-status` once it has loaded the
-    /// profile; the controller-side confirmation poller (Slice 1c)
-    /// uses it to promote `Compiled → Ready`.
+    /// the compiled ConfigMap. Set when `spec.agtProfile.inline` OR
+    /// `spec.agtProfile.bundleRef` produces a profile. The router
+    /// echoes this digest on `GET /internal/policy-status` once it
+    /// has loaded the profile; the controller-side confirmation
+    /// poller uses it to promote `Compiled → Ready`.
     #[serde(default)]
     pub agt_profile_digest: Option<String>,
+
+    /// Verified OCI manifest digest when the AGT profile was sourced
+    /// from `spec.agtProfile.bundleRef`. Distinct from
+    /// [`Self::agt_profile_digest`]: that one is the length-prefixed
+    /// hash over the *content* (wire contract with the router); this
+    /// one is the *OCI manifest digest* re-validated against
+    /// `bundleRef.digest` after cosign verification (the supply-chain
+    /// attestation). `None` when the profile came from `inline`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agt_profile_bundle_digest: Option<String>,
 }

--- a/controller/src/tool_policy_reconciler.rs
+++ b/controller/src/tool_policy_reconciler.rs
@@ -134,26 +134,37 @@ async fn reconcile(tp: Arc<ToolPolicy>, ctx: Arc<Ctx>) -> Result<Action, Reconci
     let profile = compile_to_profile(&tp.spec);
     let v_hash = version_hash(&profile);
 
-    // 1b. Customer AGT profile (Slice 1b). When `spec.agtProfile.inline`
-    // is set, the controller publishes the raw bytes alongside the
-    // compiled `profile.json` under key `agt-profile.yaml` so the
-    // sandbox inference-router can load it via the existing
-    // `Governance::load_policies_from_dir` (which filters `*.yaml`).
-    // We also compute the wire-contract length-prefixed sha256 digest
-    // here so the controller-side annotation matches what the router
-    // will echo on `GET /internal/policy-status` — the comparator
-    // that closes principles.md §3 (Slice 1c).
-    let agt_profile_inline: Option<&str> = tp
-        .spec
-        .agt_profile
-        .as_ref()
-        .and_then(|p| p.inline.as_deref())
-        .filter(|s| !s.is_empty());
+    // 1b. Resolve the customer AGT profile from `spec.agtProfile`.
+    //
+    // Two sources, mutually exclusive:
+    // - `inline`: raw YAML carried in the spec (Slice 1b path)
+    // - `bundleRef`: signed OCI artifact (Slice 1c.2 path) — pulled
+    //   and cosign-verified via the kind-generic policy_fetcher
+    //   pipeline with `ToolsKind` as the discriminator.
+    //
+    // Both paths converge into `agt_profile_bytes: Option<String>`,
+    // which is then written verbatim into the compiled-profile
+    // ConfigMap under `agt-profile.yaml`. The router echoes the
+    // length-prefixed digest computed over those exact bytes — same
+    // wire contract for both sources, so the existing confirmation
+    // poller works unchanged.
+    //
+    // `bundle_digest_for_status` carries the OCI manifest digest
+    // forward to status.agtProfileBundleDigest when the profile came
+    // from bundleRef (supply-chain attestation, distinct from the
+    // length-prefixed wire-contract digest).
+    let (agt_profile_bytes, bundle_digest_for_status, agt_source_degraded): (
+        Option<String>,
+        Option<String>,
+        Option<(&'static str, String)>,
+    ) = resolve_agt_profile_source(&tp).await;
+
+    let agt_profile_inline: Option<&str> = agt_profile_bytes.as_deref();
     let agt_digest: Option<String> = agt_profile_inline.map(agt_profile_digest);
 
     // 2. Persist as ConfigMap.
     let cm_name = format!("toolpolicy-{name}-profile");
-    let mut degraded: Option<(&'static str, String)> = None;
+    let mut degraded: Option<(&'static str, String)> = agt_source_degraded;
 
     match ensure_profile_configmap(
         &configmaps,
@@ -291,6 +302,7 @@ async fn reconcile(tp: Arc<ToolPolicy>, ctx: Arc<Ctx>) -> Result<Action, Reconci
             conditions: Some(new_conditions),
             last_compiled_at: Some(rfc3339_now()),
             agt_profile_digest: agt_digest,
+            agt_profile_bundle_digest: bundle_digest_for_status,
         }
     });
     api.patch_status(
@@ -320,6 +332,129 @@ async fn reconcile(tp: Arc<ToolPolicy>, ctx: Arc<Ctx>) -> Result<Action, Reconci
 
 fn rfc3339_now() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Resolve the customer AGT profile from `spec.agtProfile`. Returns:
+///
+/// - `(None, None, None)` — no `agtProfile` in the spec; back-compat
+///   path (controller stamps `Ready=True / reason=NotApplicable`).
+/// - `(Some(bytes), None, None)` — `inline` source; bytes are the spec
+///   string verbatim.
+/// - `(Some(bytes), Some(oci_digest), None)` — `bundleRef` source;
+///   bytes are the verified OCI artifact payload; `oci_digest` is the
+///   manifest digest matched against `bundleRef.digest`.
+/// - `(None, None, Some((reason, msg)))` — fetch/validation failed or
+///   the source is malformed. The reconcile loop short-circuits to
+///   `phase=Degraded / Ready=False / reason=<reason>` using the
+///   existing degraded-handling path.
+///
+/// Mutual exclusion: when both `inline` and `bundleRef` are set, this
+/// is a spec error — admission CEL also rejects it, but we re-check at
+/// runtime as defense in depth (older clusters may run without the
+/// latest CRD).
+async fn resolve_agt_profile_source(
+    tp: &ToolPolicy,
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<(&'static str, String)>,
+) {
+    let Some(src) = tp.spec.agt_profile.as_ref() else {
+        return (None, None, None);
+    };
+
+    let inline_set = src
+        .inline
+        .as_deref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    let bundle_set = src.bundle_ref.is_some();
+
+    match (inline_set, bundle_set) {
+        (false, false) => (None, None, None),
+        (true, true) => (
+            None,
+            None,
+            Some((
+                "InvalidSpec",
+                "spec.agtProfile.inline and spec.agtProfile.bundleRef are mutually exclusive"
+                    .into(),
+            )),
+        ),
+        (true, false) => {
+            // Safe to unwrap: inline_set proves the inner string is Some + non-empty.
+            let bytes = src.inline.clone().expect("inline_set implies Some");
+            (Some(bytes), None, None)
+        }
+        (false, true) => {
+            let bundle_ref = src
+                .bundle_ref
+                .as_ref()
+                .expect("bundle_set implies Some")
+                .clone();
+            let signer_policy_handle = crate::signer_policy::global();
+            let verify_result = match signer_policy_handle.snapshot() {
+                crate::signer_policy::SignerPolicyState::FromConfigMap(p) => {
+                    let cfg: crate::policy_fetcher::SignerPolicyConfig = p.into();
+                    crate::policy_fetcher::fetch_and_verify_generic::<
+                        crate::policy_canonical::tools::ToolsKind,
+                    >(&bundle_ref, &cfg)
+                    .await
+                }
+                crate::signer_policy::SignerPolicyState::Malformed(msg) => Err(
+                    crate::policy_fetcher::FetchError::SignerPolicyMalformed(msg),
+                ),
+                crate::signer_policy::SignerPolicyState::Absent => {
+                    let cfg = crate::policy_fetcher::SignerPolicyConfig::from_env();
+                    crate::policy_fetcher::fetch_and_verify_generic::<
+                        crate::policy_canonical::tools::ToolsKind,
+                    >(&bundle_ref, &cfg)
+                    .await
+                }
+            };
+            match verify_result {
+                Ok(verified) => {
+                    // bytes are valid UTF-8 because canonical-form parse
+                    // (`policy_canonical::tools::parse`) re-validates UTF-8;
+                    // a malformed payload would have produced an error
+                    // before reaching this point.
+                    let bytes = String::from_utf8(verified.bytes)
+                        .expect("ToolsKind::parse re-validates utf-8 before finalize");
+                    (Some(bytes), Some(verified.digest), None)
+                }
+                Err(e) => {
+                    let (reason, msg) = fetch_error_to_degraded(&e);
+                    tracing::warn!(
+                        toolpolicy = %tp.name_any(),
+                        registry = %bundle_ref.registry,
+                        repository = %bundle_ref.repository,
+                        digest = %bundle_ref.digest,
+                        reason,
+                        "ToolPolicy bundleRef fetch/verify failed: {msg}"
+                    );
+                    (None, None, Some((reason, msg)))
+                }
+            }
+        }
+    }
+}
+
+/// Map [`crate::policy_fetcher::FetchError`] variants to the
+/// `(reason, message)` pair the controller status machinery
+/// consumes. Delegates to
+/// [`crate::policy_fetcher::reason_for_error`] so the one shared
+/// vocabulary stays in lockstep with the egress reconciler (one
+/// vocabulary across all signed-policy kinds keeps operator-facing
+/// docs minimal and the controller's class table closed — §15.3
+/// log-injection prevention). [`crate::policy_fetcher::FetchError::Transient`]
+/// is mapped to `"Transient"` here rather than surfaced as a `None`
+/// reason: the ToolPolicy state machine does not have a
+/// "preserve last-known-good" branch (unlike the egress sandbox
+/// reconciler), so a transient fetch failure surfaces honestly as
+/// Degraded until the next requeue succeeds.
+fn fetch_error_to_degraded(e: &crate::policy_fetcher::FetchError) -> (&'static str, String) {
+    let reason = crate::policy_fetcher::reason_for_error(e).unwrap_or("Transient");
+    (reason, e.to_string())
 }
 
 /// Build the Conditions vector preserving prior `lastTransitionTime`
@@ -983,5 +1118,142 @@ mod tests {
         // Distinct from the McpServer manager — required by §10.4 #1.
         assert_eq!(FIELD_MANAGER, "azureclaw-controller/toolpolicy");
         assert_ne!(FIELD_MANAGER, "azureclaw-controller/mcp");
+    }
+
+    /// `resolve_agt_profile_source` for the four spec-shape cases that
+    /// do NOT touch network / global SignerPolicy state:
+    ///   * `agtProfile` absent — back-compat path.
+    ///   * `agtProfile` set but both children empty.
+    ///   * `inline` only — happy path.
+    ///   * `inline` + `bundleRef` both set — runtime mutual-exclusion
+    ///     guard (CEL enforces this at admission, but older clusters
+    ///     without the latest CRD must still surface a clear
+    ///     `Degraded=True / reason=InvalidSpec` here).
+    ///
+    /// The pure `bundleRef`-only path is exercised by `policy_canonical::tools`
+    /// unit tests + e2e (`tests/e2e/...`) rather than here, because it
+    /// reads the global `SignerPolicy` handle and performs an HTTPS
+    /// pull which is integration territory.
+    use crate::tool_policy::{AgtProfileSource, AppliesToSelector, ToolPolicy, ToolPolicySpec};
+
+    fn fixture_spec(agt: Option<AgtProfileSource>) -> ToolPolicySpec {
+        ToolPolicySpec {
+            applies_to: AppliesToSelector::default(),
+            commerce: None,
+            rate_limit: None,
+            approval: None,
+            display_name: None,
+            agt_profile: agt,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_agt_profile_absent_yields_all_none() {
+        let tp = ToolPolicy::new("tp-fixture", fixture_spec(None));
+        let (bytes, digest, degraded) = resolve_agt_profile_source(&tp).await;
+        assert!(bytes.is_none());
+        assert!(digest.is_none());
+        assert!(degraded.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_agt_profile_both_children_empty_yields_all_none() {
+        let tp = ToolPolicy::new(
+            "tp-fixture",
+            fixture_spec(Some(AgtProfileSource {
+                inline: None,
+                bundle_ref: None,
+            })),
+        );
+        let (bytes, digest, degraded) = resolve_agt_profile_source(&tp).await;
+        assert!(bytes.is_none());
+        assert!(digest.is_none());
+        assert!(degraded.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_agt_profile_inline_only_returns_bytes_no_digest() {
+        let body = "version: 1\nagent: foo\npolicies: []\n";
+        let tp = ToolPolicy::new(
+            "tp-fixture",
+            fixture_spec(Some(AgtProfileSource {
+                inline: Some(body.to_string()),
+                bundle_ref: None,
+            })),
+        );
+        let (bytes, digest, degraded) = resolve_agt_profile_source(&tp).await;
+        assert_eq!(bytes.as_deref(), Some(body));
+        assert!(
+            digest.is_none(),
+            "inline path must NOT stamp the OCI manifest digest"
+        );
+        assert!(degraded.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_agt_profile_both_set_yields_invalid_spec_degraded() {
+        let tp = ToolPolicy::new(
+            "tp-fixture",
+            fixture_spec(Some(AgtProfileSource {
+                inline: Some("version: 1\nagent: a\npolicies: []\n".to_string()),
+                bundle_ref: Some(crate::crd::OciArtifactRef {
+                    registry: "example.azurecr.io".into(),
+                    repository: "azureclaw/tools".into(),
+                    digest:
+                        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                            .into(),
+                    artifact_type: "application/vnd.azureclaw.agt-profile.v1+yaml".into(),
+                }),
+            })),
+        );
+        let (bytes, digest, degraded) = resolve_agt_profile_source(&tp).await;
+        assert!(bytes.is_none());
+        assert!(digest.is_none());
+        let (reason, msg) = degraded.expect("both-set must produce degraded tuple");
+        assert_eq!(reason, "InvalidSpec");
+        assert!(msg.contains("mutually exclusive"), "got: {msg}");
+    }
+
+    /// `fetch_error_to_degraded` must delegate to the shared
+    /// `reason_for_error` taxonomy and only synthesize `"Transient"`
+    /// for the Transient variant. This is a tripwire — if egress ever
+    /// renames a reason, this test fails alongside.
+    #[test]
+    fn fetch_error_to_degraded_delegates_to_shared_taxonomy() {
+        use crate::policy_fetcher::FetchError;
+        let cases: &[(FetchError, &str)] = &[
+            (FetchError::SignerPolicyMissing, "SignerPolicyMissing"),
+            (
+                FetchError::SignerPolicyMalformed("oops".into()),
+                "SignerPolicyMalformed",
+            ),
+            (FetchError::InvalidRef("bad".into()), "InvalidRef"),
+            (FetchError::Unauthorized("401".into()), "Unauthorized"),
+            (
+                FetchError::NotFound("ghcr.io/x@sha256:0".into()),
+                "NotFound",
+            ),
+            (
+                FetchError::SignatureVerifyFailed("bad sig".into()),
+                "SignatureVerifyFailed",
+            ),
+            (
+                FetchError::CanonicalFormViolation("non-empty".into()),
+                "CanonicalFormViolation",
+            ),
+            (
+                FetchError::IdentityMismatch("not pinned".into()),
+                "IdentityMismatch",
+            ),
+            (FetchError::Transient("network".into()), "Transient"),
+        ];
+        for (err, expected) in cases {
+            let (reason, msg) = fetch_error_to_degraded(err);
+            assert_eq!(
+                reason, *expected,
+                "FetchError {err:?} mapped to {reason}, expected {expected}"
+            );
+            assert!(!msg.is_empty());
+        }
     }
 }

--- a/deploy/helm/azureclaw/templates/crd-toolpolicy.yaml
+++ b/deploy/helm/azureclaw/templates/crd-toolpolicy.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: toolpolicies.azureclaw.azure.com
+  labels:
+    app.kubernetes.io/name: azureclaw
+    app.kubernetes.io/component: crd
 spec:
   group: azureclaw.azure.com
   names:

--- a/deploy/helm/azureclaw/templates/crd-toolpolicy.yaml
+++ b/deploy/helm/azureclaw/templates/crd-toolpolicy.yaml
@@ -1,25 +1,8 @@
-# AzureClaw ToolPolicy CRD
-#
-# DO NOT EDIT BY HAND. This file is the helm-side mirror of the Rust
-# schema in `controller/src/tool_policy.rs` plus the CEL rules in
-# `controller/src/crd_validations.rs::tool_policy_validations`.
-#
-# Drift between this file and the Rust schema is caught at `cargo test`
-# time by `controller/src/helm_drift.rs::helm_toolpolicy_crd_matches_rust_schema`.
-# To regenerate after schema changes, run:
-#
-#   DUMP_TOOLPOLICY_CRD_YAML=1 cargo test --bin azureclaw-controller \
-#       helm_drift::tests::dump_toolpolicy_crd_yaml -- --nocapture
-#
-# and replace the body below with the captured YAML.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: toolpolicies.azureclaw.azure.com
-  labels:
-    app.kubernetes.io/name: azureclaw
-    app.kubernetes.io/component: crd
 spec:
   group: azureclaw.azure.com
   names:
@@ -65,18 +48,73 @@ spec:
                   `/opt/azureclaw-plugin/policies/*.yaml` fallback that older
                   releases shipped has been removed.
 
-                  Slice 1b ships **inline** only; `bundleRef` (signed OCI
-                  artifact fetch) lands in Slice 1c. The wire contract between
-                  controller and router is the length-prefixed sha256 digest
-                  produced by [`crate::tool_policy_compile::agt_profile_digest`],
-                  echoed back by the router via `GET /internal/policy-status`.
+                  Two sources are supported (mutually exclusive):
+                  - `inline`: raw YAML carried in the spec (Slice 1b)
+                  - `bundleRef`: signed OCI artifact (Slice 1c.2) — the controller
+                    pulls + cosign-verifies via
+                    [`crate::policy_fetcher::fetch_and_verify_generic`] with
+                    [`crate::policy_canonical::tools::ToolsKind`] and writes the
+                    verified bytes into the same ConfigMap key. The wire contract
+                    with the router is identical to the inline path — the router
+                    doesn't know (or need to know) which source produced the bytes.
+
+                  Mutual exclusion: admission CEL (in the Helm CRD) enforces
+                  `has(inline) != has(bundleRef)`. The reconciler also checks this
+                  at runtime as a defense-in-depth measure (older clusters without
+                  the latest CRD).
 
                   Per principles.md §3: when `agtProfile` is set, the controller
                   stamps `phase=Compiled` and `Ready=False /
                   reason=AwaitingRouterEnforcement` until the router-confirmation
-                  poller (Slice 1c) closes the loop.
+                  poller closes the loop. Fetch failures (signature, ACR, parse)
+                  surface as `Ready=False / reason=AllowlistMissing|…` — reusing
+                  the egress error taxonomy via [`crate::policy_fetcher::FetchError`].
                 nullable: true
                 properties:
+                  bundleRef:
+                    description: |-
+                      Signed OCI artifact reference. The controller pulls the artifact
+                      from `<registry>/<repository>@<digest>`, verifies the cosign
+                      signature against the active [`crate::signer_policy::SignerPolicy`],
+                      re-validates the AGT YAML structure
+                      ([`crate::policy_canonical::tools::ToolsKind`]), and writes the
+                      bytes into the compiled-profile ConfigMap under
+                      `agt-profile.yaml`. On any verification failure the controller
+                      stamps `Ready=False / reason=AllowlistMissing|AllowlistMalformed|
+                      AllowlistUnauthorized|AllowlistSignatureVerifyFailed` (the same
+                      `FetchError` variants used by egress — one error taxonomy
+                      across all signed-policy kinds).
+
+                      Artifact `artifactType` MUST be
+                      `application/vnd.azureclaw.agt-profile.v1+yaml`; a mismatch
+                      surfaces as `Ready=False / reason=InvalidRef`.
+                    nullable: true
+                    properties:
+                      artifactType:
+                        description: |-
+                          OCI artifactType media-type, e.g.
+                          `application/vnd.azureclaw.egress-allowlist.v1+yaml`. Consumers MUST
+                          reject artifacts whose pulled `artifactType` doesn't match.
+                        type: string
+                      digest:
+                        description: |-
+                          Content-addressed digest, including the algorithm prefix
+                          (`sha256:abc…`). The digest covers the canonical artifact bytes —
+                          see `docs/internal/policy-canonical-format.md` for the egress-allowlist
+                          canonicalization rules.
+                        type: string
+                      registry:
+                        description: Registry hostname (e.g. `myacr.azurecr.io`, `ghcr.io`).
+                        type: string
+                      repository:
+                        description: Repository path (e.g. `azureclaw/policies/sandbox-foo`).
+                        type: string
+                    required:
+                    - artifactType
+                    - digest
+                    - registry
+                    - repository
+                    type: object
                   inline:
                     description: |-
                       Inline AGT policy YAML body. Plain string — admission validates
@@ -192,18 +230,32 @@ spec:
             - message: spec.appliesTo.sandboxMatchLabels must contain at least one label
               reason: FieldValueInvalid
               rule: has(self.appliesTo.sandboxMatchLabels) && size(self.appliesTo.sandboxMatchLabels) > 0
+            - message: spec.agtProfile.inline and spec.agtProfile.bundleRef are mutually exclusive
+              reason: FieldValueInvalid
+              rule: '!has(self.agtProfile) || !(has(self.agtProfile.inline) && has(self.agtProfile.bundleRef))'
           status:
             nullable: true
             properties:
+              agtProfileBundleDigest:
+                description: |-
+                  Verified OCI manifest digest when the AGT profile was sourced
+                  from `spec.agtProfile.bundleRef`. Distinct from
+                  [`Self::agt_profile_digest`]: that one is the length-prefixed
+                  hash over the *content* (wire contract with the router); this
+                  one is the *OCI manifest digest* re-validated against
+                  `bundleRef.digest` after cosign verification (the supply-chain
+                  attestation). `None` when the profile came from `inline`.
+                nullable: true
+                type: string
               agtProfileDigest:
                 description: |-
                   Length-prefixed sha256 digest (Slice 1a aggregate canonical
                   format) of the AGT profile bytes the controller published to
-                  the compiled ConfigMap. Set only when
-                  `spec.agtProfile.inline` is present. The router echoes this
-                  digest on `GET /internal/policy-status` once it has loaded the
-                  profile; the controller-side confirmation poller (Slice 1c)
-                  uses it to promote `Compiled → Ready`.
+                  the compiled ConfigMap. Set when `spec.agtProfile.inline` OR
+                  `spec.agtProfile.bundleRef` produces a profile. The router
+                  echoes this digest on `GET /internal/policy-status` once it
+                  has loaded the profile; the controller-side confirmation
+                  poller uses it to promote `Compiled → Ready`.
                 nullable: true
                 type: string
               conditions:
@@ -260,4 +312,3 @@ spec:
     storage: true
     subresources:
       status: {}
-


### PR DESCRIPTION
Continues the Slice 1c-real signing-generalization arc started in 1c.1
(PR #302 — `PolicyKind` trait + `policy_canonical` module). 1c.2 wires
the **first per-kind consumer**: `ToolPolicy.spec.agtProfile` now
accepts a signed OCI artifact as an alternative to inline YAML.

## What lands

- **`AgtProfileSource.bundleRef`** — new field, mutually exclusive
  with `inline`. Controller pulls via
  `fetch_and_verify_generic::<ToolsKind>`, cosign-verifies against
  `SignerPolicy`, parses through `policy_canonical::tools::parse`,
  writes verified bytes into the compiled-profile `ConfigMap` under
  `agt-profile.yaml`. The wire contract with the router is **identical
  to the inline path** — the length-prefixed content digest (Slice 1b)
  closes the echo loop either way.
- **Media type:** `application/vnd.azureclaw.agt-profile.v1+yaml`.
  Mismatches surface as `Ready=False / reason=InvalidRef`.
- **`ToolPolicyStatus.agtProfileBundleDigest`** — stamps the verified
  OCI manifest digest (distinct from `agtProfileDigest`, which is the
  router-echoed content digest).
- **Mutual exclusion** — admission CEL + runtime defense-in-depth
  (`reason=InvalidSpec`) for older clusters.
- **Error taxonomy** reuses egress `FetchError` verbatim via
  `reason_for_error`. One vocabulary across all signed-policy kinds.
- **Canonical form** for AGT YAML permits comments (operator-authored
  profiles); OCI digest pins the bytes loaded into the router, so the
  byte-frozen "no comments" rule that egress applies for
  semantic-deduplication does NOT apply here. Validation is structural.
- **TODO comments removed** in `tool_policy.rs` — the long-deferred
  *"Slice 1c will add bundleRef"* §5 violation is now closed.

## Files

- **`controller/src/policy_canonical/tools.rs`** (NEW, ~300 LOC) —
  `ToolsKind` `PolicyKind` impl, per-kind cache, 15 unit tests.
- **`controller/src/tool_policy.rs`** — `AgtProfileSource.bundleRef`
  field + `ToolPolicyStatus.agtProfileBundleDigest` field. TODOs gone.
- **`controller/src/tool_policy_reconciler.rs`** — new
  `resolve_agt_profile_source` helper + `fetch_error_to_degraded`
  wrapper. 5 new unit tests + 1 tripwire pinning the shared taxonomy.
- **`controller/src/crd_validations.rs`** — CEL rule:
  `!has(self.agtProfile) || !(has(self.agtProfile.inline) && has(self.agtProfile.bundleRef))`.
- **`controller/src/policy_canonical/mod.rs`** + **`egress.rs`** —
  `CachedValue::Tools(_)` variant + exhaustive match.
- **`deploy/helm/azureclaw/templates/crd-toolpolicy.yaml`** —
  regenerated.
- **`CHANGELOG.md`** — Slice 1c.2 entry.

## Validation

- 619 controller tests pass (was 597 at 1c.1 — +22 = 15 tools.rs +
  5 reconciler helper + 2 trait re-uses).
- 14 helm_drift tests pass.
- clippy `--workspace --all-targets -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- 1 phase-taxonomy guard test passes.

## Not in this PR (deferred to Slice 1c.6 or a separate CLI slice)

- Unified `azureclaw policy sign --kind agt-profile` CLI. Operators
  authoring a `bundleRef` use `cosign sign` + `oras push` directly for
  now. If CLI unification adds >600 LOC TS, defer to its own slice
  (likely 1c.6 alongside `SignerPolicy.ed25519Keys[]`).
- Live e2e test that applies a real `ToolPolicy` with `bundleRef` +
  cosign-signed artifact in Kind. The pull/verify/parse paths are
  unit-tested through `policy_canonical::tools::parse` and the helper
  unit tests; the cosign + ACR integration is already exercised
  end-to-end by the egress allowlist e2e and shares the generic
  `fetch_and_verify_generic` path. A dedicated 1c.2-specific e2e is
  redundant supply-chain coverage on the same generic fetcher.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>