### PR TITLE
Slice 1c.3 — InferencePolicy.spec.bundleRef (signed OCI artifact)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1c.3 — `InferencePolicy.spec.bundleRef` (signed OCI artifact)
+
+Third step in the Slice 1c-real signing-generalization arc.
+`InferencePolicy` now joins `EgressAllowlist` (1c.1) and `ToolPolicy`
+(1c.2) on the unified `policy_fetcher::fetch_and_verify_generic`
+pipeline: a single `azureclaw policy sign --kind inference-policy`
+command (lands in Slice 1c.6) produces a cosign-signed OCI artifact
+that the controller pulls by digest and validates per
+`SignerPolicy`.
+
+**Producer side (controller)**
+
+- New `controller/src/policy_canonical/inference.rs` —
+  `InferenceKind: PolicyKind` impl with the per-kind canonical-form
+  parser. Accepts only `tokenBudget`, `contentSafety`,
+  `modelPreference`, `displayName` keys at top-level (a bundle is
+  selector-agnostic so one signed artifact can be referenced by
+  multiple `InferencePolicy` CRs with different `appliesTo`
+  selectors). Structural validation rejects negative budgets,
+  unrecognised severity types, empty `primary.deployment`,
+  malformed `fallback[]` entries, and mis-typed `requirePromptShields`.
+  Media type `application/vnd.azureclaw.inference-policy.v1+json`.
+  Per-kind cache slot via `OnceLock<CachedValue::Inference(...)>` on
+  the shared `policy_canonical` cache, gated by `policy_fetcher::CACHE_TTL`.
+  17 unit tests covering every rejection path.
+- `InferencePolicySpec.bundleRef: Option<OciArtifactRef>` field
+  added at spec top-level (mutex with `tokenBudget`/`contentSafety`/
+  `modelPreference`/`displayName` — selector flows through CR,
+  content flows from bundle).
+- `InferencePolicyStatus.bundleRefDigest: Option<String>` field
+  surfaces the verified OCI manifest digest after a successful
+  `fetch_and_verify_generic::<InferenceKind>` call (distinct from
+  `compiledDigest` which is the wire-contract value the router
+  echoes back via `/internal/policy-status`).
+- `inference_policy_reconciler::resolve_inference_source` —
+  4-way match (no inline, no bundle / inline only / bundle only /
+  both) mirroring `tool_policy_reconciler::resolve_agt_profile_source`.
+  On the bundle path, merges the verified content fields onto the
+  CR's `appliesTo` selector to produce the effective spec for
+  `compile_to_profile`. `FetchError` variants map through the shared
+  `policy_fetcher::reason_for_error` vocabulary (same as egress + tools).
+
+**Admission**
+
+- CEL rule on `InferencePolicySpec`:
+  `!has(self.bundleRef) || (!has(self.tokenBudget) && !has(self.contentSafety) && !has(self.modelPreference) && !has(self.displayName))`
+  — rejects mixed shapes at apply-time so the reconciler-side
+  defense-in-depth check only fires on stale clusters running an
+  older CRD revision.
+
+**Schema**
+
+- Regenerated `deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml`
+  via `DUMP_INFERENCEPOLICY_CRD_YAML=1 cargo test …
+  helm_drift::tests::dump_inferencepolicy_crd_yaml`. Adds the new
+  `spec.bundleRef` block + the new CEL rule + the new
+  `status.bundleRefDigest` field. CNCF C10 labels preserved.
+
+**Out of scope (deferred)**
+
+- CLI dispatch `azureclaw policy sign --kind inference-policy`
+  — lands with the unified CLI in Slice 1c.6.
+- ClawMemory `bundleRef` — Slice 1c.4.
+- McpServer `bundleRef` — Slice 1c.5.
+
+Test deltas: controller 619 → 636 (+17 inference parser tests).
+clippy `-D warnings` clean, fmt clean, helm_drift clean, CNCF
+conformance clean. Router untouched — wire contract unchanged.
+
 ### Slice 1c.2 — `ToolPolicy.spec.agtProfile.bundleRef` (signed OCI artifact)
 
 Continues the Slice 1c-real signing-generalization arc started in

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -250,6 +250,12 @@ pub fn inference_policy_validations() -> Vec<ValidationRule> {
     let severities = "['Safe','Low','Medium','High']";
     vec![
         ValidationRule {
+            rule: "!has(self.bundleRef) || (!has(self.tokenBudget) && !has(self.contentSafety) && !has(self.modelPreference) && !has(self.displayName))".into(),
+            message: Some("spec.bundleRef is mutually exclusive with spec.tokenBudget, spec.contentSafety, spec.modelPreference, and spec.displayName; the bundle carries those content fields".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
             rule: "!has(self.tokenBudget) || !has(self.tokenBudget.monthlyTokens) || !has(self.tokenBudget.dailyTokens) || self.tokenBudget.monthlyTokens >= self.tokenBudget.dailyTokens".into(),
             message: Some("spec.tokenBudget.monthlyTokens must be >= spec.tokenBudget.dailyTokens".into()),
             reason: Some("FieldValueInvalid".into()),

--- a/controller/src/inference_policy.rs
+++ b/controller/src/inference_policy.rs
@@ -82,21 +82,59 @@ pub struct InferencePolicySpec {
     pub applies_to: InferenceAppliesTo,
 
     /// Token-budget caps. Optional — absent ⇒ no budget enforcement.
+    ///
+    /// Mutually exclusive with [`Self::bundle_ref`]: when `bundleRef`
+    /// is set, the budget caps come from the signed bundle. Admission
+    /// CEL + reconciler defense-in-depth both reject specs that set
+    /// any of `tokenBudget`/`contentSafety`/`modelPreference`/
+    /// `displayName` alongside `bundleRef`.
     pub token_budget: Option<TokenBudget>,
 
     /// Content Safety severity floor. Optional — absent ⇒ governance
     /// minimum (router-default) applies. The VAP referenced in §7.14
     /// rejects changes that *lower* the floor below the cluster
-    /// minimum.
+    /// minimum. Mutually exclusive with [`Self::bundle_ref`].
     pub content_safety: Option<ContentSafetyFloor>,
 
     /// Model preference + fallback chain. Optional. **Not** a router:
     /// only declares preferred route order; selection is delegated to
-    /// the underlying provider.
+    /// the underlying provider. Mutually exclusive with
+    /// [`Self::bundle_ref`].
     pub model_preference: Option<ModelPreference>,
 
-    /// Optional human-readable label.
+    /// Optional human-readable label. Mutually exclusive with
+    /// [`Self::bundle_ref`] — when `bundleRef` is set, the label
+    /// comes from the signed bundle.
     pub display_name: Option<String>,
+
+    /// Signed OCI artifact reference. The controller pulls the
+    /// artifact from `<registry>/<repository>@<digest>`, verifies the
+    /// cosign signature against the active
+    /// [`crate::signer_policy::SignerPolicy`], re-validates the JSON
+    /// structure ([`crate::policy_canonical::inference::InferenceKind`]),
+    /// and synthesises the effective spec by combining the CR's
+    /// `appliesTo` selector with the bundle's `tokenBudget` /
+    /// `contentSafety` / `modelPreference` / `displayName` content
+    /// fields. The same compile + ConfigMap write path runs as for
+    /// inline specs — only the source of the content bytes differs.
+    ///
+    /// On any verification failure the controller stamps
+    /// `Ready=False / reason=AllowlistMissing|AllowlistMalformed|
+    /// AllowlistUnauthorized|AllowlistSignatureVerifyFailed` (the
+    /// same `FetchError` variants used by egress + tools — one
+    /// error taxonomy across all signed-policy kinds).
+    ///
+    /// Artifact `artifactType` MUST be
+    /// `application/vnd.azureclaw.inference-policy.v1+json`; a
+    /// mismatch surfaces as `Ready=False / reason=InvalidRef`.
+    ///
+    /// Mutually exclusive with the inline content fields
+    /// (`tokenBudget`, `contentSafety`, `modelPreference`,
+    /// `displayName`). `appliesTo` always comes from the CR so one
+    /// signed bundle can be referenced by multiple CRs with
+    /// different selectors. See
+    /// `docs/internal/policy-canonical-format.md`.
+    pub bundle_ref: Option<crate::crd::OciArtifactRef>,
 }
 
 /// Selector for which sandboxes / call sites an `InferencePolicy`
@@ -247,4 +285,16 @@ pub struct InferencePolicyStatus {
     /// `crd-well-oiled-machine`.)
     #[serde(default)]
     pub loaded_digest: Option<String>,
+
+    /// OCI manifest digest of the verified `spec.bundleRef` artifact
+    /// when the bundleRef path was taken; `None` for inline specs.
+    /// Stamped after [`crate::policy_fetcher::fetch_and_verify_generic`]
+    /// returns `Ok`, so its presence is operator-visible proof that
+    /// the controller actually verified the signed artifact (vs.
+    /// taking an inline shortcut). Distinct from `compiled_digest`
+    /// (the wire-contract value the router echoes) — `bundle_ref_digest`
+    /// is the supply-chain identifier. Slice 1c.3 of
+    /// `crd-well-oiled-machine`.
+    #[serde(default)]
+    pub bundle_ref_digest: Option<String>,
 }

--- a/controller/src/inference_policy_compile.rs
+++ b/controller/src/inference_policy_compile.rs
@@ -231,6 +231,7 @@ mod tests {
                 }],
             }),
             display_name: Some("Prod chat policy".into()),
+            bundle_ref: None,
         }
     }
 

--- a/controller/src/inference_policy_reconciler.rs
+++ b/controller/src/inference_policy_reconciler.rs
@@ -140,7 +140,10 @@ async fn reconcile(policy: Arc<InferencePolicy>, ctx: Arc<Ctx>) -> Result<Action
         .unwrap_or_default();
     let observed_generation = policy.metadata.generation;
 
-    let profile = compile_to_profile(&policy.spec);
+    let (effective_spec, bundle_ref_digest, source_degraded) =
+        resolve_inference_source(policy.as_ref()).await;
+
+    let profile = compile_to_profile(&effective_spec);
     let v_hash = version_hash(&profile);
     // Slice 2a — canonical bytes the router-side
     // `inference_policy_loader` will sha256 + echo via
@@ -155,39 +158,49 @@ async fn reconcile(policy: Arc<InferencePolicy>, ctx: Arc<Ctx>) -> Result<Action
     let compiled_digest = inference_policy_digest(&canonical_bytes);
 
     let cm_name = format!("inferencepolicy-{name}-profile");
-    let mut degraded: Option<(&'static str, String)> = None;
+    let mut degraded: Option<(&'static str, String)> = source_degraded;
 
-    match ensure_profile_configmap(
-        &configmaps,
-        &cm_name,
-        &name,
-        &canonical_str,
-        &v_hash,
-        &compiled_digest,
-    )
-    .await
-    {
-        Ok(()) => {
-            tracing::info!(
-                inferencepolicy = %name,
-                ns = %ns,
-                version_hash = %v_hash,
-                compiled_digest = %compiled_digest,
-                generation = observed_generation.unwrap_or(0),
-                has_token_budget = policy.spec.token_budget.is_some(),
-                has_content_safety = policy.spec.content_safety.is_some(),
-                has_model_preference = policy.spec.model_preference.is_some(),
-                "InferencePolicyCompiled"
-            );
+    if degraded.is_none() {
+        match ensure_profile_configmap(
+            &configmaps,
+            &cm_name,
+            &name,
+            &canonical_str,
+            &v_hash,
+            &compiled_digest,
+        )
+        .await
+        {
+            Ok(()) => {
+                tracing::info!(
+                    inferencepolicy = %name,
+                    ns = %ns,
+                    version_hash = %v_hash,
+                    compiled_digest = %compiled_digest,
+                    bundle_ref_digest = bundle_ref_digest.as_deref().unwrap_or("-"),
+                    generation = observed_generation.unwrap_or(0),
+                    has_token_budget = effective_spec.token_budget.is_some(),
+                    has_content_safety = effective_spec.content_safety.is_some(),
+                    has_model_preference = effective_spec.model_preference.is_some(),
+                    "InferencePolicyCompiled"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    inferencepolicy = %name,
+                    error_class = e.class(),
+                    "InferencePolicyProfileWriteFailed"
+                );
+                degraded = Some(("ProfileWriteFailed", e.to_string()));
+            }
         }
-        Err(e) => {
-            tracing::warn!(
-                inferencepolicy = %name,
-                error_class = e.class(),
-                "InferencePolicyProfileWriteFailed"
-            );
-            degraded = Some(("ProfileWriteFailed", e.to_string()));
-        }
+    } else {
+        tracing::warn!(
+            inferencepolicy = %name,
+            ns = %ns,
+            reason = degraded.as_ref().map(|(r, _)| *r).unwrap_or("-"),
+            "InferencePolicySourceResolveFailed; skipping ConfigMap write"
+        );
     }
 
     // Slice 2a — close the §3 "Ready ⇔ router echo" loop. List
@@ -289,6 +302,7 @@ async fn reconcile(policy: Arc<InferencePolicy>, ctx: Arc<Ctx>) -> Result<Action
             last_compiled_at: Some(rfc3339_now()),
             compiled_digest: Some(compiled_digest),
             loaded_digest,
+            bundle_ref_digest: bundle_ref_digest.clone(),
         }
     });
     api.patch_status(
@@ -310,6 +324,223 @@ async fn reconcile(policy: Arc<InferencePolicy>, ctx: Arc<Ctx>) -> Result<Action
 
 fn rfc3339_now() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Resolve `InferencePolicy.spec` to the effective spec the reconciler
+/// will compile + serialize. Slice 1c.3 (`crd-well-oiled-machine`).
+///
+/// Four spec shapes are accepted, matching the
+/// [`PolicyKind`](crate::policy_canonical::PolicyKind) trait's
+/// invariants:
+///
+/// - **Inline (back-compat, no signature)**: any of `tokenBudget` /
+///   `contentSafety` / `modelPreference` / `displayName` set; no
+///   `bundleRef`. Returns the spec verbatim. `bundle_ref_digest = None`.
+/// - **Signed bundle**: `bundleRef` set, content fields all `None`.
+///   Fetches + verifies the OCI artifact via
+///   [`crate::policy_fetcher::fetch_and_verify_generic`]
+///   parameterised by
+///   [`crate::policy_canonical::inference::InferenceKind`]. The
+///   bundle's content fields are merged onto the CR's `appliesTo`
+///   selector. `bundle_ref_digest = Some(<manifest digest>)`.
+/// - **Selector-only (no content)**: no `bundleRef` and no inline
+///   content fields. Acceptable today: the compile path still emits
+///   a valid `inference-policy.json` (all content fields null) so
+///   the router echo loop still closes. `bundle_ref_digest = None`.
+/// - **Both inline + bundleRef** *(rejected at runtime as
+///   defense-in-depth — admission CEL already rejects)*: returns a
+///   `(InvalidSpec, msg)` degraded reason without performing the
+///   fetch. Older clusters running without the latest CRD CEL still
+///   surface the error honestly.
+///
+/// Returns a triple:
+/// - `effective_spec`: the spec the reconciler will compile (always
+///   contains `appliesTo` from the CR; content fields come from
+///   either the inline fields or the verified bundle).
+/// - `bundle_ref_digest`: `Some(<sha256:...>)` when the bundleRef path
+///   was taken (operator-visible proof the signature was checked);
+///   `None` otherwise.
+/// - `degraded`: `Some((reason, message))` on fetch/verify failure or
+///   spec-shape error. The reconcile loop short-circuits to
+///   `phase=Degraded / Ready=False / reason=<reason>` using the
+///   existing degraded-handling path.
+async fn resolve_inference_source(
+    policy: &InferencePolicy,
+) -> (
+    crate::inference_policy::InferencePolicySpec,
+    Option<String>,
+    Option<(&'static str, String)>,
+) {
+    let spec = &policy.spec;
+    let inline_any = spec.token_budget.is_some()
+        || spec.content_safety.is_some()
+        || spec.model_preference.is_some()
+        || spec.display_name.is_some();
+    let bundle_set = spec.bundle_ref.is_some();
+
+    if inline_any && bundle_set {
+        return (
+            // selector-only synthesis; we won't compile this branch
+            crate::inference_policy::InferencePolicySpec {
+                applies_to: spec.applies_to.clone(),
+                ..Default::default()
+            },
+            None,
+            Some((
+                "InvalidSpec",
+                "spec.bundleRef is mutually exclusive with spec.tokenBudget, \
+                 spec.contentSafety, spec.modelPreference, and spec.displayName"
+                    .into(),
+            )),
+        );
+    }
+
+    if !bundle_set {
+        // Inline-only or selector-only: pass spec verbatim.
+        return (spec.clone(), None, None);
+    }
+
+    let bundle_ref = spec
+        .bundle_ref
+        .as_ref()
+        .expect("bundle_set implies Some")
+        .clone();
+
+    let signer_policy_handle = crate::signer_policy::global();
+    let verify_result = match signer_policy_handle.snapshot() {
+        crate::signer_policy::SignerPolicyState::FromConfigMap(p) => {
+            let cfg: crate::policy_fetcher::SignerPolicyConfig = p.into();
+            crate::policy_fetcher::fetch_and_verify_generic::<
+                crate::policy_canonical::inference::InferenceKind,
+            >(&bundle_ref, &cfg)
+            .await
+        }
+        crate::signer_policy::SignerPolicyState::Malformed(msg) => Err(
+            crate::policy_fetcher::FetchError::SignerPolicyMalformed(msg),
+        ),
+        crate::signer_policy::SignerPolicyState::Absent => {
+            let cfg = crate::policy_fetcher::SignerPolicyConfig::from_env();
+            crate::policy_fetcher::fetch_and_verify_generic::<
+                crate::policy_canonical::inference::InferenceKind,
+            >(&bundle_ref, &cfg)
+            .await
+        }
+    };
+
+    match verify_result {
+        Ok(verified) => {
+            let effective = merge_bundle_with_selector(&spec.applies_to, &verified);
+            (effective, Some(verified.digest), None)
+        }
+        Err(e) => {
+            let (reason, msg) = fetch_error_to_degraded(&e);
+            tracing::warn!(
+                inferencepolicy = %policy.name_any(),
+                registry = %bundle_ref.registry,
+                repository = %bundle_ref.repository,
+                digest = %bundle_ref.digest,
+                reason,
+                "InferencePolicy bundleRef fetch/verify failed: {msg}"
+            );
+            (
+                crate::inference_policy::InferencePolicySpec {
+                    applies_to: spec.applies_to.clone(),
+                    ..Default::default()
+                },
+                None,
+                Some((reason, msg)),
+            )
+        }
+    }
+}
+
+/// Merge the verified-bundle content fields onto the CR's selector to
+/// produce the effective spec for [`compile_to_profile`]. The bundle
+/// owns the content; the CR owns the selector.
+fn merge_bundle_with_selector(
+    applies_to: &crate::inference_policy::InferenceAppliesTo,
+    verified: &crate::policy_canonical::inference::VerifiedInferencePolicy,
+) -> crate::inference_policy::InferencePolicySpec {
+    use crate::inference_policy::{
+        ContentSafetyFloor, InferencePolicySpec, ModelPreference, ModelRef, TokenBudget,
+    };
+    use serde_json::Value;
+
+    let token_budget = verified.token_budget.as_ref().map(|v| TokenBudget {
+        per_request_tokens: v.get("perRequestTokens").and_then(Value::as_u64),
+        daily_tokens: v.get("dailyTokens").and_then(Value::as_u64),
+        monthly_tokens: v.get("monthlyTokens").and_then(Value::as_u64),
+    });
+
+    let content_safety = verified
+        .content_safety
+        .as_ref()
+        .map(|v| ContentSafetyFloor {
+            hate: v.get("hate").and_then(Value::as_str).map(str::to_owned),
+            self_harm: v.get("selfHarm").and_then(Value::as_str).map(str::to_owned),
+            sexual: v.get("sexual").and_then(Value::as_str).map(str::to_owned),
+            violence: v.get("violence").and_then(Value::as_str).map(str::to_owned),
+            require_prompt_shields: v.get("requirePromptShields").and_then(Value::as_bool),
+        });
+
+    let model_preference = verified.model_preference.as_ref().and_then(|v| {
+        let primary_obj = v.get("primary")?.as_object()?;
+        let primary = ModelRef {
+            provider: primary_obj
+                .get("provider")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned(),
+            deployment: primary_obj
+                .get("deployment")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned(),
+        };
+        let fallback = v
+            .get("fallback")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|e| {
+                        let o = e.as_object()?;
+                        Some(ModelRef {
+                            provider: o.get("provider").and_then(Value::as_str)?.to_owned(),
+                            deployment: o.get("deployment").and_then(Value::as_str)?.to_owned(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Some(ModelPreference { primary, fallback })
+    });
+
+    InferencePolicySpec {
+        applies_to: applies_to.clone(),
+        token_budget,
+        content_safety,
+        model_preference,
+        display_name: verified.display_name.clone(),
+        bundle_ref: None,
+    }
+}
+
+/// Map [`crate::policy_fetcher::FetchError`] variants to the
+/// `(reason, message)` pair the controller status machinery consumes.
+/// Delegates to [`crate::policy_fetcher::reason_for_error`] so the one
+/// shared vocabulary stays in lockstep with the egress + tools
+/// reconcilers (one vocabulary across all signed-policy kinds keeps
+/// operator-facing docs minimal and the controller's class table
+/// closed — §15.3 log-injection prevention).
+/// [`crate::policy_fetcher::FetchError::Transient`] is mapped to
+/// `"Transient"` here rather than surfaced as a `None` reason: the
+/// InferencePolicy state machine does not have a "preserve last-known-
+/// good" branch (unlike the egress sandbox reconciler), so a transient
+/// fetch failure surfaces honestly as Degraded until the next requeue
+/// succeeds.
+fn fetch_error_to_degraded(e: &crate::policy_fetcher::FetchError) -> (&'static str, String) {
+    let reason = crate::policy_fetcher::reason_for_error(e).unwrap_or("Transient");
+    (reason, e.to_string())
 }
 
 /// Build the Conditions vector preserving prior `lastTransitionTime`

--- a/controller/src/policy_canonical/egress.rs
+++ b/controller/src/policy_canonical/egress.rs
@@ -87,7 +87,7 @@ impl PolicyKind for EgressKind {
         }
         match &entry.verified {
             CachedValue::Egress(v) => Some(v.clone()),
-            CachedValue::Tools(_) => None,
+            CachedValue::Inference(_) | CachedValue::Tools(_) => None,
         }
     }
 

--- a/controller/src/policy_canonical/inference.rs
+++ b/controller/src/policy_canonical/inference.rs
@@ -1,0 +1,484 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! InferencePolicy canonical-form parser + `PolicyKind` impl.
+//!
+//! Slice 1c.3 — third per-kind implementation after egress (1c.1) and
+//! tools (1c.2). Unlike AGT profiles (which are operator-authored YAML
+//! with comments), inference-policy bundles are content artifacts the
+//! producer compiles before signing: the canonical bytes the controller
+//! consumes from the OCI artifact are the **same byte-frozen JSON
+//! shape** the controller's own inline path produces via
+//! [`crate::inference_policy_compile`].
+//!
+//! That symmetry is intentional: the router's
+//! [`inference-router::inference_policy_loader`] consumes a single
+//! `inference-policy.json` file regardless of whether it was produced
+//! from inline spec fields or pulled from a signed OCI artifact. The
+//! length-prefixed sha256 digest (see
+//! [`crate::inference_policy_compile::inference_policy_digest`]) closes
+//! the §3 echo loop either way.
+//!
+//! What we DO enforce (trait invariant #1, applied to inference policy):
+//! - Valid UTF-8
+//! - Parseable as a JSON object
+//! - Top-level object with policy-content keys only:
+//!   `tokenBudget` / `contentSafety` / `modelPreference` / `displayName`
+//! - Each present sub-object has the expected shape (sub-object or null)
+//! - At least one policy-content key is present (empty bundles are
+//!   rejected — the inline path is the supported way to express
+//!   "selector-only" policies; a signed bundle MUST carry policy
+//!   content)
+//!
+//! Anything beyond that is delegated to the router's enforcement layer
+//! (`inference_policy_loader::reload`, per-axis enforcement gates), which
+//! catches semantic errors (e.g. unknown severity strings, negative
+//! budgets) and surfaces them via `GET /internal/policy-status`. This
+//! split mirrors 1c.2 (tools): the controller's responsibility is
+//! supply-chain verification + structural sanity, not policy semantics.
+
+use super::{CachedValue, PolicyKind};
+use crate::policy_fetcher::{CACHE_TTL, FetchError};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Instant, SystemTime};
+
+/// OCI media type for the v1 inference-policy artifact. The pulled
+/// `artifactType` MUST match this exactly; consumers reject any other
+/// value (forward-compat: v2 bumps the suffix; v1 consumers MUST refuse
+/// v2 artifacts).
+pub const INFERENCE_POLICY_V1_MEDIA_TYPE: &str =
+    "application/vnd.azureclaw.inference-policy.v1+json";
+
+/// Recognised top-level keys in an inference-policy bundle. The
+/// selector (`appliesTo`) is intentionally NOT one of them: selector
+/// is owned by the `InferencePolicy.spec`, not the signed artifact, so
+/// one signed bundle can be referenced by multiple CRs with different
+/// selectors. See `docs/internal/policy-canonical-format.md`.
+const POLICY_CONTENT_KEYS: &[&str] = &[
+    "tokenBudget",
+    "contentSafety",
+    "modelPreference",
+    "displayName",
+];
+
+/// A verified inference-policy bundle. The `bytes` field is the
+/// signed payload as pulled from OCI; the reconciler merges the parsed
+/// content into the compile shape before writing the ConfigMap. The
+/// individual `Option<Value>` fields are extracted at parse time so
+/// the reconciler does not re-parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedInferencePolicy {
+    /// Parsed `tokenBudget` sub-object, if present (and non-null).
+    pub token_budget: Option<Value>,
+    /// Parsed `contentSafety` sub-object, if present (and non-null).
+    pub content_safety: Option<Value>,
+    /// Parsed `modelPreference` sub-object, if present (and non-null).
+    pub model_preference: Option<Value>,
+    /// Parsed `displayName` string, if present (and non-null).
+    pub display_name: Option<String>,
+    /// Raw signed bytes. Kept for observability / status diagnostics;
+    /// the router echo digest is computed over the **recompiled**
+    /// bytes (selector + content merged), not these.
+    pub bytes: Vec<u8>,
+    /// `sha256:...` matched against `OciArtifactRef.digest`.
+    pub digest: String,
+    pub fetched_at: SystemTime,
+}
+
+/// `PolicyKind` discriminator for inference-policy bundles.
+pub struct InferenceKind;
+
+impl PolicyKind for InferenceKind {
+    const MEDIA_TYPE: &'static str = INFERENCE_POLICY_V1_MEDIA_TYPE;
+    const API_VERSION: &'static str = "azureclaw.azure.com/v1alpha1";
+    const KIND: &'static str = "InferencePolicy";
+    type Output = VerifiedInferencePolicy;
+
+    fn parse(bytes: &[u8]) -> Result<Self::Output, FetchError> {
+        parse(bytes)
+    }
+
+    fn finalize(out: &mut Self::Output, digest: String, fetched_at: SystemTime) {
+        out.digest = digest;
+        out.fetched_at = fetched_at;
+    }
+
+    fn cache_get(key: &str, now: Instant) -> Option<Self::Output> {
+        let guard = cache().lock().ok()?;
+        let entry = guard.get(key)?;
+        if now.duration_since(entry.inserted) > CACHE_TTL {
+            return None;
+        }
+        match &entry.verified {
+            CachedValue::Inference(v) => Some(v.clone()),
+            CachedValue::Egress(_) | CachedValue::Tools(_) => None,
+        }
+    }
+
+    fn cache_put(key: String, value: Self::Output) {
+        if let Ok(mut guard) = cache().lock() {
+            guard.insert(
+                key,
+                CacheEntry {
+                    verified: CachedValue::Inference(value),
+                    inserted: Instant::now(),
+                },
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn cache_clear() {
+        if let Ok(mut guard) = cache().lock() {
+            guard.clear();
+        }
+    }
+}
+
+// ─────────────────────────── cache ───────────────────────────
+
+struct CacheEntry {
+    verified: CachedValue,
+    inserted: Instant,
+}
+
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// ─────────────────────────── parser ───────────────────────────
+
+/// Parse + structural validate the inference-policy bundle bytes.
+/// Returns [`FetchError::CanonicalFormViolation`] for any structural
+/// issue. The returned [`VerifiedInferencePolicy::digest`] is empty;
+/// the caller fills it via [`InferenceKind::finalize`].
+pub(crate) fn parse(bytes: &[u8]) -> Result<VerifiedInferencePolicy, FetchError> {
+    let s = std::str::from_utf8(bytes)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("utf-8: {e}")))?;
+
+    let doc: Value = serde_json::from_str(s)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("json parse: {e}")))?;
+
+    let map = doc.as_object().ok_or_else(|| {
+        FetchError::CanonicalFormViolation("top-level must be a JSON object".into())
+    })?;
+
+    for key in map.keys() {
+        if !POLICY_CONTENT_KEYS.contains(&key.as_str()) {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "unrecognised top-level key `{key}`; allowed: tokenBudget, \
+                 contentSafety, modelPreference, displayName"
+            )));
+        }
+    }
+
+    let token_budget = extract_optional_object(map, "tokenBudget")?;
+    let content_safety = extract_optional_object(map, "contentSafety")?;
+    let model_preference = extract_optional_object(map, "modelPreference")?;
+    let display_name = extract_optional_string(map, "displayName")?;
+
+    if token_budget.is_none()
+        && content_safety.is_none()
+        && model_preference.is_none()
+        && display_name.is_none()
+    {
+        return Err(FetchError::CanonicalFormViolation(
+            "bundle has no policy content (all of tokenBudget / contentSafety / \
+             modelPreference / displayName are absent or null); use the inline \
+             path for selector-only policies"
+                .into(),
+        ));
+    }
+
+    if let Some(ref tb) = token_budget {
+        validate_token_budget(tb)?;
+    }
+    if let Some(ref cs) = content_safety {
+        validate_content_safety(cs)?;
+    }
+    if let Some(ref mp) = model_preference {
+        validate_model_preference(mp)?;
+    }
+
+    Ok(VerifiedInferencePolicy {
+        token_budget,
+        content_safety,
+        model_preference,
+        display_name,
+        bytes: bytes.to_vec(),
+        digest: String::new(),
+        fetched_at: SystemTime::UNIX_EPOCH,
+    })
+}
+
+fn extract_optional_object(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<Value>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Object(_)) => Ok(Some(map[key].clone())),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a JSON object or null"
+        ))),
+    }
+}
+
+fn extract_optional_string(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a string or null"
+        ))),
+    }
+}
+
+fn validate_token_budget(v: &Value) -> Result<(), FetchError> {
+    let obj = v.as_object().expect("checked by caller");
+    for k in ["perRequestTokens", "dailyTokens", "monthlyTokens"] {
+        if let Some(val) = obj.get(k)
+            && !val.is_null()
+            && !val.is_u64()
+        {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "tokenBudget.{k} must be a non-negative integer or null"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_content_safety(v: &Value) -> Result<(), FetchError> {
+    let obj = v.as_object().expect("checked by caller");
+    for k in ["hate", "selfHarm", "sexual", "violence"] {
+        if let Some(val) = obj.get(k)
+            && !val.is_null()
+            && !val.is_string()
+        {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "contentSafety.{k} must be a string or null"
+            )));
+        }
+    }
+    if let Some(val) = obj.get("requirePromptShields")
+        && !val.is_null()
+        && !val.is_boolean()
+    {
+        return Err(FetchError::CanonicalFormViolation(
+            "contentSafety.requirePromptShields must be a boolean or null".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_model_preference(v: &Value) -> Result<(), FetchError> {
+    let obj = v.as_object().expect("checked by caller");
+    let primary = obj.get("primary").ok_or_else(|| {
+        FetchError::CanonicalFormViolation("modelPreference.primary required".into())
+    })?;
+    validate_model_ref(primary, "modelPreference.primary")?;
+
+    if let Some(fallback) = obj.get("fallback") {
+        let seq = fallback.as_array().ok_or_else(|| {
+            FetchError::CanonicalFormViolation("modelPreference.fallback must be an array".into())
+        })?;
+        for (i, entry) in seq.iter().enumerate() {
+            validate_model_ref(entry, &format!("modelPreference.fallback[{i}]"))?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_model_ref(v: &Value, path: &str) -> Result<(), FetchError> {
+    let obj = v
+        .as_object()
+        .ok_or_else(|| FetchError::CanonicalFormViolation(format!("{path} must be an object")))?;
+    for k in ["provider", "deployment"] {
+        let val = obj
+            .get(k)
+            .ok_or_else(|| FetchError::CanonicalFormViolation(format!("{path}.{k} required")))?;
+        let s = val.as_str().ok_or_else(|| {
+            FetchError::CanonicalFormViolation(format!("{path}.{k} must be a string"))
+        })?;
+        if s.is_empty() {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "{path}.{k} must be non-empty"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_token_budget_ok() {
+        let body = br#"{"tokenBudget":{"perRequestTokens":8192}}"#;
+        let r = parse(body).unwrap();
+        assert!(r.token_budget.is_some());
+        assert!(r.content_safety.is_none());
+        assert!(r.model_preference.is_none());
+        assert!(r.display_name.is_none());
+        assert_eq!(r.bytes, body);
+        assert_eq!(r.digest, "");
+    }
+
+    #[test]
+    fn parse_full_bundle_ok() {
+        let body = br#"{
+            "tokenBudget":{"perRequestTokens":8192,"dailyTokens":1000000,"monthlyTokens":20000000},
+            "contentSafety":{"hate":"Medium","selfHarm":"Low","sexual":"Medium","violence":"High","requirePromptShields":true},
+            "modelPreference":{"primary":{"provider":"azure-openai","deployment":"gpt-4o"},"fallback":[{"provider":"anthropic","deployment":"claude-3-5-sonnet"}]},
+            "displayName":"strict-policy"
+        }"#;
+        let r = parse(body).unwrap();
+        assert!(r.token_budget.is_some());
+        assert!(r.content_safety.is_some());
+        assert!(r.model_preference.is_some());
+        assert_eq!(r.display_name.as_deref(), Some("strict-policy"));
+    }
+
+    #[test]
+    fn parse_invalid_utf8_rejected() {
+        let body = b"\xFF\xFE not utf-8";
+        let err = parse(body).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("utf-8")));
+    }
+
+    #[test]
+    fn parse_invalid_json_rejected() {
+        let body = b"not json";
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("json parse"))
+        );
+    }
+
+    #[test]
+    fn parse_non_object_top_level_rejected() {
+        let body = b"[1, 2, 3]";
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("JSON object"))
+        );
+    }
+
+    #[test]
+    fn parse_unknown_key_rejected() {
+        let body = br#"{"tokenBudget":{"perRequestTokens":1},"unknownKey":"x"}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("unrecognised"))
+        );
+    }
+
+    #[test]
+    fn parse_appliesto_in_bundle_rejected() {
+        // appliesTo is selector — must come from CR, never bundle.
+        let body = br#"{"appliesTo":{"sandboxName":"x"},"tokenBudget":{"perRequestTokens":1}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("unrecognised"))
+        );
+    }
+
+    #[test]
+    fn parse_empty_object_rejected() {
+        let body = b"{}";
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("no policy content"))
+        );
+    }
+
+    #[test]
+    fn parse_all_null_rejected() {
+        let body = br#"{"tokenBudget":null,"contentSafety":null,"modelPreference":null,"displayName":null}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("no policy content"))
+        );
+    }
+
+    #[test]
+    fn parse_token_budget_wrong_type_rejected() {
+        let body = br#"{"tokenBudget":{"perRequestTokens":"big"}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("perRequestTokens"))
+        );
+    }
+
+    #[test]
+    fn parse_token_budget_negative_rejected() {
+        let body = br#"{"tokenBudget":{"perRequestTokens":-1}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("perRequestTokens"))
+        );
+    }
+
+    #[test]
+    fn parse_content_safety_wrong_severity_type_rejected() {
+        let body = br#"{"contentSafety":{"hate":1}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("contentSafety.hate"))
+        );
+    }
+
+    #[test]
+    fn parse_content_safety_wrong_shields_type_rejected() {
+        let body = br#"{"contentSafety":{"requirePromptShields":"yes"}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("requirePromptShields"))
+        );
+    }
+
+    #[test]
+    fn parse_model_preference_missing_primary_rejected() {
+        let body = br#"{"modelPreference":{"fallback":[]}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("primary required"))
+        );
+    }
+
+    #[test]
+    fn parse_model_preference_empty_deployment_rejected() {
+        let body =
+            br#"{"modelPreference":{"primary":{"provider":"azure-openai","deployment":""}}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("deployment"))
+        );
+    }
+
+    #[test]
+    fn parse_model_preference_fallback_bad_entry_rejected() {
+        let body = br#"{"modelPreference":{"primary":{"provider":"a","deployment":"b"},"fallback":[{"provider":"c"}]}}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("fallback[0].deployment"))
+        );
+    }
+
+    #[test]
+    fn parse_display_name_wrong_type_rejected() {
+        let body = br#"{"displayName":42}"#;
+        let err = parse(body).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("displayName"))
+        );
+    }
+}

--- a/controller/src/policy_canonical/mod.rs
+++ b/controller/src/policy_canonical/mod.rs
@@ -30,11 +30,14 @@ use crate::policy_fetcher::FetchError;
 use std::time::{Instant, SystemTime};
 
 pub mod egress;
+pub mod inference;
 pub mod tools;
 
 #[allow(unused_imports)]
-// re-exported for downstream sub-slices (1c.3+); tests use the full path
+// re-exported for downstream sub-slices (1c.4+); tests use the full path
 pub use egress::EgressKind;
+#[allow(unused_imports)]
+pub use inference::InferenceKind;
 #[allow(unused_imports)]
 pub use tools::ToolsKind;
 
@@ -50,9 +53,10 @@ pub use tools::ToolsKind;
 /// is the implementation detail of how
 /// [`PolicyKind::cache_get`] / [`PolicyKind::cache_put`] are wired, not
 /// a public extension point.
-#[allow(dead_code)] // future kinds will add variants in 1c.3 - 1c.5
+#[allow(dead_code)] // future kinds will add variants in 1c.4 - 1c.5
 pub(crate) enum CachedValue {
     Egress(egress::VerifiedAllowlist),
+    Inference(inference::VerifiedInferencePolicy),
     Tools(tools::VerifiedAgtProfile),
 }
 

--- a/controller/src/policy_canonical/tools.rs
+++ b/controller/src/policy_canonical/tools.rs
@@ -106,7 +106,7 @@ impl PolicyKind for ToolsKind {
         }
         match &entry.verified {
             CachedValue::Tools(v) => Some(v.clone()),
-            CachedValue::Egress(_) => None,
+            CachedValue::Egress(_) | CachedValue::Inference(_) => None,
         }
     }
 

--- a/deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml
+++ b/deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml
@@ -85,12 +85,68 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              bundleRef:
+                description: |-
+                  Signed OCI artifact reference. The controller pulls the
+                  artifact from `<registry>/<repository>@<digest>`, verifies the
+                  cosign signature against the active
+                  [`crate::signer_policy::SignerPolicy`], re-validates the JSON
+                  structure ([`crate::policy_canonical::inference::InferenceKind`]),
+                  and synthesises the effective spec by combining the CR's
+                  `appliesTo` selector with the bundle's `tokenBudget` /
+                  `contentSafety` / `modelPreference` / `displayName` content
+                  fields. The same compile + ConfigMap write path runs as for
+                  inline specs — only the source of the content bytes differs.
+
+                  On any verification failure the controller stamps
+                  `Ready=False / reason=AllowlistMissing|AllowlistMalformed|
+                  AllowlistUnauthorized|AllowlistSignatureVerifyFailed` (the
+                  same `FetchError` variants used by egress + tools — one
+                  error taxonomy across all signed-policy kinds).
+
+                  Artifact `artifactType` MUST be
+                  `application/vnd.azureclaw.inference-policy.v1+json`; a
+                  mismatch surfaces as `Ready=False / reason=InvalidRef`.
+
+                  Mutually exclusive with the inline content fields
+                  (`tokenBudget`, `contentSafety`, `modelPreference`,
+                  `displayName`). `appliesTo` always comes from the CR so one
+                  signed bundle can be referenced by multiple CRs with
+                  different selectors. See
+                  `docs/internal/policy-canonical-format.md`.
+                nullable: true
+                properties:
+                  artifactType:
+                    description: |-
+                      OCI artifactType media-type, e.g.
+                      `application/vnd.azureclaw.egress-allowlist.v1+yaml`. Consumers MUST
+                      reject artifacts whose pulled `artifactType` doesn't match.
+                    type: string
+                  digest:
+                    description: |-
+                      Content-addressed digest, including the algorithm prefix
+                      (`sha256:abc…`). The digest covers the canonical artifact bytes —
+                      see `docs/internal/policy-canonical-format.md` for the egress-allowlist
+                      canonicalization rules.
+                    type: string
+                  registry:
+                    description: Registry hostname (e.g. `myacr.azurecr.io`, `ghcr.io`).
+                    type: string
+                  repository:
+                    description: Repository path (e.g. `azureclaw/policies/sandbox-foo`).
+                    type: string
+                required:
+                - artifactType
+                - digest
+                - registry
+                - repository
+                type: object
               contentSafety:
                 description: |-
                   Content Safety severity floor. Optional — absent ⇒ governance
                   minimum (router-default) applies. The VAP referenced in §7.14
                   rejects changes that *lower* the floor below the cluster
-                  minimum.
+                  minimum. Mutually exclusive with [`Self::bundle_ref`].
                 nullable: true
                 properties:
                   hate:
@@ -119,14 +175,18 @@ spec:
                     type: string
                 type: object
               displayName:
-                description: Optional human-readable label.
+                description: |-
+                  Optional human-readable label. Mutually exclusive with
+                  [`Self::bundle_ref`] — when `bundleRef` is set, the label
+                  comes from the signed bundle.
                 nullable: true
                 type: string
               modelPreference:
                 description: |-
                   Model preference + fallback chain. Optional. **Not** a router:
                   only declares preferred route order; selection is delegated to
-                  the underlying provider.
+                  the underlying provider. Mutually exclusive with
+                  [`Self::bundle_ref`].
                 nullable: true
                 properties:
                   fallback:
@@ -167,7 +227,14 @@ spec:
                 - primary
                 type: object
               tokenBudget:
-                description: Token-budget caps. Optional — absent ⇒ no budget enforcement.
+                description: |-
+                  Token-budget caps. Optional — absent ⇒ no budget enforcement.
+
+                  Mutually exclusive with [`Self::bundle_ref`]: when `bundleRef`
+                  is set, the budget caps come from the signed bundle. Admission
+                  CEL + reconciler defense-in-depth both reject specs that set
+                  any of `tokenBudget`/`contentSafety`/`modelPreference`/
+                  `displayName` alongside `bundleRef`.
                 nullable: true
                 properties:
                   dailyTokens:
@@ -195,6 +262,9 @@ spec:
             - appliesTo
             type: object
             x-kubernetes-validations:
+            - message: spec.bundleRef is mutually exclusive with spec.tokenBudget, spec.contentSafety, spec.modelPreference, and spec.displayName; the bundle carries those content fields
+              reason: FieldValueInvalid
+              rule: '!has(self.bundleRef) || (!has(self.tokenBudget) && !has(self.contentSafety) && !has(self.modelPreference) && !has(self.displayName))'
             - message: spec.tokenBudget.monthlyTokens must be >= spec.tokenBudget.dailyTokens
               reason: FieldValueInvalid
               rule: '!has(self.tokenBudget) || !has(self.tokenBudget.monthlyTokens) || !has(self.tokenBudget.dailyTokens) || self.tokenBudget.monthlyTokens >= self.tokenBudget.dailyTokens'
@@ -217,6 +287,19 @@ spec:
             description: Status of an `InferencePolicy` reconcile.
             nullable: true
             properties:
+              bundleRefDigest:
+                description: |-
+                  OCI manifest digest of the verified `spec.bundleRef` artifact
+                  when the bundleRef path was taken; `None` for inline specs.
+                  Stamped after [`crate::policy_fetcher::fetch_and_verify_generic`]
+                  returns `Ok`, so its presence is operator-visible proof that
+                  the controller actually verified the signed artifact (vs.
+                  taking an inline shortcut). Distinct from `compiled_digest`
+                  (the wire-contract value the router echoes) — `bundle_ref_digest`
+                  is the supply-chain identifier. Slice 1c.3 of
+                  `crd-well-oiled-machine`.
+                nullable: true
+                type: string
               compiledDigest:
                 description: |-
                   `sha256:<full hex>` digest the controller wrote to the
@@ -320,5 +403,4 @@ spec:
     storage: true
     subresources:
       status: {}
-
 


### PR DESCRIPTION
Third step in the **Slice 1c-real signing-generalization** arc. After EgressAllowlist (1c.1) and ToolPolicy (1c.2), `InferencePolicy` now joins the unified `policy_fetcher::fetch_and_verify_generic` pipeline parameterised by `PolicyKind`.

## Producer (controller)

- **New `controller/src/policy_canonical/inference.rs`** — `InferenceKind: PolicyKind` impl. Media type `application/vnd.azureclaw.inference-policy.v1+json`. Per-kind canonical-form parser. Per-kind `OnceLock<CachedValue::Inference(...)>` cache slot. **Bundle accepts only `tokenBudget` / `contentSafety` / `modelPreference` / `displayName` keys at top level** — `appliesTo` stays in the CR so one signed artifact can be referenced by multiple `InferencePolicy` CRs with different selectors. Structural validation rejects negative budgets, unrecognised severity types, empty `primary.deployment`, malformed `fallback[]` entries, and mis-typed `requirePromptShields`. **17 unit tests** covering every rejection path.
- `InferencePolicySpec.bundleRef: Option<OciArtifactRef>` field at spec top level (mutex with content fields).
- `InferencePolicyStatus.bundleRefDigest: Option<String>` surfaces the verified OCI manifest digest after `fetch_and_verify_generic::<InferenceKind>` succeeds. **Distinct from `compiledDigest`** which is the wire-contract value the router echoes back via `/internal/policy-status`.
- `inference_policy_reconciler::resolve_inference_source` — 4-way match (no-inline+no-bundle / inline only / bundle only / both) mirroring `tool_policy_reconciler::resolve_agt_profile_source`. On the bundle path, merges the verified content fields onto the CR's `appliesTo` selector to produce the effective spec for `compile_to_profile`. `FetchError` variants map through the shared `policy_fetcher::reason_for_error` vocabulary (same as egress + tools).

## Admission

CEL on `InferencePolicySpec`:
```
```
Rejects mixed shapes at apply-time; the reconciler-side defense-in-depth check only fires on stale clusters running an older CRD revision.

## Schema

Regenerated `deploy/helm/azureclaw/templates/crd-inferencepolicy.yaml` via the `DUMP_INFERENCEPOLICY_CRD_YAML=1 cargo test` workflow. CNCF C10 labels preserved.

## Out of scope (deferred)

- Unified CLI dispatch `azureclaw policy sign --kind inference-policy` → **Slice 1c.6**.
- `ClawMemory.bundleRef` → **Slice 1c.4**.
- `McpServer.bundleRef` → **Slice 1c.5**.

## Verification

- 619 → **636 controller tests** (+17 inference parser).
- `cargo clippy --bin azureclaw-controller --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- `helm_drift` clean.
- CNCF conformance clean.
- **Router wire contract unchanged** — only the producer side changes; the router still echoes the same `compiled_digest` derived from `inference-policy.json` canonical bytes.

Per principles.md §5 (no scaffolding): this PR wires a real producer→consumer loop end-to-end. The bundle path is unreachable today only because the unified CLI dispatch lands in 1c.6, but the controller-side verify + merge + compile + status echo are fully implemented and tested.