### PR TITLE
Slice 1c.5 — McpServer.spec.bundleRef (signed OCI artifact)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1c.5 — `McpServer.spec.bundleRef` (signed OCI artifact)
+
+Fifth and final per-kind step in the Slice 1c-real
+signing-generalization arc. `McpServer` now joins `EgressAllowlist`
+(1c.1), `ToolPolicy` (1c.2), `InferencePolicy` (1c.3), and
+`ClawMemory` (1c.4) on the unified
+`policy_fetcher::fetch_and_verify_generic` pipeline.
+
+**Producer side (controller)**
+
+- New `controller/src/policy_canonical/mcp_server.rs` —
+  `McpServerKind: PolicyKind` impl. Bundle carries the server
+  identity + tool surface: `url`, `oauth` (issuer / audience /
+  resource / pkce), `productionMode`, `scopes`, `allowedTools`,
+  `displayName`. The `allowedSandboxes` selector stays on the CR
+  — the parser explicitly rejects it inside a bundle so one signed
+  artifact can be referenced by multiple `McpServer` CRs with
+  different sandbox selectors (the multi-tenant fan-out pattern
+  established in 1c.4). Structural validation: type-checked
+  scalars, non-empty string arrays, RFC 7636 PKCE constraint
+  surfaced via the canonical-form parser too. Media type
+  `application/vnd.azureclaw.mcp-server-bundle.v1+json`. Per-kind
+  cache slot via `OnceLock<CachedValue::McpServer(...)>` on the
+  shared `policy_canonical` cache. 22 unit tests covering every
+  rejection path.
+- `McpServerSpec.bundleRef: Option<OciArtifactRef>` added; the
+  inline content fields (`url`, `oauth`, `productionMode`,
+  `scopes`, `allowedTools`, `displayName`) are now `Option`-typed
+  and required only on the inline path.
+- `McpServerStatus.bundleRefDigest: Option<String>` surfaces the
+  verified OCI manifest digest after a successful
+  `fetch_and_verify_generic::<McpServerKind>` call.
+- `mcp_server_reconciler::resolve_mcp_source` — 4-way match
+  (no inline / inline only / bundle only / both) mirroring
+  `inference_policy_reconciler::resolve_inference_source` and
+  `claw_memory_reconciler::resolve_memory_source`. On the bundle
+  path, merges the verified content onto the CR's
+  `allowedSandboxes` selector to produce the effective spec
+  consumed by the rest of the reconcile loop (JWKS write,
+  productionMode guard, signing secret, ConfigMap mirror).
+  `FetchError` variants map through the shared
+  `policy_fetcher::reason_for_error` vocabulary. On any degraded
+  branch (mutex / fetch / verify) the per-server JWKS ConfigMap
+  write is skipped so the router's last-good server registry
+  remains in force until the operator fixes the spec.
+
+**Admission**
+
+- CEL rules on `McpServerSpec` rewritten:
+  - The pre-existing `productionMode → oauth.issuer` rule and the
+    `productionMode → url https://` rule are now wrapped in
+    `has(self.bundleRef) || !has(self.productionMode) || …` so
+    the inline-path validations only fire when the bundle path is
+    unused (and `productionMode` is set + true).
+  - New mutex rule:
+    `!has(self.bundleRef) || (!has(self.url) && !has(self.oauth) && !has(self.productionMode) && !has(self.scopes) && !has(self.allowedTools) && !has(self.displayName))`
+    — rejects mixed shapes at apply-time.
+
+**Schema**
+
+- Regenerated `deploy/helm/azureclaw/templates/crd-mcpserver.yaml`
+  via `DUMP_MCP_CRD_YAML=1 cargo test …
+  helm_drift::tests::dump_mcp_crd_yaml`. Adds the `spec.bundleRef`
+  block, makes the content fields optional in the schema, and adds
+  the new CEL mutex rule + `status.bundleRefDigest`. CNCF C10
+  labels preserved.
+
+**Out of scope (deferred)**
+
+- CLI dispatch `azureclaw policy sign --kind mcp-server-bundle`
+  — lands with the unified CLI in Slice 1c.6.
+- `SignerPolicy.ed25519Keys[]` forward-compat for the grant lane
+  — Slice 1c.6.
+- `EgressApproval` CRD — Slice 5e-thin (independent code path).
+
+Test deltas: controller 654 → 677 (+22 mcp_server parser tests +
++1 mcp_server_validations injection). clippy `-D warnings` clean,
+fmt clean, helm_drift clean, workspace tests clean. Router
+untouched — wire contract unchanged (per-server JWKS bytes are
+identical whether the spec is inline or merged from a verified
+bundle).
+
 ### Slice 1c.4 — `ClawMemory.spec.bundleRef` (signed OCI artifact)
 
 Fourth step in the Slice 1c-real signing-generalization arc.
@@ -72,7 +154,6 @@ and `InferencePolicy` (1c.3) on the unified
 
 - CLI dispatch `azureclaw policy sign --kind memory-binding` — lands
   with the unified CLI in Slice 1c.6.
-- McpServer `bundleRef` — Slice 1c.5.
 
 Test deltas: controller 636 → 654 (+18 memory parser tests).
 clippy `-D warnings` clean, fmt clean, helm_drift clean, CNCF
@@ -142,7 +223,6 @@ that the controller pulls by digest and validates per
 
 - CLI dispatch `azureclaw policy sign --kind inference-policy`
   — lands with the unified CLI in Slice 1c.6.
-- McpServer `bundleRef` — Slice 1c.5.
 
 Test deltas: controller 619 → 636 (+17 inference parser tests).
 clippy `-D warnings` clean, fmt clean, helm_drift clean, CNCF

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -64,19 +64,30 @@ use crate::tool_policy::ToolPolicy;
 ///    `https://`.
 /// 3. `oauth.pkce`, when present, must be `S256` (RFC 7636 §4.2 — the
 ///    one PKCE method this CRD supports).
+/// 4. `bundleRef` is mutually exclusive with the inline content
+///    fields (`url`, `oauth`, `productionMode`, `scopes`,
+///    `allowedTools`, `displayName`). The CR may either inline the
+///    server identity + tool surface or reference a signed OCI
+///    bundle, never both. (Selector field `allowedSandboxes` stays
+///    on the CR in both modes — it's authoring metadata, not
+///    bundle content.)
 #[must_use]
 pub fn mcp_server_validations() -> Vec<ValidationRule> {
     vec![
         ValidationRule {
-            rule:
-                "self.productionMode == false || (has(self.oauth) && size(self.oauth.issuer) > 0)"
-                    .into(),
+            rule: "has(self.bundleRef) || !has(self.productionMode) || \
+                   self.productionMode == false || \
+                   (has(self.oauth) && size(self.oauth.issuer) > 0)"
+                .into(),
             message: Some("productionMode requires spec.oauth.issuer to be set".into()),
             reason: Some("FieldValueInvalid".into()),
             ..ValidationRule::default()
         },
         ValidationRule {
-            rule: "self.productionMode == false || self.url.startsWith('https://')".into(),
+            rule: "has(self.bundleRef) || !has(self.productionMode) || \
+                   self.productionMode == false || \
+                   (has(self.url) && self.url.startsWith('https://'))"
+                .into(),
             message: Some("productionMode requires spec.url to begin with https://".into()),
             reason: Some("FieldValueInvalid".into()),
             ..ValidationRule::default()
@@ -84,6 +95,20 @@ pub fn mcp_server_validations() -> Vec<ValidationRule> {
         ValidationRule {
             rule: "!has(self.oauth) || !has(self.oauth.pkce) || self.oauth.pkce == 'S256'".into(),
             message: Some("spec.oauth.pkce, when set, must be 'S256' (RFC 7636 §4.2)".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.bundleRef) || (!has(self.url) && !has(self.oauth) && \
+                   !has(self.productionMode) && !has(self.scopes) && \
+                   !has(self.allowedTools) && !has(self.displayName))"
+                .into(),
+            message: Some(
+                "spec.bundleRef is mutually exclusive with spec.url, spec.oauth, \
+                 spec.productionMode, spec.scopes, spec.allowedTools, and \
+                 spec.displayName"
+                    .into(),
+            ),
             reason: Some("FieldValueInvalid".into()),
             ..ValidationRule::default()
         },

--- a/controller/src/mcp_server.rs
+++ b/controller/src/mcp_server.rs
@@ -32,6 +32,17 @@ use serde::{Deserialize, Serialize};
 /// `McpServer.spec` — declares an MCP 2026 server reachable from sandboxes
 /// in the same namespace (or, if `crossNamespaceAllowed: true` on the
 /// server side, cluster-wide).
+///
+/// ## Two authoring paths
+///
+/// The content fields (`url`, `oauth`, `productionMode`, `scopes`,
+/// `allowedTools`, `displayName`) are mutually exclusive with
+/// [`bundle_ref`](McpServerSpec::bundle_ref): either inline the values
+/// (no supply-chain attestation) or reference a signed OCI artifact
+/// (cosign-verified against the cluster `SignerPolicy`). The
+/// `allowedSandboxes` selector is owned exclusively by the CR — one
+/// signed server bundle can be referenced by multiple `McpServer` CRs
+/// with different sandbox selectors.
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[kube(
     group = "azureclaw.azure.com",
@@ -49,36 +60,63 @@ use serde::{Deserialize, Serialize};
 pub struct McpServerSpec {
     /// Server endpoint URL. MUST be `https://` when `productionMode: true`.
     /// Validated by admission CEL.
-    pub url: String,
+    ///
+    /// Optional: a signed bundle can supply this via [`bundle_ref`]. At
+    /// reconcile time, exactly one of `url` or `bundle_ref.url` must
+    /// resolve to a non-empty value, otherwise the reconciler stamps
+    /// `Degraded=True/SpecInvalid`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 
     /// OAuth 2.1 configuration. Required when `productionMode: true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth: Option<McpOAuthConfig>,
 
     /// When true, the router rejects calls that are not bearer-token-
     /// authenticated against `oauth.issuer` with a verified PKCE flow.
     /// `false` allows unauthenticated calls — dev-only; admission policy
     /// rejects this for non-dev tenants (mirrors `Null*` provider rule).
-    #[serde(default)]
-    pub production_mode: bool,
+    ///
+    /// Optional: a signed bundle can supply this. When neither inline
+    /// nor bundle sets the field, the effective value defaults to
+    /// `false` (back-compat with the pre-1c.5 schema).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub production_mode: Option<bool>,
 
     /// OAuth 2.1 scopes that the router will request when fronting calls
     /// from sandboxes to this server. The actual per-tool gating is
     /// expressed in `ToolPolicy` resources, not here.
-    #[serde(default)]
-    pub scopes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<Vec<String>>,
 
     /// Allow-list of tool names. Empty list means "no tools allowed";
     /// to allow all tools, use `["*"]` and lean on `ToolPolicy` for
     /// per-tool governance. Default empty — fail-closed.
-    #[serde(default)]
-    pub allowed_tools: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
 
     /// Selector restricting which sandboxes can reach this server.
     /// Empty = same-namespace only.
+    ///
+    /// **CR-owned field**: deliberately NOT part of any signed bundle.
+    /// The selector is a deployment-time concern; one signed server
+    /// bundle can be referenced by multiple `McpServer` CRs in
+    /// different environments with different selectors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_sandboxes: Option<SandboxSelector>,
 
     /// Optional human-readable label for operator-TUI display.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
+    /// Reference to a signed OCI artifact carrying the policy content
+    /// (`url`, `oauth`, `productionMode`, `scopes`, `allowedTools`,
+    /// `displayName`). Mutually exclusive with inline content fields —
+    /// enforced by admission CEL and re-checked by the reconciler.
+    ///
+    /// Slice 1c.5 of `crd-well-oiled-machine`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_ref: Option<crate::crd::OciArtifactRef>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
@@ -149,6 +187,17 @@ pub struct McpServerStatus {
     /// `azureclaw-controller/mcp`.
     #[serde(default)]
     pub jwks_config_map_ref: Option<LocalObjectRef>,
+
+    /// OCI manifest digest of the verified signed bundle, when the
+    /// `bundleRef` authoring path was taken. Operator-visible proof
+    /// that the signature was checked and the bundle's bytes shaped
+    /// the effective server config.
+    ///
+    /// `None` when the inline path was used.
+    ///
+    /// Slice 1c.5 of `crd-well-oiled-machine`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_ref_digest: Option<String>,
 }
 
 /// Minimal `LocalObjectReference`-shaped struct with `name` only — the

--- a/controller/src/mcp_server_reconciler.rs
+++ b/controller/src/mcp_server_reconciler.rs
@@ -287,22 +287,28 @@ async fn reconcile(mcp: Arc<McpServer>, ctx: Arc<Ctx>) -> Result<Action, Reconci
         .unwrap_or_default();
     let observed_generation = mcp.metadata.generation;
 
+    // Resolve the effective spec: either pass the CR verbatim (inline
+    // path) or fetch + cosign-verify the referenced OCI bundle and
+    // merge its content onto the CR's `allowedSandboxes` selector
+    // (signed path). See [`resolve_mcp_source`] doc-comment.
+    let (effective_spec, bundle_ref_digest, source_degraded) = resolve_mcp_source(&mcp).await;
+
     // 1. Ensure signing keypair Secret.
     let secret_name = format!("mcp-{name}-signing");
     let signing_kid = ensure_signing_secret(&secrets, &secret_name, &name).await?;
 
     // 2. Ensure JWKS ConfigMap when productionMode=true.
     let mut jwks_ref: Option<LocalObjectRef> = None;
-    let mut degraded: Option<(&'static str, String)> = None;
+    let mut degraded: Option<(&'static str, String)> = source_degraded;
 
-    if mcp.spec.production_mode {
-        let issuer_opt = mcp.spec.oauth.as_ref().map(|o| o.issuer.clone());
+    if degraded.is_none() && effective_spec.production_mode.unwrap_or(false) {
+        let issuer_opt = effective_spec.oauth.as_ref().map(|o| o.issuer.clone());
         match issuer_opt {
             Some(issuer) if !issuer.is_empty() => {
                 let cm_name = format!("mcp-{name}-jwks");
                 match ctx.jwks_fetcher.fetch(&issuer).await {
                     Ok(fetched) => {
-                        let meta = McpServerMeta::from_spec(&mcp.spec);
+                        let meta = McpServerMeta::from_spec(&effective_spec);
                         ensure_jwks_configmap(&configmaps, &cm_name, &name, &fetched.raw, &meta)
                             .await?;
                         jwks_ref = Some(LocalObjectRef {
@@ -332,7 +338,8 @@ async fn reconcile(mcp: Arc<McpServer>, ctx: Arc<Ctx>) -> Result<Action, Reconci
                 // controller upgraded ahead of CRD). Fail loudly.
                 degraded = Some((
                     "SpecInvalid",
-                    "productionMode=true requires spec.oauth.issuer".into(),
+                    "productionMode=true requires spec.oauth.issuer (inline or via bundleRef)"
+                        .into(),
                 ));
             }
         }
@@ -374,6 +381,7 @@ async fn reconcile(mcp: Arc<McpServer>, ctx: Arc<Ctx>) -> Result<Action, Reconci
             last_probed_at: Some(rfc3339_now()),
             signing_key_ref: Some(signing_ref),
             jwks_config_map_ref: jwks_ref,
+            bundle_ref_digest: bundle_ref_digest.clone(),
         }
     });
     api.patch_status(
@@ -624,9 +632,9 @@ impl McpServerMeta {
         Self {
             issuer,
             audience,
-            scopes: spec.scopes.clone(),
-            url: spec.url.clone(),
-            allowed_tools: spec.allowed_tools.clone(),
+            scopes: spec.scopes.clone().unwrap_or_default(),
+            url: spec.url.clone().unwrap_or_default(),
+            allowed_tools: spec.allowed_tools.clone().unwrap_or_default(),
         }
     }
 }
@@ -776,6 +784,160 @@ pub async fn run(client: Client) -> Result<()> {
         })
         .await;
     Ok(())
+}
+
+/// Resolve the effective spec the reconciler will operate on.
+///
+/// Slice 1c.5 of `crd-well-oiled-machine` introduces a signed
+/// `bundleRef` authoring path for `McpServer`. This helper closes the
+/// inline-vs-bundle authoring choice with a single normalised
+/// `McpServerSpec` returned to the reconcile loop:
+///
+/// - **Inline (back-compat, no signature)**: any of `url`, `oauth`,
+///   `productionMode`, `scopes`, `allowedTools`, `displayName` set; no
+///   `bundleRef`. Returns the spec verbatim. `bundle_ref_digest = None`.
+/// - **Signed bundle**: `bundleRef` set, content fields all `None`.
+///   Fetches + verifies the OCI artifact via
+///   [`crate::policy_fetcher::fetch_and_verify_generic`] parameterised
+///   by [`crate::policy_canonical::mcp_server::McpServerKind`]. The
+///   bundle's content fields are merged onto the CR's
+///   `allowedSandboxes` selector. `bundle_ref_digest = Some(<digest>)`.
+/// - **Selector-only**: no `bundleRef` and no content fields set.
+///   Acceptable shape (the CR carries only a selector) but
+///   `productionMode` defaults to `false` and `url` resolves to empty
+///   — the reconciler treats this as a degraded `SpecInvalid` only
+///   when `productionMode` would also be `true`; selector-only
+///   prod-mode-false is intentionally allowed for in-progress
+///   authoring drafts.
+/// - **Both inline + bundleRef** *(rejected at runtime as
+///   defense-in-depth — admission CEL already rejects)*: returns
+///   `(InvalidSpec, msg)` without performing the fetch.
+async fn resolve_mcp_source(
+    mcp: &crate::mcp_server::McpServer,
+) -> (
+    crate::mcp_server::McpServerSpec,
+    Option<String>,
+    Option<(&'static str, String)>,
+) {
+    let spec = &mcp.spec;
+    let inline_any = spec.url.is_some()
+        || spec.oauth.is_some()
+        || spec.production_mode.is_some()
+        || spec.scopes.is_some()
+        || spec.allowed_tools.is_some()
+        || spec.display_name.is_some();
+    let bundle_set = spec.bundle_ref.is_some();
+
+    if inline_any && bundle_set {
+        return (
+            // selector-only synthesis; we won't compile this branch
+            crate::mcp_server::McpServerSpec {
+                allowed_sandboxes: spec.allowed_sandboxes.clone(),
+                ..Default::default()
+            },
+            None,
+            Some((
+                "InvalidSpec",
+                "spec.bundleRef is mutually exclusive with spec.url, spec.oauth, \
+                 spec.productionMode, spec.scopes, spec.allowedTools, and \
+                 spec.displayName"
+                    .into(),
+            )),
+        );
+    }
+
+    if !bundle_set {
+        return (spec.clone(), None, None);
+    }
+
+    let bundle_ref = spec
+        .bundle_ref
+        .as_ref()
+        .expect("bundle_set implies Some")
+        .clone();
+
+    let signer_policy_handle = crate::signer_policy::global();
+    let verify_result = match signer_policy_handle.snapshot() {
+        crate::signer_policy::SignerPolicyState::FromConfigMap(p) => {
+            let cfg: crate::policy_fetcher::SignerPolicyConfig = p.into();
+            crate::policy_fetcher::fetch_and_verify_generic::<
+                crate::policy_canonical::mcp_server::McpServerKind,
+            >(&bundle_ref, &cfg)
+            .await
+        }
+        crate::signer_policy::SignerPolicyState::Malformed(msg) => Err(
+            crate::policy_fetcher::FetchError::SignerPolicyMalformed(msg),
+        ),
+        crate::signer_policy::SignerPolicyState::Absent => {
+            let cfg = crate::policy_fetcher::SignerPolicyConfig::from_env();
+            crate::policy_fetcher::fetch_and_verify_generic::<
+                crate::policy_canonical::mcp_server::McpServerKind,
+            >(&bundle_ref, &cfg)
+            .await
+        }
+    };
+
+    match verify_result {
+        Ok(verified) => {
+            let effective = merge_bundle_with_selector(spec, &verified);
+            (effective, Some(verified.digest), None)
+        }
+        Err(e) => {
+            let (reason, msg) = fetch_error_to_degraded(&e);
+            tracing::warn!(
+                mcpserver = %mcp.name_any(),
+                registry = %bundle_ref.registry,
+                repository = %bundle_ref.repository,
+                digest = %bundle_ref.digest,
+                reason,
+                "McpServer bundleRef fetch/verify failed: {msg}"
+            );
+            (
+                crate::mcp_server::McpServerSpec {
+                    allowed_sandboxes: spec.allowed_sandboxes.clone(),
+                    ..Default::default()
+                },
+                None,
+                Some((reason, msg)),
+            )
+        }
+    }
+}
+
+/// Merge the verified bundle's content fields onto the CR's
+/// `allowedSandboxes` selector. The bundle owns the content; the CR
+/// owns the selector — same pattern as InferencePolicy + ClawMemory.
+fn merge_bundle_with_selector(
+    cr_spec: &crate::mcp_server::McpServerSpec,
+    verified: &crate::policy_canonical::mcp_server::VerifiedMcpServerBundle,
+) -> crate::mcp_server::McpServerSpec {
+    use crate::mcp_server::{McpOAuthConfig, McpServerSpec};
+
+    let oauth = verified.oauth.as_ref().map(|o| McpOAuthConfig {
+        issuer: o.issuer.clone(),
+        audience: o.audience.clone(),
+        resource: o.resource.clone(),
+        pkce: o.pkce.clone().unwrap_or_else(|| "S256".to_string()),
+    });
+
+    McpServerSpec {
+        url: verified.url.clone(),
+        oauth,
+        production_mode: verified.production_mode,
+        scopes: verified.scopes.clone(),
+        allowed_tools: verified.allowed_tools.clone(),
+        allowed_sandboxes: cr_spec.allowed_sandboxes.clone(),
+        display_name: verified.display_name.clone(),
+        bundle_ref: None,
+    }
+}
+
+/// Map [`crate::policy_fetcher::FetchError`] to the `(reason, message)`
+/// degraded pair. Mirrors the same helper in the other 1c.x reconcilers
+/// — the controller's class table stays closed.
+fn fetch_error_to_degraded(e: &crate::policy_fetcher::FetchError) -> (&'static str, String) {
+    let reason = crate::policy_fetcher::reason_for_error(e).unwrap_or("Transient");
+    (reason, e.to_string())
 }
 
 #[cfg(test)]

--- a/controller/src/policy_canonical/egress.rs
+++ b/controller/src/policy_canonical/egress.rs
@@ -87,7 +87,10 @@ impl PolicyKind for EgressKind {
         }
         match &entry.verified {
             CachedValue::Egress(v) => Some(v.clone()),
-            CachedValue::Inference(_) | CachedValue::Memory(_) | CachedValue::Tools(_) => None,
+            CachedValue::Inference(_)
+            | CachedValue::McpServer(_)
+            | CachedValue::Memory(_)
+            | CachedValue::Tools(_) => None,
         }
     }
 

--- a/controller/src/policy_canonical/inference.rs
+++ b/controller/src/policy_canonical/inference.rs
@@ -113,7 +113,10 @@ impl PolicyKind for InferenceKind {
         }
         match &entry.verified {
             CachedValue::Inference(v) => Some(v.clone()),
-            CachedValue::Egress(_) | CachedValue::Memory(_) | CachedValue::Tools(_) => None,
+            CachedValue::Egress(_)
+            | CachedValue::McpServer(_)
+            | CachedValue::Memory(_)
+            | CachedValue::Tools(_) => None,
         }
     }
 

--- a/controller/src/policy_canonical/mcp_server.rs
+++ b/controller/src/policy_canonical/mcp_server.rs
@@ -1,0 +1,569 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! McpServer canonical-form parser + `PolicyKind` impl.
+//!
+//! Slice 1c.5 — fifth per-kind implementation after egress (1c.1),
+//! tools (1c.2), inference (1c.3), and memory (1c.4). An McpServer
+//! bundle carries the **server identity + OAuth + tool-allowlist
+//! content** the controller will merge onto the per-CR
+//! `allowedSandboxes` selector:
+//!
+//! - `url`
+//! - `oauth`  (object: `issuer`, `audience?`, `resource?`, `pkce?`)
+//! - `productionMode`
+//! - `scopes`
+//! - `allowedTools`
+//! - `displayName`
+//!
+//! `allowedSandboxes` is intentionally NOT a bundle key. The set of
+//! sandboxes permitted to reach a server is a deployment-time
+//! decision owned by the `McpServer` CR — one signed bundle can
+//! therefore be referenced by multiple CRs (e.g. fleet rollout of the
+//! same MCP server scoped to different sandbox-label selectors).
+//! This mirrors the inference-policy and memory-binding patterns:
+//! **selector stays in the CR, content lives in the bundle**.
+//!
+//! What this parser enforces (trait invariant #1, applied to mcp-server):
+//! - Valid UTF-8
+//! - Parseable as a JSON object
+//! - Top-level keys are policy-content keys only (no `allowedSandboxes`)
+//! - `url` (when present) is a non-empty string
+//! - `oauth` (when present) is an object whose `issuer` is a non-empty
+//!   string, and whose `audience`/`resource`/`pkce` (when present) are
+//!   strings
+//! - `productionMode` (when present) is a boolean
+//! - `scopes` / `allowedTools` (when present) are arrays of non-empty
+//!   strings
+//! - `displayName` (when present) is a string
+//! - At least one policy-content key is present (empty bundles are
+//!   rejected — the inline path is the supported way to express server
+//!   metadata without supply-chain verification)
+//!
+//! Semantic checks (HTTPS-required-when-productionMode, valid issuer
+//! URL shape, registered-tool-name format) stay in the existing
+//! `crd_validations::mcp_server_validations` admission layer and the
+//! reconciler's productionMode-vs-issuer guard.
+
+use super::{CachedValue, PolicyKind};
+use crate::policy_fetcher::{CACHE_TTL, FetchError};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Instant, SystemTime};
+
+/// OCI media type for the v1 mcp-server-bundle artifact. The pulled
+/// `artifactType` MUST match this exactly; consumers reject any other
+/// value (forward-compat: v2 bumps the suffix; v1 consumers MUST
+/// refuse v2 artifacts).
+pub const MCP_SERVER_BUNDLE_V1_MEDIA_TYPE: &str =
+    "application/vnd.azureclaw.mcp-server-bundle.v1+json";
+
+/// Recognised top-level keys in an mcp-server bundle. `allowedSandboxes`
+/// is intentionally NOT one of them: the selector targets sandboxes
+/// owned by the `McpServer.spec`, not the signed artifact.
+const POLICY_CONTENT_KEYS: &[&str] = &[
+    "url",
+    "oauth",
+    "productionMode",
+    "scopes",
+    "allowedTools",
+    "displayName",
+];
+
+/// Parsed OAuth sub-object from the bundle. Mirrors
+/// [`crate::mcp_server::McpOAuthConfig`] except all fields are owned
+/// strings extracted at parse time — keeps the merge step
+/// allocation-free at reconcile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedOAuthConfig {
+    pub issuer: String,
+    pub audience: Option<String>,
+    pub resource: Option<String>,
+    pub pkce: Option<String>,
+}
+
+/// A verified mcp-server bundle. Each `Option` field is extracted at
+/// parse time so the reconciler does not re-parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedMcpServerBundle {
+    pub url: Option<String>,
+    pub oauth: Option<VerifiedOAuthConfig>,
+    pub production_mode: Option<bool>,
+    pub scopes: Option<Vec<String>>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub display_name: Option<String>,
+    /// Raw signed bytes. Kept for observability; the operator-visible
+    /// `bundleRefDigest` is the OCI manifest digest, not a hash of
+    /// these bytes (mirrors the memory + inference modules).
+    pub bytes: Vec<u8>,
+    /// `sha256:...` matched against `OciArtifactRef.digest`.
+    pub digest: String,
+    pub fetched_at: SystemTime,
+}
+
+/// `PolicyKind` discriminator for mcp-server bundles.
+pub struct McpServerKind;
+
+impl PolicyKind for McpServerKind {
+    const MEDIA_TYPE: &'static str = MCP_SERVER_BUNDLE_V1_MEDIA_TYPE;
+    const API_VERSION: &'static str = "azureclaw.azure.com/v1alpha1";
+    const KIND: &'static str = "McpServer";
+    type Output = VerifiedMcpServerBundle;
+
+    fn parse(bytes: &[u8]) -> Result<Self::Output, FetchError> {
+        parse(bytes)
+    }
+
+    fn finalize(out: &mut Self::Output, digest: String, fetched_at: SystemTime) {
+        out.digest = digest;
+        out.fetched_at = fetched_at;
+    }
+
+    fn cache_get(key: &str, now: Instant) -> Option<Self::Output> {
+        let guard = cache().lock().ok()?;
+        let entry = guard.get(key)?;
+        if now.duration_since(entry.inserted) > CACHE_TTL {
+            return None;
+        }
+        match &entry.verified {
+            CachedValue::McpServer(v) => Some(v.clone()),
+            CachedValue::Egress(_)
+            | CachedValue::Tools(_)
+            | CachedValue::Inference(_)
+            | CachedValue::Memory(_) => None,
+        }
+    }
+
+    fn cache_put(key: String, value: Self::Output) {
+        if let Ok(mut guard) = cache().lock() {
+            guard.insert(
+                key,
+                CacheEntry {
+                    verified: CachedValue::McpServer(value),
+                    inserted: Instant::now(),
+                },
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn cache_clear() {
+        if let Ok(mut guard) = cache().lock() {
+            guard.clear();
+        }
+    }
+}
+
+// ─────────────────────────── cache ───────────────────────────
+
+struct CacheEntry {
+    verified: CachedValue,
+    inserted: Instant,
+}
+
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// ─────────────────────────── parser ───────────────────────────
+
+pub(crate) fn parse(bytes: &[u8]) -> Result<VerifiedMcpServerBundle, FetchError> {
+    let s = std::str::from_utf8(bytes)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("utf-8: {e}")))?;
+
+    let doc: Value = serde_json::from_str(s)
+        .map_err(|e| FetchError::CanonicalFormViolation(format!("json parse: {e}")))?;
+
+    let map = doc.as_object().ok_or_else(|| {
+        FetchError::CanonicalFormViolation("top-level must be a JSON object".into())
+    })?;
+
+    for key in map.keys() {
+        if !POLICY_CONTENT_KEYS.contains(&key.as_str()) {
+            return Err(FetchError::CanonicalFormViolation(format!(
+                "unrecognised top-level key `{key}`; allowed: url, oauth, productionMode, \
+                 scopes, allowedTools, displayName"
+            )));
+        }
+    }
+
+    let url = extract_optional_nonempty_string(map, "url")?;
+    let oauth = extract_optional_oauth(map, "oauth")?;
+    let production_mode = extract_optional_bool(map, "productionMode")?;
+    let scopes = extract_optional_string_array(map, "scopes")?;
+    let allowed_tools = extract_optional_string_array(map, "allowedTools")?;
+    let display_name = extract_optional_string(map, "displayName")?;
+
+    if url.is_none()
+        && oauth.is_none()
+        && production_mode.is_none()
+        && scopes.is_none()
+        && allowed_tools.is_none()
+        && display_name.is_none()
+    {
+        return Err(FetchError::CanonicalFormViolation(
+            "bundle has no policy content (all of url / oauth / productionMode / scopes / \
+             allowedTools / displayName are absent or null); use the inline path for \
+             selector-only McpServer CRs"
+                .into(),
+        ));
+    }
+
+    Ok(VerifiedMcpServerBundle {
+        url,
+        oauth,
+        production_mode,
+        scopes,
+        allowed_tools,
+        display_name,
+        bytes: bytes.to_vec(),
+        digest: String::new(),
+        fetched_at: SystemTime::UNIX_EPOCH,
+    })
+}
+
+fn extract_optional_nonempty_string(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
+        Some(Value::String(_)) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a non-empty string"
+        ))),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a non-empty string or null"
+        ))),
+    }
+}
+
+fn extract_optional_string(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a string or null"
+        ))),
+    }
+}
+
+fn extract_optional_bool(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<bool>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(b)) => Ok(Some(*b)),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a boolean or null"
+        ))),
+    }
+}
+
+fn extract_optional_string_array(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<Vec<String>>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Array(arr)) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for (i, v) in arr.iter().enumerate() {
+                match v {
+                    Value::String(s) if !s.is_empty() => out.push(s.clone()),
+                    Value::String(_) => {
+                        return Err(FetchError::CanonicalFormViolation(format!(
+                            "`{key}[{i}]` must be a non-empty string"
+                        )));
+                    }
+                    _ => {
+                        return Err(FetchError::CanonicalFormViolation(format!(
+                            "`{key}[{i}]` must be a non-empty string"
+                        )));
+                    }
+                }
+            }
+            Ok(Some(out))
+        }
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be an array of strings or null"
+        ))),
+    }
+}
+
+fn extract_optional_oauth(
+    map: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<VerifiedOAuthConfig>, FetchError> {
+    match map.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Object(obj)) => {
+            const OAUTH_KEYS: &[&str] = &["issuer", "audience", "resource", "pkce"];
+            for k in obj.keys() {
+                if !OAUTH_KEYS.contains(&k.as_str()) {
+                    return Err(FetchError::CanonicalFormViolation(format!(
+                        "unrecognised key `{key}.{k}`; allowed: issuer, audience, \
+                         resource, pkce"
+                    )));
+                }
+            }
+            let issuer = match obj.get("issuer") {
+                Some(Value::String(s)) if !s.is_empty() => s.clone(),
+                _ => {
+                    return Err(FetchError::CanonicalFormViolation(format!(
+                        "`{key}.issuer` is required and must be a non-empty string"
+                    )));
+                }
+            };
+            let audience = extract_oauth_optional_string(obj, "audience", key)?;
+            let resource = extract_oauth_optional_string(obj, "resource", key)?;
+            let pkce = extract_oauth_optional_string(obj, "pkce", key)?;
+            Ok(Some(VerifiedOAuthConfig {
+                issuer,
+                audience,
+                resource,
+                pkce,
+            }))
+        }
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{key}` must be a JSON object or null"
+        ))),
+    }
+}
+
+fn extract_oauth_optional_string(
+    obj: &serde_json::Map<String, Value>,
+    child: &str,
+    parent: &str,
+) -> Result<Option<String>, FetchError> {
+    match obj.get(child) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(FetchError::CanonicalFormViolation(format!(
+            "`{parent}.{child}` must be a string or null"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_bundle_ok() {
+        let body = br#"{
+            "url": "https://mcp.example.com",
+            "oauth": {
+                "issuer": "https://issuer.example.com",
+                "audience": "mcp-api",
+                "resource": "https://mcp.example.com",
+                "pkce": "S256"
+            },
+            "productionMode": true,
+            "scopes": ["read", "write"],
+            "allowedTools": ["search", "fetch"],
+            "displayName": "Example MCP"
+        }"#;
+        let v = parse(body).unwrap();
+        assert_eq!(v.url.as_deref(), Some("https://mcp.example.com"));
+        let oauth = v.oauth.unwrap();
+        assert_eq!(oauth.issuer, "https://issuer.example.com");
+        assert_eq!(oauth.audience.as_deref(), Some("mcp-api"));
+        assert_eq!(oauth.resource.as_deref(), Some("https://mcp.example.com"));
+        assert_eq!(oauth.pkce.as_deref(), Some("S256"));
+        assert_eq!(v.production_mode, Some(true));
+        assert_eq!(
+            v.scopes.as_deref(),
+            Some(["read".to_string(), "write".to_string()].as_slice())
+        );
+        assert_eq!(
+            v.allowed_tools.as_deref(),
+            Some(["search".to_string(), "fetch".to_string()].as_slice())
+        );
+        assert_eq!(v.display_name.as_deref(), Some("Example MCP"));
+    }
+
+    #[test]
+    fn parse_url_only_ok() {
+        let body = br#"{"url":"https://mcp.example.com"}"#;
+        let v = parse(body).unwrap();
+        assert_eq!(v.url.as_deref(), Some("https://mcp.example.com"));
+        assert!(v.oauth.is_none());
+    }
+
+    #[test]
+    fn parse_invalid_utf8_rejected() {
+        let body = [0xFFu8, 0xFE];
+        let err = parse(&body).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("utf-8")));
+    }
+
+    #[test]
+    fn parse_invalid_json_rejected() {
+        let err = parse(b"{not json").unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("json parse"))
+        );
+    }
+
+    #[test]
+    fn parse_non_object_top_level_rejected() {
+        let err = parse(b"[]").unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("top-level"))
+        );
+    }
+
+    #[test]
+    fn parse_unknown_key_rejected() {
+        let err = parse(br#"{"foo":1}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("unrecognised"))
+        );
+    }
+
+    #[test]
+    fn parse_allowed_sandboxes_in_bundle_rejected() {
+        // allowedSandboxes is owned by the CR, not the bundle
+        let err = parse(br#"{"url":"https://x","allowedSandboxes":{"matchLabels":{"a":"b"}}}"#)
+            .unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("allowedSandboxes"))
+        );
+    }
+
+    #[test]
+    fn parse_empty_object_rejected() {
+        let err = parse(b"{}").unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("no policy content"))
+        );
+    }
+
+    #[test]
+    fn parse_all_null_rejected() {
+        let err = parse(
+            br#"{"url":null,"oauth":null,"productionMode":null,"scopes":null,"allowedTools":null,"displayName":null}"#,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("no policy content"))
+        );
+    }
+
+    #[test]
+    fn parse_empty_url_rejected() {
+        let err = parse(br#"{"url":""}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-empty"))
+        );
+    }
+
+    #[test]
+    fn parse_url_wrong_type_rejected() {
+        let err = parse(br#"{"url":42}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("non-empty"))
+        );
+    }
+
+    #[test]
+    fn parse_production_mode_wrong_type_rejected() {
+        let err = parse(br#"{"productionMode":"yes"}"#).unwrap_err();
+        assert!(matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("boolean")));
+    }
+
+    #[test]
+    fn parse_oauth_missing_issuer_rejected() {
+        let err = parse(br#"{"oauth":{"audience":"a"}}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("oauth.issuer"))
+        );
+    }
+
+    #[test]
+    fn parse_oauth_empty_issuer_rejected() {
+        let err = parse(br#"{"oauth":{"issuer":""}}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("oauth.issuer"))
+        );
+    }
+
+    #[test]
+    fn parse_oauth_wrong_type_rejected() {
+        let err = parse(br#"{"oauth":"https://example.com"}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("must be a JSON object"))
+        );
+    }
+
+    #[test]
+    fn parse_oauth_unknown_subkey_rejected() {
+        let err = parse(br#"{"oauth":{"issuer":"https://x","clientId":"y"}}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("unrecognised key `oauth.clientId`"))
+        );
+    }
+
+    #[test]
+    fn parse_scopes_wrong_type_rejected() {
+        let err = parse(br#"{"scopes":"read"}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("must be an array of strings"))
+        );
+    }
+
+    #[test]
+    fn parse_scopes_with_empty_string_rejected() {
+        let err = parse(br#"{"scopes":["read",""]}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("scopes[1]"))
+        );
+    }
+
+    #[test]
+    fn parse_scopes_with_non_string_rejected() {
+        let err = parse(br#"{"scopes":["read",42]}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("scopes[1]"))
+        );
+    }
+
+    #[test]
+    fn parse_allowed_tools_wrong_type_rejected() {
+        let err = parse(br#"{"allowedTools":{"a":"b"}}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("must be an array of strings"))
+        );
+    }
+
+    #[test]
+    fn parse_display_name_wrong_type_rejected() {
+        let err = parse(br#"{"url":"https://x","displayName":42}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("displayName"))
+        );
+    }
+
+    #[test]
+    fn parse_empty_scopes_array_ok() {
+        // Empty array means "no scopes requested" — semantically valid
+        // (e.g. the CR-side selector handles per-sandbox auth).
+        let v = parse(br#"{"url":"https://x","scopes":[]}"#).unwrap();
+        assert_eq!(v.scopes.as_deref(), Some([].as_slice()));
+    }
+
+    #[test]
+    fn parse_oauth_audience_wrong_type_rejected() {
+        let err = parse(br#"{"oauth":{"issuer":"https://x","audience":42}}"#).unwrap_err();
+        assert!(
+            matches!(err, FetchError::CanonicalFormViolation(ref m) if m.contains("oauth.audience"))
+        );
+    }
+}

--- a/controller/src/policy_canonical/memory.rs
+++ b/controller/src/policy_canonical/memory.rs
@@ -107,7 +107,10 @@ impl PolicyKind for MemoryKind {
         }
         match &entry.verified {
             CachedValue::Memory(v) => Some(v.clone()),
-            CachedValue::Egress(_) | CachedValue::Tools(_) | CachedValue::Inference(_) => None,
+            CachedValue::Egress(_)
+            | CachedValue::Inference(_)
+            | CachedValue::McpServer(_)
+            | CachedValue::Tools(_) => None,
         }
     }
 

--- a/controller/src/policy_canonical/mod.rs
+++ b/controller/src/policy_canonical/mod.rs
@@ -31,6 +31,7 @@ use std::time::{Instant, SystemTime};
 
 pub mod egress;
 pub mod inference;
+pub mod mcp_server;
 pub mod memory;
 pub mod tools;
 
@@ -39,6 +40,8 @@ pub mod tools;
 pub use egress::EgressKind;
 #[allow(unused_imports)]
 pub use inference::InferenceKind;
+#[allow(unused_imports)]
+pub use mcp_server::McpServerKind;
 #[allow(unused_imports)]
 pub use memory::MemoryKind;
 #[allow(unused_imports)]
@@ -56,10 +59,11 @@ pub use tools::ToolsKind;
 /// is the implementation detail of how
 /// [`PolicyKind::cache_get`] / [`PolicyKind::cache_put`] are wired, not
 /// a public extension point.
-#[allow(dead_code)] // future kinds will add variants in 1c.5
+#[allow(dead_code)] // future kinds (eval-corpus) will add variants
 pub(crate) enum CachedValue {
     Egress(egress::VerifiedAllowlist),
     Inference(inference::VerifiedInferencePolicy),
+    McpServer(mcp_server::VerifiedMcpServerBundle),
     Memory(memory::VerifiedMemoryBinding),
     Tools(tools::VerifiedAgtProfile),
 }

--- a/controller/src/policy_canonical/tools.rs
+++ b/controller/src/policy_canonical/tools.rs
@@ -106,7 +106,10 @@ impl PolicyKind for ToolsKind {
         }
         match &entry.verified {
             CachedValue::Tools(v) => Some(v.clone()),
-            CachedValue::Egress(_) | CachedValue::Inference(_) | CachedValue::Memory(_) => None,
+            CachedValue::Egress(_)
+            | CachedValue::Inference(_)
+            | CachedValue::McpServer(_)
+            | CachedValue::Memory(_) => None,
         }
     }
 

--- a/deploy/helm/azureclaw/templates/crd-mcpserver.yaml
+++ b/deploy/helm/azureclaw/templates/crd-mcpserver.yaml
@@ -53,11 +53,27 @@ spec:
               `McpServer.spec` — declares an MCP 2026 server reachable from sandboxes
               in the same namespace (or, if `crossNamespaceAllowed: true` on the
               server side, cluster-wide).
+
+              ## Two authoring paths
+
+              The content fields (`url`, `oauth`, `productionMode`, `scopes`,
+              `allowedTools`, `displayName`) are mutually exclusive with
+              [`bundle_ref`](McpServerSpec::bundle_ref): either inline the values
+              (no supply-chain attestation) or reference a signed OCI artifact
+              (cosign-verified against the cluster `SignerPolicy`). The
+              `allowedSandboxes` selector is owned exclusively by the CR — one
+              signed server bundle can be referenced by multiple `McpServer` CRs
+              with different sandbox selectors.
             properties:
               allowedSandboxes:
                 description: |-
                   Selector restricting which sandboxes can reach this server.
                   Empty = same-namespace only.
+
+                  **CR-owned field**: deliberately NOT part of any signed bundle.
+                  The selector is a deployment-time concern; one signed server
+                  bundle can be referenced by multiple `McpServer` CRs in
+                  different environments with different selectors.
                 nullable: true
                 properties:
                   matchLabels:
@@ -70,14 +86,49 @@ spec:
                     type: object
                 type: object
               allowedTools:
-                default: []
                 description: |-
                   Allow-list of tool names. Empty list means "no tools allowed";
                   to allow all tools, use `["*"]` and lean on `ToolPolicy` for
                   per-tool governance. Default empty — fail-closed.
                 items:
                   type: string
+                nullable: true
                 type: array
+              bundleRef:
+                description: |-
+                  Reference to a signed OCI artifact carrying the policy content
+                  (`url`, `oauth`, `productionMode`, `scopes`, `allowedTools`,
+                  `displayName`). Mutually exclusive with inline content fields —
+                  enforced by admission CEL and re-checked by the reconciler.
+
+                  Slice 1c.5 of `crd-well-oiled-machine`.
+                nullable: true
+                properties:
+                  artifactType:
+                    description: |-
+                      OCI artifactType media-type, e.g.
+                      `application/vnd.azureclaw.egress-allowlist.v1+yaml`. Consumers MUST
+                      reject artifacts whose pulled `artifactType` doesn't match.
+                    type: string
+                  digest:
+                    description: |-
+                      Content-addressed digest, including the algorithm prefix
+                      (`sha256:abc…`). The digest covers the canonical artifact bytes —
+                      see `docs/internal/policy-canonical-format.md` for the egress-allowlist
+                      canonicalization rules.
+                    type: string
+                  registry:
+                    description: Registry hostname (e.g. `myacr.azurecr.io`, `ghcr.io`).
+                    type: string
+                  repository:
+                    description: Repository path (e.g. `azureclaw/policies/sandbox-foo`).
+                    type: string
+                required:
+                - artifactType
+                - digest
+                - registry
+                - repository
+                type: object
               displayName:
                 description: Optional human-readable label for operator-TUI display.
                 nullable: true
@@ -111,43 +162,66 @@ spec:
                 - issuer
                 type: object
               productionMode:
-                default: false
                 description: |-
                   When true, the router rejects calls that are not bearer-token-
                   authenticated against `oauth.issuer` with a verified PKCE flow.
                   `false` allows unauthenticated calls — dev-only; admission policy
                   rejects this for non-dev tenants (mirrors `Null*` provider rule).
+
+                  Optional: a signed bundle can supply this. When neither inline
+                  nor bundle sets the field, the effective value defaults to
+                  `false` (back-compat with the pre-1c.5 schema).
+                nullable: true
                 type: boolean
               scopes:
-                default: []
                 description: |-
                   OAuth 2.1 scopes that the router will request when fronting calls
                   from sandboxes to this server. The actual per-tool gating is
                   expressed in `ToolPolicy` resources, not here.
                 items:
                   type: string
+                nullable: true
                 type: array
               url:
                 description: |-
                   Server endpoint URL. MUST be `https://` when `productionMode: true`.
                   Validated by admission CEL.
+
+                  Optional: a signed bundle can supply this via [`bundle_ref`]. At
+                  reconcile time, exactly one of `url` or `bundle_ref.url` must
+                  resolve to a non-empty value, otherwise the reconciler stamps
+                  `Degraded=True/SpecInvalid`.
+                nullable: true
                 type: string
-            required:
-            - url
             type: object
             x-kubernetes-validations:
             - message: productionMode requires spec.oauth.issuer to be set
               reason: FieldValueInvalid
-              rule: self.productionMode == false || (has(self.oauth) && size(self.oauth.issuer) > 0)
+              rule: has(self.bundleRef) || !has(self.productionMode) || self.productionMode == false || (has(self.oauth) && size(self.oauth.issuer) > 0)
             - message: productionMode requires spec.url to begin with https://
               reason: FieldValueInvalid
-              rule: self.productionMode == false || self.url.startsWith('https://')
+              rule: has(self.bundleRef) || !has(self.productionMode) || self.productionMode == false || (has(self.url) && self.url.startsWith('https://'))
             - message: spec.oauth.pkce, when set, must be 'S256' (RFC 7636 §4.2)
               reason: FieldValueInvalid
               rule: '!has(self.oauth) || !has(self.oauth.pkce) || self.oauth.pkce == ''S256'''
+            - message: spec.bundleRef is mutually exclusive with spec.url, spec.oauth, spec.productionMode, spec.scopes, spec.allowedTools, and spec.displayName
+              reason: FieldValueInvalid
+              rule: '!has(self.bundleRef) || (!has(self.url) && !has(self.oauth) && !has(self.productionMode) && !has(self.scopes) && !has(self.allowedTools) && !has(self.displayName))'
           status:
             nullable: true
             properties:
+              bundleRefDigest:
+                description: |-
+                  OCI manifest digest of the verified signed bundle, when the
+                  `bundleRef` authoring path was taken. Operator-visible proof
+                  that the signature was checked and the bundle's bytes shaped
+                  the effective server config.
+
+                  `None` when the inline path was used.
+
+                  Slice 1c.5 of `crd-well-oiled-machine`.
+                nullable: true
+                type: string
               conditions:
                 description: Standard K8s Conditions, KEP-1623 shape.
                 items:


### PR DESCRIPTION
Fifth and final per-kind step in the Slice 1c-real
signing-generalization arc. `McpServer` joins `EgressAllowlist`
(1c.1), `ToolPolicy` (1c.2), `InferencePolicy` (1c.3), and
`ClawMemory` (1c.4) on the unified
`policy_fetcher::fetch_and_verify_generic` pipeline.

## Producer side (controller)

- New `controller/src/policy_canonical/mcp_server.rs` —
  `McpServerKind: PolicyKind` impl + 22 unit tests. Bundle keys:
  `url`, `oauth` (issuer / audience / resource / pkce),
  `productionMode`, `scopes`, `allowedTools`, `displayName`.
  `allowedSandboxes` stays on the CR — the parser explicitly
  rejects it inside a bundle so one signed artifact can be
  referenced by multiple `McpServer` CRs with different sandbox
  selectors (the multi-tenant fan-out pattern established in 1c.4).
  Media type
  `application/vnd.azureclaw.mcp-server-bundle.v1+json`. Per-kind
  cache slot via `OnceLock<CachedValue::McpServer(...)>` on the
  shared `policy_canonical` cache.
- `McpServerSpec.bundleRef: Option<OciArtifactRef>` added; the
  inline content fields are now `Option`-typed.
- `McpServerStatus.bundleRefDigest: Option<String>` surfaces the
  verified OCI manifest digest.
- `mcp_server_reconciler::resolve_mcp_source` — 4-way match
  mirroring `resolve_inference_source` + `resolve_memory_source`.
  Merges verified bundle content onto the CR's `allowedSandboxes`
  selector. `FetchError` variants map through the shared
  `policy_fetcher::reason_for_error` vocabulary. Degraded branches
  skip the per-server JWKS ConfigMap write so the router's
  last-good server registry remains in force.

## Admission

- Pre-existing `productionMode → oauth.issuer` and
  `productionMode → url https://` CEL rules wrapped in
  `has(self.bundleRef) || !has(self.productionMode) || …` so the
  inline-path validations only fire when the bundle path is unused.
- New mutex rule:
  `!has(self.bundleRef) || (!has(self.url) && !has(self.oauth) && !has(self.productionMode) && !has(self.scopes) && !has(self.allowedTools) && !has(self.displayName))`.

## Schema

- Regenerated `deploy/helm/azureclaw/templates/crd-mcpserver.yaml`
  via the standard `DUMP_MCP_CRD_YAML=1 cargo test
  helm_drift::tests::dump_mcp_crd_yaml` workflow. Content fields
  optional, new `spec.bundleRef` block, new CEL mutex rule,
  `status.bundleRefDigest`. CNCF C10 labels preserved.

## Verification

- Controller tests: 654 → 677 (+22 parser + +1 validations).
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- `cargo test --workspace` clean.
- Router untouched — wire contract unchanged (per-server JWKS bytes
  are identical whether the spec is inline or merged from a
  verified bundle).

## Out of scope (deferred)

- CLI dispatch `azureclaw policy sign --kind mcp-server-bundle`
  — lands with the unified CLI in Slice 1c.6.
- `SignerPolicy.ed25519Keys[]` forward-compat for the grant lane
  — Slice 1c.6.
- `EgressApproval` CRD — Slice 5e-thin (independent code path).