### PR TITLE
Slice 1c.4: ClawMemory.spec.bundleRef (signed OCI artifact)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1c.4 — `ClawMemory.spec.bundleRef` (signed OCI artifact)
+
+Fourth step in the Slice 1c-real signing-generalization arc.
+`ClawMemory` now joins `EgressAllowlist` (1c.1), `ToolPolicy` (1c.2),
+and `InferencePolicy` (1c.3) on the unified
+`policy_fetcher::fetch_and_verify_generic` pipeline.
+
+**Producer side (controller)**
+
+- New `controller/src/policy_canonical/memory.rs` —
+  `MemoryKind: PolicyKind` impl. Bundle carries `storeName`, `scope`,
+  `retentionDays`, `deleteOnSandboxDelete`, `displayName`. The
+  `sandboxRef` selector stays in the CR — the parser explicitly
+  rejects it inside a bundle so one signed artifact can be referenced
+  by multiple `ClawMemory` CRs targeting different sandboxes.
+  Structural validation: DNS-label `storeName` (1-63), non-empty
+  `scope`, `retentionDays > 0`, type-checked `deleteOnSandboxDelete`
+  / `displayName`. Media type
+  `application/vnd.azureclaw.memory-binding.v1+json`. Per-kind cache
+  slot via `OnceLock<CachedValue::Memory(...)>` on the shared
+  `policy_canonical` cache. 18 unit tests covering every rejection
+  path.
+- `ClawMemorySpec.bundleRef: Option<OciArtifactRef>` added; the
+  inline content fields (`storeName`, `scope`, `retentionDays`,
+  `deleteOnSandboxDelete`, `displayName`) are now `Option`-typed and
+  required only on the inline path.
+- `ClawMemoryStatus.bundleRefDigest: Option<String>` surfaces the
+  verified OCI manifest digest after a successful
+  `fetch_and_verify_generic::<MemoryKind>` call.
+- `claw_memory_reconciler::resolve_memory_source` — 4-way match
+  (no inline / inline only / bundle only / both) mirroring
+  `inference_policy_reconciler::resolve_inference_source`. On the
+  bundle path, merges the verified content onto the CR's
+  `sandboxRef` selector to produce the effective spec for
+  `compile_to_binding`. `FetchError` variants map through the shared
+  `policy_fetcher::reason_for_error` vocabulary. On any degraded
+  branch (mutex / fetch / verify) the binding ConfigMap write is
+  skipped so the router's last-good binding remains in force until
+  the operator fixes the spec.
+- `claw_memory_compile::compile_to_binding` now tolerates the new
+  Optional spec fields, applying the same defaults the inline path
+  always implied (`deleteOnSandboxDelete` defaults to `true`, others
+  to empty / `None`).
+
+**Admission**
+
+- CEL rule on `ClawMemorySpec`:
+  `!has(self.bundleRef) || (!has(self.storeName) && !has(self.scope) && !has(self.retentionDays) && !has(self.deleteOnSandboxDelete) && !has(self.displayName))`
+  — rejects mixed shapes at apply-time. The pre-existing `storeName`
+  and `scope` rules are wrapped in `has(self.bundleRef) || …` so the
+  inline-path validations only fire when the bundle path is unused.
+
+**Schema**
+
+- Regenerated `deploy/helm/azureclaw/templates/crd-clawmemory.yaml`
+  via `DUMP_CLAWMEMORY_CRD_YAML=1 cargo test …
+  helm_drift::tests::dump_clawmemory_crd_yaml`. Adds the
+  `spec.bundleRef` block, relaxes `required: [storeName, scope]` on
+  the spec to `required: [sandboxRef]`, and adds the new CEL mutex
+  rule + `status.bundleRefDigest`. CNCF C10 labels preserved.
+
+**Out of scope (deferred)**
+
+- CLI dispatch `azureclaw policy sign --kind memory-binding` — lands
+  with the unified CLI in Slice 1c.6.
+- McpServer `bundleRef` — Slice 1c.5.
+
+Test deltas: controller 636 → 654 (+18 memory parser tests).
+clippy `-D warnings` clean, fmt clean, helm_drift clean, CNCF
+conformance clean. Router untouched — wire contract unchanged
+(`compile_to_binding` produces identical bytes from the effective
+spec regardless of provenance).
+
 ### Slice 1c.3 — `InferencePolicy.spec.bundleRef` (signed OCI artifact)
 
 Third step in the Slice 1c-real signing-generalization arc.
@@ -69,7 +142,6 @@ that the controller pulls by digest and validates per
 
 - CLI dispatch `azureclaw policy sign --kind inference-policy`
   — lands with the unified CLI in Slice 1c.6.
-- ClawMemory `bundleRef` — Slice 1c.4.
 - McpServer `bundleRef` — Slice 1c.5.
 
 Test deltas: controller 619 → 636 (+17 inference parser tests).

--- a/controller/src/claw_memory.rs
+++ b/controller/src/claw_memory.rs
@@ -94,16 +94,28 @@ pub struct ClawMemorySpec {
     /// (`cli/src/plugin.ts::ensureMemoryStore`) creates the store
     /// on first use if absent. CEL: non-empty,
     /// DNS-label-style (lowercase alphanumeric + dashes).
-    pub store_name: String,
+    ///
+    /// Required when [`Self::bundle_ref`] is absent (the inline
+    /// path); MUST be absent when [`Self::bundle_ref`] is set
+    /// (the bundle supplies the value). Admission CEL enforces
+    /// the mutex.
+    #[serde(default)]
+    pub store_name: Option<String>,
 
-    /// Sandbox this binding applies to.
+    /// Sandbox this binding applies to. Owned by the CR (never the
+    /// signed bundle) — one signed bundle can be referenced by
+    /// multiple `ClawMemory` CRs targeting different sandboxes.
     pub sandbox_ref: SandboxRef,
 
     /// Scope key under which this sandbox writes/reads memories.
     /// Foundry Memory Store partitions data per scope. CEL:
     /// non-empty. Default convention (set by the runtime path if
     /// absent here): `agent:{sandboxName}`.
-    pub scope: String,
+    ///
+    /// Required when [`Self::bundle_ref`] is absent (the inline
+    /// path); MUST be absent when [`Self::bundle_ref`] is set.
+    #[serde(default)]
+    pub scope: Option<String>,
 
     /// Optional retention floor in days. Runtime path may apply a
     /// `delete_scope` sweep when entries exceed this age. CEL:
@@ -115,15 +127,33 @@ pub struct ClawMemorySpec {
     /// deleted. The controller-side cleanup is finalizer-only on the
     /// binding ConfigMap; Foundry-side delete via the router is
     /// wired in S7+.
-    #[serde(default = "default_true")]
-    pub delete_on_sandbox_delete: bool,
+    ///
+    /// When [`Self::bundle_ref`] is set, the bundle supplies this
+    /// value; the CR's inline value MUST be absent in that case.
+    /// Default-true is applied at the reconciler layer (after the
+    /// bundle / inline merge) so `None` here is meaningful (= "use
+    /// bundle value or default").
+    #[serde(default)]
+    pub delete_on_sandbox_delete: Option<bool>,
 
-    /// Optional human-readable label.
+    /// Optional human-readable label. MUST be absent when
+    /// [`Self::bundle_ref`] is set.
     pub display_name: Option<String>,
-}
 
-fn default_true() -> bool {
-    true
+    /// Signed OCI artifact carrying the binding content
+    /// (`storeName`, `scope`, `retentionDays`,
+    /// `deleteOnSandboxDelete`, `displayName`). When set, the
+    /// controller pulls the artifact by digest, verifies its
+    /// cosign signature against the active
+    /// [`crate::signer_policy::SignerPolicy`], and merges the
+    /// bundle content onto `sandboxRef` (always owned by the CR)
+    /// before writing the binding ConfigMap. Slice 1c.4 of the
+    /// `crd-well-oiled-machine` plan.
+    ///
+    /// Mutually exclusive with the inline content fields above.
+    /// Admission CEL enforces the mutex; the reconciler also checks
+    /// as defense-in-depth.
+    pub bundle_ref: Option<crate::crd::OciArtifactRef>,
 }
 
 /// Reference to a sandbox by name (within the same namespace as the
@@ -181,4 +211,12 @@ pub struct ClawMemoryStatus {
     /// `compiledDigest` here.
     #[serde(default)]
     pub loaded_digest: Option<String>,
+
+    /// `sha256:...` of the signed bundle the controller last pulled
+    /// for `spec.bundleRef`. Stamped when the bundle path produced
+    /// the effective spec used in the latest reconcile; `None` when
+    /// the spec used the inline path or no successful fetch has
+    /// happened yet. Slice 1c.4.
+    #[serde(default)]
+    pub bundle_ref_digest: Option<String>,
 }

--- a/controller/src/claw_memory_compile.rs
+++ b/controller/src/claw_memory_compile.rs
@@ -54,11 +54,11 @@ pub const MEMORY_BINDING_FILENAME: &str = "binding.json";
 #[must_use]
 pub fn compile_to_binding(spec: &ClawMemorySpec) -> Value {
     json!({
-        "storeName": spec.store_name,
+        "storeName": spec.store_name.clone().unwrap_or_default(),
         "sandboxRef": { "name": spec.sandbox_ref.name },
-        "scope": spec.scope,
+        "scope": spec.scope.clone().unwrap_or_default(),
         "retentionDays": spec.retention_days,
-        "deleteOnSandboxDelete": spec.delete_on_sandbox_delete,
+        "deleteOnSandboxDelete": spec.delete_on_sandbox_delete.unwrap_or(true),
         "displayName": spec.display_name,
     })
 }
@@ -121,25 +121,26 @@ mod tests {
 
     fn full_spec() -> ClawMemorySpec {
         ClawMemorySpec {
-            store_name: "agent-x-mem".into(),
+            store_name: Some("agent-x-mem".into()),
             sandbox_ref: SandboxRef {
                 name: "agent-x".into(),
             },
-            scope: "agent:agent-x".into(),
+            scope: Some("agent:agent-x".into()),
             retention_days: Some(30),
-            delete_on_sandbox_delete: true,
+            delete_on_sandbox_delete: Some(true),
             display_name: Some("Agent X memory".into()),
+            bundle_ref: None,
         }
     }
 
     #[test]
     fn compile_minimal_spec_round_trips() {
         let spec = ClawMemorySpec {
-            store_name: "minimal".into(),
+            store_name: Some("minimal".into()),
             sandbox_ref: SandboxRef {
                 name: "agent".into(),
             },
-            scope: "agent:agent".into(),
+            scope: Some("agent:agent".into()),
             ..ClawMemorySpec::default()
         };
         let binding = compile_to_binding(&spec);
@@ -147,8 +148,9 @@ mod tests {
         assert_eq!(binding["sandboxRef"]["name"], "agent");
         assert_eq!(binding["scope"], "agent:agent");
         assert!(binding["retentionDays"].is_null());
-        // delete_on_sandbox_delete defaults to false on Default ⇒ false.
-        assert_eq!(binding["deleteOnSandboxDelete"], false);
+        // delete_on_sandbox_delete defaults to true at compile time
+        // (preserving the prior bool-default semantics).
+        assert_eq!(binding["deleteOnSandboxDelete"], true);
     }
 
     #[test]

--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -152,7 +152,16 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
         .unwrap_or_default();
     let observed_generation = memory.metadata.generation;
 
-    let binding = compile_to_binding(&memory.spec);
+    // Slice 1c.4 — resolve bundleRef (if set) into an effective spec
+    // before compile. The bundle carries content (storeName, scope,
+    // retentionDays, deleteOnSandboxDelete, displayName); `sandboxRef`
+    // always stays in the CR. When `bundleRef` is unset the path is
+    // a no-op and returns the CR's spec verbatim.
+    let (effective_spec, bundle_ref_digest, bundle_degraded) =
+        resolve_memory_source(memory.as_ref()).await;
+    let mut degraded: Option<(&'static str, String)> = bundle_degraded;
+
+    let binding = compile_to_binding(&effective_spec);
     let v_hash = version_hash(&binding);
     // Slice 3a — canonical bytes the router-side `memory_binding_loader`
     // will sha256 + echo via `GET /internal/policy-status`. The bytes
@@ -165,37 +174,45 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
     let compiled_digest = claw_memory_digest(&canonical_bytes);
 
     let cm_name = format!("clawmemory-{name}-binding");
-    let mut degraded: Option<(&'static str, String)> = None;
 
-    match ensure_binding_configmap(
-        &configmaps,
-        &cm_name,
-        &name,
-        &canonical_str,
-        &v_hash,
-        &compiled_digest,
-    )
-    .await
-    {
-        Ok(()) => {
-            tracing::info!(
-                clawmemory = %name,
-                ns = %ns,
-                version_hash = %v_hash,
-                compiled_digest = %compiled_digest,
-                generation = observed_generation.unwrap_or(0),
-                store_name = %memory.spec.store_name,
-                scope = %memory.spec.scope,
-                "ClawMemoryCompiled"
-            );
-        }
-        Err(e) => {
-            tracing::warn!(
-                clawmemory = %name,
-                error_class = e.class(),
-                "ClawMemoryBindingWriteFailed"
-            );
-            degraded = Some(("BindingWriteFailed", e.to_string()));
+    // If bundleRef resolution already marked us Degraded
+    // (InvalidSpec mutex / fetch / verify failure), skip the
+    // ConfigMap write — `effective_spec` is the selector-only
+    // sentinel and compiling it would publish empty bytes that
+    // every router would reject anyway. Mirrors the 1c.3
+    // InferencePolicy path.
+    if degraded.is_none() {
+        match ensure_binding_configmap(
+            &configmaps,
+            &cm_name,
+            &name,
+            &canonical_str,
+            &v_hash,
+            &compiled_digest,
+        )
+        .await
+        {
+            Ok(()) => {
+                tracing::info!(
+                    clawmemory = %name,
+                    ns = %ns,
+                    version_hash = %v_hash,
+                    compiled_digest = %compiled_digest,
+                    generation = observed_generation.unwrap_or(0),
+                    store_name = effective_spec.store_name.as_deref().unwrap_or(""),
+                    scope = effective_spec.scope.as_deref().unwrap_or(""),
+                    bundle_ref_digest = bundle_ref_digest.as_deref().unwrap_or(""),
+                    "ClawMemoryCompiled"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    clawmemory = %name,
+                    error_class = e.class(),
+                    "ClawMemoryBindingWriteFailed"
+                );
+                degraded = Some(("BindingWriteFailed", e.to_string()));
+            }
         }
     }
 
@@ -322,6 +339,7 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
             last_reconciled_at: Some(rfc3339_now()),
             compiled_digest: Some(compiled_digest),
             loaded_digest,
+            bundle_ref_digest,
         }
     });
     api.patch_status(
@@ -343,6 +361,145 @@ async fn reconcile(memory: Arc<ClawMemory>, ctx: Arc<Ctx>) -> Result<Action, Rec
 
 fn rfc3339_now() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Slice 1c.4 — resolve `spec.bundleRef` (if set) into an effective
+/// [`crate::claw_memory::ClawMemorySpec`] for [`compile_to_binding`].
+///
+/// Returns a 3-tuple `(effective_spec, bundle_ref_digest, degraded)`:
+/// - `effective_spec` is what compile_to_binding will see. When
+///   `bundleRef` is unset, this is the CR's spec verbatim (the
+///   inline path). When `bundleRef` is set and the fetch + cosign
+///   verification succeed, the bundle's content fields are merged
+///   onto the CR's `sandboxRef`. On any error this is a
+///   selector-only sentinel that won't be compiled.
+/// - `bundle_ref_digest` is the verified bundle's
+///   `sha256:...` (stamped into `status.bundleRefDigest`) when the
+///   bundle path succeeded; `None` otherwise.
+/// - `degraded`, when `Some`, carries the `(reason, message)` for
+///   the `Degraded=True` condition the reconciler will surface.
+///
+/// The bundle path goes through
+/// [`crate::policy_fetcher::fetch_and_verify_generic`] with
+/// [`crate::policy_canonical::memory::MemoryKind`], so this function
+/// inherits the same cosign trust-root, ACR auth, and `FetchError`
+/// taxonomy as the egress, tools, and inference paths.
+async fn resolve_memory_source(
+    memory: &ClawMemory,
+) -> (
+    crate::claw_memory::ClawMemorySpec,
+    Option<String>,
+    Option<(&'static str, String)>,
+) {
+    let spec = &memory.spec;
+    let inline_any = spec.store_name.is_some()
+        || spec.scope.is_some()
+        || spec.retention_days.is_some()
+        || spec.delete_on_sandbox_delete.is_some()
+        || spec.display_name.is_some();
+    let bundle_set = spec.bundle_ref.is_some();
+
+    if inline_any && bundle_set {
+        return (
+            crate::claw_memory::ClawMemorySpec {
+                sandbox_ref: spec.sandbox_ref.clone(),
+                ..Default::default()
+            },
+            None,
+            Some((
+                "InvalidSpec",
+                "spec.bundleRef is mutually exclusive with spec.storeName, \
+                 spec.scope, spec.retentionDays, spec.deleteOnSandboxDelete, \
+                 and spec.displayName"
+                    .into(),
+            )),
+        );
+    }
+
+    if !bundle_set {
+        return (spec.clone(), None, None);
+    }
+
+    let bundle_ref = spec
+        .bundle_ref
+        .as_ref()
+        .expect("bundle_set implies Some")
+        .clone();
+
+    let signer_policy_handle = crate::signer_policy::global();
+    let verify_result = match signer_policy_handle.snapshot() {
+        crate::signer_policy::SignerPolicyState::FromConfigMap(p) => {
+            let cfg: crate::policy_fetcher::SignerPolicyConfig = p.into();
+            crate::policy_fetcher::fetch_and_verify_generic::<
+                crate::policy_canonical::memory::MemoryKind,
+            >(&bundle_ref, &cfg)
+            .await
+        }
+        crate::signer_policy::SignerPolicyState::Malformed(msg) => Err(
+            crate::policy_fetcher::FetchError::SignerPolicyMalformed(msg),
+        ),
+        crate::signer_policy::SignerPolicyState::Absent => {
+            let cfg = crate::policy_fetcher::SignerPolicyConfig::from_env();
+            crate::policy_fetcher::fetch_and_verify_generic::<
+                crate::policy_canonical::memory::MemoryKind,
+            >(&bundle_ref, &cfg)
+            .await
+        }
+    };
+
+    match verify_result {
+        Ok(verified) => {
+            let effective = merge_bundle_with_selector(&spec.sandbox_ref, &verified);
+            (effective, Some(verified.digest), None)
+        }
+        Err(e) => {
+            let (reason, msg) = fetch_error_to_degraded(&e);
+            tracing::warn!(
+                clawmemory = %memory.name_any(),
+                registry = %bundle_ref.registry,
+                repository = %bundle_ref.repository,
+                digest = %bundle_ref.digest,
+                reason,
+                "ClawMemory bundleRef fetch/verify failed: {msg}"
+            );
+            (
+                crate::claw_memory::ClawMemorySpec {
+                    sandbox_ref: spec.sandbox_ref.clone(),
+                    ..Default::default()
+                },
+                None,
+                Some((reason, msg)),
+            )
+        }
+    }
+}
+
+/// Merge the verified-bundle content fields onto the CR's
+/// `sandboxRef` to produce the effective spec for
+/// [`compile_to_binding`]. The bundle owns content; the CR owns the
+/// sandbox the binding applies to.
+fn merge_bundle_with_selector(
+    sandbox_ref: &crate::claw_memory::SandboxRef,
+    verified: &crate::policy_canonical::memory::VerifiedMemoryBinding,
+) -> crate::claw_memory::ClawMemorySpec {
+    crate::claw_memory::ClawMemorySpec {
+        store_name: verified.store_name.clone(),
+        sandbox_ref: sandbox_ref.clone(),
+        scope: verified.scope.clone(),
+        retention_days: verified.retention_days,
+        delete_on_sandbox_delete: verified.delete_on_sandbox_delete,
+        display_name: verified.display_name.clone(),
+        bundle_ref: None,
+    }
+}
+
+/// Map [`crate::policy_fetcher::FetchError`] to the `(reason,
+/// message)` pair surfaced as a `Degraded=True` condition. Shares
+/// the one vocabulary [`crate::policy_fetcher::reason_for_error`]
+/// owns across all signed-policy kinds.
+fn fetch_error_to_degraded(e: &crate::policy_fetcher::FetchError) -> (&'static str, String) {
+    let reason = crate::policy_fetcher::reason_for_error(e).unwrap_or("Transient");
+    (reason, e.to_string())
 }
 
 /// Slice 3b.4 — scan the per-sandbox poll outcomes for a router-side

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -332,9 +332,9 @@ pub fn inference_policy_crd() -> CustomResourceDefinition {
 pub fn claw_memory_validations() -> Vec<ValidationRule> {
     vec![
         ValidationRule {
-            rule: "size(self.storeName) > 0 && size(self.storeName) <= 63 && self.storeName.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')".into(),
+            rule: "has(self.bundleRef) || (has(self.storeName) && size(self.storeName) > 0 && size(self.storeName) <= 63 && self.storeName.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))".into(),
             message: Some(
-                "spec.storeName must be a DNS-label (1-63 chars, lowercase alphanumeric + dashes)".into(),
+                "spec.storeName must be a DNS-label (1-63 chars, lowercase alphanumeric + dashes) when spec.bundleRef is not set".into(),
             ),
             reason: Some("FieldValueInvalid".into()),
             ..ValidationRule::default()
@@ -346,8 +346,8 @@ pub fn claw_memory_validations() -> Vec<ValidationRule> {
             ..ValidationRule::default()
         },
         ValidationRule {
-            rule: "size(self.scope) > 0 && size(self.scope) <= 256".into(),
-            message: Some("spec.scope must be 1-256 characters".into()),
+            rule: "has(self.bundleRef) || (has(self.scope) && size(self.scope) > 0 && size(self.scope) <= 256)".into(),
+            message: Some("spec.scope must be 1-256 characters when spec.bundleRef is not set".into()),
             reason: Some("FieldValueInvalid".into()),
             ..ValidationRule::default()
         },
@@ -355,6 +355,18 @@ pub fn claw_memory_validations() -> Vec<ValidationRule> {
             rule: "!has(self.retentionDays) || self.retentionDays > 0".into(),
             message: Some(
                 "spec.retentionDays must be > 0 when set (use delete_scope for immediate deletion)".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        // Slice 1c.4 mutex: bundleRef is mutually exclusive with the
+        // inline content fields (storeName, scope, retentionDays,
+        // deleteOnSandboxDelete, displayName). sandboxRef stays in
+        // the CR in either branch.
+        ValidationRule {
+            rule: "!has(self.bundleRef) || (!has(self.storeName) && !has(self.scope) && !has(self.retentionDays) && !has(self.deleteOnSandboxDelete) && !has(self.displayName))".into(),
+            message: Some(
+                "spec.bundleRef is mutually exclusive with spec.storeName, spec.scope, spec.retentionDays, spec.deleteOnSandboxDelete, and spec.displayName".into(),
             ),
             reason: Some("FieldValueInvalid".into()),
             ..ValidationRule::default()

--- a/controller/src/policy_canonical/egress.rs
+++ b/controller/src/policy_canonical/egress.rs
@@ -87,7 +87,7 @@ impl PolicyKind for EgressKind {
         }
         match &entry.verified {
             CachedValue::Egress(v) => Some(v.clone()),
-            CachedValue::Inference(_) | CachedValue::Tools(_) => None,
+            CachedValue::Inference(_) | CachedValue::Memory(_) | CachedValue::Tools(_) => None,
         }
     }
 

--- a/controller/src/policy_canonical/inference.rs
+++ b/controller/src/policy_canonical/inference.rs
@@ -113,7 +113,7 @@ impl PolicyKind for InferenceKind {
         }
         match &entry.verified {
             CachedValue::Inference(v) => Some(v.clone()),
-            CachedValue::Egress(_) | CachedValue::Tools(_) => None,
+            CachedValue::Egress(_) | CachedValue::Memory(_) | CachedValue::Tools(_) => None,
         }
     }
 

--- a/controller/src/policy_canonical/memory.rs
+++ b/controller/src/policy_canonical/memory.rs
@@ -1,0 +1,420 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ClawMemory canonical-form parser + `PolicyKind` impl.
+//!
+//! Slice 1c.4 — fourth per-kind implementation after egress (1c.1),
+//! tools (1c.2), and inference (1c.3). A ClawMemory bundle carries
+//! the **Foundry Memory Store binding content** the controller will
+//! merge onto the per-CR `sandboxRef`:
+//!
+//! - `storeName`
+//! - `scope`
+//! - `retentionDays`
+//! - `deleteOnSandboxDelete`
+//! - `displayName`
+//!
+//! `sandboxRef` is intentionally NOT a bundle key. The sandbox a
+//! binding applies to is owned by the `ClawMemory` CR — one signed
+//! bundle can therefore be referenced by multiple CRs (e.g. fleet
+//! rollout of an identical memory configuration to several sandboxes).
+//! This mirrors the inference-policy and tool-policy patterns:
+//! **selector stays in the CR, content lives in the bundle**.
+//!
+//! What this parser enforces (trait invariant #1, applied to memory):
+//! - Valid UTF-8
+//! - Parseable as a JSON object
+//! - Top-level keys are policy-content keys only (no `sandboxRef`)
+//! - `storeName` (when present) is a non-empty string
+//! - `scope` (when present) is a non-empty string
+//! - `retentionDays` (when present) is a non-negative integer
+//! - `deleteOnSandboxDelete` (when present) is a boolean
+//! - `displayName` (when present) is a string
+//! - At least one policy-content key is present (empty bundles are
+//!   rejected — the inline path is the supported way to express
+//!   binding metadata without supply-chain verification)
+//!
+//! Semantic checks (DNS-label-style `storeName`, valid `scope`
+//! prefixes, retention floor sanity) stay in the existing
+//! `crd_validations::claw_memory_validations` admission layer and the
+//! runtime path (`cli/src/plugin.ts::ensureMemoryStore`).
+
+use super::{CachedValue, PolicyKind};
+use crate::policy_fetcher::{CACHE_TTL, FetchError};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Instant, SystemTime};
+
+/// OCI media type for the v1 memory-binding artifact. The pulled
+/// `artifactType` MUST match this exactly; consumers reject any other
+/// value (forward-compat: v2 bumps the suffix; v1 consumers MUST
+/// refuse v2 artifacts).
+pub const MEMORY_BINDING_V1_MEDIA_TYPE: &str = "application/vnd.azureclaw.memory-binding.v1+json";
+
+/// Recognised top-level keys in a memory-binding bundle. `sandboxRef`
+/// is intentionally NOT one of them: the binding targets a sandbox
+/// owned by the `ClawMemory.spec`, not the signed artifact.
+const POLICY_CONTENT_KEYS: &[&str] = &[
+    "storeName",
+    "scope",
+    "retentionDays",
+    "deleteOnSandboxDelete",
+    "displayName",
+];
+
+/// A verified memory-binding bundle. Each `Option` field is extracted
+/// at parse time so the reconciler does not re-parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedMemoryBinding {
+    pub store_name: Option<String>,
+    pub scope: Option<String>,
+    pub retention_days: Option<u32>,
+    pub delete_on_sandbox_delete: Option<bool>,
+    pub display_name: Option<String>,
+    /// Raw signed bytes. Kept for observability; the router echo
+    /// digest is computed over the **recompiled** bytes (sandboxRef
+    /// merged with content), not these.
+    pub bytes: Vec<u8>,
+    /// `sha256:...` matched against `OciArtifactRef.digest`.
+    pub digest: String,
+    pub fetched_at: SystemTime,
+}
+
+/// `PolicyKind` discriminator for memory-binding bundles.
+pub struct MemoryKind;
+
+impl PolicyKind for MemoryKind {
+    const MEDIA_TYPE: &'static str = MEMORY_BINDING_V1_MEDIA_TYPE;
+    const API_VERSION: &'static str = "azureclaw.azure.com/v1alpha1";
+    const KIND: &'static str = "ClawMemory";
+    type Output = VerifiedMemoryBinding;
+
+    fn parse(bytes: &[u8]) -> Result<Self::Output, FetchError> {
+        parse(bytes)
+    }
+
+    fn finalize(out: &mut Self::Output, digest: String, fetched_at: SystemTime) {
+        out.digest = digest;
+        out.fetched_at = fetched_at;
+    }
+
+    fn cache_get(key: &str, now: Instant) -> Option<Self::Output> {
+        let guard = cache().lock().ok()?;
+        let entry = guard.get(key)?;
+        if now.duration_since(entry.inserted) > CACHE_TTL {
+            return None;
+        }
+        match &entry.verified {
+            CachedValue::Memory(v) => Some(v.clone()),
+            CachedValue::Egress(_) | CachedValue::Tools(_) | CachedValue::Inference(_) => None,
+        }
+    }
+
+    fn cache_put(key: String, value: Self::Output) {
+        if let Ok(mut guard) = cache().lock() {
+            guard.insert(
+                key,
+                CacheEntry {
+                    verified: CachedValue::Memory(value),
+                    inserted: Instant::now(),
+                },
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn cache_clear() {
+        if let Ok(mut guard) = cache().lock() {
+            guard.clear();
+        }
+    }
+}
+
+// ─────────────────────────── cache ───────────────────────────
+
+struct CacheEntry {
+    verified: CachedValue,
+    inserted: Instant,
+}
+
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// ─────────────────────────── parser ───────────────────────────
+
+pub(crate) fn parse(bytes: &[u8]) -> Result<VerifiedMemoryBinding, FetchError> {
+    let s = std::str::from_utf8(bytes)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("utf-8: {e}")))?;
+
+    let doc: Value = serde_json::from_str(s)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("json parse: {e}")))?;
+
+    let map = doc.as_object().ok_or_else(|| {
+        FetchError::CanonicalFormViolation("top-level must be a JSON object".into())
+    })?;
+
+    for key in map.keys() {
+        if !POLICY_CONTENT_KEYS.contains(&key.as_str()) {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "unrecognised top-level key `{key}`; allowed: storeName, scope, \
+                 retentionDays, deleteOnSandboxDelete, displayName"
+            )));
+        }
+    }
+
+    let store_name = extract_optional_nonempty_string(map, "storeName")?;
+    let scope = extract_optional_nonempty_string(map, "scope")?;
+    let retention_days = extract_optional_u32(map, "retentionDays")?;
+    let delete_on_sandbox_delete = extract_optional_bool(map, "deleteOnSandboxDelete")?;
+    let display_name = extract_optional_string(map, "displayName")?;
+
+    if store_name.is_none()
+        && scope.is_none()
+        && retention_days.is_none()
+        && delete_on_sandbox_delete.is_none()
+        && display_name.is_none()
+    {
+        return Err(FetchError::CanonicalFormViolation(
+            "bundle has no policy content (all of storeName / scope / retentionDays / \
+             deleteOnSandboxDelete / displayName are absent or null); use the inline \
+             path for selector-only bindings"
+                .into(),
+        ));
+    }
+
+    Ok(VerifiedMemoryBinding {
+        store_name,
+        scope,
+        retention_days,
+        delete_on_sandbox_delete,
+        display_name,
+        bytes: bytes.to_vec(),
+        digest: String::new(),
+        fetched_at: SystemTime::UNIX_EPOCH,
+    })
+}
+
+fn extract_optional_nonempty_string(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
+        Some(Value::String(_)) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a non-empty string"
+        ))),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a non-empty string or null"
+        ))),
+    }
+}
+
+fn extract_optional_string(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a string or null"
+        ))),
+    }
+}
+
+fn extract_optional_u32(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<u32>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(n)) => {
+            let v = n.as_u64().ok_or_else(|| {
+                FetchError::CanonicalFormViolation(format!(
+                    "`{key}` must be a non-negative integer (got {n})"
+                ))
+            })?;
+            u32::try_from(v).map(Some).map_err(|_| {
+                FetchError::CanonicalFormViolation(format!("`{key}` must fit in u32 (got {v})"))
+            })
+        }
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a non-negative integer or null"
+        ))),
+    }
+}
+
+fn extract_optional_bool(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<bool>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(b)) => Ok(Some(*b)),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a boolean or null"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_bundle_ok() {
+        let body = br#"{
+            "storeName": "agent-x-mem",
+            "scope": "agent:agent-x",
+            "retentionDays": 30,
+            "deleteOnSandboxDelete": true,
+            "displayName": "Agent X memory"
+        }"#;
+        let v = parse(body).unwrap();
+        assert_eq!(v.store_name.as_deref(), Some("agent-x-mem"));
+        assert_eq!(v.scope.as_deref(), Some("agent:agent-x"));
+        assert_eq!(v.retention_days, Some(30));
+        assert_eq!(v.delete_on_sandbox_delete, Some(true));
+        assert_eq!(v.display_name.as_deref(), Some("Agent X memory"));
+    }
+
+    #[test]
+    fn parse_store_name_only_ok() {
+        let body = br#"{"storeName":"agent-x-mem"}"#;
+        let v = parse(body).unwrap();
+        assert_eq!(v.store_name.as_deref(), Some("agent-x-mem"));
+        assert!(v.scope.is_none());
+    }
+
+    #[test]
+    fn parse_invalid_utf8_rejected() {
+        let body = [0xFFu8, 0xFE];
+        let err = parse(&body).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("utf-8")));
+    }
+
+    #[test]
+    fn parse_invalid_json_rejected() {
+        let err = parse(b"{not json").unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("json parse"))
+        );
+    }
+
+    #[test]
+    fn parse_non_object_top_level_rejected() {
+        let err = parse(b"[]").unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("top-level"))
+        );
+    }
+
+    #[test]
+    fn parse_unknown_key_rejected() {
+        let err = parse(br#"{"foo":1}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("unrecognised"))
+        );
+    }
+
+    #[test]
+    fn parse_sandboxref_in_bundle_rejected() {
+        // sandboxRef is owned by the CR, not the bundle
+        let err = parse(br#"{"storeName":"x","sandboxRef":{"name":"y"}}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("sandboxRef"))
+        );
+    }
+
+    #[test]
+    fn parse_empty_object_rejected() {
+        let err = parse(b"{}").unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("no policy content"))
+        );
+    }
+
+    #[test]
+    fn parse_all_null_rejected() {
+        let err = parse(
+            br#"{"storeName":null,"scope":null,"retentionDays":null,"deleteOnSandboxDelete":null,"displayName":null}"#,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("no policy content"))
+        );
+    }
+
+    #[test]
+    fn parse_empty_store_name_rejected() {
+        let err = parse(br#"{"storeName":""}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-empty"))
+        );
+    }
+
+    #[test]
+    fn parse_store_name_wrong_type_rejected() {
+        let err = parse(br#"{"storeName":42}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-empty"))
+        );
+    }
+
+    #[test]
+    fn parse_empty_scope_rejected() {
+        let err = parse(br#"{"scope":""}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-empty"))
+        );
+    }
+
+    #[test]
+    fn parse_retention_days_negative_rejected() {
+        let err = parse(br#"{"retentionDays":-1}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-negative"))
+        );
+    }
+
+    #[test]
+    fn parse_retention_days_wrong_type_rejected() {
+        let err = parse(br#"{"retentionDays":"thirty"}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-negative"))
+        );
+    }
+
+    #[test]
+    fn parse_retention_days_overflow_rejected() {
+        let err = parse(br#"{"retentionDays":4294967296}"#).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("u32")));
+    }
+
+    #[test]
+    fn parse_delete_on_sandbox_delete_wrong_type_rejected() {
+        let err = parse(br#"{"deleteOnSandboxDelete":"yes"}"#).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("boolean")));
+    }
+
+    #[test]
+    fn parse_display_name_wrong_type_rejected() {
+        let err = parse(br#"{"storeName":"x","displayName":42}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("displayName"))
+        );
+    }
+
+    #[test]
+    fn parse_retention_days_zero_ok() {
+        // zero is a valid non-negative integer; semantic "retention
+        // must be > 0" is enforced by admission CEL on the CR, not
+        // here on the bundle.
+        let v = parse(br#"{"retentionDays":0}"#).unwrap();
+        assert_eq!(v.retention_days, Some(0));
+    }
+}

--- a/controller/src/policy_canonical/mod.rs
+++ b/controller/src/policy_canonical/mod.rs
@@ -31,6 +31,7 @@ use std::time::{Instant, SystemTime};
 
 pub mod egress;
 pub mod inference;
+pub mod memory;
 pub mod tools;
 
 #[allow(unused_imports)]
@@ -38,6 +39,8 @@ pub mod tools;
 pub use egress::EgressKind;
 #[allow(unused_imports)]
 pub use inference::InferenceKind;
+#[allow(unused_imports)]
+pub use memory::MemoryKind;
 #[allow(unused_imports)]
 pub use tools::ToolsKind;
 
@@ -53,10 +56,11 @@ pub use tools::ToolsKind;
 /// is the implementation detail of how
 /// [`PolicyKind::cache_get`] / [`PolicyKind::cache_put`] are wired, not
 /// a public extension point.
-#[allow(dead_code)] // future kinds will add variants in 1c.4 - 1c.5
+#[allow(dead_code)] // future kinds will add variants in 1c.5
 pub(crate) enum CachedValue {
     Egress(egress::VerifiedAllowlist),
     Inference(inference::VerifiedInferencePolicy),
+    Memory(memory::VerifiedMemoryBinding),
     Tools(tools::VerifiedAgtProfile),
 }
 

--- a/controller/src/policy_canonical/tools.rs
+++ b/controller/src/policy_canonical/tools.rs
@@ -106,7 +106,7 @@ impl PolicyKind for ToolsKind {
         }
         match &entry.verified {
             CachedValue::Tools(v) => Some(v.clone()),
-            CachedValue::Egress(_) | CachedValue::Inference(_) => None,
+            CachedValue::Egress(_) | CachedValue::Inference(_) | CachedValue::Memory(_) => None,
         }
     }
 

--- a/deploy/helm/azureclaw/templates/crd-clawmemory.yaml
+++ b/deploy/helm/azureclaw/templates/crd-clawmemory.yaml
@@ -48,17 +48,67 @@ spec:
               must declare distinct `scope` values. Conflict detection is
               router-side (S7) — the CRD admission only validates shape.
             properties:
+              bundleRef:
+                description: |-
+                  Signed OCI artifact carrying the binding content
+                  (`storeName`, `scope`, `retentionDays`,
+                  `deleteOnSandboxDelete`, `displayName`). When set, the
+                  controller pulls the artifact by digest, verifies its
+                  cosign signature against the active
+                  [`crate::signer_policy::SignerPolicy`], and merges the
+                  bundle content onto `sandboxRef` (always owned by the CR)
+                  before writing the binding ConfigMap. Slice 1c.4 of the
+                  `crd-well-oiled-machine` plan.
+
+                  Mutually exclusive with the inline content fields above.
+                  Admission CEL enforces the mutex; the reconciler also checks
+                  as defense-in-depth.
+                nullable: true
+                properties:
+                  artifactType:
+                    description: |-
+                      OCI artifactType media-type, e.g.
+                      `application/vnd.azureclaw.egress-allowlist.v1+yaml`. Consumers MUST
+                      reject artifacts whose pulled `artifactType` doesn't match.
+                    type: string
+                  digest:
+                    description: |-
+                      Content-addressed digest, including the algorithm prefix
+                      (`sha256:abc…`). The digest covers the canonical artifact bytes —
+                      see `docs/internal/policy-canonical-format.md` for the egress-allowlist
+                      canonicalization rules.
+                    type: string
+                  registry:
+                    description: Registry hostname (e.g. `myacr.azurecr.io`, `ghcr.io`).
+                    type: string
+                  repository:
+                    description: Repository path (e.g. `azureclaw/policies/sandbox-foo`).
+                    type: string
+                required:
+                - artifactType
+                - digest
+                - registry
+                - repository
+                type: object
               deleteOnSandboxDelete:
-                default: true
                 description: |-
                   If true (default), the runtime path must call `delete_scope`
                   on this scope when the sandbox is deleted or this CR is
                   deleted. The controller-side cleanup is finalizer-only on the
                   binding ConfigMap; Foundry-side delete via the router is
                   wired in S7+.
+
+                  When [`Self::bundle_ref`] is set, the bundle supplies this
+                  value; the CR's inline value MUST be absent in that case.
+                  Default-true is applied at the reconciler layer (after the
+                  bundle / inline merge) so `None` here is meaningful (= "use
+                  bundle value or default").
+                nullable: true
                 type: boolean
               displayName:
-                description: Optional human-readable label.
+                description: |-
+                  Optional human-readable label. MUST be absent when
+                  [`Self::bundle_ref`] is set.
                 nullable: true
                 type: string
               retentionDays:
@@ -71,7 +121,10 @@ spec:
                 nullable: true
                 type: integer
               sandboxRef:
-                description: Sandbox this binding applies to.
+                description: |-
+                  Sandbox this binding applies to. Owned by the CR (never the
+                  signed bundle) — one signed bundle can be referenced by
+                  multiple `ClawMemory` CRs targeting different sandboxes.
                 properties:
                   name:
                     description: Sandbox name (`ClawSandbox.metadata.name`).
@@ -85,6 +138,10 @@ spec:
                   Foundry Memory Store partitions data per scope. CEL:
                   non-empty. Default convention (set by the runtime path if
                   absent here): `agent:{sandboxName}`.
+
+                  Required when [`Self::bundle_ref`] is absent (the inline
+                  path); MUST be absent when [`Self::bundle_ref`] is set.
+                nullable: true
                 type: string
               storeName:
                 description: |-
@@ -92,25 +149,32 @@ spec:
                   (`cli/src/plugin.ts::ensureMemoryStore`) creates the store
                   on first use if absent. CEL: non-empty,
                   DNS-label-style (lowercase alphanumeric + dashes).
+
+                  Required when [`Self::bundle_ref`] is absent (the inline
+                  path); MUST be absent when [`Self::bundle_ref`] is set
+                  (the bundle supplies the value). Admission CEL enforces
+                  the mutex.
+                nullable: true
                 type: string
             required:
             - sandboxRef
-            - scope
-            - storeName
             type: object
             x-kubernetes-validations:
-            - message: spec.storeName must be a DNS-label (1-63 chars, lowercase alphanumeric + dashes)
+            - message: spec.storeName must be a DNS-label (1-63 chars, lowercase alphanumeric + dashes) when spec.bundleRef is not set
               reason: FieldValueInvalid
-              rule: size(self.storeName) > 0 && size(self.storeName) <= 63 && self.storeName.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+              rule: has(self.bundleRef) || (has(self.storeName) && size(self.storeName) > 0 && size(self.storeName) <= 63 && self.storeName.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
             - message: spec.sandboxRef.name must be 1-253 characters
               reason: FieldValueInvalid
               rule: size(self.sandboxRef.name) > 0 && size(self.sandboxRef.name) <= 253
-            - message: spec.scope must be 1-256 characters
+            - message: spec.scope must be 1-256 characters when spec.bundleRef is not set
               reason: FieldValueInvalid
-              rule: size(self.scope) > 0 && size(self.scope) <= 256
+              rule: has(self.bundleRef) || (has(self.scope) && size(self.scope) > 0 && size(self.scope) <= 256)
             - message: spec.retentionDays must be > 0 when set (use delete_scope for immediate deletion)
               reason: FieldValueInvalid
               rule: '!has(self.retentionDays) || self.retentionDays > 0'
+            - message: spec.bundleRef is mutually exclusive with spec.storeName, spec.scope, spec.retentionDays, spec.deleteOnSandboxDelete, and spec.displayName
+              reason: FieldValueInvalid
+              rule: '!has(self.bundleRef) || (!has(self.storeName) && !has(self.scope) && !has(self.retentionDays) && !has(self.deleteOnSandboxDelete) && !has(self.displayName))'
           status:
             description: Status of a `ClawMemory` reconcile.
             nullable: true
@@ -127,6 +191,24 @@ spec:
                 required:
                 - name
                 type: object
+              bundleRefDigest:
+                description: |-
+                  `sha256:...` of the signed bundle the controller last pulled
+                  for `spec.bundleRef`. Stamped when the bundle path produced
+                  the effective spec used in the latest reconcile; `None` when
+                  the spec used the inline path or no successful fetch has
+                  happened yet. Slice 1c.4.
+                nullable: true
+                type: string
+              compiledDigest:
+                description: |-
+                  `sha256:<hex>` digest of the canonical binding JSON the
+                  controller published — the value every referencing sandbox's
+                  router must echo via `GET /internal/policy-status` before the
+                  CR is promoted to `phase=Ready` (principles.md §3, Slice 3a).
+                  Stays unset on `phase=Failed`.
+                nullable: true
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
@@ -160,15 +242,6 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              compiledDigest:
-                description: |-
-                  `sha256:<hex>` digest of the canonical binding JSON the
-                  controller published — the value every referencing sandbox's
-                  router must echo via `GET /internal/policy-status` before the
-                  CR is promoted to `phase=Ready` (principles.md §3, Slice 3a).
-                  Stays unset on `phase=Failed`.
-                nullable: true
-                type: string
               lastReconciledAt:
                 description: Last time the binding was compiled and pushed.
                 nullable: true
@@ -206,3 +279,4 @@ spec:
     storage: true
     subresources:
       status: {}
+


### PR DESCRIPTION
Fourth step in the Slice 1c-real signing-generalization arc.

`ClawMemory` now joins `EgressAllowlist` (#302), `ToolPolicy` (#303), and `InferencePolicy` (#304) on the unified `policy_fetcher::fetch_and_verify_generic` pipeline.

## Producer side (controller)
- New `controller/src/policy_canonical/memory.rs` — `MemoryKind: PolicyKind` impl. Bundle carries `storeName`, `scope`, `retentionDays`, `deleteOnSandboxDelete`, `displayName`. `sandboxRef` stays in the CR (one signed artifact can be referenced by multiple CRs targeting different sandboxes; parser explicitly rejects `sandboxRef` inside a bundle). Media type `application/vnd.azureclaw.memory-binding.v1+json`. Per-kind cache slot via `OnceLock<CachedValue::Memory(...)>`. **18 unit tests** covering every rejection path.
- `ClawMemorySpec.bundleRef: Option<OciArtifactRef>` added; `storeName`, `scope`, and `deleteOnSandboxDelete` made `Option`-typed and required only on the inline path. `ClawMemoryStatus.bundleRefDigest` surfaces the verified manifest digest.
- `claw_memory_reconciler::resolve_memory_source` — 4-way match mirroring `resolve_inference_source`. Bundle path merges verified content onto the CR's `sandboxRef` selector. Degraded branches skip the ConfigMap write so the router's last-good binding remains in force.
- `claw_memory_compile::compile_to_binding` tolerates the new Optional spec fields with the same defaults the inline path always implied (`deleteOnSandboxDelete` defaults `true`).

## Admission
- CEL mutex rule: `bundleRef` rejects coexistence with the inline content fields. `storeName`/`scope` rules wrapped in `has(self.bundleRef) || …`.

## Schema
- Regenerated `deploy/helm/azureclaw/templates/crd-clawmemory.yaml`. `required: [sandboxRef]` only on spec. CNCF C10 labels preserved.

## Out of scope (deferred)
- CLI dispatch `azureclaw policy sign --kind memory-binding` — Slice 1c.6.
- McpServer `bundleRef` — Slice 1c.5.

## Test deltas
- controller: 636 → 654 (+18 memory parser tests)
- clippy `-D warnings` clean, fmt clean, helm_drift clean, CNCF conformance clean
- Router untouched — `compile_to_binding` produces identical bytes from the effective spec regardless of provenance