### PR TITLE
Slice 5e.1 — EgressApproval CRD shape + CEL + Helm install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,103 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Slice 5e.1 — `EgressApproval` CRD shape + CEL + Helm install
+
+Opens the **grant lane** of `principles.md §2.4` /
+`signing-model.md §6`: a namespaced, short-TTL, attributable widening
+of a sandbox's baseline egress allowlist. The CRD shape, admission
+CEL, Helm manifest, and `azureclaw:egress-approver` ClusterRole all
+land here; the reconciler + router merge + CLI ship in Slices 5e.2 →
+5e.4.
+
+The slice is intentionally **additive-only** — no consumer paths run
+yet. The CRD installs cleanly, admission rejects malformed approvals,
+and operators can experiment by `kubectl apply`-ing fixtures without
+any side effect on running sandboxes.
+
+**Producer side (controller)**
+
+- `controller/src/egress_approval.rs` (new, ~370 LOC including tests)
+  defines `EgressApprovalSpec { sandbox, hosts, reason, ticket, ttl }`
+  and `EgressApprovalStatus { phase, observedGeneration, effectiveAt,
+  expiresAt, mergedDigest, hostCount, usageCount, conditions }` plus
+  a `condition_reasons` module pinning the seven stable reason strings
+  (`BlockedOnSandbox`, `RouterConfirmed`, `AwaitingRouterEcho`,
+  `TtlExceedsCeiling`, `TtlInvalid`, `ReasonInvalid`, `Expired`).
+  Group `azureclaw.azure.com`, version `v1alpha1`, shortname `eappr`,
+  five printer columns (Sandbox / Phase / Expires / Hosts / Age).
+  `hosts` reuses the existing `crd::EndpointConfig` — no parallel
+  endpoint type.
+- `controller/src/crd_validations.rs` gains `egress_approval_validations()`
+  (9 CEL rules: sandbox length cap, host-count 1–16, per-host port
+  range, reason length cap + ASCII control-byte guard, ticket length
+  cap, ISO 8601 positive-duration regex + non-zero guard) and
+  `egress_approval_crd()` injecting them.
+- `controller/src/main.rs` declares `mod egress_approval` behind an
+  `#[allow(dead_code)]` (the explicit marker for the unread-today
+  reconciler surface, matching the Slice 1c.6 pattern).
+- `controller/src/helm_drift.rs` extends the drift-detection suite
+  with the new `crd-egressapproval.yaml` manifest and a one-shot
+  dumper.
+
+**Forward-compatible to Slice 5e+ (deferred, demand-gated)**: the
+cryptographic-attestation field (`spec.attestation: Option<Attestation>`)
+adds without a schema break. The 1c.6 `SignerPolicy.spec.ed25519Keys[]`
+registry is the future verification anchor.
+
+**Helm**
+
+- `deploy/helm/azureclaw/templates/crd-egressapproval.yaml` (new) —
+  the helm-installed CRD manifest. Schema generated via the standard
+  `DUMP_EGRESSAPPROVAL_CRD_YAML=1 cargo test` workflow + helm labels
+  applied. Helm-drift test passes byte-for-byte.
+- `deploy/helm/azureclaw/templates/rbac.yaml` —
+  - extends the existing `azureclaw-controller` ClusterRole with
+    `egressapprovals` / `egressapprovals/status` /
+    `egressapprovals/finalizers` (the reconciler in 5e.2 needs all
+    three);
+  - adds a new `azureclaw:egress-approver` ClusterRole carrying
+    `get/list` on `clawsandboxes` (so an approver can verify the
+    target before granting) and `get/list/watch/create/delete` on
+    `egressapprovals` (`update` intentionally excluded — approvals
+    are immutable; revocation is `delete`). Aggregation labels
+    (`aggregate-to-admin`, `aggregate-to-edit`) wire it into the
+    standard k8s composite roles cleanly. Not bound by default —
+    operators bind explicitly per cluster convention.
+
+**Tests**
+
+- 11 new tests in `egress_approval` module: spec round-trip with/
+  without optional fields, camelCase wire-shape pin, status round-trip,
+  status defaults, `merged_host_count` correctness,
+  condition_reasons string-stability pin, CRD shape + printcolumn
+  shape pins.
+- 5 new tests in `crd_validations` covering the CEL rule list:
+  non-empty, message + rule populated on every rule, schema-injection
+  count matches, core-invariant coverage (sandbox / hosts cap / port
+  / reason / control-byte guard / ticket / TTL ISO-8601 regex),
+  serde round-trip.
+- helm-drift suite reports 16 passing tests (was 14): the new dumper
+  + the new drift assertion.
+- Total controller suite **697 → 713** (+16 new). `cargo clippy
+  --all-targets -- -D warnings` clean across the workspace,
+  `cargo fmt --check` clean.
+
+**Out of scope (deferred to subsequent 5e sub-slices)**
+
+- Reconciler (Pending → Active → Expired state machine, finalizer,
+  expiry tick, sibling-sandbox-Ready gate, TTL ceiling enforcement
+  beyond CEL) — Slice 5e.2.
+- Router-side merge logic + per-approval usage counter +
+  `/internal/policy-status` echo extension — Slice 5e.3.
+- CLI surface (`azureclaw egress approve / revoke / approvals`) —
+  Slice 5e.4.
+- Cryptographic attestation (ed25519 signature over canonical
+  approval bytes, verified against `SignerPolicy.spec.ed25519Keys[]`)
+  — Slice 5e+ (demand-gated; the registration half landed in 1c.6).
+- Headlamp panel — Slice 5e.6 (deferable, mirrors the 1c.6 chip
+  deferral pattern).
+
 ### Slice 1c.6 — `SignerPolicy.spec.ed25519Keys[]` + unified `azureclaw policy sign --kind X`
 
 Wraps the Slice 1c-real signing-generalization arc with two

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -51,6 +51,7 @@ use kube::CustomResourceExt;
 use crate::a2a_agent::A2AAgent;
 use crate::claw_eval::ClawEval;
 use crate::claw_memory::ClawMemory;
+use crate::egress_approval::EgressApproval;
 use crate::inference_policy::InferencePolicy;
 use crate::mcp_server::McpServer;
 use crate::tool_policy::ToolPolicy;
@@ -555,6 +556,131 @@ pub fn trust_graph_crd() -> CustomResourceDefinition {
     .expect("kube-rs derive must produce a spec property on TrustGraph")
 }
 
+/// `EgressApproval.spec` CEL rules. Slice 5e-thin of
+/// `crd-well-oiled-machine`.
+///
+/// `EgressApproval` is an ephemeral, scoped, attributable widening of a
+/// sandbox's baseline egress allowlist. The CRD is shape-only — the
+/// authority decision is K8s RBAC on the `create` verb, and the
+/// reconciler is the runtime enforcer of TTL semantics.
+///
+/// Admission CEL covers what we can verify *without* a cluster
+/// lookup; the reconciler re-checks every rule plus the cluster
+/// invariants (sibling sandbox Ready, TTL ceiling) for
+/// defense-in-depth.
+///
+/// Rules:
+///
+/// - `sandbox`: non-empty, 1–253 chars (k8s object-name length cap).
+/// - `hosts`: 1–16 entries; each `host` non-empty + 1–253 chars; each
+///   `port`, when set, ∈ `[1, 65535]`. The router's egress matcher
+///   defaults missing ports to 443 — `EndpointConfig.port` is
+///   `Option<u16>` upstream so we don't force operators to spell out
+///   the obvious HTTPS case.
+/// - `reason`: 1–512 chars; must not contain ASCII control bytes
+///   (rejected to keep audit log + CLI output safe to render).
+/// - `ticket`: when set, 1–128 chars (loose — no shape constraint
+///   beyond length).
+/// - `ttl`: matches an ISO 8601 positive-duration regex. The
+///   regex is intentionally permissive — the reconciler does the
+///   authoritative parse, including the cluster ceiling check; here
+///   we just reject obviously malformed inputs (`""`, `"forever"`,
+///   negative). Form: `P[<n>D]T[<n>H][<n>M][<n>S]` or `P<n>D` etc.
+#[must_use]
+pub fn egress_approval_validations() -> Vec<ValidationRule> {
+    vec![
+        ValidationRule {
+            rule: "size(self.sandbox) > 0 && size(self.sandbox) <= 253".into(),
+            message: Some("spec.sandbox must be 1-253 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "size(self.hosts) >= 1 && size(self.hosts) <= 16".into(),
+            message: Some(
+                "spec.hosts must contain between 1 and 16 entries (small, scoped grants only)"
+                    .into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "self.hosts.all(h, size(h.host) > 0 && size(h.host) <= 253)".into(),
+            message: Some("each spec.hosts[*].host must be 1-253 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "self.hosts.all(h, !has(h.port) || (h.port >= 1 && h.port <= 65535))".into(),
+            message: Some("each spec.hosts[*].port, when set, must be 1-65535".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "size(self.reason) >= 1 && size(self.reason) <= 512".into(),
+            message: Some("spec.reason must be 1-512 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        // ASCII control byte guard. The regex covers C0 controls
+        // (0x00-0x1F) except tab (0x09), newline (0x0A), and
+        // carriage return (0x0D) — those three are common in
+        // operator-written prose; DEL (0x7F) is also rejected.
+        // The CEL `matches` operator uses RE2 syntax.
+        ValidationRule {
+            rule: "!self.reason.matches('[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]')".into(),
+            message: Some(
+                "spec.reason must not contain ASCII control bytes (audit-log injection guard)"
+                    .into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "!has(self.ticket) || (size(self.ticket) >= 1 && size(self.ticket) <= 128)"
+                .into(),
+            message: Some("spec.ticket, when set, must be 1-128 characters".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        // ISO 8601 positive-duration regex.
+        //
+        // Accepts: P<n>D, P<n>W, P<n>Y[<n>M[<n>D]], PT<n>H[<n>M[<n>S]],
+        // P<n>D T<n>H..., where n ∈ [0-9]+ (no fractional, no
+        // negative). At least one numeric component must be present.
+        // The reconciler does the authoritative parse-and-clamp.
+        //
+        // We disallow the zero-only form (`PT0S`, `P0D`) by requiring
+        // that at least one digit is non-zero — implemented as a
+        // negative-lookahead-free rule: the duration must contain a
+        // digit '1'-'9' somewhere. RE2 supports that as a separate
+        // `matches`.
+        ValidationRule {
+            rule: "self.ttl.matches('^P(\\\\d+Y)?(\\\\d+M)?(\\\\d+W)?(\\\\d+D)?(T(\\\\d+H)?(\\\\d+M)?(\\\\d+S)?)?$')".into(),
+            message: Some(
+                "spec.ttl must be a positive ISO 8601 duration (e.g. PT15M, PT4H, P1D)".into(),
+            ),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+        ValidationRule {
+            rule: "self.ttl.matches('[1-9]')".into(),
+            message: Some("spec.ttl must be > 0 (e.g. PT15M, not PT0S)".into()),
+            reason: Some("FieldValueInvalid".into()),
+            ..ValidationRule::default()
+        },
+    ]
+}
+
+/// `EgressApproval` CRD with [`egress_approval_validations`] injected.
+///
+/// Panics only if kube-rs ever produces a CRD whose `spec` is missing.
+#[must_use]
+pub fn egress_approval_crd() -> CustomResourceDefinition {
+    inject_spec_validations(EgressApproval::crd(), egress_approval_validations())
+        .expect("kube-rs derive must produce a spec property on EgressApproval")
+}
+
 /// `ClawSandbox` CRD as produced by the kube-rs derive.
 ///
 /// Currently no `claw_sandbox_validations()` helper exists — `ClawSandbox`
@@ -908,6 +1034,84 @@ mod tests {
         assert!(y.contains("sandboxRef"));
         assert!(y.contains("evaluators"));
         assert!(y.contains("threshold"));
+    }
+
+    // ---- EgressApproval (5e-thin) --------------------------------------
+
+    #[test]
+    fn egress_approval_validations_are_non_empty() {
+        assert!(!egress_approval_validations().is_empty());
+    }
+
+    #[test]
+    fn every_egress_approval_rule_has_message_and_rule() {
+        for rule in egress_approval_validations() {
+            assert!(!rule.rule.is_empty(), "rule body must not be empty");
+            let msg = rule.message.as_deref().unwrap_or("");
+            assert!(!msg.is_empty(), "rule '{}' missing message", rule.rule);
+        }
+    }
+
+    #[test]
+    fn egress_approval_crd_has_spec_validations_after_injection() {
+        let crd = egress_approval_crd();
+        let v = spec_validations(&crd);
+        assert_eq!(v.len(), egress_approval_validations().len());
+    }
+
+    #[test]
+    fn egress_approval_rules_cover_core_invariants() {
+        let rules: Vec<String> = egress_approval_validations()
+            .into_iter()
+            .map(|r| r.rule)
+            .collect();
+        assert!(
+            rules.iter().any(|r| r.contains("self.sandbox")),
+            "must validate sandbox name; got: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("self.hosts") && r.contains("16")),
+            "must cap hosts at 16; got: {rules:?}"
+        );
+        assert!(
+            rules.iter().any(|r| r.contains("h.port")),
+            "must validate per-host port range; got: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("self.reason") && r.contains("512")),
+            "must cap reason length; got: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("\\x00") || r.contains("control")),
+            "must guard against ASCII control bytes in reason; got: {rules:?}"
+        );
+        assert!(
+            rules.iter().any(|r| r.contains("self.ticket")),
+            "must validate ticket length; got: {rules:?}"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.contains("self.ttl") && r.contains("^P")),
+            "must validate ISO 8601 duration shape; got: {rules:?}"
+        );
+    }
+
+    #[test]
+    fn egress_approval_crd_is_serde_round_trippable() {
+        let crd = egress_approval_crd();
+        let y = serde_yaml::to_string(&crd).expect("serializes");
+        assert!(y.contains("x-kubernetes-validations"));
+        assert!(y.contains("sandbox"));
+        assert!(y.contains("hosts"));
+        assert!(y.contains("reason"));
+        assert!(y.contains("ttl"));
     }
 
     #[test]

--- a/controller/src/egress_approval.rs
+++ b/controller/src/egress_approval.rs
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `EgressApproval` CRD — Slice 5e-thin of `crd-well-oiled-machine`.
+//!
+//! The grant lane (per `principles.md §2.4` and
+//! `docs/internal/crd-well-oiled-machine/signing-model.md §6`).
+//!
+//! ## What it is
+//!
+//! A short-TTL, scoped, attributable, **ephemeral** widening of the
+//! baseline egress allowlist for a single sandbox. The baseline lives
+//! in `ClawSandbox.spec.networkPolicy.allowlistRef` (a cosign-signed
+//! OCI artifact, Slice 1c.1). An `EgressApproval` adds a small list of
+//! hosts on top of that baseline for the duration declared in
+//! `spec.ttl`, then auto-expires. Approvals **never** migrate into the
+//! signed bundle automatically — operators who want a hostname
+//! permanent re-sign the bundle the normal way.
+//!
+//! ## Authority model (thin)
+//!
+//! K8s RBAC is the authority. Binding the
+//! `azureclaw:egress-approver` ClusterRole grants `create / get /
+//! list / delete` on this CRD; the k8s audit log records who used it.
+//!
+//! Slice 5e+ (deferred, demand-gated) layers an optional cryptographic
+//! attestation on top — an ed25519 signature over the canonical
+//! approval bytes, verified against the controller-side
+//! `SignerPolicy.spec.ed25519Keys[]` registry that landed in Slice
+//! 1c.6. The CRD shape here is forward-compatible (no schema change
+//! required when the attestation field is added).
+//!
+//! ## Resolution invariants
+//!
+//! 1. `spec.sandbox` is a `ClawSandbox` in the **same namespace** as
+//!    the approval. Cross-namespace approvals are explicitly out of
+//!    scope; one approval = one sandbox.
+//! 2. `spec.hosts.length in 1..=16` — small, scoped grants only.
+//! 3. `spec.reason.length in 1..=512` — non-empty, audit-grade text.
+//! 4. `spec.ttl` parses as a positive ISO 8601 duration ≤ the
+//!    cluster's `maxApprovalTtl` Helm value (default 24h, hard ceiling
+//!    7d). The reconciler enforces the upper bound at admission time
+//!    in addition to CEL.
+//!
+//! ## Lifecycle
+//!
+//! `Pending` (admitted, sibling sandbox not yet Ready) →
+//! `Active` (router echoed the merged digest) →
+//! `Expired` (TTL elapsed; mount dropped; router echoed the baseline
+//! digest again).
+//!
+//! Deletion at any phase is honoured via the finalizer; the reconciler
+//! drops the approval's mount file, waits for the router to echo the
+//! post-removal merged digest, then removes the finalizer.
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::crd::EndpointConfig;
+
+/// `EgressApproval.spec` — declares a temporary, scoped widening of a
+/// sandbox's baseline egress allowlist.
+///
+/// The CR is namespaced; `spec.sandbox` MUST refer to a `ClawSandbox`
+/// in the same namespace.
+#[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[kube(
+    group = "azureclaw.azure.com",
+    version = "v1alpha1",
+    kind = "EgressApproval",
+    namespaced,
+    status = "EgressApprovalStatus",
+    shortname = "eappr",
+    printcolumn = r#"{"name":"Sandbox","type":"string","jsonPath":".spec.sandbox"}"#,
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Expires","type":"string","jsonPath":".status.expiresAt"}"#,
+    printcolumn = r#"{"name":"Hosts","type":"integer","jsonPath":".status.hostCount"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct EgressApprovalSpec {
+    /// Sandbox name (within the same namespace as this CR). The
+    /// reconciler resolves the `ClawSandbox`, fails admission if
+    /// absent, and waits for `phase=Ready` before promoting the
+    /// approval to `Active`.
+    pub sandbox: String,
+
+    /// Hosts to grant on top of the baseline. Same canonical form as
+    /// `ClawSandbox.spec.networkPolicy.allowedEndpoints`. CEL bound:
+    /// 1..=16 entries per approval. Per-entry CEL is delegated to the
+    /// `EndpointConfig` schema (host non-empty, port 1..=65535).
+    pub hosts: Vec<EndpointConfig>,
+
+    /// Human-readable reason. CEL: 1..=512 chars; the reconciler also
+    /// rejects control bytes as a defense-in-depth check. Surfaced in
+    /// audit log + CLI listing.
+    pub reason: String,
+
+    /// Optional ticket / incident reference (e.g. `INC-12345`). Not
+    /// validated for shape; surfaced in audit log only. CEL: when set,
+    /// 1..=128 chars.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ticket: Option<String>,
+
+    /// Time-to-live. ISO 8601 duration form (`PT15M`, `PT4H`, `P1D`).
+    /// CEL: must parse and be > 0; the reconciler enforces the
+    /// cluster ceiling (`maxApprovalTtl`, default 24h, hard 7d).
+    pub ttl: String,
+}
+
+/// Status of an `EgressApproval` reconcile.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EgressApprovalStatus {
+    /// One of `Pending` (waiting for sibling sandbox or admission
+    /// failure recoverable), `Active` (mount in place + router echoed
+    /// the merged digest), `Expired` (TTL elapsed, mount removed,
+    /// baseline re-echoed). `None` when the CR was just admitted and
+    /// the reconciler hasn't run yet.
+    #[serde(default)]
+    pub phase: Option<String>,
+
+    /// `metadata.generation` last successfully reconciled. KEP-1623.
+    #[serde(default)]
+    pub observed_generation: Option<i64>,
+
+    /// RFC 3339 timestamp at which the approval first became active.
+    /// Set on the `Pending → Active` transition and never changes
+    /// afterwards (the TTL is measured from this point; re-reconciles
+    /// MUST NOT bump it).
+    #[serde(default)]
+    pub effective_at: Option<String>,
+
+    /// RFC 3339 timestamp at which the approval expires. Computed as
+    /// `effective_at + spec.ttl` at the `Pending → Active`
+    /// transition. Stable across re-reconciles.
+    #[serde(default)]
+    pub expires_at: Option<String>,
+
+    /// `sha256:<hex>` digest of the canonical merged
+    /// (baseline ∪ approval.hosts) allowlist this approval contributes
+    /// to. Identical to the value the router echoes via
+    /// `GET /internal/policy-status` once the mount lands.
+    #[serde(default)]
+    pub merged_digest: Option<String>,
+
+    /// Number of hosts in `spec.hosts`. Mirrored to status for kubectl
+    /// printer-column convenience; the CRD-derive printcolumn config
+    /// expects this field by name.
+    #[serde(default)]
+    pub host_count: Option<i64>,
+
+    /// Number of requests the router has allowed via **this**
+    /// approval (i.e. a hostname that matched an approval entry and
+    /// would NOT have matched the baseline alone). Reported by the
+    /// router and pushed via `/internal/policy-status`. Useful for
+    /// auditors evaluating whether an approval was actually needed.
+    #[serde(default)]
+    pub usage_count: Option<i64>,
+
+    /// Standard k8s conditions. Reasons drawn from
+    /// [`condition_reasons`].
+    #[serde(default)]
+    pub conditions: Option<Vec<Condition>>,
+}
+
+/// Canonical condition reasons emitted on `EgressApproval` status.
+///
+/// Stable strings — public CLIs and dashboards key off them. Adding
+/// new reasons is fine; renaming an existing one is a breaking change
+/// (treat as CRD migration).
+pub mod condition_reasons {
+    /// The sibling `ClawSandbox` named by `spec.sandbox` does not
+    /// exist or is not yet `phase=Ready`. The approval stays in
+    /// `Pending`; the reconciler retries.
+    pub const BLOCKED_ON_SANDBOX: &str = "BlockedOnSandbox";
+
+    /// The mount file landed and the router echoed the merged
+    /// digest. The approval is `Active`.
+    pub const ROUTER_CONFIRMED: &str = "RouterConfirmed";
+
+    /// The router has not yet echoed the merged digest. Transient.
+    pub const AWAITING_ROUTER_ECHO: &str = "AwaitingRouterEcho";
+
+    /// `spec.ttl` exceeds the cluster ceiling (`maxApprovalTtl`).
+    /// The approval is rejected (Pending with a terminal reason);
+    /// admission CEL should also catch this, but the reconciler
+    /// emits this reason in case the ceiling changed under us.
+    pub const TTL_EXCEEDS_CEILING: &str = "TtlExceedsCeiling";
+
+    /// `spec.ttl` failed to parse as a positive ISO 8601 duration.
+    /// CEL should catch this; defense-in-depth reason.
+    pub const TTL_INVALID: &str = "TtlInvalid";
+
+    /// `spec.reason` contained ASCII control bytes (excluding tab /
+    /// newline / carriage return). Rejected as malicious audit-log
+    /// injection input.
+    pub const REASON_INVALID: &str = "ReasonInvalid";
+
+    /// The TTL elapsed; the mount is removed and the router echoed
+    /// the post-removal merged (= baseline) digest.
+    pub const EXPIRED: &str = "Expired";
+}
+
+impl EgressApproval {
+    /// Convenience: hostname canonicalization used by canonical-form
+    /// merge + audit log. Mirrors
+    /// `policy_canonical::egress::CanonicalEndpoint` shape.
+    pub fn merged_host_count(&self) -> usize {
+        self.spec.hosts.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kube::CustomResourceExt;
+
+    fn sample_spec() -> EgressApprovalSpec {
+        EgressApprovalSpec {
+            sandbox: "demo".to_string(),
+            hosts: vec![
+                EndpointConfig {
+                    host: "example.com".to_string(),
+                    port: Some(443),
+                },
+                EndpointConfig {
+                    host: "api.example.com".to_string(),
+                    port: None,
+                },
+            ],
+            reason: "INC-1234 incident response".to_string(),
+            ticket: Some("INC-1234".to_string()),
+            ttl: "PT15M".to_string(),
+        }
+    }
+
+    #[test]
+    fn spec_round_trips_with_all_fields() {
+        let spec = sample_spec();
+        let json = serde_json::to_string(&spec).expect("serializes");
+        let back: EgressApprovalSpec = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back.sandbox, "demo");
+        assert_eq!(back.hosts.len(), 2);
+        assert_eq!(back.reason, "INC-1234 incident response");
+        assert_eq!(back.ticket.as_deref(), Some("INC-1234"));
+        assert_eq!(back.ttl, "PT15M");
+    }
+
+    #[test]
+    fn spec_round_trips_with_ticket_omitted() {
+        let mut spec = sample_spec();
+        spec.ticket = None;
+        let json = serde_json::to_string(&spec).expect("serializes");
+        // `ticket` is skip_serializing_if = Option::is_none — must NOT appear.
+        assert!(
+            !json.contains("ticket"),
+            "ticket=None must be omitted from wire form; got {json}"
+        );
+        let back: EgressApprovalSpec = serde_json::from_str(&json).expect("deserializes");
+        assert!(back.ticket.is_none());
+    }
+
+    #[test]
+    fn spec_uses_camel_case_on_the_wire() {
+        let spec = sample_spec();
+        let json = serde_json::to_string(&spec).expect("serializes");
+        assert!(json.contains("\"sandbox\""));
+        assert!(json.contains("\"hosts\""));
+        assert!(json.contains("\"reason\""));
+        assert!(json.contains("\"ttl\""));
+        // Nothing snake_case in the spec — bare nouns, no camelization needed.
+    }
+
+    #[test]
+    fn status_round_trips_with_all_fields() {
+        let status = EgressApprovalStatus {
+            phase: Some("Active".to_string()),
+            observed_generation: Some(3),
+            effective_at: Some("2026-05-15T10:00:00Z".to_string()),
+            expires_at: Some("2026-05-15T10:15:00Z".to_string()),
+            merged_digest: Some("sha256:abc123".to_string()),
+            host_count: Some(2),
+            usage_count: Some(7),
+            conditions: Some(vec![]),
+        };
+        let json = serde_json::to_string(&status).expect("serializes");
+        // camelCase keys per #[serde(rename_all = "camelCase")].
+        assert!(json.contains("\"observedGeneration\""));
+        assert!(json.contains("\"effectiveAt\""));
+        assert!(json.contains("\"expiresAt\""));
+        assert!(json.contains("\"mergedDigest\""));
+        assert!(json.contains("\"hostCount\""));
+        assert!(json.contains("\"usageCount\""));
+        let back: EgressApprovalStatus = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back.phase.as_deref(), Some("Active"));
+        assert_eq!(back.observed_generation, Some(3));
+        assert_eq!(back.host_count, Some(2));
+    }
+
+    #[test]
+    fn status_defaults_to_all_none() {
+        let s = EgressApprovalStatus::default();
+        assert!(s.phase.is_none());
+        assert!(s.observed_generation.is_none());
+        assert!(s.effective_at.is_none());
+        assert!(s.expires_at.is_none());
+        assert!(s.merged_digest.is_none());
+        assert!(s.host_count.is_none());
+        assert!(s.usage_count.is_none());
+        assert!(s.conditions.is_none());
+    }
+
+    #[test]
+    fn merged_host_count_matches_spec_hosts_len() {
+        let approval = EgressApproval::new("demo-approval", sample_spec());
+        assert_eq!(approval.merged_host_count(), 2);
+        let approval = EgressApproval::new(
+            "empty",
+            EgressApprovalSpec {
+                hosts: vec![],
+                ..sample_spec()
+            },
+        );
+        assert_eq!(approval.merged_host_count(), 0);
+    }
+
+    #[test]
+    fn condition_reasons_are_stable_strings() {
+        // Wire-contract pin — these strings appear in CLI output,
+        // dashboards, and operator runbooks. Renames are CRD-migration
+        // events. This test fails loudly on any change.
+        use condition_reasons::*;
+        assert_eq!(BLOCKED_ON_SANDBOX, "BlockedOnSandbox");
+        assert_eq!(ROUTER_CONFIRMED, "RouterConfirmed");
+        assert_eq!(AWAITING_ROUTER_ECHO, "AwaitingRouterEcho");
+        assert_eq!(TTL_EXCEEDS_CEILING, "TtlExceedsCeiling");
+        assert_eq!(TTL_INVALID, "TtlInvalid");
+        assert_eq!(REASON_INVALID, "ReasonInvalid");
+        assert_eq!(EXPIRED, "Expired");
+    }
+
+    #[test]
+    fn crd_shape_pinned() {
+        let crd = EgressApproval::crd();
+        assert_eq!(crd.spec.group, "azureclaw.azure.com");
+        assert_eq!(crd.spec.names.kind, "EgressApproval");
+        assert_eq!(crd.spec.names.plural, "egressapprovals");
+        assert_eq!(
+            crd.spec.names.short_names.as_deref(),
+            Some(&["eappr".to_string()][..])
+        );
+        assert_eq!(crd.spec.scope, "Namespaced");
+        assert_eq!(crd.spec.versions.len(), 1);
+        assert_eq!(crd.spec.versions[0].name, "v1alpha1");
+        assert!(crd.spec.versions[0].served);
+        assert!(crd.spec.versions[0].storage);
+        // status subresource enabled
+        assert!(crd.spec.versions[0].subresources.is_some());
+    }
+
+    #[test]
+    fn crd_advertises_status_printcolumns() {
+        let crd = EgressApproval::crd();
+        let cols = crd.spec.versions[0]
+            .additional_printer_columns
+            .as_ref()
+            .expect("printcolumns present");
+        let names: Vec<&str> = cols.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"Sandbox"));
+        assert!(names.contains(&"Phase"));
+        assert!(names.contains(&"Expires"));
+        assert!(names.contains(&"Hosts"));
+        assert!(names.contains(&"Age"));
+    }
+}

--- a/controller/src/helm_drift.rs
+++ b/controller/src/helm_drift.rs
@@ -32,8 +32,8 @@
 
 #[cfg(test)]
 use crate::crd_validations::{
-    a2a_agent_crd, claw_eval_crd, claw_memory_crd, inference_policy_crd, mcp_server_crd,
-    tool_policy_crd, trust_graph_crd,
+    a2a_agent_crd, claw_eval_crd, claw_memory_crd, egress_approval_crd, inference_policy_crd,
+    mcp_server_crd, tool_policy_crd, trust_graph_crd,
 };
 
 const MCP_HELM_CRD_PATH: &str = concat!(
@@ -69,6 +69,11 @@ const CLAWEVAL_HELM_CRD_PATH: &str = concat!(
 const TRUSTGRAPH_HELM_CRD_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../deploy/helm/azureclaw/templates/crd-trustgraph.yaml"
+);
+
+const EGRESSAPPROVAL_HELM_CRD_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../deploy/helm/azureclaw/templates/crd-egressapproval.yaml"
 );
 
 /// Strip non-schema fields that legitimately differ between the Rust
@@ -271,5 +276,30 @@ mod tests {
         let rust_crd_value =
             serde_json::to_value(trust_graph_crd()).expect("rust crd serializes to JSON");
         assert_helm_matches_rust(TRUSTGRAPH_HELM_CRD_PATH, rust_crd_value, "trustgraph");
+    }
+
+    /// One-shot dumper for the egressapproval CRD. Run via:
+    ///
+    ///   DUMP_EGRESSAPPROVAL_CRD_YAML=1 cargo test --bin azureclaw-controller \
+    ///       helm_drift::tests::dump_egressapproval_crd_yaml -- --nocapture
+    #[test]
+    fn dump_egressapproval_crd_yaml() {
+        if std::env::var("DUMP_EGRESSAPPROVAL_CRD_YAML").is_err() {
+            return;
+        }
+        let crd = egress_approval_crd();
+        let yaml = serde_yaml::to_string(&crd).expect("serialize crd to YAML");
+        println!("---\n{yaml}");
+    }
+
+    #[test]
+    fn helm_egressapproval_crd_matches_rust_schema() {
+        let rust_crd_value =
+            serde_json::to_value(egress_approval_crd()).expect("rust crd serializes to JSON");
+        assert_helm_matches_rust(
+            EGRESSAPPROVAL_HELM_CRD_PATH,
+            rust_crd_value,
+            "egressapproval",
+        );
     }
 }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -30,6 +30,12 @@ mod crd;
 // CRD-installation pipeline (Phase 1 close-out + future kubectl-claw-attest) consumes these helpers.
 mod crd_validations;
 mod egress_allowlist_compile;
+#[allow(dead_code)]
+// Slice 5e.1 lands the CRD shape + CEL + Helm install; the reconciler
+// (consumer of condition_reasons + merged_host_count) ships in Slice
+// 5e.2. The dead_code allowance is the explicit marker for the
+// unread-today surface.
+mod egress_approval;
 mod fedcred;
 mod fedcred_reaper;
 mod field_managers;

--- a/deploy/helm/azureclaw/templates/crd-egressapproval.yaml
+++ b/deploy/helm/azureclaw/templates/crd-egressapproval.yaml
@@ -1,0 +1,232 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: egressapprovals.azureclaw.azure.com
+  labels:
+    app.kubernetes.io/name: azureclaw
+    app.kubernetes.io/component: crd
+spec:
+  group: azureclaw.azure.com
+  names:
+    categories: []
+    kind: EgressApproval
+    plural: egressapprovals
+    shortNames:
+    - eappr
+    singular: egressapproval
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sandbox
+      name: Sandbox
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.expiresAt
+      name: Expires
+      type: string
+    - jsonPath: .status.hostCount
+      name: Hosts
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for EgressApprovalSpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
+              `EgressApproval.spec` — declares a temporary, scoped widening of a
+              sandbox's baseline egress allowlist.
+
+              The CR is namespaced; `spec.sandbox` MUST refer to a `ClawSandbox`
+              in the same namespace.
+            properties:
+              hosts:
+                description: |-
+                  Hosts to grant on top of the baseline. Same canonical form as
+                  `ClawSandbox.spec.networkPolicy.allowedEndpoints`. CEL bound:
+                  1..=16 entries per approval. Per-entry CEL is delegated to the
+                  `EndpointConfig` schema (host non-empty, port 1..=65535).
+                items:
+                  properties:
+                    host:
+                      type: string
+                    port:
+                      format: uint16
+                      maximum: 65535.0
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                  required:
+                  - host
+                  type: object
+                type: array
+              reason:
+                description: |-
+                  Human-readable reason. CEL: 1..=512 chars; the reconciler also
+                  rejects control bytes as a defense-in-depth check. Surfaced in
+                  audit log + CLI listing.
+                type: string
+              sandbox:
+                description: |-
+                  Sandbox name (within the same namespace as this CR). The
+                  reconciler resolves the `ClawSandbox`, fails admission if
+                  absent, and waits for `phase=Ready` before promoting the
+                  approval to `Active`.
+                type: string
+              ticket:
+                description: |-
+                  Optional ticket / incident reference (e.g. `INC-12345`). Not
+                  validated for shape; surfaced in audit log only. CEL: when set,
+                  1..=128 chars.
+                nullable: true
+                type: string
+              ttl:
+                description: |-
+                  Time-to-live. ISO 8601 duration form (`PT15M`, `PT4H`, `P1D`).
+                  CEL: must parse and be > 0; the reconciler enforces the
+                  cluster ceiling (`maxApprovalTtl`, default 24h, hard 7d).
+                type: string
+            required:
+            - hosts
+            - reason
+            - sandbox
+            - ttl
+            type: object
+            x-kubernetes-validations:
+            - message: spec.sandbox must be 1-253 characters
+              reason: FieldValueInvalid
+              rule: size(self.sandbox) > 0 && size(self.sandbox) <= 253
+            - message: spec.hosts must contain between 1 and 16 entries (small, scoped grants only)
+              reason: FieldValueInvalid
+              rule: size(self.hosts) >= 1 && size(self.hosts) <= 16
+            - message: each spec.hosts[*].host must be 1-253 characters
+              reason: FieldValueInvalid
+              rule: self.hosts.all(h, size(h.host) > 0 && size(h.host) <= 253)
+            - message: each spec.hosts[*].port, when set, must be 1-65535
+              reason: FieldValueInvalid
+              rule: self.hosts.all(h, !has(h.port) || (h.port >= 1 && h.port <= 65535))
+            - message: spec.reason must be 1-512 characters
+              reason: FieldValueInvalid
+              rule: size(self.reason) >= 1 && size(self.reason) <= 512
+            - message: spec.reason must not contain ASCII control bytes (audit-log injection guard)
+              reason: FieldValueInvalid
+              rule: '!self.reason.matches(''[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]'')'
+            - message: spec.ticket, when set, must be 1-128 characters
+              reason: FieldValueInvalid
+              rule: '!has(self.ticket) || (size(self.ticket) >= 1 && size(self.ticket) <= 128)'
+            - message: spec.ttl must be a positive ISO 8601 duration (e.g. PT15M, PT4H, P1D)
+              reason: FieldValueInvalid
+              rule: self.ttl.matches('^P(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+S)?)?$')
+            - message: spec.ttl must be > 0 (e.g. PT15M, not PT0S)
+              reason: FieldValueInvalid
+              rule: self.ttl.matches('[1-9]')
+          status:
+            description: Status of an `EgressApproval` reconcile.
+            nullable: true
+            properties:
+              conditions:
+                description: |-
+                  Standard k8s conditions. Reasons drawn from
+                  [`condition_reasons`].
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              effectiveAt:
+                description: |-
+                  RFC 3339 timestamp at which the approval first became active.
+                  Set on the `Pending → Active` transition and never changes
+                  afterwards (the TTL is measured from this point; re-reconciles
+                  MUST NOT bump it).
+                nullable: true
+                type: string
+              expiresAt:
+                description: |-
+                  RFC 3339 timestamp at which the approval expires. Computed as
+                  `effective_at + spec.ttl` at the `Pending → Active`
+                  transition. Stable across re-reconciles.
+                nullable: true
+                type: string
+              hostCount:
+                description: |-
+                  Number of hosts in `spec.hosts`. Mirrored to status for kubectl
+                  printer-column convenience; the CRD-derive printcolumn config
+                  expects this field by name.
+                format: int64
+                nullable: true
+                type: integer
+              mergedDigest:
+                description: |-
+                  `sha256:<hex>` digest of the canonical merged
+                  (baseline ∪ approval.hosts) allowlist this approval contributes
+                  to. Identical to the value the router echoes via
+                  `GET /internal/policy-status` once the mount lands.
+                nullable: true
+                type: string
+              observedGeneration:
+                description: '`metadata.generation` last successfully reconciled. KEP-1623.'
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                description: |-
+                  One of `Pending` (waiting for sibling sandbox or admission
+                  failure recoverable), `Active` (mount in place + router echoed
+                  the merged digest), `Expired` (TTL elapsed, mount removed,
+                  baseline re-echoed). `None` when the CR was just admitted and
+                  the reconciler hasn't run yet.
+                nullable: true
+                type: string
+              usageCount:
+                description: |-
+                  Number of requests the router has allowed via **this**
+                  approval (i.e. a hostname that matched an approval entry and
+                  would NOT have matched the baseline alone). Reported by the
+                  router and pushed via `/internal/policy-status`. Useful for
+                  auditors evaluating whether an approval was actually needed.
+                format: int64
+                nullable: true
+                type: integer
+            type: object
+        required:
+        - spec
+        title: EgressApproval
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/helm/azureclaw/templates/rbac.yaml
+++ b/deploy/helm/azureclaw/templates/rbac.yaml
@@ -46,6 +46,9 @@ rules:
       - "trustgraphs/status"
       - "signerpolicies"
       - "signerpolicies/status"
+      - "egressapprovals"
+      - "egressapprovals/status"
+      - "egressapprovals/finalizers"
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Create and manage sandbox namespaces
   - apiGroups: [""]
@@ -105,3 +108,36 @@ rules:
   - apiGroups: ["azureclaw.azure.com"]
     resources: ["clawsandboxes"]
     verbs: ["get", "list", "create", "delete"]
+---
+# Egress approver ClusterRole — authority lane for Slice 5e-thin
+# EgressApproval CRDs. Binding this role (or an aggregating role that
+# selects on its label) IS the authority decision: any subject with
+# `create` on `egressapprovals.azureclaw.azure.com` can widen a
+# sandbox's baseline egress allowlist for the TTL declared in
+# `spec.ttl`. The k8s audit log records who used it; the controller
+# enforces TTL, host caps, and the sibling-sandbox-Ready invariant.
+#
+# Not bound by default — operators bind explicitly per cluster
+# convention (e.g. to an on-call group, an SRE rotation, or a break-
+# glass account). The aggregation label allows higher-level roles
+# (admin, edit) to inherit it cleanly.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: azureclaw:egress-approver
+  labels:
+    app.kubernetes.io/name: azureclaw
+    app.kubernetes.io/component: rbac
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  # Sibling sandbox must be readable so an approver can verify the
+  # target before creating the approval.
+  - apiGroups: ["azureclaw.azure.com"]
+    resources: ["clawsandboxes"]
+    verbs: ["get", "list"]
+  # Full lifecycle on EgressApproval. Update is intentionally
+  # excluded — approvals are immutable; revocation is delete.
+  - apiGroups: ["azureclaw.azure.com"]
+    resources: ["egressapprovals"]
+    verbs: ["get", "list", "watch", "create", "delete"]


### PR DESCRIPTION
Opens the **grant lane** of `principles.md §2.4` /
`docs/internal/crd-well-oiled-machine/signing-model.md §6`: a
namespaced, short-TTL, attributable widening of a sandbox's baseline
egress allowlist. The CRD shape, admission CEL, Helm manifest, and
`azureclaw:egress-approver` ClusterRole all land here.

**Additive-only** — no consumer paths run yet. The CRD installs
cleanly, admission rejects malformed approvals, and operators can
experiment by `kubectl apply`-ing fixtures without any side effect
on running sandboxes. The reconciler + router merge + CLI ship in
Slices 5e.2 → 5e.4.

## What lands

**Controller**
- `controller/src/egress_approval.rs` (new, ~370 LOC) —
  `EgressApprovalSpec { sandbox, hosts, reason, ticket, ttl }`
  + `EgressApprovalStatus { phase, observedGeneration, effectiveAt,
  expiresAt, mergedDigest, hostCount, usageCount, conditions }`
  + `condition_reasons` module pinning 7 stable reason strings
  (`BlockedOnSandbox`, `RouterConfirmed`, `AwaitingRouterEcho`,
  `TtlExceedsCeiling`, `TtlInvalid`, `ReasonInvalid`,
  `Expired`).
- Group `azureclaw.azure.com`, version `v1alpha1`, shortname
  `eappr`, 5 printer columns (Sandbox / Phase / Expires / Hosts /
  Age). `hosts` reuses existing `crd::EndpointConfig` — no
  parallel endpoint type.
- `crd_validations.rs` gains `egress_approval_validations()`
  (9 CEL rules) + `egress_approval_crd()` injector.

**Helm**
- `crd-egressapproval.yaml` (new) — generated via the standard
  `DUMP_EGRESSAPPROVAL_CRD_YAML=1` workflow + helm labels.
  Helm-drift test passes byte-for-byte.
- `rbac.yaml` extends `azureclaw-controller` perms
  (egressapprovals + /status + /finalizers) and adds
  `azureclaw:egress-approver` ClusterRole (aggregated to
  admin+edit; `update` excluded — approvals are immutable,
  revocation is `delete`). Not bound by default — operators bind
  per cluster convention.

## CEL rules

| Rule | Bound |
|------|-------|
| `sandbox` | 1–253 chars |
| `hosts` | 1–16 entries |
| `hosts[*].host` | 1–253 chars |
| `hosts[*].port` | 1–65535 when set |
| `reason` | 1–512 chars |
| `reason` | no ASCII control bytes (audit-log injection guard) |
| `ticket` | 1–128 chars when set |
| `ttl` | ISO 8601 positive-duration regex |
| `ttl` | non-zero (must contain digit 1-9) |

Reconciler (5e.2) re-checks every rule plus cluster invariants
(sibling sandbox Ready, TTL ceiling) for defense-in-depth.

## Forward-compat to Slice 5e+ (deferred, demand-gated)

`spec.attestation: Option<Attestation>` will add without a schema
break. The Slice 1c.6 `SignerPolicy.spec.ed25519Keys[]` registry
is the future verification anchor.

## Verification

- Controller tests: **697 → 713** (+16 new)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `helm_drift` suite: 14 → 16 tests passing
- CRD-shape pins prevent silent regressions on group / version /
  shortname / printcolumns
- Condition-reason strings pinned by test — renames are
  CRD-migration events

## Out of scope

- Reconciler (Pending → Active → Expired, finalizer, expiry tick) — 5e.2
- Router merge + usage counter + `/internal/policy-status` echo — 5e.3
- CLI `azureclaw egress approve / revoke / approvals` — 5e.4
- E2E + docs final — 5e.5
- Headlamp panel — 5e.6 (deferable like 1c.6 chip)
- Cryptographic attestation (ed25519 verify) — Slice 5e+

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>