### PR TITLE
Slice 1c.6 — SignerPolicy.ed25519Keys forward-compat + unified `policy sign --kind` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 1c.6 — `SignerPolicy.spec.ed25519Keys[]` + unified `azureclaw policy sign --kind X`
+
+Wraps the Slice 1c-real signing-generalization arc with two
+forward-compat surfaces: the controller-side registration point for
+ephemeral-grant signing keys (Slice 5e+ verifier consumer) and a
+single CLI dispatch covering all five signed policy artifact kinds.
+
+**Producer side (controller)**
+
+- `controller/src/signer_policy.rs` gains an optional
+  `ed25519Keys: [{id, publicKeyBase64, allowedSubjects[]}]` JSON
+  array in the SignerPolicy ConfigMap, parsed via
+  `parse_ed25519_keys` with strict validation: DNS-label IDs
+  (≤ 63 chars, `[a-z0-9-]`, no leading/trailing dash, deduped),
+  base64 keys decoding to **either** 32-byte raw Ed25519 **or**
+  44-byte SPKI/DER form (cosign-compat), non-empty allowedSubjects
+  list (empty strings within rejected), `deny_unknown_fields`. The
+  parsed keys surface on `SignerPolicy::ed25519_keys()` and ride
+  through `policy_fetcher::SignerPolicyConfig` via the existing
+  `From<SignerPolicy>` impl. No verifier wired today —
+  `#[allow(dead_code)]` flags mark them as the Slice 5e+ grant-lane
+  consumer surface, and `apply_configmap` emits a `tracing::info!`
+  with the registered key count so operators get immediate feedback
+  that their config landed. **20 new unit tests** cover absent,
+  empty-array, raw-pubkey, DER-pubkey, multi-key, malformed JSON,
+  non-array, DNS-label edge cases, base64 errors, allowed-subjects
+  hygiene, deduplication, and the round-trip through `SharedSignerPolicy`
+  + `SignerPolicyConfig`. Controller test count: 677 → **697**.
+
+**CLI side**
+
+- New `cli/src/commands/policy/sign.ts` registers
+  `azureclaw policy sign --kind {egress-allowlist | agt-profile |
+   inference-policy | memory-binding | mcp-server-bundle}
+   --file <path> --registry <host> --repository <repo>` (plus
+  optional `--tag`, `--sign-mode`, `--sign-key`, `--json`,
+  `--print-bundle-ref`). Per-kind dispatch table maps `--kind` to
+  the exact media type the controller's `policy_canonical::*::parse`
+  expects, byte-for-byte mirroring the `MEDIA_TYPE` consts. The
+  command does only cheap pre-flight (file exists, non-empty,
+  valid UTF-8) and pushes the operator's pre-canonicalised bytes
+  as-is via `oras push` + `cosign sign` — canonical-form validation
+  remains the controller's authoritative responsibility, exposed
+  via crisp `Degraded / SpecInvalid` conditions on the consuming
+  CRD. `azureclaw egress … --sign` stays unchanged for back-compat
+  (it owns the egress-specific canonical-bytes builder). 13 new
+  CLI unit tests cover the per-kind media-type table, unknown-kind
+  rejection, the file pre-flight branches (missing / empty /
+  non-UTF-8 / unknown kind), the digest-format check, the default
+  tag, and the `renderBundleRefSnippet` YAML output.
+
+**Why this closes the 1c-real arc**
+
+Slice 1c.1–1c.5 wired every policy kind to
+`fetch_and_verify_generic` on the controller side, satisfying
+`principles.md §2` architecturally. The CLI surface remained
+egress-only — operators authoring the other four kinds had to
+drop down to raw `oras push` + `cosign sign`. Slice 1c.6 collapses
+that authoring asymmetry into one command without touching the
+data plane. The ed25519Keys field is the smallest possible
+forward-compat surface the controller needs to absorb Slice 5e's
+EgressApproval verifier without a second SignerPolicy migration:
+the wire shape, parser, validation rules, accessor, and audit
+event all land here so 5e's PR is pure consumer wiring.
+
+**Files changed**
+
+- `controller/src/signer_policy.rs` — wire docs, `Ed25519Key`
+  struct, 5 new error variants, `parse_ed25519_keys` helper,
+  `ed25519_keys()` accessor, 20 unit tests
+- `controller/src/policy_fetcher.rs` — `ed25519_keys` on
+  `SignerPolicyConfig` with `#[allow(dead_code)]` + Slice 5e+
+  comment, `From<SignerPolicy>` impl pass-through, one test
+  struct init updated
+- `cli/src/commands/policy.ts` — wires
+  `registerPolicySignSubcommand`
+- `cli/src/commands/policy/sign.ts` — new (~280 LOC)
+- `cli/src/commands/policy/sign.test.ts` — new (13 tests)
+
 ### Slice 1c.5 — `McpServer.spec.bundleRef` (signed OCI artifact)
 
 Fifth and final per-kind step in the Slice 1c-real

--- a/cli/src/commands/policy.ts
+++ b/cli/src/commands/policy.ts
@@ -5,11 +5,16 @@ import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";
 import { getAdminToken, withAdminAuth } from "../router-admin.js";
+import { registerPolicySignSubcommand } from "./policy/sign.js";
 
 export function policyCommand(): Command {
   const cmd = new Command("policy");
 
   cmd.description("Manage sandbox network and security policies");
+
+  // Slice 1c.6 — unified `azureclaw policy sign --kind X` surface
+  // covering all five signed policy artifact kinds.
+  registerPolicySignSubcommand(cmd);
 
   cmd
     .command("allow")

--- a/cli/src/commands/policy/sign.test.ts
+++ b/cli/src/commands/policy/sign.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 

--- a/cli/src/commands/policy/sign.test.ts
+++ b/cli/src/commands/policy/sign.test.ts
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  POLICY_KIND_IDS,
+  POLICY_KIND_SPECS,
+  lookupPolicyKindSpec,
+  signPolicyArtifact,
+  renderBundleRefSnippet,
+} from "./sign.js";
+
+describe("POLICY_KIND_SPECS", () => {
+  it("covers exactly the five signed policy kinds", () => {
+    expect(POLICY_KIND_IDS).toEqual([
+      "egress-allowlist",
+      "agt-profile",
+      "inference-policy",
+      "memory-binding",
+      "mcp-server-bundle",
+    ]);
+  });
+
+  it("declares the canonical media types matching the controller", () => {
+    expect(POLICY_KIND_SPECS["egress-allowlist"].mediaType).toBe(
+      "application/vnd.azureclaw.egress-allowlist.v1+yaml",
+    );
+    expect(POLICY_KIND_SPECS["agt-profile"].mediaType).toBe(
+      "application/vnd.azureclaw.agt-profile.v1+yaml",
+    );
+    expect(POLICY_KIND_SPECS["inference-policy"].mediaType).toBe(
+      "application/vnd.azureclaw.inference-policy.v1+json",
+    );
+    expect(POLICY_KIND_SPECS["memory-binding"].mediaType).toBe(
+      "application/vnd.azureclaw.memory-binding.v1+json",
+    );
+    expect(POLICY_KIND_SPECS["mcp-server-bundle"].mediaType).toBe(
+      "application/vnd.azureclaw.mcp-server-bundle.v1+json",
+    );
+  });
+
+  it("each spec has a non-empty controllerKind + extension", () => {
+    for (const id of POLICY_KIND_IDS) {
+      const spec = POLICY_KIND_SPECS[id];
+      expect(spec.controllerKind.length).toBeGreaterThan(0);
+      expect(spec.expectedExt.startsWith(".")).toBe(true);
+    }
+  });
+});
+
+describe("lookupPolicyKindSpec", () => {
+  it("resolves a known kind", () => {
+    expect(lookupPolicyKindSpec("inference-policy").controllerKind).toBe(
+      "InferencePolicy",
+    );
+  });
+
+  it("rejects an unknown kind with a helpful message", () => {
+    expect(() => lookupPolicyKindSpec("egress")).toThrow(
+      /unknown --kind 'egress'/,
+    );
+    expect(() => lookupPolicyKindSpec("egress")).toThrow(
+      /egress-allowlist/,
+    );
+  });
+});
+
+describe("renderBundleRefSnippet", () => {
+  it("emits YAML with all four bundleRef coordinates", () => {
+    const snippet = renderBundleRefSnippet({
+      kind: "agt-profile",
+      mediaType: POLICY_KIND_SPECS["agt-profile"].mediaType,
+      registry: "myacr.azurecr.io",
+      repository: "policies/agt-profile",
+      tag: "v3",
+      digest: "sha256:" + "a".repeat(64),
+      signMode: "keyless",
+    });
+    expect(snippet).toBe(
+      [
+        "bundleRef:",
+        "  registry: myacr.azurecr.io",
+        "  repository: policies/agt-profile",
+        "  tag: v3",
+        `  digest: sha256:${"a".repeat(64)}`,
+      ].join("\n"),
+    );
+  });
+});
+
+describe("signPolicyArtifact — pre-flight", () => {
+  function makeTmpFile(contents: string): { path: string; cleanup: () => void } {
+    const dir = mkdtempSync(join(tmpdir(), "policy-sign-test-"));
+    const path = join(dir, "artifact.json");
+    writeFileSync(path, contents, { encoding: "utf8" });
+    return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  it("rejects a missing file before spawning anything", async () => {
+    await expect(
+      signPolicyArtifact({
+        kind: "inference-policy",
+        filePath: "/no/such/file/please.json",
+        registry: "r",
+        repository: "p",
+        signMode: "keyed",
+        signKey: "/dev/null",
+        skipSign: true,
+        digestOverride: `sha256:${"0".repeat(64)}`,
+        env: {},
+        isTTY: false,
+      }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it("rejects an empty file", async () => {
+    const f = makeTmpFile("");
+    try {
+      await expect(
+        signPolicyArtifact({
+          kind: "inference-policy",
+          filePath: f.path,
+          registry: "r",
+          repository: "p",
+          signMode: "keyed",
+          signKey: "/dev/null",
+          skipSign: true,
+          digestOverride: `sha256:${"0".repeat(64)}`,
+          env: {},
+          isTTY: false,
+        }),
+      ).rejects.toThrow(/is empty/);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  it("rejects an unknown --kind", async () => {
+    const f = makeTmpFile("{}");
+    try {
+      await expect(
+        signPolicyArtifact({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          kind: "bogus-kind" as any,
+          filePath: f.path,
+          registry: "r",
+          repository: "p",
+          signMode: "keyed",
+          signKey: "/dev/null",
+          skipSign: true,
+          digestOverride: `sha256:${"0".repeat(64)}`,
+          env: {},
+          isTTY: false,
+        }),
+      ).rejects.toThrow(/unknown --kind/);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  it("rejects non-UTF-8 bytes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "policy-sign-test-"));
+    const path = join(dir, "binary.json");
+    writeFileSync(path, Buffer.from([0xff, 0xfe, 0xfd, 0x00]));
+    try {
+      await expect(
+        signPolicyArtifact({
+          kind: "inference-policy",
+          filePath: path,
+          registry: "r",
+          repository: "p",
+          signMode: "keyed",
+          signKey: "/dev/null",
+          skipSign: true,
+          digestOverride: `sha256:${"0".repeat(64)}`,
+          env: {},
+          isTTY: false,
+        }),
+      ).rejects.toThrow(/not valid UTF-8/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts a valid file and returns a populated SignedPolicyArtifact (skipSign)", async () => {
+    const f = makeTmpFile('{"version":1}');
+    try {
+      const out = await signPolicyArtifact({
+        kind: "inference-policy",
+        filePath: f.path,
+        registry: "myacr.azurecr.io",
+        repository: "policies/inf",
+        tag: "v7",
+        signMode: "keyed",
+        signKey: "/dev/null",
+        skipSign: true,
+        digestOverride: `sha256:${"b".repeat(64)}`,
+        env: {},
+        isTTY: false,
+      });
+      expect(out.kind).toBe("inference-policy");
+      expect(out.mediaType).toBe(
+        "application/vnd.azureclaw.inference-policy.v1+json",
+      );
+      expect(out.registry).toBe("myacr.azurecr.io");
+      expect(out.repository).toBe("policies/inf");
+      expect(out.tag).toBe("v7");
+      expect(out.digest).toBe(`sha256:${"b".repeat(64)}`);
+      expect(out.signMode).toBe("keyed");
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  it("rejects a digestOverride that is not sha256:…", async () => {
+    const f = makeTmpFile('{"version":1}');
+    try {
+      await expect(
+        signPolicyArtifact({
+          kind: "inference-policy",
+          filePath: f.path,
+          registry: "r",
+          repository: "p",
+          signMode: "keyed",
+          signKey: "/dev/null",
+          skipSign: true,
+          digestOverride: "deadbeef",
+          env: {},
+          isTTY: false,
+        }),
+      ).rejects.toThrow(/not a sha256/);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  it("defaults the tag to 'latest' when omitted", async () => {
+    const f = makeTmpFile('{"version":1}');
+    try {
+      const out = await signPolicyArtifact({
+        kind: "memory-binding",
+        filePath: f.path,
+        registry: "r",
+        repository: "p",
+        signMode: "keyed",
+        signKey: "/dev/null",
+        skipSign: true,
+        digestOverride: `sha256:${"c".repeat(64)}`,
+        env: {},
+        isTTY: false,
+      });
+      expect(out.tag).toBe("latest");
+    } finally {
+      f.cleanup();
+    }
+  });
+});

--- a/cli/src/commands/policy/sign.ts
+++ b/cli/src/commands/policy/sign.ts
@@ -1,0 +1,311 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Slice 1c.6 — `azureclaw policy sign --kind X` unified signing CLI.
+//
+// Single dispatch surface that supersedes the egress-only signing flow
+// inside `azureclaw egress`. Operators authoring any of the five signed
+// policy artifact kinds (egress-allowlist | agt-profile |
+// inference-policy | memory-binding | mcp-server-bundle) point this at
+// a prebuilt canonical-form file on disk; the command pushes the bytes
+// to an OCI registry under the per-kind media type, signs the manifest
+// digest with cosign, and (optionally) emits the matching `bundleRef`
+// snippet for the operator to paste into the consuming CRD.
+//
+// **Canonical form is the operator's responsibility.** The controller's
+// `policy_canonical::*::parse` is the authoritative byte-level
+// validator (per the canonical-format doc in
+// `docs/internal/crd-well-oiled-machine/policy-canonical-format.md`).
+// The CLI does only cheap pre-flight (file exists, non-empty UTF-8) and
+// trusts the controller to reject malformed bytes post-fetch with a
+// crisp `Degraded / SpecInvalid` condition.
+//
+// The egress-allowlist kind also supports the canonical-builder flow
+// (see `azureclaw egress` — that command builds the canonical YAML from
+// CR-side `allowedEndpoints` and then calls into this signing pipeline
+// internally). This top-level command is for the other four kinds
+// where the operator already has the bytes.
+
+import { Command } from "commander";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename } from "node:path";
+
+import {
+  EGRESS_ALLOWLIST_MEDIA_TYPE,
+  autoDetectSignMode,
+  pushArtifact,
+  signArtifact,
+  type SignMode,
+} from "../egress/sign.js";
+
+/** Identifier accepted on the `--kind` flag. Must mirror the controller
+ *  `policy_canonical::*::KIND` constants for clarity in operator UX, but
+ *  the CLI uses lowercase-hyphenated form (industry convention for
+ *  flag values) — the wire-level media type is what actually flows on
+ *  the registry, so the discriminator is unambiguous. */
+export type PolicyKindId =
+  | "egress-allowlist"
+  | "agt-profile"
+  | "inference-policy"
+  | "memory-binding"
+  | "mcp-server-bundle";
+
+export const POLICY_KIND_IDS: readonly PolicyKindId[] = [
+  "egress-allowlist",
+  "agt-profile",
+  "inference-policy",
+  "memory-binding",
+  "mcp-server-bundle",
+] as const;
+
+/** Wire-level metadata for one signed-artifact kind. The MIME types
+ *  here MUST match the controller's `MEDIA_TYPE` consts byte-for-byte
+ *  (see `controller/src/policy_canonical/*.rs`). */
+export interface PolicyKindSpec {
+  /** CLI flag value, e.g. `egress-allowlist`. */
+  id: PolicyKindId;
+  /** Controller-side CRD-kind constant (display only). */
+  controllerKind: string;
+  /** OCI artifactType for the registry push + cosign verify. */
+  mediaType: string;
+  /** Default file extension for the canonical bytes (display only). */
+  expectedExt: string;
+}
+
+export const POLICY_KIND_SPECS: Record<PolicyKindId, PolicyKindSpec> = {
+  "egress-allowlist": {
+    id: "egress-allowlist",
+    controllerKind: "EgressAllowlist",
+    mediaType: EGRESS_ALLOWLIST_MEDIA_TYPE,
+    expectedExt: ".yaml",
+  },
+  "agt-profile": {
+    id: "agt-profile",
+    controllerKind: "AgtProfile",
+    mediaType: "application/vnd.azureclaw.agt-profile.v1+yaml",
+    expectedExt: ".yaml",
+  },
+  "inference-policy": {
+    id: "inference-policy",
+    controllerKind: "InferencePolicy",
+    mediaType: "application/vnd.azureclaw.inference-policy.v1+json",
+    expectedExt: ".json",
+  },
+  "memory-binding": {
+    id: "memory-binding",
+    controllerKind: "ClawMemory",
+    mediaType: "application/vnd.azureclaw.memory-binding.v1+json",
+    expectedExt: ".json",
+  },
+  "mcp-server-bundle": {
+    id: "mcp-server-bundle",
+    controllerKind: "McpServer",
+    mediaType: "application/vnd.azureclaw.mcp-server-bundle.v1+json",
+    expectedExt: ".json",
+  },
+};
+
+export function lookupPolicyKindSpec(id: string): PolicyKindSpec {
+  const spec = (POLICY_KIND_SPECS as Record<string, PolicyKindSpec | undefined>)[id];
+  if (!spec) {
+    throw new Error(
+      `unknown --kind '${id}'. valid kinds: ${POLICY_KIND_IDS.join(", ")}`,
+    );
+  }
+  return spec;
+}
+
+/** Result returned by [`signPolicyArtifact`]; suitable for JSON output
+ *  + bundleRef-snippet generation. */
+export interface SignedPolicyArtifact {
+  kind: PolicyKindId;
+  mediaType: string;
+  registry: string;
+  repository: string;
+  tag: string;
+  digest: string;
+  signMode: SignMode;
+}
+
+export interface SignPolicyArtifactOpts {
+  kind: PolicyKindId;
+  filePath: string;
+  registry: string;
+  repository: string;
+  tag?: string;
+  signMode?: string;
+  signKey?: string;
+  /** Override for tests. */
+  orasPath?: string;
+  /** Override for tests. */
+  cosignPath?: string;
+  /** Override for tests. */
+  isTTY?: boolean;
+  /** Override for tests. */
+  env?: NodeJS.ProcessEnv;
+  /** Override for tests — when set, `pushArtifact` is bypassed and
+   *  this digest is treated as authoritative. */
+  digestOverride?: string;
+  /** Override for tests — when true, `signArtifact` is bypassed. */
+  skipSign?: boolean;
+}
+
+/**
+ * Pre-flight a kind+file pair and run the full push → sign pipeline.
+ * Pure-ish — every spawn is overridable for tests.
+ *
+ * The canonical-form validation responsibility is **deliberately not
+ * here**. The controller's `policy_canonical::*::parse` is the
+ * authoritative checker; bytes the operator wants to ship are
+ * pushed as-is. The CLI catches only the gross hygiene errors
+ * (missing file, empty file, non-UTF-8 bytes) so we don't waste a
+ * Fulcio cert on something the controller will reject in 5 seconds.
+ */
+export async function signPolicyArtifact(
+  opts: SignPolicyArtifactOpts,
+): Promise<SignedPolicyArtifact> {
+  const spec = lookupPolicyKindSpec(opts.kind);
+
+  // Pre-flight: file exists + non-empty + valid UTF-8.
+  if (!existsSync(opts.filePath)) {
+    throw new Error(`--file '${opts.filePath}' does not exist`);
+  }
+  const stat = statSync(opts.filePath);
+  if (!stat.isFile()) {
+    throw new Error(`--file '${opts.filePath}' is not a regular file`);
+  }
+  if (stat.size === 0) {
+    throw new Error(`--file '${opts.filePath}' is empty`);
+  }
+  // Pull bytes; verify they're valid UTF-8 (Buffer→string with strict
+  // decode catches embedded NULs + invalid surrogates). All five
+  // canonical formats are UTF-8 text — JSON, YAML, or YAML-with-comments.
+  const buf = readFileSync(opts.filePath);
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(buf);
+  } catch (e) {
+    throw new Error(
+      `--file '${opts.filePath}' is not valid UTF-8: ${(e as Error).message}`,
+    );
+  }
+  const bytes = buf.toString("utf8");
+
+  // Sign-mode auto-detect: respects user-explicit override, env hints,
+  // TTY presence — identical heuristic to `azureclaw egress --sign`.
+  const env = opts.env ?? process.env;
+  const isTTY = opts.isTTY ?? Boolean(process.stdin?.isTTY);
+  const signMode = autoDetectSignMode({
+    signModeFlag: opts.signMode,
+    signKey: opts.signKey,
+    isTTY,
+    env,
+  });
+
+  const tag = opts.tag ?? "latest";
+
+  // Push.
+  let digest: string;
+  if (opts.digestOverride) {
+    digest = opts.digestOverride;
+  } else {
+    digest = await pushArtifact({
+      orasPath: opts.orasPath ?? "oras",
+      registry: opts.registry,
+      repository: opts.repository,
+      yaml: bytes,
+      artifactType: spec.mediaType,
+      tag,
+    });
+  }
+  if (!digest.startsWith("sha256:")) {
+    throw new Error(`pushed digest is not a sha256: ${digest}`);
+  }
+
+  // Sign.
+  if (!opts.skipSign) {
+    await signArtifact({
+      cosignPath: opts.cosignPath ?? "cosign",
+      registry: opts.registry,
+      repository: opts.repository,
+      digest,
+      mode: signMode,
+      keyRef: opts.signKey,
+    });
+  }
+
+  return {
+    kind: opts.kind,
+    mediaType: spec.mediaType,
+    registry: opts.registry,
+    repository: opts.repository,
+    tag,
+    digest,
+    signMode,
+  };
+}
+
+/** Render a copy-pasteable `bundleRef` snippet for the operator's CRD.
+ *  Returns a multi-line YAML fragment (no trailing newline) that
+ *  embeds under `spec.<field>` of the consuming kind. */
+export function renderBundleRefSnippet(artifact: SignedPolicyArtifact): string {
+  return [
+    "bundleRef:",
+    `  registry: ${artifact.registry}`,
+    `  repository: ${artifact.repository}`,
+    `  tag: ${artifact.tag}`,
+    `  digest: ${artifact.digest}`,
+  ].join("\n");
+}
+
+/** Register `azureclaw policy sign` on an existing `Command`
+ *  (typically the `policy` parent created by
+ *  `cli/src/commands/policy.ts`). */
+export function registerPolicySignSubcommand(parent: Command): Command {
+  return parent
+    .command("sign")
+    .description(
+      "Sign a policy artifact (egress-allowlist, agt-profile, inference-policy, memory-binding, mcp-server-bundle)",
+    )
+    .requiredOption(
+      "--kind <kind>",
+      `Artifact kind. One of: ${POLICY_KIND_IDS.join(", ")}`,
+    )
+    .requiredOption("--file <path>", "Path to canonical-form artifact bytes")
+    .requiredOption("--registry <host>", "OCI registry hostname (e.g. myacr.azurecr.io)")
+    .requiredOption("--repository <repo>", "OCI repository path under the registry")
+    .option("--tag <tag>", "Tag to push under (informational; cosign signs by digest)", "latest")
+    .option("--sign-mode <mode>", "cosign mode: keyless | identity-token | keyed")
+    .option("--sign-key <ref>", "cosign key reference (required for --sign-mode keyed)")
+    .option("--json", "Emit a JSON envelope instead of human-readable output")
+    .option("--print-bundle-ref", "Print a YAML bundleRef snippet ready to paste into the consuming CRD", false)
+    .action(async (raw: Record<string, unknown>) => {
+      try {
+        const kind = String(raw.kind);
+        const result = await signPolicyArtifact({
+          kind: lookupPolicyKindSpec(kind).id,
+          filePath: String(raw.file),
+          registry: String(raw.registry),
+          repository: String(raw.repository),
+          tag: raw.tag ? String(raw.tag) : undefined,
+          signMode: raw.signMode ? String(raw.signMode) : undefined,
+          signKey: raw.signKey ? String(raw.signKey) : undefined,
+        });
+
+        if (raw.json) {
+          process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+        } else {
+          process.stdout.write(`signed ${basename(String(raw.file))} as ${result.kind}\n`);
+          process.stdout.write(`  artifactType: ${result.mediaType}\n`);
+          process.stdout.write(`  digest: ${result.digest}\n`);
+          process.stdout.write(`  mode:   ${result.signMode}\n`);
+        }
+
+        if (raw.printBundleRef) {
+          process.stdout.write(`\n${renderBundleRefSnippet(result)}\n`);
+        }
+      } catch (e) {
+        process.stderr.write(`azureclaw policy sign: ${(e as Error).message}\n`);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/cli/src/commands/policy/sign.ts
+++ b/cli/src/commands/policy/sign.ts
@@ -27,7 +27,7 @@
 // where the operator already has the bytes.
 
 import { Command } from "commander";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 
 import {
@@ -166,21 +166,28 @@ export async function signPolicyArtifact(
 ): Promise<SignedPolicyArtifact> {
   const spec = lookupPolicyKindSpec(opts.kind);
 
-  // Pre-flight: file exists + non-empty + valid UTF-8.
-  if (!existsSync(opts.filePath)) {
-    throw new Error(`--file '${opts.filePath}' does not exist`);
+  // Pre-flight: read bytes in one shot (no check-then-use TOCTOU
+  // window). Map ENOENT/EISDIR/etc. errno strings to a single
+  // operator-friendly message; everything else surfaces verbatim.
+  let buf: Buffer;
+  try {
+    buf = readFileSync(opts.filePath);
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") {
+      throw new Error(`--file '${opts.filePath}' does not exist`);
+    }
+    if (err.code === "EISDIR") {
+      throw new Error(`--file '${opts.filePath}' is not a regular file`);
+    }
+    throw new Error(`--file '${opts.filePath}': ${err.message}`);
   }
-  const stat = statSync(opts.filePath);
-  if (!stat.isFile()) {
-    throw new Error(`--file '${opts.filePath}' is not a regular file`);
-  }
-  if (stat.size === 0) {
+  if (buf.length === 0) {
     throw new Error(`--file '${opts.filePath}' is empty`);
   }
-  // Pull bytes; verify they're valid UTF-8 (Buffer→string with strict
-  // decode catches embedded NULs + invalid surrogates). All five
-  // canonical formats are UTF-8 text — JSON, YAML, or YAML-with-comments.
-  const buf = readFileSync(opts.filePath);
+  // Verify bytes are valid UTF-8 (Buffer→string with strict decode
+  // catches embedded NULs + invalid surrogates). All five canonical
+  // formats are UTF-8 text — JSON, YAML, or YAML-with-comments.
   try {
     new TextDecoder("utf-8", { fatal: true }).decode(buf);
   } catch (e) {

--- a/controller/src/policy_fetcher.rs
+++ b/controller/src/policy_fetcher.rs
@@ -153,6 +153,14 @@ pub struct SignerPolicyConfig {
     /// (keyless OIDC). Glob wildcards: `*` matches any run of non-`/`
     /// chars; `?` matches one. Empty → reject all.
     pub san_patterns: Vec<String>,
+    /// Registered Ed25519 keys for the grant lane (Slice 5e+). Mirrored
+    /// from the SignerPolicy ConfigMap and surfaced through the
+    /// verifier so future grant-lane consumers can read it without a
+    /// second env-var path. **Not consulted** by the data-plane policy
+    /// verify path (egress / tools / inference / memory / mcp-server);
+    /// kept opaque here. Empty when the env constructor is used.
+    #[allow(dead_code)] // Slice 5e+ grant-lane verifier consumer.
+    pub ed25519_keys: Vec<crate::signer_policy::Ed25519Key>,
 }
 
 impl SignerPolicyConfig {
@@ -162,6 +170,7 @@ impl SignerPolicyConfig {
         Self {
             fulcio_issuers: split_csv_env(SIGNER_FULCIO_ISSUERS_ENV),
             san_patterns: split_csv_env(SIGNER_SAN_PATTERNS_ENV),
+            ed25519_keys: Vec::new(),
         }
     }
 
@@ -169,7 +178,9 @@ impl SignerPolicyConfig {
     /// and a SAN allow-list are present. Either one alone is unsafe (any
     /// SAN with no issuer pinning permits arbitrary trust roots; any
     /// issuer with no SAN pinning permits arbitrary identities under
-    /// that issuer), so we require both.
+    /// that issuer), so we require both. `ed25519_keys` does not
+    /// participate — the grant lane has its own readiness gate (Slice
+    /// 5e+).
     pub fn is_configured(&self) -> bool {
         !self.fulcio_issuers.is_empty() && !self.san_patterns.is_empty()
     }
@@ -180,6 +191,7 @@ impl From<crate::signer_policy::SignerPolicy> for SignerPolicyConfig {
         Self {
             fulcio_issuers: s.fulcio_issuers,
             san_patterns: s.san_patterns,
+            ed25519_keys: s.ed25519_keys,
         }
     }
 }
@@ -1791,6 +1803,7 @@ mod tests {
             SharedSignerPolicy::from_state(SignerPolicyState::FromConfigMap(ParsedSignerPolicy {
                 fulcio_issuers: vec!["https://token.actions.githubusercontent.com".into()],
                 san_patterns: vec!["signer@example.com".into()],
+                ed25519_keys: Vec::new(),
             }));
         // ConfigMap is configured so we proceed past the policy gate;
         // the next failure mode is whatever sigstore does with our

--- a/controller/src/signer_policy.rs
+++ b/controller/src/signer_policy.rs
@@ -27,12 +27,23 @@
 //!   sanPatterns: |
 //!     https://github.com/Azure/azureclaw/.github/workflows/*.yml@*
 //!     signer@example.com
+//!   ed25519Keys: |
+//!     [
+//!       {
+//!         "id": "grant-signer-2026-q2",
+//!         "publicKeyBase64": "MCowBQYDK2VwAyEA...",
+//!         "allowedSubjects": ["egress-approval"]
+//!       }
+//!     ]
 //! ```
 //!
-//! Both keys are **required**; both lists must be non-empty after
-//! trimming and `#` comment stripping. Either being empty is a parse
-//! error (`SignerPolicyError::EmptyKey`) — empty issuers + empty SANs
-//! together is *not* an implicit accept-all (per S12.d trust model).
+//! `fulcioIssuers` + `sanPatterns` are **required** and govern the
+//! data-plane policy lane (egress allowlist / tool policy /
+//! inference / memory / mcp-server bundles, all signed via cosign +
+//! Fulcio). `ed25519Keys` is **optional** forward-compat for the
+//! grant lane that lands in Slice 5e+ (`EgressApproval`) — parsed
+//! and surfaced here, but **not yet enforced**. Empty + absent are
+//! treated identically.
 //!
 //! ## Trust model
 //!
@@ -43,7 +54,9 @@
 //!   existing controller `ClusterRole` already grants this; no
 //!   broadening needed).
 //! - Fail-closed: malformed → `SignerPolicyMalformed`. Absent +
-//!   no-env → `SignerPolicyMissing`.
+//!   no-env → `SignerPolicyMissing`. Malformed `ed25519Keys` blocks
+//!   the **whole** policy parse — the grant lane defers to 5e+ but
+//!   broken JSON is never silently ignored.
 
 use std::sync::{Arc, RwLock};
 
@@ -65,6 +78,49 @@ pub const KEY_FULCIO_ISSUERS: &str = "fulcioIssuers";
 /// (`*`, `?`) is the same as the env-var path.
 pub const KEY_SAN_PATTERNS: &str = "sanPatterns";
 
+/// `data.ed25519Keys` key — JSON array of [`Ed25519Key`] entries.
+///
+/// **Optional** ConfigMap key. Absent or `[]` means "no grant-lane
+/// signers registered" — equivalent for forward-compat purposes.
+/// Parsed + surfaced here for Slice 5e+ consumption; the data-plane
+/// policy lane (1c.1–1c.5) does **not** consult this list.
+pub const KEY_ED25519_KEYS: &str = "ed25519Keys";
+
+/// A registered Ed25519 public key for the grant lane (Slice 5e+).
+///
+/// Wire shape (a single element of the `ed25519Keys` JSON array):
+///
+/// ```json
+/// {
+///   "id": "grant-signer-2026-q2",
+///   "publicKeyBase64": "MCowBQYDK2VwAyEA...",
+///   "allowedSubjects": ["egress-approval"]
+/// }
+/// ```
+///
+/// **Field semantics:**
+///
+/// - `id` — operator-chosen stable identifier. Must be non-empty,
+///   DNS-label-safe (1-63 chars, `[a-z0-9-]`, no leading/trailing
+///   dash) so it can flow through K8s labels + ConfigMap names in
+///   5e+. Duplicate ids across entries are a parse error.
+/// - `public_key_b64` — standard base64-encoded raw Ed25519 public
+///   key (32 bytes raw → 44 chars base64). Both raw + DER/PKIX
+///   forms are accepted to ease cosign-issued material; the 5e+
+///   verifier normalises before use.
+/// - `allowed_subjects` — list of grant-artifact subject types this
+///   key is authorised to sign. Initial vocabulary:
+///   `egress-approval`. Empty list means "the key is registered
+///   but cannot authorise anything yet" — explicit and intentional.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Ed25519Key {
+    pub id: String,
+    pub public_key_base64: String,
+    #[serde(default)]
+    pub allowed_subjects: Vec<String>,
+}
+
 /// Parsed signer policy. The wire shape mirrors
 /// [`crate::policy_fetcher::SignerPolicyConfig`] for a zero-cost
 /// conversion.
@@ -74,6 +130,10 @@ pub struct SignerPolicy {
     pub fulcio_issuers: Vec<String>,
     /// Allowed SAN glob patterns. Empty → reject all.
     pub san_patterns: Vec<String>,
+    /// Registered Ed25519 keys for the grant lane (Slice 5e+).
+    /// Parsed + surfaced; **not enforced** in this slice. Empty +
+    /// absent are equivalent.
+    pub ed25519_keys: Vec<Ed25519Key>,
 }
 
 impl SignerPolicy {
@@ -99,6 +159,18 @@ pub enum SignerPolicyError {
         entry: String,
         reason: &'static str,
     },
+    #[error("ConfigMap key `ed25519Keys` is not valid JSON: {0}")]
+    Ed25519JsonParse(String),
+    #[error("ConfigMap key `ed25519Keys` must be a JSON array")]
+    Ed25519NotArray,
+    #[error("ed25519Keys[{index}].{field} is invalid: {reason}")]
+    Ed25519InvalidEntry {
+        index: usize,
+        field: &'static str,
+        reason: String,
+    },
+    #[error("ed25519Keys contains duplicate id `{0}`")]
+    Ed25519DuplicateId(String),
 }
 
 /// Parse a `ConfigMap` into a [`SignerPolicy`]. Strict — see module docs
@@ -128,7 +200,121 @@ pub fn parse_configmap(cm: &ConfigMap) -> Result<SignerPolicy, SignerPolicyError
     Ok(SignerPolicy {
         fulcio_issuers,
         san_patterns,
+        ed25519_keys: match data.get(KEY_ED25519_KEYS) {
+            Some(raw) => parse_ed25519_keys(raw)?,
+            None => Vec::new(),
+        },
     })
+}
+
+/// Parse the `ed25519Keys` ConfigMap value (a JSON array of
+/// [`Ed25519Key`] objects) into a deduplicated, validated `Vec`.
+///
+/// Strict: empty whitespace and `[]` both parse to an empty `Vec`
+/// (forward-compat — operators wire the data key in early without
+/// having keys yet). Any other malformed shape is an error.
+pub fn parse_ed25519_keys(raw: &str) -> Result<Vec<Ed25519Key>, SignerPolicyError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed)
+        .map_err(|e| SignerPolicyError::Ed25519JsonParse(e.to_string()))?;
+    let arr = value
+        .as_array()
+        .ok_or(SignerPolicyError::Ed25519NotArray)?
+        .clone();
+
+    let mut out: Vec<Ed25519Key> = Vec::with_capacity(arr.len());
+    let mut seen_ids: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for (index, entry) in arr.into_iter().enumerate() {
+        let key: Ed25519Key =
+            serde_json::from_value(entry).map_err(|e| SignerPolicyError::Ed25519InvalidEntry {
+                index,
+                field: "<entry>",
+                reason: e.to_string(),
+            })?;
+        validate_ed25519_key(index, &key)?;
+        if !seen_ids.insert(key.id.clone()) {
+            return Err(SignerPolicyError::Ed25519DuplicateId(key.id));
+        }
+        out.push(key);
+    }
+    Ok(out)
+}
+
+fn validate_ed25519_key(index: usize, key: &Ed25519Key) -> Result<(), SignerPolicyError> {
+    if key.id.is_empty() {
+        return Err(SignerPolicyError::Ed25519InvalidEntry {
+            index,
+            field: "id",
+            reason: "must be non-empty".to_string(),
+        });
+    }
+    if key.id.len() > 63 {
+        return Err(SignerPolicyError::Ed25519InvalidEntry {
+            index,
+            field: "id",
+            reason: format!("must be ≤63 chars (got {})", key.id.len()),
+        });
+    }
+    if !is_dns_label(&key.id) {
+        return Err(SignerPolicyError::Ed25519InvalidEntry {
+            index,
+            field: "id",
+            reason: "must be a DNS label ([a-z0-9-], no leading/trailing dash)".to_string(),
+        });
+    }
+    let b64 = key.public_key_base64.trim();
+    if b64.is_empty() {
+        return Err(SignerPolicyError::Ed25519InvalidEntry {
+            index,
+            field: "publicKeyBase64",
+            reason: "must be non-empty".to_string(),
+        });
+    }
+    use base64::Engine as _;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|e| SignerPolicyError::Ed25519InvalidEntry {
+            index,
+            field: "publicKeyBase64",
+            reason: format!("invalid base64: {e}"),
+        })?;
+    // Accept raw 32-byte Ed25519 pubkeys + the 44-byte DER/PKIX SPKI
+    // form cosign emits. Sub-44-byte payloads with `MCowBQYDK2VwAyEA`
+    // prefix are not valid PKIX — reject.
+    let len = decoded.len();
+    if !matches!(len, 32 | 44) {
+        return Err(SignerPolicyError::Ed25519InvalidEntry {
+            index,
+            field: "publicKeyBase64",
+            reason: format!("must decode to 32 (raw) or 44 (DER) bytes, got {len}"),
+        });
+    }
+    for (s_idx, subject) in key.allowed_subjects.iter().enumerate() {
+        if subject.trim().is_empty() {
+            return Err(SignerPolicyError::Ed25519InvalidEntry {
+                index,
+                field: "allowedSubjects",
+                reason: format!("entry [{s_idx}] is empty"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn is_dns_label(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    if bytes[0] == b'-' || bytes[bytes.len() - 1] == b'-' {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || *b == b'-')
 }
 
 fn parse_list(
@@ -222,7 +408,16 @@ impl SharedSignerPolicy {
     /// [`SignerPolicyState::Malformed`] on parse-error.
     pub fn apply_configmap(&self, cm: &ConfigMap) {
         let next = match parse_configmap(cm) {
-            Ok(p) => SignerPolicyState::FromConfigMap(p),
+            Ok(p) => {
+                tracing::info!(
+                    fulcio_issuers = p.fulcio_issuers.len(),
+                    san_patterns = p.san_patterns.len(),
+                    ed25519_keys = p.ed25519_keys.len(),
+                    ed25519_key_ids = ?p.ed25519_keys.iter().map(|k| k.id.as_str()).collect::<Vec<_>>(),
+                    "SignerPolicy ConfigMap applied",
+                );
+                SignerPolicyState::FromConfigMap(p)
+            }
             Err(e) => {
                 tracing::warn!(
                     error = %e,
@@ -234,6 +429,27 @@ impl SharedSignerPolicy {
         if let Ok(mut w) = self.inner.write() {
             *w = next;
         }
+    }
+
+    /// Snapshot of the registered Ed25519 keys (grant lane, Slice 5e+).
+    ///
+    /// Returns an empty `Vec` when the SignerPolicy ConfigMap is
+    /// absent, malformed, or omits the `ed25519Keys` data key. Cheap
+    /// to call — clones the inner `Vec<Ed25519Key>` (which is
+    /// typically 0–4 entries in practice).
+    ///
+    /// **Forward-compat surface.** The data-plane policy verifier
+    /// (egress / tools / inference / memory / mcp-server) does not
+    /// call this method; Slice 5e+ grant-lane verification will.
+    #[allow(dead_code)] // Slice 5e+ grant-lane verifier consumer.
+    pub fn ed25519_keys(&self) -> Vec<Ed25519Key> {
+        self.inner
+            .read()
+            .map(|g| match &*g {
+                SignerPolicyState::FromConfigMap(p) => p.ed25519_keys.clone(),
+                _ => Vec::new(),
+            })
+            .unwrap_or_default()
     }
 
     /// Reset to [`SignerPolicyState::Absent`]. Used on watcher delete
@@ -499,5 +715,230 @@ mod tests {
         let s2 = s.clone();
         s.apply_configmap(&cm_with(Some(good_data())));
         assert!(matches!(s2.snapshot(), SignerPolicyState::FromConfigMap(_)));
+    }
+
+    // ─── Slice 1c.6: ed25519 grant-lane forward-compat ───
+
+    /// Raw 32-byte all-zero Ed25519 pubkey base64 (44 chars + padding).
+    const RAW_PUBKEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    /// DER/PKIX SPKI-wrapped Ed25519 pubkey (44 raw bytes → 60 base64
+    /// chars + padding). Header `30 2a 30 05 06 03 2b 65 70 03 21 00`
+    /// is the standard `id-Ed25519` SubjectPublicKeyInfo prefix.
+    const DER_PUBKEY_B64: &str = "MCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    fn good_data_with_ed25519(ed: &str) -> BTreeMap<String, String> {
+        let mut d = good_data();
+        d.insert(KEY_ED25519_KEYS.into(), ed.into());
+        d
+    }
+
+    #[test]
+    fn ed25519_absent_yields_empty_vec() {
+        let p = parse_configmap(&cm_with(Some(good_data()))).expect("parses");
+        assert!(p.ed25519_keys.is_empty());
+    }
+
+    #[test]
+    fn ed25519_empty_string_yields_empty_vec() {
+        let p = parse_configmap(&cm_with(Some(good_data_with_ed25519("   \n  ")))).expect("parses");
+        assert!(p.ed25519_keys.is_empty());
+    }
+
+    #[test]
+    fn ed25519_empty_array_yields_empty_vec() {
+        let p = parse_configmap(&cm_with(Some(good_data_with_ed25519("[]")))).expect("parses");
+        assert!(p.ed25519_keys.is_empty());
+    }
+
+    #[test]
+    fn ed25519_parses_single_raw_key() {
+        let json = format!(
+            r#"[{{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":["egress-approval"]}}]"#
+        );
+        let p = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).expect("parses");
+        assert_eq!(p.ed25519_keys.len(), 1);
+        assert_eq!(p.ed25519_keys[0].id, "signer-a");
+        assert_eq!(p.ed25519_keys[0].allowed_subjects, vec!["egress-approval"]);
+    }
+
+    #[test]
+    fn ed25519_parses_der_key() {
+        let json = format!(
+            r#"[{{"id":"signer-b","publicKeyBase64":"{DER_PUBKEY_B64}","allowedSubjects":["egress-approval"]}}]"#
+        );
+        parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).expect("parses DER form");
+    }
+
+    #[test]
+    fn ed25519_parses_multiple_keys() {
+        let json = format!(
+            r#"[
+                {{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":["egress-approval"]}},
+                {{"id":"signer-b","publicKeyBase64":"{DER_PUBKEY_B64}","allowedSubjects":["egress-approval","future-grant"]}}
+            ]"#
+        );
+        let p = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).expect("parses");
+        assert_eq!(p.ed25519_keys.len(), 2);
+    }
+
+    #[test]
+    fn ed25519_rejects_malformed_json() {
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519("[{]")))).unwrap_err();
+        assert!(matches!(err, SignerPolicyError::Ed25519JsonParse(_)));
+    }
+
+    #[test]
+    fn ed25519_rejects_non_array_json() {
+        let json = format!(
+            r#"{{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":[]}}"#
+        );
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        assert!(matches!(err, SignerPolicyError::Ed25519NotArray));
+    }
+
+    #[test]
+    fn ed25519_rejects_empty_id() {
+        let json =
+            format!(r#"[{{"id":"","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":[]}}]"#);
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        match err {
+            SignerPolicyError::Ed25519InvalidEntry { field: "id", .. } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ed25519_rejects_non_dns_label_id() {
+        let json = format!(
+            r#"[{{"id":"Signer_A","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":[]}}]"#
+        );
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        match err {
+            SignerPolicyError::Ed25519InvalidEntry { field: "id", .. } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ed25519_rejects_long_id() {
+        let long_id = "a".repeat(64);
+        let json = format!(
+            r#"[{{"id":"{long_id}","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":[]}}]"#
+        );
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        match err {
+            SignerPolicyError::Ed25519InvalidEntry { field: "id", .. } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ed25519_rejects_wrong_pubkey_length() {
+        // 33-byte payload (32-byte raw key + extra byte) → length 33 ≠ 32 ≠ 44.
+        let bad_pk = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB";
+        let json =
+            format!(r#"[{{"id":"signer-a","publicKeyBase64":"{bad_pk}","allowedSubjects":[]}}]"#);
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        match err {
+            SignerPolicyError::Ed25519InvalidEntry {
+                field: "publicKeyBase64",
+                ..
+            } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ed25519_rejects_invalid_base64() {
+        let json =
+            r#"[{"id":"signer-a","publicKeyBase64":"!!!not-base64!!!","allowedSubjects":[]}]"#;
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(json)))).unwrap_err();
+        match err {
+            SignerPolicyError::Ed25519InvalidEntry {
+                field: "publicKeyBase64",
+                ..
+            } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ed25519_rejects_empty_subject_string() {
+        let json = format!(
+            r#"[{{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":["egress-approval", "  "]}}]"#
+        );
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        match err {
+            SignerPolicyError::Ed25519InvalidEntry {
+                field: "allowedSubjects",
+                ..
+            } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ed25519_rejects_duplicate_ids() {
+        let json = format!(
+            r#"[
+                {{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":[]}},
+                {{"id":"signer-a","publicKeyBase64":"{DER_PUBKEY_B64}","allowedSubjects":[]}}
+            ]"#
+        );
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        assert!(matches!(err, SignerPolicyError::Ed25519DuplicateId(id) if id == "signer-a"));
+    }
+
+    #[test]
+    fn ed25519_rejects_unknown_field() {
+        let json = format!(
+            r#"[{{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":[],"foo":"bar"}}]"#
+        );
+        let err = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).unwrap_err();
+        // serde_json's deny_unknown_fields surfaces as Ed25519InvalidEntry with the parse error message.
+        assert!(matches!(
+            err,
+            SignerPolicyError::Ed25519InvalidEntry {
+                field: "<entry>",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn shared_ed25519_keys_accessor_round_trips() {
+        let s = SharedSignerPolicy::new();
+        let json = format!(
+            r#"[{{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":["egress-approval"]}}]"#
+        );
+        s.apply_configmap(&cm_with(Some(good_data_with_ed25519(&json))));
+        let keys = s.ed25519_keys();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].id, "signer-a");
+    }
+
+    #[test]
+    fn shared_ed25519_keys_empty_on_absent() {
+        let s = SharedSignerPolicy::default();
+        assert!(s.ed25519_keys().is_empty());
+    }
+
+    #[test]
+    fn shared_ed25519_keys_empty_on_malformed() {
+        let s = SharedSignerPolicy::new();
+        s.apply_configmap(&cm_with(Some(good_data_with_ed25519("[{]"))));
+        assert!(s.ed25519_keys().is_empty());
+        assert!(matches!(s.snapshot(), SignerPolicyState::Malformed(_)));
+    }
+
+    #[test]
+    fn signer_policy_config_from_surfaces_ed25519() {
+        let json = format!(
+            r#"[{{"id":"signer-a","publicKeyBase64":"{RAW_PUBKEY_B64}","allowedSubjects":["egress-approval"]}}]"#
+        );
+        let p = parse_configmap(&cm_with(Some(good_data_with_ed25519(&json)))).expect("parses");
+        let cfg: crate::policy_fetcher::SignerPolicyConfig = p.into();
+        assert_eq!(cfg.ed25519_keys.len(), 1);
+        assert_eq!(cfg.ed25519_keys[0].id, "signer-a");
     }
 }


### PR DESCRIPTION
Wraps the **Slice 1c-real signing-generalization arc** (1c.1–1c.5
already on dev). This PR adds two surfaces:

1. **`SignerPolicy.spec.ed25519Keys[]`** (forward-compat) — registration
   point for ephemeral-grant signing keys consumed by Slice 5e+
   EgressApproval. No verifier wired today; the wire shape, parser,
   validation, accessor, and audit event all land here so 5e's
   PR is pure consumer wiring.
2. **`azureclaw policy sign --kind X`** — single CLI dispatch covering
   all five signed policy artifact kinds (egress-allowlist,
   agt-profile, inference-policy, memory-binding, mcp-server-bundle).
   Per-kind media-type table mirrors the controller's
   `policy_canonical::*::MEDIA_TYPE` consts byte-for-byte.

## Controller side

- `controller/src/signer_policy.rs`: new optional \`ed25519Keys\` JSON
  array key on the SignerPolicy ConfigMap. Strict validation:
  DNS-label IDs (≤63 chars, \`[a-z0-9-]\`, deduped), base64 keys
  decoding to **either** 32-byte raw Ed25519 or 44-byte SPKI/DER
  (cosign-compat), non-empty allowedSubjects (empty strings within
  rejected), \`deny_unknown_fields\`. Parsed keys surface on
  \`SharedSignerPolicy::ed25519_keys()\`.
- \`controller/src/policy_fetcher.rs\`: \`SignerPolicyConfig\` gains
  \`ed25519_keys\` field with \`#[allow(dead_code)]\` + Slice 5e+
  comment, ridden through the existing \`From<SignerPolicy>\` impl.
- 20 new unit tests covering absent/empty/raw-pubkey/DER-pubkey/
  multi-key/malformed-JSON/non-array/DNS-label edge cases/base64
  errors/allowed-subjects hygiene/dedup/SharedSignerPolicy round-trip.
- Controller test count: 677 → **697**. clippy \`-D warnings\` clean,
  fmt clean.

## CLI side

- New \`cli/src/commands/policy/sign.ts\` (~280 LOC) registers
  \`azureclaw policy sign --kind {…} --file <p> --registry <r>
  --repository <p>\` plus \`--tag\`, \`--sign-mode\`, \`--sign-key\`,
  \`--json\`, \`--print-bundle-ref\`.
- Cheap pre-flight only (file exists, non-empty, valid UTF-8). The
  controller's \`policy_canonical::*::parse\` remains the authoritative
  canonical-form checker — operators ship pre-canonicalised bytes.
- \`azureclaw egress … --sign\` stays unchanged for back-compat
  (it owns the egress-specific canonical-bytes builder).
- 13 new CLI unit tests covering per-kind media-type table,
  unknown-kind rejection, all four pre-flight branches, digest
  format check, default tag, bundleRef snippet render.

## Why this closes the 1c-real arc

Slices 1c.1–1c.5 wired every policy kind to
\`fetch_and_verify_generic\` on the controller side, satisfying
\`principles.md §2\` architecturally. The CLI surface remained
egress-only — operators authoring the other four kinds had to drop
to raw oras+cosign. 1c.6 collapses that authoring asymmetry into
one command without touching the data plane.

## Local verification

- \`cargo test --package azureclaw-controller --bins\` → 697 pass
- \`cargo clippy --package azureclaw-controller --all-targets
  -- -D warnings\` → clean
- \`cargo fmt --all --check\` → clean
- \`cd cli && npm run build\` → clean
- \`cd cli && npm test\` → 705 pass / 2 skipped
- \`cd cli && npm run typecheck\` → clean
- \`cd cli && npm run lint\` → 0 errors (16 pre-existing warnings)