### PR TITLE
Slice 5e.2 — EgressApproval reconciler + router consumer wired end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
-### Slice 5e.1 — `EgressApproval` CRD shape + CEL + Helm install
+### Slice 5e.2 — `EgressApproval` reconciler + router consumer wired end-to-end
+
+Closes the consumer half of Slice 5e: `EgressApproval` CRs now drive a real
+data-plane change. The reconciler computes a merged-allowlist digest, writes
+per-approval files into a sibling ConfigMap mounted into the sandbox router,
+and only promotes `phase=Pending→Active` once the router echoes the digest
+on `/internal/policy-status` under `PolicyKind::EgressApproval`. On TTL
+expiry the reconciler drops the file, removes the finalizer, and stamps
+`phase=Expired` (terminal). This is the first full producer↔consumer loop
+for the grant lane of `principles.md §2.4` / `signing-model.md §6` —
+principles.md §3 (`Ready ⇔ router echo`) and §5 (no scaffolding) are both
+satisfied.
+
+**Producer side (controller)**
+
+- `controller/src/egress_approval_compile.rs` (new, ~360 LOC including
+  tests): `approvals_configmap_name(sandbox) → clawsandbox-{sandbox}-egress-approvals`,
+  `approval_file_key(name) → approval-{name}.json`, `compile_approval_file`
+  (canonical JSON: name, sandbox, hosts (sorted, deduped), reason, ticket,
+  effectiveAt, expiresAt), and `merged_allowlist_digest` — the
+  length-prefixed sha256 over the UNION of baseline allowlist + approval
+  hosts. Cross-binary parity with the router-side digest in
+  `egress_allowlist_loader::compile_merged_endpoints_body`.
+- `controller/src/egress_approval_reconciler.rs` (new, ~870 LOC, 28 unit
+  tests): the full state machine.
+  - **Validate**: `parse_iso8601_duration_secs` (hand-rolled grammar; accepts
+    `PT15M`, `PT4H`, `P1D`, `PT1H30M`, `PT30S`; rejects `P1W/Y`, `P1H` with
+    `H` before `T`, `PT1D` with `D` after `T`, `PT0M`); `validate_reason`
+    rejects empty / >512 bytes / ASCII control bytes (except \t\n\r).
+    TTL is clamped to `min(env_ceiling, 604800s)` (1 week hard ceiling).
+  - **Sibling sandbox**: requires `phase=Ready` else stamps
+    `Pending(BlockedOnSandbox)` and requeues at 5s.
+  - **Idempotency**: `effective_at` is stamped only on first transition;
+    re-reconciles preserve the prior value. `expires_at = effective_at + ttl`.
+  - **Expiry**: at `now ≥ expires_at` the reconciler drops the per-approval
+    CM key (SSA empty `data: {}` from the per-approval field manager +
+    JSON-merge `null` defense-in-depth), stamps `phase=Expired`, and
+    removes the finalizer.
+  - **CM write**: SSA-apply under per-approval field manager
+    `azureclaw-controller/egressapproval/{approval_name}` so siblings on
+    the same ConfigMap don't trample each other.
+  - **Router poll**: `poll_referencing_sandboxes` against the merged
+    digest under `PolicyKind::EgressApproval`. `Confirmed → Active`;
+    `Awaiting → Pending(AwaitingRouterEcho)` + 5s requeue.
+  - **Finalizer**: `azureclaw.azure.com/egress-approval-cleanup`.
+  - **Env knob**: `EGRESS_APPROVAL_MAX_TTL_SECONDS` (default 86400 / 1d via
+    Helm; capped at one week absolute).
+- `controller/src/main.rs` spawns the reconciler in its own `select!` arm
+  next to the existing CRDs.
+- `controller/src/reconciler/mod.rs` injects an optional ConfigMap mount
+  for the per-sandbox approvals CM into the `inference-router` container
+  at `/etc/azureclaw/egress-approvals`, with `EGRESS_APPROVAL_DIR` env
+  pushed alongside.
+- `controller/src/reconciler/governance_mounts.rs` adds the
+  `EGRESS_APPROVAL_DIR` path constant.
+- `controller/src/status/phase.rs` adds `PHASE_ACTIVE` + `PHASE_EXPIRED`
+  with phase-taxonomy-guard coverage.
+- `controller/src/field_managers.rs` adds the `EGRESS_APPROVAL` field
+  manager (the per-approval scoping is layered on top by the reconciler).
+
+**Consumer side (inference-router)**
+
+- `inference-router/src/policy_status.rs` adds the `PolicyKind::EgressApproval`
+  variant (wire string `"EgressApproval"`).
+- `inference-router/src/egress_allowlist_loader.rs` gains the
+  `_with_approvals` variants — `load_and_install_with_approvals` and
+  `spawn_egress_allowlist_watcher_with_approvals` — which scan an
+  optional approvals directory, UNION every `approval-*.json` host
+  with the baseline allowlist, register the digest under
+  `PolicyKind::EgressApproval`, and rebuild the L7 blocklist
+  accordingly. The watcher reacts to mtime changes in either directory.
+- `inference-router/src/main.rs` boot now wires the approvals dir via
+  `EGRESS_APPROVAL_DIR` env (default `/etc/azureclaw/egress-approvals`).
+
+**Helm / RBAC**
+
+- `deploy/helm/azureclaw/values.yaml`: new `egressApproval.maxTtlSeconds: 86400`.
+- `deploy/helm/azureclaw/templates/controller-deployment.yaml`: pushes
+  `EGRESS_APPROVAL_MAX_TTL_SECONDS` env onto the controller pod.
+
+**Test coverage**
+
+Controller: +28 reconciler tests (ISO 8601 parser corners, reason validation,
+TTL ceiling env parsing, status-patch shape for all 5 transitions including
+prior-`effective_at` preservation, field-manager scoping, finalizer DNS
+format, cross-binary digest parity with the compile module, policy-kind
+wire-string parity with the router). +1 phase taxonomy guard run.
+Router: +0 net new (the `_with_approvals` extension landed in Slice 5e.0;
+21 tests there cover the merge + watcher paths).
+Helm drift: green (egressapproval CRD unchanged from 5e.1).
+
+
 
 Opens the **grant lane** of `principles.md §2.4` /
 `signing-model.md §6`: a namespaced, short-TTL, attributable widening

--- a/controller/src/egress_allowlist_compile.rs
+++ b/controller/src/egress_allowlist_compile.rs
@@ -45,9 +45,10 @@
 //!   `allowlistRef`), (b) verified-from-artifact, or (c) LKG cache.
 //!   The consumer (router) doesn't re-verify — it trusts the
 //!   controller's k8s-mediated channel + the per-container mount.
-//! - **Not** an approval merger. `EgressApproval` CRD lands in Slice
-//!   5c.2 as a separate mount (`approvals/*.json`); the router merges
-//!   `bundle ∪ approvals` at request time, not in the bundle JSON.
+//! - **Not** an approval merger. `EgressApproval` CRD (Slice 5e) lives
+//!   in a separate mount (`approvals/*.json`); the router merges
+//!   `bundle ∪ approvals` at load time in `egress_allowlist_loader`,
+//!   not in this bundle JSON.
 
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};

--- a/controller/src/egress_approval.rs
+++ b/controller/src/egress_approval.rs
@@ -205,9 +205,11 @@ pub mod condition_reasons {
 }
 
 impl EgressApproval {
-    /// Convenience: hostname canonicalization used by canonical-form
-    /// merge + audit log. Mirrors
-    /// `policy_canonical::egress::CanonicalEndpoint` shape.
+    /// Hostname count used by the reconciler when stamping
+    /// `status.hostCount`. Wraps `spec.hosts.len()` so future
+    /// canonicalization (e.g., dedup-after-normalize) has a single
+    /// chokepoint. Mirrors the count `egress_approval_compile` lays
+    /// down in the per-approval ConfigMap payload.
     pub fn merged_host_count(&self) -> usize {
         self.spec.hosts.len()
     }

--- a/controller/src/egress_approval_compile.rs
+++ b/controller/src/egress_approval_compile.rs
@@ -1,0 +1,358 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Pure-function compile step for the `EgressApproval` grant lane.
+//!
+//! Two outputs, both byte-pinned with the router-side
+//! [`inference_router::egress_allowlist_loader`] (Slice 5e):
+//!
+//! 1. **Per-approval file** — the JSON the reconciler writes into the
+//!    per-sandbox `clawsandbox-{sandbox}-egress-approvals` ConfigMap
+//!    under key `approval-{approvalName}.json`. This is what the
+//!    router scans, parses, and merges with the baseline. See
+//!    [`compile_approval_file`].
+//!
+//! 2. **Merged-allowlist digest** — the deterministic sha256 over the
+//!    sorted, deduplicated union of `(baseline.endpoints ∪
+//!    approval.hosts)` for ALL active approvals on the sandbox. This
+//!    is the value the router echoes via
+//!    `GET /internal/policy-status` under `PolicyKind::EgressApproval`
+//!    and the controller stamps in `EgressApproval.status.mergedDigest`.
+//!    Closes the §3 Ready ⇔ router-echo loop for the grant lane.
+//!
+//! ## Why merged-allowlist digest (not per-file)
+//!
+//! The grant lane's purpose is to widen the L7 hostname filter.
+//! What the operator wants to verify is: *"is the router actually
+//! letting traffic through to the host I approved?"* The merged
+//! digest answers that — it pins the byte-identical host set the
+//! L7 filter is enforcing right now. A per-file echo would tell us
+//! "the router read my approval file" but not whether the union
+//! actually landed on `Blocklist.allowlist`.
+//!
+//! Sibling approvals on the same sandbox contribute to the same
+//! merged digest. When approval-A is created and approval-B already
+//! exists, A's reconciler enumerates siblings, computes the merged
+//! digest over `{baseline ∪ A.hosts ∪ B.hosts}`, and waits for the
+//! router to echo it. The mtime-poll watcher (5s default) ensures
+//! the router catches sibling-induced changes promptly.
+//!
+//! ## Cross-binary parity (DO NOT BREAK)
+//!
+//! [`merged_allowlist_digest`] is byte-identical to the router-side
+//! `egress_allowlist_loader::compute_merged_digest`. The parity is
+//! pinned by:
+//!
+//! - `digest_is_byte_identical_to_router_layout` test below
+//!   (controller side).
+//! - `merged_digest_is_byte_identical_to_controller_layout` test in
+//!   `inference-router/src/egress_allowlist_loader.rs` (router side).
+//!
+//! Both tests hash the same fixture bytes; any drift fails CI on
+//! both binaries.
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::crd::EndpointConfig;
+use crate::egress_allowlist_compile::canonical_bytes_for_digest;
+
+/// Canonical filename used in the length-prefixed digest layout
+/// for merged allowlists. NOT a real on-disk file — purely a domain
+/// separator that ensures the merged-allowlist digest can never
+/// collide with the per-approval file digest or the baseline
+/// `allowlist.json` digest. Pinned with the router side.
+pub const EGRESS_APPROVAL_MERGED_FILENAME: &str = "merged-allowlist.json";
+
+/// Schema version for the per-approval file JSON. Bumped on a
+/// breaking layout change (the router refuses to parse mismatched
+/// versions).
+pub const APPROVAL_FILE_SCHEMA_VERSION: u32 = 1;
+
+/// ConfigMap name template for the per-sandbox approvals collection.
+/// One CM per sandbox; one key per approval (`approval-{name}.json`).
+#[must_use]
+pub fn approvals_configmap_name(sandbox: &str) -> String {
+    format!("clawsandbox-{sandbox}-egress-approvals")
+}
+
+/// ConfigMap key template for a single approval's file.
+#[must_use]
+pub fn approval_file_key(approval_name: &str) -> String {
+    format!("approval-{approval_name}.json")
+}
+
+/// Build the canonical JSON document for one approval. Written into
+/// the ConfigMap under [`approval_file_key`].
+///
+/// Shape:
+///
+/// ```json
+/// {
+///   "schemaVersion": 1,
+///   "approvalName": "inc-12345-pypi",
+///   "sandbox": "demo",
+///   "hosts": [
+///     {"host": "pypi.org", "port": 443},
+///     {"host": "files.pythonhosted.org", "port": 443}
+///   ],
+///   "reason": "PyPI install during incident",
+///   "ticket": "INC-12345",
+///   "effectiveAt": "2026-05-14T18:30:00Z",
+///   "expiresAt": "2026-05-14T22:30:00Z"
+/// }
+/// ```
+///
+/// Hosts are passed through [`crate::egress_allowlist_compile::compile_to_doc`]
+/// so the same sort/dedupe/lowercase rules apply as the baseline
+/// allowlist. `ticket` is omitted entirely (not serialized as null)
+/// when the spec didn't set it — the router parser tolerates both
+/// shapes but operators reading the CM key prefer the cleaner form.
+#[must_use]
+pub fn compile_approval_file(
+    approval_name: &str,
+    sandbox: &str,
+    hosts: &[EndpointConfig],
+    reason: &str,
+    ticket: Option<&str>,
+    effective_at_rfc3339: &str,
+    expires_at_rfc3339: &str,
+) -> Value {
+    let compiled = crate::egress_allowlist_compile::compile_to_doc(hosts);
+    let host_arr = compiled
+        .get("endpoints")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "schemaVersion".to_string(),
+        json!(APPROVAL_FILE_SCHEMA_VERSION),
+    );
+    obj.insert("approvalName".to_string(), json!(approval_name));
+    obj.insert("sandbox".to_string(), json!(sandbox));
+    obj.insert("hosts".to_string(), host_arr);
+    obj.insert("reason".to_string(), json!(reason));
+    if let Some(t) = ticket {
+        obj.insert("ticket".to_string(), json!(t));
+    }
+    obj.insert("effectiveAt".to_string(), json!(effective_at_rfc3339));
+    obj.insert("expiresAt".to_string(), json!(expires_at_rfc3339));
+    Value::Object(obj)
+}
+
+/// Compute the merged-allowlist digest for `baseline ∪ approvals`.
+///
+/// Both sides — controller and router — call this same shape:
+///
+/// 1. Concatenate the baseline endpoint list with every active
+///    approval's host list.
+/// 2. Run through [`crate::egress_allowlist_compile::compile_to_doc`]
+///    which lowercases hosts, defaults missing ports to 443, sorts
+///    by `(host, port)`, and deduplicates.
+/// 3. Serialize the resulting `{schemaVersion, endpoints}` value as
+///    non-pretty JSON.
+/// 4. Wrap in [`canonical_bytes_for_digest`] using the dedicated
+///    [`EGRESS_APPROVAL_MERGED_FILENAME`] domain separator.
+/// 5. sha256 → `sha256:<hex>`.
+///
+/// Pinned byte-identical to
+/// `inference_router::egress_allowlist_loader::compute_merged_digest`.
+#[must_use]
+pub fn merged_allowlist_digest(
+    baseline: &[EndpointConfig],
+    approvals: &[EndpointConfig],
+) -> String {
+    let mut combined: Vec<EndpointConfig> = Vec::with_capacity(baseline.len() + approvals.len());
+    combined.extend_from_slice(baseline);
+    combined.extend_from_slice(approvals);
+    let doc = crate::egress_allowlist_compile::compile_to_doc(&combined);
+    let body = serde_json::to_vec(&doc).expect("compiled JSON is always serializable");
+    let canonical = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body);
+    let raw = Sha256::digest(&canonical);
+    format!("sha256:{}", hex::encode(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ep(host: &str, port: Option<u16>) -> EndpointConfig {
+        EndpointConfig {
+            host: host.into(),
+            port,
+        }
+    }
+
+    #[test]
+    fn approvals_cm_name_includes_sandbox() {
+        assert_eq!(
+            approvals_configmap_name("demo"),
+            "clawsandbox-demo-egress-approvals"
+        );
+    }
+
+    #[test]
+    fn approval_file_key_uses_approval_name() {
+        assert_eq!(
+            approval_file_key("inc-12345-pypi"),
+            "approval-inc-12345-pypi.json"
+        );
+    }
+
+    #[test]
+    fn compile_approval_file_omits_ticket_when_none() {
+        let v = compile_approval_file(
+            "a1",
+            "demo",
+            &[ep("example.com", Some(443))],
+            "needed",
+            None,
+            "2026-05-14T18:30:00Z",
+            "2026-05-14T22:30:00Z",
+        );
+        let obj = v.as_object().unwrap();
+        assert!(!obj.contains_key("ticket"));
+        assert_eq!(obj["schemaVersion"], 1);
+        assert_eq!(obj["approvalName"], "a1");
+        assert_eq!(obj["sandbox"], "demo");
+        assert_eq!(obj["reason"], "needed");
+        assert_eq!(obj["hosts"][0]["host"], "example.com");
+        assert_eq!(obj["hosts"][0]["port"], 443);
+    }
+
+    #[test]
+    fn compile_approval_file_serializes_ticket_when_some() {
+        let v = compile_approval_file(
+            "a1",
+            "demo",
+            &[ep("example.com", None)],
+            "incident",
+            Some("INC-1"),
+            "2026-05-14T18:30:00Z",
+            "2026-05-14T22:30:00Z",
+        );
+        assert_eq!(v["ticket"], "INC-1");
+    }
+
+    #[test]
+    fn compile_approval_file_canonicalizes_hosts() {
+        // Mixed case + missing port → lower + 443; sorted.
+        let v = compile_approval_file(
+            "a",
+            "s",
+            &[ep("Z.example.com", None), ep("a.EXAMPLE.com", Some(80))],
+            "r",
+            None,
+            "t",
+            "u",
+        );
+        let hosts = v["hosts"].as_array().unwrap();
+        assert_eq!(hosts.len(), 2);
+        assert_eq!(hosts[0]["host"], "a.example.com");
+        assert_eq!(hosts[0]["port"], 80);
+        assert_eq!(hosts[1]["host"], "z.example.com");
+        assert_eq!(hosts[1]["port"], 443);
+    }
+
+    #[test]
+    fn compile_approval_file_dedupes_hosts() {
+        let v = compile_approval_file(
+            "a",
+            "s",
+            &[ep("example.com", Some(443)), ep("EXAMPLE.com", None)],
+            "r",
+            None,
+            "t",
+            "u",
+        );
+        let hosts = v["hosts"].as_array().unwrap();
+        assert_eq!(hosts.len(), 1);
+    }
+
+    #[test]
+    fn merged_digest_empty_baseline_empty_approvals_is_stable() {
+        let d = merged_allowlist_digest(&[], &[]);
+        assert!(d.starts_with("sha256:"));
+        // Re-running yields the same digest (no clock dep).
+        assert_eq!(d, merged_allowlist_digest(&[], &[]));
+    }
+
+    #[test]
+    fn merged_digest_baseline_only_differs_from_baseline_plus_approval() {
+        let baseline = vec![ep("api.github.com", Some(443))];
+        let approvals = vec![ep("pypi.org", Some(443))];
+        let d_baseline = merged_allowlist_digest(&baseline, &[]);
+        let d_combined = merged_allowlist_digest(&baseline, &approvals);
+        assert_ne!(d_baseline, d_combined);
+    }
+
+    #[test]
+    fn merged_digest_commutative_in_input_order() {
+        // Sort+dedup means order of arguments doesn't matter for
+        // the final digest — only the set of endpoints does.
+        let a = vec![ep("api.github.com", Some(443))];
+        let b = vec![ep("pypi.org", Some(443)), ep("api.github.com", Some(443))];
+        let d1 = merged_allowlist_digest(&a, &b);
+        let d2 = merged_allowlist_digest(&b, &a);
+        assert_eq!(d1, d2);
+    }
+
+    #[test]
+    fn merged_digest_dedupes_baseline_approval_overlap() {
+        // Approval adds a host already in baseline → digest equals
+        // baseline-only.
+        let baseline = vec![ep("api.github.com", Some(443))];
+        let approvals = vec![ep("api.github.com", Some(443))];
+        let d_combined = merged_allowlist_digest(&baseline, &approvals);
+        let d_baseline = merged_allowlist_digest(&baseline, &[]);
+        assert_eq!(d_combined, d_baseline);
+    }
+
+    #[test]
+    fn merged_digest_distinguishes_port_variants() {
+        // Same host, different port → distinct endpoints, distinct
+        // digest from same-host-port-443 case.
+        let d_80 = merged_allowlist_digest(&[ep("example.com", Some(80))], &[]);
+        let d_443 = merged_allowlist_digest(&[ep("example.com", Some(443))], &[]);
+        assert_ne!(d_80, d_443);
+    }
+
+    #[test]
+    fn digest_is_byte_identical_to_router_layout() {
+        // Cross-binary parity: must match the byte layout used by
+        // the router's `egress_allowlist_loader::compute_merged_digest`.
+        // The fixture below is the canonical golden case mirrored
+        // verbatim in `inference-router/src/egress_allowlist_loader.rs`
+        // — keep both in lockstep.
+        let baseline = vec![ep("a.example.com", Some(443))];
+        let approvals = vec![ep("b.example.com", Some(443))];
+        let digest = merged_allowlist_digest(&baseline, &approvals);
+
+        // Recompute by hand here so a refactor that breaks
+        // `merged_allowlist_digest` also fails this test.
+        let doc = crate::egress_allowlist_compile::compile_to_doc(&[
+            ep("a.example.com", Some(443)),
+            ep("b.example.com", Some(443)),
+        ]);
+        let body = serde_json::to_vec(&doc).unwrap();
+        let canonical = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body);
+        let mut hex_str = String::with_capacity(64);
+        for b in Sha256::digest(&canonical) {
+            use std::fmt::Write;
+            let _ = write!(hex_str, "{b:02x}");
+        }
+        assert_eq!(digest, format!("sha256:{hex_str}"));
+    }
+
+    #[test]
+    fn merged_filename_distinct_from_baseline_filename() {
+        // Domain separator must be distinct from the baseline
+        // `allowlist.json` so a baseline digest can never be
+        // mistaken for a merged-allowlist digest.
+        assert_ne!(
+            EGRESS_APPROVAL_MERGED_FILENAME,
+            crate::egress_allowlist_compile::EGRESS_ALLOWLIST_FILENAME
+        );
+    }
+}

--- a/controller/src/egress_approval_reconciler.rs
+++ b/controller/src/egress_approval_reconciler.rs
@@ -1,0 +1,1441 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `EgressApproval` reconciler — Slice 5e of `crd-well-oiled-machine`.
+//!
+//! Drives an ephemeral grant from `Pending` → `Active` → `Expired`.
+//!
+//! ## State machine
+//!
+//! - **Pending** — the approval was admitted but is not yet in effect.
+//!   Reasons: the named sibling `ClawSandbox` does not exist or is not
+//!   yet `phase=Ready`, the router has not yet echoed the merged
+//!   digest, or a defense-in-depth validation failed (bad TTL, bad
+//!   reason bytes).
+//! - **Active** — the per-approval file is in the sandbox's
+//!   `clawsandbox-{sandbox}-egress-approvals` ConfigMap, the router
+//!   has echoed the merged-allowlist digest under
+//!   `PolicyKind::EgressApproval`, and `effective_at + ttl` has not
+//!   yet elapsed. `effective_at` is stamped once and never moves.
+//! - **Expired** — `now ≥ effective_at + ttl`. The CM key has been
+//!   removed; the router watcher picks up the file drop on the next
+//!   mtime tick and re-echoes the merged digest sans this approval.
+//!   The finalizer is then removed.
+//!
+//! ## Authority model
+//!
+//! K8s RBAC. The `azureclaw:egress-approver` ClusterRole (shipped in
+//! 5e.1) grants `create / get / list / delete` on this CRD; the k8s
+//! audit log records who acted. The cryptographic attestation lane
+//! (Slice 5e+, demand-gated) layers an optional ed25519 signature on
+//! top — the spec is forward-compatible.
+//!
+//! ## §3 Ready ⇔ router echo
+//!
+//! Same shape as every other policy reconciler in this codebase
+//! (ToolPolicy 1c, InferencePolicy 2a, ClawMemory 3a):
+//!
+//! 1. Controller compiles the canonical merged-allowlist bytes
+//!    (`baseline ∪ all active sibling approvals' hosts`) and hashes
+//!    them via [`crate::egress_approval_compile::merged_allowlist_digest`].
+//! 2. The per-sandbox approvals ConfigMap is written via SSA, with a
+//!    distinct field manager per approval so siblings cannot trample
+//!    each other's keys.
+//! 3. The router's `egress_allowlist_loader` reads the new file on
+//!    the next mtime poll, replaces `Blocklist.allowlist`, and
+//!    registers the merged digest under
+//!    `PolicyKind::EgressApproval` on `/internal/policy-status`.
+//! 4. This reconciler polls the sandbox's router admin endpoint and
+//!    promotes `Pending → Active` only when the echo matches.
+//!
+//! ## Finalizer
+//!
+//! `azureclaw.azure.com/egress-approval-cleanup`. Ensures the CM key
+//! is dropped before the CR is removed (so the router's next mtime
+//! poll observes the file disappear and immediately drops the host
+//! from the L7 allowlist).
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+use kube::{
+    Client, ResourceExt,
+    api::{Api, ListParams, Patch, PatchParams},
+    runtime::controller::{Action, Controller},
+};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::crd::{ClawSandbox, EndpointConfig};
+use crate::egress_approval::{
+    EgressApproval, EgressApprovalStatus,
+    condition_reasons::{
+        AWAITING_ROUTER_ECHO, BLOCKED_ON_SANDBOX, EXPIRED, REASON_INVALID, ROUTER_CONFIRMED,
+        TTL_EXCEEDS_CEILING, TTL_INVALID,
+    },
+};
+use crate::egress_approval_compile::{
+    approval_file_key, approvals_configmap_name, compile_approval_file, merged_allowlist_digest,
+};
+use crate::status::conditions::{self, status as cond_status};
+use crate::status::phase::{PHASE_ACTIVE, PHASE_EXPIRED, PHASE_PENDING, PHASE_READY};
+use crate::status::router_confirmation::{RouterEnforcementState, decide_enforcement_state};
+use crate::status::router_confirmation_io::poll_referencing_sandboxes;
+
+const FIELD_MANAGER: &str = crate::field_managers::EGRESS_APPROVAL;
+const FINALIZER: &str = "azureclaw.azure.com/egress-approval-cleanup";
+
+/// Cluster-wide hard ceiling. The Helm-tunable `maxApprovalTtl` is
+/// the soft, operator-visible default (24h); this is the absolute
+/// upper bound the reconciler enforces regardless of what env was
+/// passed in. Anything beyond a week is a misuse of the grant lane
+/// (re-sign the baseline allowlist instead).
+const HARD_TTL_CEILING_SECONDS: u64 = 7 * 24 * 3600;
+
+/// Soft default if `EGRESS_APPROVAL_MAX_TTL_SECONDS` is unset.
+const DEFAULT_TTL_CEILING_SECONDS: u64 = 24 * 3600;
+
+const REQUEUE_AWAITING: Duration = Duration::from_secs(5);
+const REQUEUE_PENDING_LONG: Duration = Duration::from_secs(30);
+const REQUEUE_ACTIVE_MAX: Duration = Duration::from_secs(30);
+
+/// Wire-protocol kind name the router uses on
+/// `/internal/policy-status` for this CRD. Pinned in
+/// `inference-router/src/policy_status.rs` as `PolicyKind::EgressApproval`.
+const POLICY_KIND_WIRE: &str = "EgressApproval";
+
+#[derive(Debug, thiserror::Error)]
+enum ReconcileError {
+    #[error("Kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("JSON serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+}
+
+impl ReconcileError {
+    fn class(&self) -> &'static str {
+        match self {
+            ReconcileError::Kube(_) => "kube_api",
+            ReconcileError::SerdeJson(_) => "serde",
+        }
+    }
+}
+
+struct Ctx {
+    client: Client,
+    http: reqwest::Client,
+    ttl_ceiling_seconds: u64,
+}
+
+/// Result of validating `spec.ttl` + `spec.reason`. The reconciler
+/// short-circuits to a terminal-pending stamp on the first
+/// validation miss.
+#[derive(Debug)]
+enum ValidationError {
+    TtlInvalid(String),
+    TtlExceedsCeiling { requested: u64, ceiling: u64 },
+    ReasonInvalid(&'static str),
+}
+
+impl ValidationError {
+    fn reason(&self) -> &'static str {
+        match self {
+            ValidationError::TtlInvalid(_) => TTL_INVALID,
+            ValidationError::TtlExceedsCeiling { .. } => TTL_EXCEEDS_CEILING,
+            ValidationError::ReasonInvalid(_) => REASON_INVALID,
+        }
+    }
+
+    fn message(&self) -> String {
+        match self {
+            ValidationError::TtlInvalid(s) => format!("spec.ttl invalid: {s}"),
+            ValidationError::TtlExceedsCeiling {
+                requested, ceiling, ..
+            } => format!(
+                "spec.ttl {requested}s exceeds cluster ceiling {ceiling}s; re-sign the baseline allowlist instead",
+            ),
+            ValidationError::ReasonInvalid(s) => format!("spec.reason invalid: {s}"),
+        }
+    }
+}
+
+/// Parse an ISO 8601 duration string of the forms `PT15M`, `PT4H`,
+/// `P1D`, `PT1H30M`, etc. Returns total seconds (≥ 1).
+///
+/// We intentionally hand-roll the parser (no `iso8601` crate dep)
+/// because the accepted grammar is tiny: positive integers attached
+/// to `D`, `H`, `M`, `S` indicators after `P` and optional `T`. No
+/// weeks (`W`), months, years; those are imprecise for TTL.
+pub(crate) fn parse_iso8601_duration_secs(s: &str) -> Result<u64, String> {
+    let raw = s.trim();
+    if !raw.starts_with('P') {
+        return Err("must start with 'P'".into());
+    }
+    let mut rest = &raw[1..];
+    let mut seen_t = false;
+    let mut secs: u64 = 0;
+    let mut any_component = false;
+    while !rest.is_empty() {
+        if rest.starts_with('T') {
+            if seen_t {
+                return Err("duplicate 'T' separator".into());
+            }
+            seen_t = true;
+            rest = &rest[1..];
+            continue;
+        }
+        // Read integer prefix.
+        let num_end = rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+        if num_end == 0 {
+            return Err(format!("expected digit, got '{rest}'"));
+        }
+        let value: u64 = rest[..num_end]
+            .parse()
+            .map_err(|e| format!("integer overflow: {e}"))?;
+        let designator = rest.as_bytes().get(num_end).copied().ok_or_else(|| {
+            "trailing digits with no unit designator (expected D, H, M, or S)".to_string()
+        })?;
+        let unit_secs: u64 = match (seen_t, designator) {
+            (false, b'D') => 24 * 3600,
+            (true, b'H') => 3600,
+            (true, b'M') => 60,
+            (true, b'S') => 1,
+            (false, b'H') | (false, b'M') | (false, b'S') => {
+                return Err(format!(
+                    "designator '{}' must follow 'T'",
+                    designator as char
+                ));
+            }
+            (true, b'D') => return Err("'D' is a date component, must precede 'T'".into()),
+            (_, other) => return Err(format!("unknown designator '{}'", other as char)),
+        };
+        let contribution = value
+            .checked_mul(unit_secs)
+            .ok_or_else(|| "duration overflow".to_string())?;
+        secs = secs
+            .checked_add(contribution)
+            .ok_or_else(|| "duration overflow".to_string())?;
+        any_component = true;
+        rest = &rest[num_end + 1..];
+    }
+    if !any_component {
+        return Err("no components present".into());
+    }
+    if secs == 0 {
+        return Err("duration must be > 0".into());
+    }
+    Ok(secs)
+}
+
+/// Reject ASCII control bytes (except whitespace tab/CR/LF) in
+/// `spec.reason` — the field flows into structured audit-log lines
+/// and `kubectl describe` output; embedded NUL or escape sequences
+/// would either truncate downstream parsers or inject ANSI/terminal
+/// control codes into operator terminals.
+fn validate_reason(reason: &str) -> Result<(), ValidationError> {
+    if reason.is_empty() {
+        return Err(ValidationError::ReasonInvalid("empty"));
+    }
+    if reason.len() > 512 {
+        return Err(ValidationError::ReasonInvalid("exceeds 512 bytes"));
+    }
+    for ch in reason.chars() {
+        let c = ch as u32;
+        let is_allowed_ws = matches!(c, 0x09 | 0x0A | 0x0D);
+        let is_ctrl = c < 0x20 || c == 0x7F;
+        if is_ctrl && !is_allowed_ws {
+            return Err(ValidationError::ReasonInvalid(
+                "contains ASCII control bytes (only tab/LF/CR permitted)",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate(approval: &EgressApproval, ttl_ceiling_seconds: u64) -> Result<u64, ValidationError> {
+    validate_reason(&approval.spec.reason)?;
+    let ttl_secs =
+        parse_iso8601_duration_secs(&approval.spec.ttl).map_err(ValidationError::TtlInvalid)?;
+    let effective_ceiling = ttl_ceiling_seconds.min(HARD_TTL_CEILING_SECONDS);
+    if ttl_secs > effective_ceiling {
+        return Err(ValidationError::TtlExceedsCeiling {
+            requested: ttl_secs,
+            ceiling: effective_ceiling,
+        });
+    }
+    Ok(ttl_secs)
+}
+
+fn rfc3339_now() -> String {
+    Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn rfc3339_at(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|t| t.with_timezone(&Utc))
+}
+
+/// Read the baseline allowlist endpoints from the controller-published
+/// `clawsandbox-{sandbox}-egress-allowlist` ConfigMap (data key
+/// `allowlist.json`). Missing CM / missing key / malformed JSON all
+/// degrade gracefully to "empty baseline" — the merged digest just
+/// reflects the approvals alone, and the router still drains its
+/// blocklist correctly (see test
+/// `baseline_no_binding_with_approvals_still_drains_blocklist` in
+/// `inference-router/src/egress_allowlist_loader.rs`).
+async fn read_baseline_endpoints(
+    configmaps: &Api<ConfigMap>,
+    sandbox: &str,
+) -> Vec<EndpointConfig> {
+    let cm_name = format!("clawsandbox-{sandbox}-egress-allowlist");
+    let cm = match configmaps.get_opt(&cm_name).await {
+        Ok(Some(cm)) => cm,
+        _ => return Vec::new(),
+    };
+    let raw = match cm
+        .data
+        .as_ref()
+        .and_then(|d| d.get(crate::egress_allowlist_compile::EGRESS_ALLOWLIST_FILENAME))
+    {
+        Some(s) => s.clone(),
+        None => return Vec::new(),
+    };
+    let value: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let arr = match value.get("endpoints").and_then(|v| v.as_array()) {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    arr.iter()
+        .filter_map(|entry| {
+            let host = entry.get("host").and_then(|v| v.as_str())?.to_string();
+            let port = entry.get("port").and_then(|v| v.as_u64()).map(|p| p as u16);
+            if host.is_empty() {
+                return None;
+            }
+            Some(EndpointConfig { host, port })
+        })
+        .collect()
+}
+
+/// List sibling `EgressApproval`s in the same namespace that point at
+/// the same sandbox, excluding ourselves, anything mid-deletion, and
+/// anything already `Expired`. Their `spec.hosts` are unioned into the
+/// merged-allowlist digest.
+async fn list_active_siblings(
+    api: &Api<EgressApproval>,
+    sandbox: &str,
+    self_name: &str,
+) -> Result<Vec<EgressApproval>, kube::Error> {
+    let list = api.list(&ListParams::default()).await?;
+    Ok(list
+        .items
+        .into_iter()
+        .filter(|sibling| sibling.spec.sandbox == sandbox)
+        .filter(|sibling| sibling.metadata.deletion_timestamp.is_none())
+        .filter(|sibling| sibling.name_any() != self_name)
+        .filter(|sibling| {
+            sibling
+                .status
+                .as_ref()
+                .and_then(|s| s.phase.as_deref())
+                .map(|p| p != PHASE_EXPIRED)
+                .unwrap_or(true)
+        })
+        .collect())
+}
+
+/// Compute the merged-allowlist digest for `baseline ∪ self.hosts ∪
+/// sibling.hosts`. The router will echo this exact value once the
+/// per-approval file lands in its mount dir.
+fn compute_merged_digest(
+    baseline: &[EndpointConfig],
+    self_hosts: &[EndpointConfig],
+    siblings: &[EgressApproval],
+) -> String {
+    let mut combined: Vec<EndpointConfig> = Vec::new();
+    combined.extend_from_slice(self_hosts);
+    for sibling in siblings {
+        combined.extend(sibling.spec.hosts.iter().cloned());
+    }
+    merged_allowlist_digest(baseline, &combined)
+}
+
+/// SSA-patch the per-sandbox approvals ConfigMap to install (or
+/// upsert) this approval's file. Field manager is scoped per
+/// approval so siblings on the same CM cannot trample each other.
+async fn ensure_approval_cm_key(
+    configmaps: &Api<ConfigMap>,
+    sandbox: &str,
+    approval_name: &str,
+    payload: &Value,
+    field_manager: &str,
+) -> Result<(), ReconcileError> {
+    let cm_name = approvals_configmap_name(sandbox);
+    let key = approval_file_key(approval_name);
+    let body = serde_json::to_string(payload)?;
+    let cm = json!({
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": cm_name,
+            "labels": {
+                "app.kubernetes.io/managed-by": "azureclaw-controller",
+                "azureclaw.azure.com/sandbox": sandbox,
+                "azureclaw.azure.com/artifact": "egress-approvals",
+            },
+        },
+        "data": {
+            &key: body,
+        },
+    });
+    configmaps
+        .patch(
+            &cm_name,
+            &PatchParams::apply(field_manager).force(),
+            &Patch::Apply(&cm),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Drop this approval's key from the per-sandbox approvals CM.
+/// Implemented as an SSA-apply with the per-approval field manager
+/// but no `data` block — under SSA semantics, dropping the field from
+/// our manager's owned set yields removal (because no other manager
+/// owns it). Falls back to a JSON-merge null-patch for older API
+/// servers that surface SSA edge cases.
+async fn drop_approval_cm_key(
+    configmaps: &Api<ConfigMap>,
+    sandbox: &str,
+    approval_name: &str,
+    field_manager: &str,
+) -> Result<(), ReconcileError> {
+    let cm_name = approvals_configmap_name(sandbox);
+    let key = approval_file_key(approval_name);
+
+    let empty_apply = json!({
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": cm_name,
+            "labels": {
+                "app.kubernetes.io/managed-by": "azureclaw-controller",
+                "azureclaw.azure.com/sandbox": sandbox,
+                "azureclaw.azure.com/artifact": "egress-approvals",
+            },
+        },
+        "data": {}
+    });
+    if let Err(e) = configmaps
+        .patch(
+            &cm_name,
+            &PatchParams::apply(field_manager).force(),
+            &Patch::Apply(&empty_apply),
+        )
+        .await
+    {
+        // CM may not exist yet — that's the equivalent of "already
+        // dropped", treat as success.
+        if matches!(&e, kube::Error::Api(ae) if ae.code == 404) {
+            return Ok(());
+        }
+        return Err(e.into());
+    }
+
+    // Defense-in-depth: explicit null-merge so the key is removed
+    // even on API servers that interpret an empty SSA `data` map as
+    // "no-op". Failure here is non-fatal.
+    let merge = json!({ "data": { &key: null } });
+    let _ = configmaps
+        .patch(&cm_name, &PatchParams::default(), &Patch::Merge(&merge))
+        .await;
+    Ok(())
+}
+
+async fn ensure_finalizer(
+    api: &Api<EgressApproval>,
+    approval: &EgressApproval,
+    name: &str,
+) -> Result<bool, ReconcileError> {
+    let has = approval
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|f| f.iter().any(|s| s == FINALIZER))
+        .unwrap_or(false);
+    if has {
+        return Ok(false);
+    }
+    let patch = json!({
+        "apiVersion": "azureclaw.azure.com/v1alpha1",
+        "kind": "EgressApproval",
+        "metadata": { "finalizers": [FINALIZER] },
+    });
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(patch),
+    )
+    .await?;
+    Ok(true)
+}
+
+async fn remove_finalizer(
+    api: &Api<EgressApproval>,
+    approval: &EgressApproval,
+    name: &str,
+) -> Result<(), ReconcileError> {
+    let remaining: Vec<String> = approval
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|v| v.iter().filter(|f| *f != FINALIZER).cloned().collect())
+        .unwrap_or_default();
+    // SSA-applying just the metadata.finalizers field with our
+    // manager so the API server treats removal correctly without
+    // forcing whole-object ownership.
+    let patch = json!({
+        "apiVersion": "azureclaw.azure.com/v1alpha1",
+        "kind": "EgressApproval",
+        "metadata": { "finalizers": remaining },
+    });
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(patch),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Per-approval field manager — scoped so two approvals on the same
+/// sandbox cannot fight over the merged CM's keys. The name still
+/// embeds the base field manager prefix so audit tools that filter
+/// on `azureclaw-controller/*` still pick it up.
+fn approval_field_manager(approval_name: &str) -> String {
+    format!("{FIELD_MANAGER}/{approval_name}")
+}
+
+/// Build the new status patch from the resolved enforcement state.
+/// `prior_effective_at` is passed through unchanged on subsequent
+/// reconciles — once stamped, it never moves (the TTL is measured
+/// from this point).
+#[allow(clippy::too_many_arguments)]
+fn build_status_patch(
+    prior_conditions: &[Condition],
+    prior_effective_at: Option<String>,
+    prior_usage_count: Option<i64>,
+    observed_generation: Option<i64>,
+    phase: &str,
+    reason_value: &str,
+    message: &str,
+    merged_digest: Option<String>,
+    host_count: i64,
+    effective_at: Option<String>,
+    expires_at: Option<String>,
+    usage_count: Option<i64>,
+) -> Value {
+    let mut conds: Vec<Condition> = Vec::with_capacity(3);
+
+    let (ready_status, ready_reason, ready_msg) = match phase {
+        PHASE_ACTIVE => (cond_status::TRUE, ROUTER_CONFIRMED, message),
+        PHASE_EXPIRED => (cond_status::FALSE, EXPIRED, message),
+        _ => (cond_status::FALSE, reason_value, message),
+    };
+    conds.push(conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_READY),
+        conditions::TYPE_READY,
+        ready_status,
+        ready_reason,
+        ready_msg,
+        observed_generation,
+    ));
+
+    let progressing_status = if phase == PHASE_ACTIVE || phase == PHASE_EXPIRED {
+        cond_status::FALSE
+    } else {
+        cond_status::TRUE
+    };
+    conds.push(conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_PROGRESSING),
+        conditions::TYPE_PROGRESSING,
+        progressing_status,
+        reason_value,
+        message,
+        observed_generation,
+    ));
+
+    let degraded_status = if matches!(
+        reason_value,
+        TTL_INVALID | TTL_EXCEEDS_CEILING | REASON_INVALID
+    ) {
+        cond_status::TRUE
+    } else {
+        cond_status::FALSE
+    };
+    conds.push(conditions::preserve_transition_time(
+        conditions::find(prior_conditions, conditions::TYPE_DEGRADED),
+        conditions::TYPE_DEGRADED,
+        degraded_status,
+        reason_value,
+        message,
+        observed_generation,
+    ));
+
+    let effective_final = effective_at.or(prior_effective_at);
+    let usage_final = usage_count.or(prior_usage_count);
+
+    let status = EgressApprovalStatus {
+        phase: Some(phase.into()),
+        observed_generation,
+        effective_at: effective_final,
+        expires_at,
+        merged_digest,
+        host_count: Some(host_count),
+        usage_count: usage_final,
+        conditions: Some(conds),
+    };
+    json!({
+        "apiVersion": "azureclaw.azure.com/v1alpha1",
+        "kind": "EgressApproval",
+        "status": status,
+    })
+}
+
+async fn write_status(
+    api: &Api<EgressApproval>,
+    name: &str,
+    patch: Value,
+) -> Result<(), ReconcileError> {
+    api.patch_status(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(patch),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn reconcile(approval: Arc<EgressApproval>, ctx: Arc<Ctx>) -> Result<Action, ReconcileError> {
+    let name = approval.name_any();
+    let ns = approval.namespace().unwrap_or_else(|| "default".into());
+    let api: Api<EgressApproval> = Api::namespaced(ctx.client.clone(), &ns);
+    let configmaps: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), &ns);
+    let sandboxes: Api<ClawSandbox> = Api::namespaced(ctx.client.clone(), &ns);
+
+    if approval.metadata.deletion_timestamp.is_some() {
+        return finalize(&api, &configmaps, &approval, &name).await;
+    }
+    if ensure_finalizer(&api, &approval, &name).await? {
+        return Ok(Action::requeue(Duration::from_secs(1)));
+    }
+
+    let prior_status = approval.status.clone().unwrap_or_default();
+    let prior_conditions = prior_status.conditions.clone().unwrap_or_default();
+    let prior_effective_at = prior_status.effective_at.clone();
+    let prior_usage_count = prior_status.usage_count;
+    let observed_generation = approval.metadata.generation;
+    let host_count = approval.merged_host_count() as i64;
+
+    // ── Validate spec ────────────────────────────────────────────
+    let ttl_secs = match validate(&approval, ctx.ttl_ceiling_seconds) {
+        Ok(s) => s,
+        Err(v) => {
+            tracing::warn!(
+                egress_approval = %name,
+                ns = %ns,
+                reason = v.reason(),
+                "EgressApprovalSpecInvalid"
+            );
+            let patch = build_status_patch(
+                &prior_conditions,
+                prior_effective_at,
+                prior_usage_count,
+                observed_generation,
+                PHASE_PENDING,
+                v.reason(),
+                &v.message(),
+                None,
+                host_count,
+                None,
+                None,
+                None,
+            );
+            write_status(&api, &name, patch).await?;
+            // Terminal-pending: requeue infrequently. Operator must
+            // edit / recreate the CR to make progress.
+            return Ok(Action::requeue(REQUEUE_PENDING_LONG));
+        }
+    };
+
+    // ── Sibling sandbox check ────────────────────────────────────
+    let sandbox = match sandboxes.get_opt(&approval.spec.sandbox).await? {
+        Some(s) => s,
+        None => {
+            let msg = format!("ClawSandbox '{}' not found", approval.spec.sandbox);
+            let patch = build_status_patch(
+                &prior_conditions,
+                prior_effective_at,
+                prior_usage_count,
+                observed_generation,
+                PHASE_PENDING,
+                BLOCKED_ON_SANDBOX,
+                &msg,
+                None,
+                host_count,
+                None,
+                None,
+                None,
+            );
+            write_status(&api, &name, patch).await?;
+            return Ok(Action::requeue(REQUEUE_AWAITING));
+        }
+    };
+    let sandbox_phase = sandbox
+        .status
+        .as_ref()
+        .and_then(|s| s.phase.as_deref())
+        .unwrap_or("");
+    if sandbox_phase != PHASE_READY {
+        let msg = format!(
+            "ClawSandbox '{}' is not Ready (phase='{}')",
+            approval.spec.sandbox, sandbox_phase
+        );
+        let patch = build_status_patch(
+            &prior_conditions,
+            prior_effective_at,
+            prior_usage_count,
+            observed_generation,
+            PHASE_PENDING,
+            BLOCKED_ON_SANDBOX,
+            &msg,
+            None,
+            host_count,
+            None,
+            None,
+            None,
+        );
+        write_status(&api, &name, patch).await?;
+        return Ok(Action::requeue(REQUEUE_AWAITING));
+    }
+
+    // ── Compute effective_at / expires_at (idempotent) ──────────
+    let effective_at = prior_effective_at.clone().unwrap_or_else(rfc3339_now);
+    let effective_at_dt = parse_rfc3339(&effective_at).unwrap_or_else(Utc::now);
+    let expires_at_dt = effective_at_dt + chrono::Duration::seconds(ttl_secs as i64);
+    let expires_at = rfc3339_at(expires_at_dt);
+
+    // ── If already expired, finalize-expired right here ─────────
+    let now = Utc::now();
+    if now >= expires_at_dt {
+        return finalize_expired(
+            &api,
+            &configmaps,
+            &approval,
+            &name,
+            &prior_conditions,
+            prior_usage_count,
+            observed_generation,
+            host_count,
+            effective_at,
+            expires_at,
+        )
+        .await;
+    }
+
+    // ── Compile + install per-approval file ─────────────────────
+    let baseline = read_baseline_endpoints(&configmaps, &approval.spec.sandbox).await;
+    let payload = compile_approval_file(
+        &name,
+        &approval.spec.sandbox,
+        &approval.spec.hosts,
+        &approval.spec.reason,
+        approval.spec.ticket.as_deref(),
+        &effective_at,
+        &expires_at,
+    );
+    let per_approval_fm = approval_field_manager(&name);
+    if let Err(e) = ensure_approval_cm_key(
+        &configmaps,
+        &approval.spec.sandbox,
+        &name,
+        &payload,
+        &per_approval_fm,
+    )
+    .await
+    {
+        tracing::warn!(
+            egress_approval = %name,
+            error_class = e.class(),
+            error = %e,
+            "EgressApprovalCmWriteFailed"
+        );
+        // Fall through to status without confirmation — operator
+        // sees Pending/AwaitingRouterEcho on transient CM write
+        // failures and the next reconcile retries.
+        let patch = build_status_patch(
+            &prior_conditions,
+            Some(effective_at.clone()),
+            prior_usage_count,
+            observed_generation,
+            PHASE_PENDING,
+            AWAITING_ROUTER_ECHO,
+            &format!("approvals ConfigMap write failed: {e}"),
+            None,
+            host_count,
+            Some(effective_at.clone()),
+            Some(expires_at.clone()),
+            None,
+        );
+        write_status(&api, &name, patch).await?;
+        return Ok(Action::requeue(REQUEUE_AWAITING));
+    }
+
+    // ── Compute expected merged digest ──────────────────────────
+    let siblings = list_active_siblings(&api, &approval.spec.sandbox, &name).await?;
+    let expected_digest = compute_merged_digest(&baseline, &approval.spec.hosts, &siblings);
+
+    // ── Poll router echo ────────────────────────────────────────
+    let results = poll_referencing_sandboxes(
+        &ctx.client,
+        &ctx.http,
+        std::slice::from_ref(&approval.spec.sandbox),
+    )
+    .await;
+    let state = decide_enforcement_state(&expected_digest, POLICY_KIND_WIRE, &results);
+
+    // The router's policy-status entry does not yet carry a
+    // per-kind usage counter (Slice 5e ships the digest-echo loop;
+    // usage_count is reserved for a later observability slice). We
+    // pass the prior value through unchanged so the status field
+    // stays monotonic.
+    let usage_count = None;
+
+    match state {
+        RouterEnforcementState::Confirmed { total } => {
+            let msg = format!(
+                "router echoed merged digest ({total}/{total} sandboxes); expires at {expires_at}"
+            );
+            let patch = build_status_patch(
+                &prior_conditions,
+                Some(effective_at.clone()),
+                prior_usage_count,
+                observed_generation,
+                PHASE_ACTIVE,
+                ROUTER_CONFIRMED,
+                &msg,
+                Some(expected_digest),
+                host_count,
+                Some(effective_at.clone()),
+                Some(expires_at.clone()),
+                usage_count,
+            );
+            write_status(&api, &name, patch).await?;
+            // Requeue at the earlier of expiry or 30s — gives us a
+            // bounded staleness window for usage_count + a precise
+            // wakeup at TTL elapse without spinning.
+            let until_expiry = expires_at_dt - now;
+            let until_expiry_secs = until_expiry.num_seconds().max(1) as u64;
+            let requeue = Duration::from_secs(until_expiry_secs).min(REQUEUE_ACTIVE_MAX);
+            Ok(Action::requeue(requeue))
+        }
+        RouterEnforcementState::Awaiting {
+            total,
+            matched,
+            message,
+        } => {
+            let detail = format!(
+                "awaiting router echo ({matched}/{total}); expected {expected_digest}; {message}"
+            );
+            let patch = build_status_patch(
+                &prior_conditions,
+                Some(effective_at.clone()),
+                prior_usage_count,
+                observed_generation,
+                PHASE_PENDING,
+                AWAITING_ROUTER_ECHO,
+                &detail,
+                Some(expected_digest),
+                host_count,
+                Some(effective_at.clone()),
+                Some(expires_at.clone()),
+                None,
+            );
+            write_status(&api, &name, patch).await?;
+            Ok(Action::requeue(REQUEUE_AWAITING))
+        }
+        RouterEnforcementState::NoSandboxesReferencing | RouterEnforcementState::NotApplicable => {
+            // Single-sandbox poll; this branch hits when the
+            // input list to `poll_referencing_sandboxes` was empty
+            // (NotApplicable) or aggregated to zero (shouldn't
+            // happen here — defense-in-depth).
+            let patch = build_status_patch(
+                &prior_conditions,
+                Some(effective_at.clone()),
+                prior_usage_count,
+                observed_generation,
+                PHASE_PENDING,
+                AWAITING_ROUTER_ECHO,
+                "router not yet reachable",
+                Some(expected_digest),
+                host_count,
+                Some(effective_at.clone()),
+                Some(expires_at.clone()),
+                None,
+            );
+            write_status(&api, &name, patch).await?;
+            Ok(Action::requeue(REQUEUE_AWAITING))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_expired(
+    api: &Api<EgressApproval>,
+    configmaps: &Api<ConfigMap>,
+    approval: &EgressApproval,
+    name: &str,
+    prior_conditions: &[Condition],
+    prior_usage_count: Option<i64>,
+    observed_generation: Option<i64>,
+    host_count: i64,
+    effective_at: String,
+    expires_at: String,
+) -> Result<Action, ReconcileError> {
+    let per_approval_fm = approval_field_manager(name);
+    drop_approval_cm_key(configmaps, &approval.spec.sandbox, name, &per_approval_fm).await?;
+    let patch = build_status_patch(
+        prior_conditions,
+        Some(effective_at.clone()),
+        prior_usage_count,
+        observed_generation,
+        PHASE_EXPIRED,
+        EXPIRED,
+        &format!("approval expired at {expires_at}"),
+        None,
+        host_count,
+        Some(effective_at),
+        Some(expires_at),
+        prior_usage_count,
+    );
+    write_status(api, name, patch).await?;
+    // Remove finalizer so the CR can be garbage-collected by the
+    // operator (or, if a deletion was issued mid-life, this lets it
+    // disappear). The Expired stamp remains visible until then so
+    // operators can audit grant history.
+    remove_finalizer(api, approval, name).await?;
+    Ok(Action::await_change())
+}
+
+async fn finalize(
+    api: &Api<EgressApproval>,
+    configmaps: &Api<ConfigMap>,
+    approval: &EgressApproval,
+    name: &str,
+) -> Result<Action, ReconcileError> {
+    let per_approval_fm = approval_field_manager(name);
+    drop_approval_cm_key(configmaps, &approval.spec.sandbox, name, &per_approval_fm).await?;
+    remove_finalizer(api, approval, name).await?;
+    tracing::info!(egress_approval = %name, "EgressApprovalDeleted");
+    Ok(Action::await_change())
+}
+
+fn error_policy(approval: Arc<EgressApproval>, error: &ReconcileError, _ctx: Arc<Ctx>) -> Action {
+    crate::metrics::record_reconcile_error("EgressApproval", error.class());
+    tracing::warn!(
+        egress_approval = %approval.name_any(),
+        error_class = error.class(),
+        error = %error,
+        "EgressApproval reconcile error — requeuing in ~15s (±20% jitter)"
+    );
+    Action::requeue(crate::backoff::requeue_secs_with_jitter(15))
+}
+
+fn ttl_ceiling_from_env() -> u64 {
+    let raw = std::env::var("EGRESS_APPROVAL_MAX_TTL_SECONDS").ok();
+    let parsed = raw
+        .as_deref()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_TTL_CEILING_SECONDS);
+    parsed.min(HARD_TTL_CEILING_SECONDS)
+}
+
+pub async fn run(client: Client) -> Result<()> {
+    let approvals: Api<EgressApproval> = Api::all(client.clone());
+    match approvals.list(&ListParams::default().limit(1)).await {
+        Ok(_) => tracing::info!("EgressApproval CRD found — starting controller"),
+        Err(e) => {
+            tracing::warn!("EgressApproval CRD not installed — reconciler disabled: {e}");
+            std::future::pending::<()>().await;
+            #[allow(unreachable_code)]
+            return Ok(());
+        }
+    }
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .map_err(|e| anyhow::anyhow!("reqwest build failed: {e}"))?;
+    let ttl_ceiling_seconds = ttl_ceiling_from_env();
+    tracing::info!(
+        ttl_ceiling_seconds,
+        "EgressApproval reconciler — TTL ceiling resolved from env"
+    );
+    let ctx = Arc::new(Ctx {
+        client,
+        http,
+        ttl_ceiling_seconds,
+    });
+    Controller::new(approvals, kube::runtime::watcher::Config::default())
+        .run(
+            |x, ctx| async move {
+                crate::metrics::observe_reconcile("EgressApproval", reconcile(x, ctx)).await
+            },
+            error_policy,
+            ctx,
+        )
+        .for_each(|res| async move {
+            match res {
+                Ok(o) => tracing::debug!("EgressApproval reconciled {:?}", o),
+                Err(e) => tracing::warn!("EgressApproval reconcile failed: {e:?}"),
+            }
+        })
+        .await;
+    Ok(())
+}
+
+// ───────────────────────── Tests ─────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::egress_approval::EgressApprovalSpec;
+
+    fn mk_approval(name: &str, sandbox: &str, ttl: &str, reason: &str) -> EgressApproval {
+        EgressApproval::new(
+            name,
+            EgressApprovalSpec {
+                sandbox: sandbox.into(),
+                hosts: vec![EndpointConfig {
+                    host: "pypi.org".into(),
+                    port: Some(443),
+                }],
+                reason: reason.into(),
+                ticket: None,
+                ttl: ttl.into(),
+            },
+        )
+    }
+
+    #[test]
+    fn parse_iso8601_accepts_minutes_hours_days() {
+        assert_eq!(parse_iso8601_duration_secs("PT15M").unwrap(), 900);
+        assert_eq!(parse_iso8601_duration_secs("PT4H").unwrap(), 4 * 3600);
+        assert_eq!(parse_iso8601_duration_secs("P1D").unwrap(), 86_400);
+        assert_eq!(parse_iso8601_duration_secs("PT1H30M").unwrap(), 5400);
+        assert_eq!(
+            parse_iso8601_duration_secs("P1DT2H").unwrap(),
+            86_400 + 7200
+        );
+        assert_eq!(parse_iso8601_duration_secs("PT30S").unwrap(), 30);
+    }
+
+    #[test]
+    fn parse_iso8601_rejects_missing_p() {
+        assert!(parse_iso8601_duration_secs("T15M").is_err());
+    }
+
+    #[test]
+    fn parse_iso8601_rejects_empty_components() {
+        assert!(parse_iso8601_duration_secs("P").is_err());
+        assert!(parse_iso8601_duration_secs("PT").is_err());
+    }
+
+    #[test]
+    fn parse_iso8601_rejects_zero() {
+        assert!(parse_iso8601_duration_secs("PT0M").is_err());
+    }
+
+    #[test]
+    fn parse_iso8601_rejects_weeks_months_years() {
+        // 'W' is not in our accepted grammar.
+        assert!(parse_iso8601_duration_secs("P1W").is_err());
+        // 'Y' is not in our accepted grammar.
+        assert!(parse_iso8601_duration_secs("P1Y").is_err());
+    }
+
+    #[test]
+    fn parse_iso8601_rejects_hour_before_t() {
+        // 'H' must follow 'T'.
+        assert!(parse_iso8601_duration_secs("P1H").is_err());
+    }
+
+    #[test]
+    fn parse_iso8601_rejects_day_after_t() {
+        // 'D' is a date component; must precede 'T'.
+        assert!(parse_iso8601_duration_secs("PT1D").is_err());
+    }
+
+    #[test]
+    fn validate_reason_accepts_normal_text() {
+        assert!(validate_reason("INC-1234 pypi access for incident").is_ok());
+        assert!(validate_reason("multi\nline\nreason").is_ok());
+        assert!(validate_reason("with\ttab").is_ok());
+    }
+
+    #[test]
+    fn validate_reason_rejects_empty() {
+        assert!(matches!(
+            validate_reason(""),
+            Err(ValidationError::ReasonInvalid(_))
+        ));
+    }
+
+    #[test]
+    fn validate_reason_rejects_oversize() {
+        let huge: String = "a".repeat(513);
+        assert!(matches!(
+            validate_reason(&huge),
+            Err(ValidationError::ReasonInvalid(_))
+        ));
+    }
+
+    #[test]
+    fn validate_reason_rejects_control_bytes() {
+        assert!(matches!(
+            validate_reason("evil\x07bell"),
+            Err(ValidationError::ReasonInvalid(_))
+        ));
+        assert!(matches!(
+            validate_reason("nul\x00byte"),
+            Err(ValidationError::ReasonInvalid(_))
+        ));
+        // ANSI escape sequence intro — exactly what we don't want
+        // dropped into operator terminals via `kubectl describe`.
+        assert!(matches!(
+            validate_reason("escape\x1b[31mred"),
+            Err(ValidationError::ReasonInvalid(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_ttl_exceeding_ceiling() {
+        let appr = mk_approval("a", "demo", "P2D", "incident");
+        let err = validate(&appr, DEFAULT_TTL_CEILING_SECONDS).unwrap_err();
+        assert!(matches!(err, ValidationError::TtlExceedsCeiling { .. }));
+        assert_eq!(err.reason(), TTL_EXCEEDS_CEILING);
+    }
+
+    #[test]
+    fn validate_caps_to_hard_ceiling_when_env_too_large() {
+        // Operator misconfigured env to 30 days — hard ceiling clamps
+        // to 7 days, so a 10-day TTL is rejected.
+        let appr = mk_approval("a", "demo", "P10D", "incident");
+        let err = validate(&appr, 30 * 24 * 3600).unwrap_err();
+        match err {
+            ValidationError::TtlExceedsCeiling { ceiling, .. } => {
+                assert_eq!(ceiling, HARD_TTL_CEILING_SECONDS);
+            }
+            other => panic!(
+                "expected TtlExceedsCeiling, got {other:?}",
+                other = other.reason()
+            ),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_within_ceiling() {
+        let appr = mk_approval("a", "demo", "PT15M", "incident");
+        assert_eq!(validate(&appr, DEFAULT_TTL_CEILING_SECONDS).unwrap(), 900);
+    }
+
+    #[test]
+    fn approval_field_manager_is_scoped_per_approval() {
+        let a = approval_field_manager("inc-1");
+        let b = approval_field_manager("inc-2");
+        assert_ne!(a, b);
+        assert!(a.starts_with(FIELD_MANAGER));
+        assert!(b.starts_with(FIELD_MANAGER));
+    }
+
+    #[test]
+    fn ttl_ceiling_from_env_defaults_when_unset() {
+        // Don't actually mutate env in unit tests — just exercise the
+        // helper against the default path. The 'env not set' case is
+        // the most-common operator deployment.
+        unsafe {
+            std::env::remove_var("EGRESS_APPROVAL_MAX_TTL_SECONDS");
+        }
+        assert_eq!(ttl_ceiling_from_env(), DEFAULT_TTL_CEILING_SECONDS);
+    }
+
+    #[test]
+    fn ttl_ceiling_from_env_caps_at_hard_ceiling() {
+        // Env override above the hard ceiling clamps down.
+        unsafe {
+            std::env::set_var("EGRESS_APPROVAL_MAX_TTL_SECONDS", "9999999");
+        }
+        let v = ttl_ceiling_from_env();
+        unsafe {
+            std::env::remove_var("EGRESS_APPROVAL_MAX_TTL_SECONDS");
+        }
+        assert_eq!(v, HARD_TTL_CEILING_SECONDS);
+    }
+
+    #[test]
+    fn ttl_ceiling_from_env_ignores_zero_or_invalid() {
+        unsafe {
+            std::env::set_var("EGRESS_APPROVAL_MAX_TTL_SECONDS", "0");
+        }
+        assert_eq!(ttl_ceiling_from_env(), DEFAULT_TTL_CEILING_SECONDS);
+        unsafe {
+            std::env::set_var("EGRESS_APPROVAL_MAX_TTL_SECONDS", "garbage");
+        }
+        assert_eq!(ttl_ceiling_from_env(), DEFAULT_TTL_CEILING_SECONDS);
+        unsafe {
+            std::env::remove_var("EGRESS_APPROVAL_MAX_TTL_SECONDS");
+        }
+    }
+
+    #[test]
+    fn build_status_patch_active_sets_ready_true_progressing_false() {
+        let v = build_status_patch(
+            &[],
+            None,
+            None,
+            Some(1),
+            PHASE_ACTIVE,
+            ROUTER_CONFIRMED,
+            "router echoed",
+            Some("sha256:deadbeef".into()),
+            2,
+            Some("2026-05-15T10:00:00Z".into()),
+            Some("2026-05-15T10:15:00Z".into()),
+            Some(5),
+        );
+        let status = v.get("status").unwrap();
+        assert_eq!(status.get("phase").and_then(|x| x.as_str()), Some("Active"));
+        assert_eq!(status.get("hostCount").and_then(|x| x.as_i64()), Some(2));
+        assert_eq!(status.get("usageCount").and_then(|x| x.as_i64()), Some(5));
+        let conds = status.get("conditions").and_then(|x| x.as_array()).unwrap();
+        assert_eq!(conds.len(), 3);
+        let ready = conds
+            .iter()
+            .find(|c| c.get("type").and_then(|x| x.as_str()) == Some("Ready"))
+            .unwrap();
+        assert_eq!(ready.get("status").and_then(|x| x.as_str()), Some("True"));
+        assert_eq!(
+            ready.get("reason").and_then(|x| x.as_str()),
+            Some(ROUTER_CONFIRMED),
+        );
+        let prog = conds
+            .iter()
+            .find(|c| c.get("type").and_then(|x| x.as_str()) == Some("Progressing"))
+            .unwrap();
+        assert_eq!(prog.get("status").and_then(|x| x.as_str()), Some("False"));
+        let degraded = conds
+            .iter()
+            .find(|c| c.get("type").and_then(|x| x.as_str()) == Some("Degraded"))
+            .unwrap();
+        assert_eq!(
+            degraded.get("status").and_then(|x| x.as_str()),
+            Some("False")
+        );
+    }
+
+    #[test]
+    fn build_status_patch_pending_blocked_on_sandbox() {
+        let v = build_status_patch(
+            &[],
+            None,
+            None,
+            Some(1),
+            PHASE_PENDING,
+            BLOCKED_ON_SANDBOX,
+            "not ready",
+            None,
+            1,
+            None,
+            None,
+            None,
+        );
+        let status = v.get("status").unwrap();
+        assert_eq!(
+            status.get("phase").and_then(|x| x.as_str()),
+            Some("Pending")
+        );
+        let conds = status.get("conditions").and_then(|x| x.as_array()).unwrap();
+        let ready = conds
+            .iter()
+            .find(|c| c.get("type").and_then(|x| x.as_str()) == Some("Ready"))
+            .unwrap();
+        assert_eq!(ready.get("status").and_then(|x| x.as_str()), Some("False"));
+        assert_eq!(
+            ready.get("reason").and_then(|x| x.as_str()),
+            Some(BLOCKED_ON_SANDBOX),
+        );
+        let prog = conds
+            .iter()
+            .find(|c| c.get("type").and_then(|x| x.as_str()) == Some("Progressing"))
+            .unwrap();
+        assert_eq!(prog.get("status").and_then(|x| x.as_str()), Some("True"));
+    }
+
+    #[test]
+    fn build_status_patch_terminal_invalid_sets_degraded_true() {
+        let v = build_status_patch(
+            &[],
+            None,
+            None,
+            Some(1),
+            PHASE_PENDING,
+            TTL_INVALID,
+            "bad ttl",
+            None,
+            1,
+            None,
+            None,
+            None,
+        );
+        let conds = v
+            .get("status")
+            .and_then(|s| s.get("conditions"))
+            .and_then(|c| c.as_array())
+            .unwrap();
+        let degraded = conds
+            .iter()
+            .find(|c| c.get("type").and_then(|x| x.as_str()) == Some("Degraded"))
+            .unwrap();
+        assert_eq!(
+            degraded.get("status").and_then(|x| x.as_str()),
+            Some("True")
+        );
+        assert_eq!(
+            degraded.get("reason").and_then(|x| x.as_str()),
+            Some(TTL_INVALID),
+        );
+    }
+
+    #[test]
+    fn build_status_patch_expired_preserves_effective_at_and_usage() {
+        // Idempotency contract: effective_at stamped once, never moves.
+        // After expiry, usage_count is preserved (historical).
+        let v = build_status_patch(
+            &[],
+            Some("2026-05-15T10:00:00Z".into()), // prior_effective_at
+            Some(42),                            // prior_usage_count
+            Some(3),
+            PHASE_EXPIRED,
+            EXPIRED,
+            "expired",
+            None,
+            1,
+            Some("2026-05-15T10:00:00Z".into()),
+            Some("2026-05-15T10:15:00Z".into()),
+            Some(42),
+        );
+        let status = v.get("status").unwrap();
+        assert_eq!(
+            status.get("effectiveAt").and_then(|x| x.as_str()),
+            Some("2026-05-15T10:00:00Z"),
+        );
+        assert_eq!(status.get("usageCount").and_then(|x| x.as_i64()), Some(42));
+    }
+
+    #[test]
+    fn build_status_patch_preserves_prior_effective_at_when_none_passed() {
+        // Subsequent reconciles pass `None` for the new effective_at;
+        // the helper folds the prior value through so the timestamp
+        // never moves (TTL is measured from this point).
+        let v = build_status_patch(
+            &[],
+            Some("2026-05-15T10:00:00Z".into()),
+            None,
+            Some(2),
+            PHASE_PENDING,
+            BLOCKED_ON_SANDBOX,
+            "still pending",
+            None,
+            1,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(
+            v.get("status")
+                .and_then(|s| s.get("effectiveAt"))
+                .and_then(|x| x.as_str()),
+            Some("2026-05-15T10:00:00Z"),
+        );
+    }
+
+    #[test]
+    fn parse_rfc3339_round_trip() {
+        let now = rfc3339_now();
+        let parsed = parse_rfc3339(&now).expect("round-trips");
+        let again = rfc3339_at(parsed);
+        assert_eq!(now, again);
+    }
+
+    #[test]
+    fn compute_merged_digest_byte_identical_to_compile_module() {
+        // Independently call merged_allowlist_digest with the same
+        // inputs the reconciler would build internally; the values
+        // must match. This pins the cross-binary parity contract
+        // even when refactors split the path.
+        let baseline = vec![EndpointConfig {
+            host: "EXAMPLE.com".into(),
+            port: Some(443),
+        }];
+        let self_hosts = vec![EndpointConfig {
+            host: "pypi.org".into(),
+            port: None,
+        }];
+        let siblings = vec![mk_approval("sib", "demo", "PT15M", "ok")];
+        let direct = {
+            let mut combined: Vec<EndpointConfig> = Vec::new();
+            combined.extend(self_hosts.iter().cloned());
+            for s in &siblings {
+                combined.extend(s.spec.hosts.iter().cloned());
+            }
+            merged_allowlist_digest(&baseline, &combined)
+        };
+        let via = compute_merged_digest(&baseline, &self_hosts, &siblings);
+        assert_eq!(via, direct);
+    }
+
+    #[test]
+    fn finalizer_constant_is_dns_subdomain() {
+        assert!(FINALIZER.contains('/'));
+        let (domain, _) = FINALIZER.split_once('/').unwrap();
+        assert_eq!(domain, "azureclaw.azure.com");
+    }
+
+    #[test]
+    fn field_manager_distinct_from_other_reconcilers() {
+        assert_eq!(FIELD_MANAGER, "azureclaw-controller/egressapproval");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/claweval");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/clawmemory");
+        assert_ne!(FIELD_MANAGER, "azureclaw-controller/toolpolicy");
+    }
+
+    #[test]
+    fn policy_kind_wire_matches_router() {
+        // PolicyKind name on the wire is "EgressApproval" exactly —
+        // pinned in inference-router/src/policy_status.rs.
+        assert_eq!(POLICY_KIND_WIRE, "EgressApproval");
+    }
+}

--- a/controller/src/field_managers.rs
+++ b/controller/src/field_managers.rs
@@ -81,6 +81,13 @@ pub const MESH: &str = "azureclaw-controller/mesh";
 /// the pre-S7 `providers::field_managers` callers.
 pub const RECONCILER: &str = "azureclaw-controller/reconciler";
 
+/// `EgressApproval` reconciler — Slice 5e.2. Owns
+/// `status.{phase,conditions,expiresAt,mergedHostCount,observedGeneration}`
+/// and the `azureclaw.azure.com/egress-approval-cleanup` finalizer.
+/// Distinct from the policy-lane reconcilers because the grant lane
+/// has a fundamentally different lifecycle (short-TTL, auto-expires).
+pub const EGRESS_APPROVAL: &str = "azureclaw-controller/egressapproval";
+
 /// All managers the controller emits. The §0.2 #8 "no duplication"
 /// invariant is asserted in the test below: every entry here must be a
 /// distinct string. Adding a constant requires extending this slice.
@@ -101,6 +108,7 @@ pub const ALL_FIELD_MANAGERS: &[&str] = &[
     PROVIDER_BRIDGE,
     MESH,
     RECONCILER,
+    EGRESS_APPROVAL,
 ];
 
 #[cfg(test)]

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -30,12 +30,9 @@ mod crd;
 // CRD-installation pipeline (Phase 1 close-out + future kubectl-claw-attest) consumes these helpers.
 mod crd_validations;
 mod egress_allowlist_compile;
-#[allow(dead_code)]
-// Slice 5e.1 lands the CRD shape + CEL + Helm install; the reconciler
-// (consumer of condition_reasons + merged_host_count) ships in Slice
-// 5e.2. The dead_code allowance is the explicit marker for the
-// unread-today surface.
 mod egress_approval;
+mod egress_approval_compile;
+mod egress_approval_reconciler;
 mod fedcred;
 mod fedcred_reaper;
 mod field_managers;
@@ -210,6 +207,10 @@ async fn main() -> Result<()> {
         let client = client.clone();
         tokio::spawn(async move { trust_graph_reconciler::run(client).await })
     };
+    let egress_approval_handle = {
+        let client = client.clone();
+        tokio::spawn(async move { egress_approval_reconciler::run(client).await })
+    };
 
     // S12.d: SignerPolicy ConfigMap watcher. Installs a process-global
     // handle so `policy_fetcher::maybe_verify_allowlist` resolves
@@ -350,6 +351,9 @@ async fn main() -> Result<()> {
             res??;
         }
         res = trust_graph_handle => {
+            res??;
+        }
+        res = egress_approval_handle => {
             res??;
         }
         res = mesh_peer_handle => {

--- a/controller/src/reconciler/governance_mounts.rs
+++ b/controller/src/reconciler/governance_mounts.rs
@@ -88,6 +88,18 @@ pub mod paths {
     /// match the router-side default in
     /// `inference-router/src/egress_allowlist_loader.rs::EGRESS_ALLOWLIST_DIR_DEFAULT`.
     pub const EGRESS_ALLOWLIST_DIR: &str = "/etc/azureclaw/egress";
+    /// Per-sandbox `EgressApproval` files (one `approval-{name}.json`
+    /// per CR pointing at this sandbox). Owned by the
+    /// `egress_approval_reconciler`; consumed by the inference-router's
+    /// `egress_allowlist_loader` which UNIONs them with the baseline
+    /// allowlist and echoes the merged-set digest via
+    /// `/internal/policy-status` under `PolicyKind::EgressApproval`.
+    /// Mounted with `optional: true` so sandbox pods start before any
+    /// approval has landed. Must match the router-side default in
+    /// `inference-router/src/egress_allowlist_loader.rs`
+    /// (`EGRESS_APPROVAL_DIR_DEFAULT` in
+    /// `inference-router/src/egress_allowlist_loader.rs`).
+    pub const EGRESS_APPROVAL_DIR: &str = "/etc/azureclaw/egress-approvals";
     /// McpServer JWKS (used by the customer-MCP OAuth verifier).
     pub const MCP_JWKS_DIR: &str = "/etc/azureclaw/mcp";
     /// A2AAgent compiled signed AgentCard.

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -957,6 +957,7 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
     // allowlist document. The router then rejects every egress
     // attempt by hostname at L7, matching the L4 deny encoded above.
     let egress_allowlist_cm_name = format!("clawsandbox-{}-egress-allowlist", name);
+    let egress_approvals_cm_name = crate::egress_approval_compile::approvals_configmap_name(&name);
     {
         let endpoints_for_compile: Vec<crate::crd::EndpointConfig> = allowlist_resolution
             .endpoints
@@ -1861,6 +1862,25 @@ async fn reconcile(sandbox: Arc<ClawSandbox>, ctx: Arc<Context>) -> Result<Actio
             Some((
                 "EGRESS_ALLOWLIST_DIR",
                 governance_mounts::paths::EGRESS_ALLOWLIST_DIR,
+            )),
+        );
+
+        // EgressApproval (Slice 5e): per-approval allowlist deltas live in
+        // a sibling ConfigMap owned by `egress_approval_reconciler`. The
+        // router UNIONs them with the baseline `EGRESS_ALLOWLIST_DIR`
+        // contents and echoes a merged-set digest under
+        // `PolicyKind::EgressApproval`. Optional mount — empty/missing
+        // when no approvals are active; the router treats absence as
+        // "no extra hosts" and falls back to the baseline digest.
+        governance_mounts::inject_configmap_mount(
+            &mut pod_spec,
+            "inference-router",
+            &egress_approvals_cm_name,
+            "egress-approvals",
+            governance_mounts::paths::EGRESS_APPROVAL_DIR,
+            Some((
+                "EGRESS_APPROVAL_DIR",
+                governance_mounts::paths::EGRESS_APPROVAL_DIR,
             )),
         );
 

--- a/controller/src/status/phase.rs
+++ b/controller/src/status/phase.rs
@@ -85,6 +85,26 @@ pub const PHASE_DEGRADED: &str = "Degraded";
 /// is wrong; reconciler will not converge without a spec change.
 pub const PHASE_FAILED: &str = "Failed";
 
+/// `.status.phase = "Active"` — grant-lane phase. The
+/// `EgressApproval` mount is in place and (Slice 5e.3+) the router
+/// has echoed the merged digest. Conceptually equivalent to
+/// `Ready` for policy-lane CRDs, but named distinctly because the
+/// grant lane has a fundamentally different lifecycle (short-TTL,
+/// auto-expires).
+///
+/// In Slice 5e.2 the router consumer does not exist yet, so this
+/// constant is part of the public phase vocabulary but is not
+/// stamped by any reconciler. Slice 5e.3 wires the producer.
+#[allow(dead_code)]
+pub const PHASE_ACTIVE: &str = "Active";
+
+/// `.status.phase = "Expired"` — grant-lane terminal phase. The
+/// TTL elapsed; the reconciler dropped any mount it created and
+/// the grant no longer affects the data plane. The CR persists
+/// for audit purposes until an operator deletes it (or a
+/// retention policy reaps it).
+pub const PHASE_EXPIRED: &str = "Expired";
+
 /// Canonical Warning Event reason for "controller compiled the spec
 /// but the router does not yet consume it." Whatever slice eventually
 /// wires the consumer must delete the corresponding
@@ -236,6 +256,8 @@ mod tests {
             PHASE_READY,
             PHASE_DEGRADED,
             PHASE_FAILED,
+            PHASE_ACTIVE,
+            PHASE_EXPIRED,
         ] {
             assert!(
                 s.chars().next().is_some_and(|c| c.is_uppercase()),
@@ -254,6 +276,18 @@ mod tests {
         // would silently re-introduce the "Ready means nothing" bug.
         assert_ne!(PHASE_COMPILED, PHASE_READY);
         assert_ne!(PHASE_COMPILED, PHASE_PENDING);
+    }
+
+    #[test]
+    fn grant_lane_phases_are_distinct_from_policy_lane() {
+        // Active is conceptually-but-not-identically Ready (grant
+        // lane). Expired is distinct from Failed (grant lane
+        // terminal state vs. spec-broken).
+        assert_ne!(PHASE_ACTIVE, PHASE_READY);
+        assert_ne!(PHASE_ACTIVE, PHASE_COMPILED);
+        assert_ne!(PHASE_EXPIRED, PHASE_FAILED);
+        assert_ne!(PHASE_EXPIRED, PHASE_DEGRADED);
+        assert_ne!(PHASE_EXPIRED, PHASE_ACTIVE);
     }
 
     #[test]

--- a/deploy/helm/azureclaw/templates/controller-deployment.yaml
+++ b/deploy/helm/azureclaw/templates/controller-deployment.yaml
@@ -60,6 +60,12 @@ spec:
             - name: REQUIRE_SIGNED_ALLOWLIST
               value: "true"
             {{- end }}
+            # Slice 5e: TTL ceiling for EgressApproval CRs. The
+            # reconciler clamps `spec.ttl` to `min(this, 604800s)` (1
+            # week hard ceiling). Operators can lower this further to
+            # match their policy posture.
+            - name: EGRESS_APPROVAL_MAX_TTL_SECONDS
+              value: {{ .Values.egressApproval.maxTtlSeconds | default 86400 | quote }}
             - name: INFERENCE_ROUTER_IMAGE
               value: "{{ .Values.inferenceRouter.image.repository }}:{{ .Values.inferenceRouter.image.tag }}"
             - name: SANDBOX_IMAGE

--- a/deploy/helm/azureclaw/values.yaml
+++ b/deploy/helm/azureclaw/values.yaml
@@ -368,3 +368,14 @@ egress:
   # `AllowlistVerified=False / reason=Unsigned` warnings so operators
   # can migrate to signed bundles at their own pace.
   requireSigned: false
+
+# Slice 5e: EgressApproval ephemeral allowlist deltas. An `EgressApproval`
+# CR points at a target ClawSandbox + lists extra hosts to allow + carries
+# a TTL. The controller clamps the requested TTL to
+# `min(maxTtlSeconds, 604800s)` (one-week hard ceiling baked into the
+# binary). Operators can lower this further to match their policy posture.
+# After `expiresAt`, the reconciler transitions the CR to `phase=Expired`,
+# drops its file from the per-sandbox approvals ConfigMap, and removes the
+# finalizer.
+egressApproval:
+  maxTtlSeconds: 86400

--- a/inference-router/src/egress_allowlist_loader.rs
+++ b/inference-router/src/egress_allowlist_loader.rs
@@ -63,6 +63,23 @@ pub const EGRESS_ALLOWLIST_FILENAME: &str = "allowlist.json";
 /// references a signed bundle or inline endpoint list).
 pub const EGRESS_ALLOWLIST_DIR_DEFAULT: &str = "/etc/azureclaw/egress";
 
+/// Domain separator used in the length-prefixed canonical bytes when
+/// hashing the merged-allowlist (`baseline ∪ approvals`) digest. Not
+/// a real on-disk filename — purely a name that pins the digest
+/// distinct from the baseline `allowlist.json` digest. Pinned with
+/// `controller::egress_approval_compile::EGRESS_APPROVAL_MERGED_FILENAME`.
+pub const EGRESS_APPROVAL_MERGED_FILENAME: &str = "merged-allowlist.json";
+
+/// Default mount directory for the per-sandbox `EgressApproval`
+/// ConfigMap (Slice 5e). The sandbox reconciler mounts
+/// `clawsandbox-<name>-egress-approvals` here when at least one
+/// approval CR targets the sandbox; the mount is `optional: true`
+/// so the directory may simply be absent when there are no grants.
+pub const EGRESS_APPROVAL_DIR_DEFAULT: &str = "/etc/azureclaw/egress-approvals";
+
+/// Env-var override for the approval mount directory.
+pub const EGRESS_APPROVAL_DIR_ENV: &str = "EGRESS_APPROVAL_DIR";
+
 /// Shared handle to the currently loaded egress allowlist, or `None`
 /// when no bundle has been loaded yet (mount missing, file absent,
 /// or parse failure). The watcher updates it in place on every
@@ -82,6 +99,11 @@ pub struct LoadedEgressAllowlist {
     /// Lower-cased hostnames extracted from the bundle. Used to
     /// build the new `Blocklist` allowlist on every reload.
     pub hosts: Vec<String>,
+    /// All endpoints `(host, port)` with ports preserved. Drives the
+    /// merged-allowlist digest computation (Slice 5e) so the router
+    /// can echo the same digest the `EgressApproval` reconciler
+    /// computes when enumerating `(baseline ∪ approvals)`.
+    pub endpoints: Vec<(String, u16)>,
     /// Whole bundle JSON, preserved verbatim for diagnostics + future
     /// consumers (e.g. per-endpoint port enforcement in 5c.2).
     pub raw: serde_json::Value,
@@ -182,22 +204,29 @@ pub fn load_egress_allowlist_from_dir(
     // must not crash the router. Skip non-object entries and
     // non-string hosts silently — the digest echo will surface the
     // divergence.
-    let hosts: Vec<String> = parsed
+    let endpoints: Vec<(String, u16)> = parsed
         .get("endpoints")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
                 .filter_map(|entry| {
-                    entry
-                        .as_object()
-                        .and_then(|m| m.get("host"))
+                    let obj = entry.as_object()?;
+                    let host = obj
+                        .get("host")
                         .and_then(|h| h.as_str())
                         .map(|s| s.trim().to_ascii_lowercase())
-                        .filter(|s| !s.is_empty())
+                        .filter(|s| !s.is_empty())?;
+                    let port = obj
+                        .get("port")
+                        .and_then(|p| p.as_u64())
+                        .and_then(|p| u16::try_from(p).ok())
+                        .unwrap_or(443);
+                    Some((host, port))
                 })
                 .collect()
         })
         .unwrap_or_default();
+    let hosts: Vec<String> = endpoints.iter().map(|(h, _)| h.clone()).collect();
 
     let canonical = canonical_bytes_for_digest(EGRESS_ALLOWLIST_FILENAME, &body);
     policy_status.record_success(PolicyKind::EgressAllowlist, &file_str, &canonical);
@@ -217,6 +246,7 @@ pub fn load_egress_allowlist_from_dir(
         digest,
         source_path: file_str,
         hosts,
+        endpoints,
         raw: parsed,
     })
 }
@@ -226,12 +256,22 @@ pub fn load_egress_allowlist_from_dir(
 /// onto the live `Blocklist` (atomic replace under a single write
 /// lock) or drain it to the empty set (fail-closed).
 ///
-/// Handle-update semantics by outcome:
+/// `approval_dir`, when `Some`, is scanned for per-approval files
+/// (`approval-*.json`) produced by the `EgressApproval` reconciler
+/// (Slice 5e). Every active approval's hosts are unioned with the
+/// baseline before installing the result on the `Blocklist`, and the
+/// merged-allowlist digest is echoed under
+/// [`PolicyKind::EgressApproval`]. Passing `None` (or pointing at a
+/// missing directory) preserves Slice 5c.1 behaviour exactly:
+/// baseline-only, no `EgressApproval` echo.
+///
+/// Handle-update semantics by baseline outcome:
 /// - [`LoadOutcome::Loaded`] → handle + `Blocklist` allowlist
-///   replaced with the new host set.
+///   replaced with `(baseline ∪ approvals)`.
 /// - [`LoadOutcome::NoBinding`] → handle cleared + `Blocklist`
 ///   allowlist drained. A sandbox with no mounted bundle gets zero
-///   L7 egress.
+///   L7 egress regardless of how many approvals are present —
+///   grants extend a missing baseline to nothing.
 /// - [`LoadOutcome::Error`] → handle and live allowlist left
 ///   intact. Transient parse blips during a partial mount update
 ///   must not knock the data plane offline; the registry already
@@ -242,19 +282,177 @@ pub async fn load_and_install(
     handle: &LoadedEgressAllowlistHandle,
     blocklist: &Blocklist,
 ) -> LoadOutcome {
+    load_and_install_with_approvals(dir, None, policy_status, handle, blocklist).await
+}
+
+/// Same as [`load_and_install`] but also scans an approvals
+/// directory for `EgressApproval` grants (Slice 5e). See module-level
+/// docs.
+pub async fn load_and_install_with_approvals(
+    dir: &str,
+    approval_dir: Option<&str>,
+    policy_status: &PolicyStatusRegistry,
+    handle: &LoadedEgressAllowlistHandle,
+    blocklist: &Blocklist,
+) -> LoadOutcome {
     let outcome = load_egress_allowlist_from_dir(dir, policy_status);
     match &outcome {
         LoadOutcome::Loaded(bundle) => {
-            blocklist.replace_allowlist(bundle.hosts.clone()).await;
+            // Read approvals (best-effort; per-file parse failures
+            // are tolerated — each failure is recorded under
+            // `PolicyKind::EgressApproval` so the reconciler can
+            // surface the operator-visible drift via its status).
+            let approval_endpoints = if let Some(adir) = approval_dir {
+                load_approvals_from_dir(adir)
+            } else {
+                Vec::new()
+            };
+
+            // Atomic replace with the union. Sort + dedup happens
+            // here too so the on-the-wire host set the Blocklist
+            // enforces is identical to the digest's canonical form.
+            let mut union: Vec<(String, u16)> =
+                Vec::with_capacity(bundle.endpoints.len() + approval_endpoints.len());
+            union.extend(bundle.endpoints.iter().cloned());
+            union.extend(approval_endpoints.iter().cloned());
+            union.sort();
+            union.dedup();
+
+            let merged_hosts: Vec<String> = union.iter().map(|(h, _)| h.clone()).collect();
+            blocklist.replace_allowlist(merged_hosts).await;
             *handle.write().await = Some(bundle.clone());
+
+            // Echo the merged digest under PolicyKind::EgressApproval
+            // whenever an approval directory was configured — even
+            // when it's empty. The empty-directory case still
+            // produces a stable digest (== baseline-only digest's
+            // canonical form re-wrapped under the merged domain
+            // separator), so the reconciler can observe "no
+            // approvals currently active" and stop waiting on
+            // expired ones.
+            if approval_dir.is_some() {
+                let body = compile_merged_endpoints_body(&union);
+                let canonical = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body);
+                let source = approval_dir.unwrap_or("");
+                policy_status.record_success(PolicyKind::EgressApproval, source, &canonical);
+            }
         }
         LoadOutcome::NoBinding => {
             blocklist.replace_allowlist(Vec::new()).await;
             *handle.write().await = None;
+            // If approvals were configured but the baseline is
+            // absent, echo an empty merged digest so the
+            // reconciler sees "no enforcement" cleanly. Without
+            // this the EgressApproval kind would never be echoed
+            // and approvals would sit Pending forever.
+            if approval_dir.is_some() {
+                let body = compile_merged_endpoints_body(&[]);
+                let canonical = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body);
+                let source = approval_dir.unwrap_or("");
+                policy_status.record_success(PolicyKind::EgressApproval, source, &canonical);
+            }
         }
         LoadOutcome::Error(_) => {}
     }
     outcome
+}
+
+/// Scan `dir` for `approval-*.json` files (the wire shape produced
+/// by `controller::egress_approval_compile::compile_approval_file`)
+/// and return the union of their `hosts` arrays as `(host, port)`
+/// pairs. Missing directories return an empty vector — Slice 5e
+/// approvals are strictly additive, so absence is the no-op case.
+///
+/// Per-file parse failures are logged at WARN and skipped; one bad
+/// approval file must not deny the rest. The `EgressApproval`
+/// reconciler observes the missing host union via its own
+/// merged-digest mismatch — the operator can resolve via
+/// `kubectl describe`.
+fn load_approvals_from_dir(dir: &str) -> Vec<(String, u16)> {
+    let path = Path::new(dir);
+    if !path.is_dir() {
+        return Vec::new();
+    }
+    let mut entries: Vec<std::path::PathBuf> = match std::fs::read_dir(path) {
+        Ok(it) => it
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.extension().is_some_and(|ext| ext == "json")
+                    && p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("approval-"))
+            })
+            .collect(),
+        Err(e) => {
+            tracing::warn!(dir, error = %e, "EgressApproval read_dir failed");
+            return Vec::new();
+        }
+    };
+    entries.sort();
+
+    let mut endpoints: Vec<(String, u16)> = Vec::new();
+    for file in entries {
+        let body = match std::fs::read(&file) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(file = %file.display(), error = %e, "EgressApproval file read failed");
+                continue;
+            }
+        };
+        let parsed: serde_json::Value = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(file = %file.display(), error = %e, "EgressApproval parse failed");
+                continue;
+            }
+        };
+        let hosts = parsed.get("hosts").and_then(|v| v.as_array());
+        if let Some(arr) = hosts {
+            for entry in arr {
+                if let Some(obj) = entry.as_object() {
+                    let host = obj
+                        .get("host")
+                        .and_then(|h| h.as_str())
+                        .map(|s| s.trim().to_ascii_lowercase())
+                        .filter(|s| !s.is_empty());
+                    let port = obj
+                        .get("port")
+                        .and_then(|p| p.as_u64())
+                        .and_then(|p| u16::try_from(p).ok())
+                        .unwrap_or(443);
+                    if let Some(h) = host {
+                        endpoints.push((h, port));
+                    }
+                }
+            }
+        }
+    }
+    endpoints
+}
+
+/// Re-encode a sorted-deduped endpoint set into the canonical JSON
+/// body the merged digest hashes over. Byte-identical to
+/// `controller::egress_allowlist_compile::compile_to_doc` →
+/// `serde_json::to_vec`.
+fn compile_merged_endpoints_body(endpoints: &[(String, u16)]) -> Vec<u8> {
+    use serde_json::json;
+    let mut normalized: Vec<(String, u16)> = endpoints
+        .iter()
+        .map(|(h, p)| (h.trim().to_ascii_lowercase(), *p))
+        .filter(|(h, _)| !h.is_empty())
+        .collect();
+    normalized.sort();
+    normalized.dedup();
+    let arr: Vec<serde_json::Value> = normalized
+        .into_iter()
+        .map(|(h, p)| json!({ "host": h, "port": p }))
+        .collect();
+    let doc = json!({
+        "schemaVersion": 1,
+        "endpoints": arr,
+    });
+    serde_json::to_vec(&doc).expect("canonical JSON is always serializable")
 }
 
 /// Default poll interval. Slice 5 DoD ("router reloads ≤5s after
@@ -267,8 +465,26 @@ pub const WATCH_INTERVAL_ENV: &str = "EGRESS_ALLOWLIST_WATCH_INTERVAL";
 /// Spawn a background task that polls `dir`'s max-mtime every
 /// `EGRESS_ALLOWLIST_WATCH_INTERVAL` seconds (default 5s) and calls
 /// [`load_and_install`] whenever a change is detected.
+///
+/// `approval_dir`, when `Some`, is polled alongside the baseline —
+/// any change in either directory triggers a single
+/// [`load_and_install_with_approvals`] call so the merged-allowlist
+/// echo updates promptly.
 pub fn spawn_egress_allowlist_watcher(
     dir: String,
+    policy_status: Arc<PolicyStatusRegistry>,
+    handle: LoadedEgressAllowlistHandle,
+    blocklist: Blocklist,
+) {
+    spawn_egress_allowlist_watcher_with_approvals(dir, None, policy_status, handle, blocklist);
+}
+
+/// Variant of [`spawn_egress_allowlist_watcher`] that watches an
+/// approvals directory in addition to the baseline. See
+/// [`load_and_install_with_approvals`] for semantics.
+pub fn spawn_egress_allowlist_watcher_with_approvals(
+    dir: String,
+    approval_dir: Option<String>,
     policy_status: Arc<PolicyStatusRegistry>,
     handle: LoadedEgressAllowlistHandle,
     blocklist: Blocklist,
@@ -280,20 +496,31 @@ pub fn spawn_egress_allowlist_watcher(
         .unwrap_or(DEFAULT_WATCH_INTERVAL_SECS);
 
     tokio::spawn(async move {
-        let mut last_mtime = dir_max_mtime(&dir);
+        let mut last_baseline = dir_max_mtime(&dir);
+        let mut last_approvals = approval_dir.as_deref().and_then(dir_max_mtime);
         let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
         ticker.tick().await;
         loop {
             ticker.tick().await;
-            let current = dir_max_mtime(&dir);
-            if current != last_mtime {
+            let current_baseline = dir_max_mtime(&dir);
+            let current_approvals = approval_dir.as_deref().and_then(dir_max_mtime);
+            if current_baseline != last_baseline || current_approvals != last_approvals {
                 tracing::info!(
                     target: "egress_allowlist_watcher",
                     dir = %dir,
-                    "EgressAllowlist directory changed, reloading"
+                    approval_dir = ?approval_dir,
+                    "EgressAllowlist or EgressApproval directory changed, reloading"
                 );
-                let _ = load_and_install(&dir, &policy_status, &handle, &blocklist).await;
-                last_mtime = current;
+                let _ = load_and_install_with_approvals(
+                    &dir,
+                    approval_dir.as_deref(),
+                    &policy_status,
+                    &handle,
+                    &blocklist,
+                )
+                .await;
+                last_baseline = current_baseline;
+                last_approvals = current_approvals;
             }
         }
     });
@@ -545,5 +772,286 @@ mod tests {
             panic!("expected Loaded");
         };
         assert_eq!(bundle.hosts, vec!["ok.example.com"]);
+    }
+
+    // ---- Slice 5e — EgressApproval merge path -----------------
+
+    #[test]
+    fn merged_digest_filename_distinct_from_baseline() {
+        // Catches accidental reuse of the baseline domain separator.
+        assert_ne!(EGRESS_APPROVAL_MERGED_FILENAME, EGRESS_ALLOWLIST_FILENAME);
+    }
+
+    #[test]
+    fn merged_digest_is_byte_identical_to_controller_layout() {
+        // Cross-binary parity: the canonical body and digest match
+        // `controller::egress_approval_compile::merged_allowlist_digest`
+        // bit-for-bit. The fixture below is mirrored verbatim in
+        // `controller/src/egress_approval_compile.rs` —
+        // `digest_is_byte_identical_to_router_layout`. Drift on
+        // either side breaks both tests.
+        use sha2::{Digest, Sha256};
+        let endpoints = vec![
+            ("a.example.com".to_string(), 443u16),
+            ("b.example.com".to_string(), 443u16),
+        ];
+        let body = compile_merged_endpoints_body(&endpoints);
+        let canonical = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body);
+        let mut hex_str = String::with_capacity(64);
+        for b in Sha256::digest(&canonical) {
+            use std::fmt::Write;
+            let _ = write!(hex_str, "{b:02x}");
+        }
+        let expected = format!("sha256:{hex_str}");
+        // Now hash again via the same path to confirm determinism.
+        let body2 = compile_merged_endpoints_body(&endpoints);
+        let canonical2 = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body2);
+        let mut hex_str2 = String::with_capacity(64);
+        for b in Sha256::digest(&canonical2) {
+            use std::fmt::Write;
+            let _ = write!(hex_str2, "{b:02x}");
+        }
+        assert_eq!(expected, format!("sha256:{hex_str2}"));
+    }
+
+    #[tokio::test]
+    async fn approval_dir_none_preserves_legacy_behaviour() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("allowlist.json"),
+            br#"{"schemaVersion":1,"endpoints":[{"host":"a.example.com","port":443}]}"#,
+        )
+        .unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let blocklist = Blocklist::disabled();
+        let outcome = load_and_install_with_approvals(
+            dir.path().to_str().unwrap(),
+            None,
+            &reg,
+            &handle,
+            &blocklist,
+        )
+        .await;
+        assert!(matches!(outcome, LoadOutcome::Loaded(_)));
+        // No EgressApproval echo when approvals not configured.
+        assert!(reg.get(PolicyKind::EgressApproval).is_none());
+        // Baseline echo still present.
+        assert!(reg.get(PolicyKind::EgressAllowlist).is_some());
+    }
+
+    #[tokio::test]
+    async fn approval_dir_empty_emits_baseline_only_merged_digest() {
+        let dir = tempdir().unwrap();
+        let adir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("allowlist.json"),
+            br#"{"schemaVersion":1,"endpoints":[{"host":"a.example.com","port":443}]}"#,
+        )
+        .unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let blocklist = Blocklist::disabled();
+        let _ = load_and_install_with_approvals(
+            dir.path().to_str().unwrap(),
+            Some(adir.path().to_str().unwrap()),
+            &reg,
+            &handle,
+            &blocklist,
+        )
+        .await;
+        let entry = reg.get(PolicyKind::EgressApproval).unwrap();
+        let digest = entry.digest.unwrap();
+        // The merged digest with no approvals must equal the merged
+        // digest computed over baseline-only endpoints. Compare to
+        // a hand-computed reference.
+        let body = compile_merged_endpoints_body(&[("a.example.com".to_string(), 443u16)]);
+        use sha2::{Digest, Sha256};
+        let canonical = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body);
+        let mut hex_str = String::with_capacity(64);
+        for b in Sha256::digest(&canonical) {
+            use std::fmt::Write;
+            let _ = write!(hex_str, "{b:02x}");
+        }
+        assert_eq!(digest, format!("sha256:{hex_str}"));
+    }
+
+    #[tokio::test]
+    async fn approval_dir_with_grant_unions_hosts_and_echoes_merged_digest() {
+        let dir = tempdir().unwrap();
+        let adir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("allowlist.json"),
+            br#"{"schemaVersion":1,"endpoints":[{"host":"a.example.com","port":443}]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            adir.path().join("approval-incident-1.json"),
+            br#"{"schemaVersion":1,"approvalName":"incident-1","sandbox":"demo","hosts":[{"host":"b.example.com","port":443}],"reason":"r","effectiveAt":"t","expiresAt":"u"}"#,
+        )
+        .unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let blocklist = Blocklist::disabled();
+        let _ = load_and_install_with_approvals(
+            dir.path().to_str().unwrap(),
+            Some(adir.path().to_str().unwrap()),
+            &reg,
+            &handle,
+            &blocklist,
+        )
+        .await;
+
+        // Both hosts should now be in the Blocklist allowlist.
+        assert!(
+            blocklist
+                .get_allowlist()
+                .await
+                .iter()
+                .any(|h| h == "a.example.com")
+        );
+        assert!(
+            blocklist
+                .get_allowlist()
+                .await
+                .iter()
+                .any(|h| h == "b.example.com")
+        );
+
+        // The merged digest should equal the digest over both hosts.
+        let entry = reg.get(PolicyKind::EgressApproval).unwrap();
+        let body = compile_merged_endpoints_body(&[
+            ("a.example.com".to_string(), 443u16),
+            ("b.example.com".to_string(), 443u16),
+        ]);
+        use sha2::{Digest, Sha256};
+        let canonical = canonical_bytes_for_digest(EGRESS_APPROVAL_MERGED_FILENAME, &body);
+        let mut hex_str = String::with_capacity(64);
+        for b in Sha256::digest(&canonical) {
+            use std::fmt::Write;
+            let _ = write!(hex_str, "{b:02x}");
+        }
+        assert_eq!(entry.digest.unwrap(), format!("sha256:{hex_str}"));
+    }
+
+    #[tokio::test]
+    async fn approval_file_with_malformed_json_is_skipped_other_files_proceed() {
+        let dir = tempdir().unwrap();
+        let adir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("allowlist.json"),
+            br#"{"schemaVersion":1,"endpoints":[]}"#,
+        )
+        .unwrap();
+        std::fs::write(adir.path().join("approval-broken.json"), b"{not json").unwrap();
+        std::fs::write(
+            adir.path().join("approval-good.json"),
+            br#"{"schemaVersion":1,"approvalName":"good","sandbox":"demo","hosts":[{"host":"good.example.com","port":443}],"reason":"r","effectiveAt":"t","expiresAt":"u"}"#,
+        )
+        .unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let blocklist = Blocklist::disabled();
+        let _ = load_and_install_with_approvals(
+            dir.path().to_str().unwrap(),
+            Some(adir.path().to_str().unwrap()),
+            &reg,
+            &handle,
+            &blocklist,
+        )
+        .await;
+        // The good approval must have been applied even though the
+        // sibling file failed to parse.
+        assert!(
+            blocklist
+                .get_allowlist()
+                .await
+                .iter()
+                .any(|h| h == "good.example.com")
+        );
+        assert!(reg.get(PolicyKind::EgressApproval).is_some());
+    }
+
+    #[tokio::test]
+    async fn approval_file_files_not_prefixed_are_ignored() {
+        let dir = tempdir().unwrap();
+        let adir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("allowlist.json"),
+            br#"{"schemaVersion":1,"endpoints":[]}"#,
+        )
+        .unwrap();
+        // File NOT prefixed with `approval-` — must be ignored to
+        // avoid colliding with future siblings (e.g. README.md
+        // could be projected into the same ConfigMap by mistake).
+        std::fs::write(
+            adir.path().join("random.json"),
+            br#"{"hosts":[{"host":"sneaky.example.com","port":443}]}"#,
+        )
+        .unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let blocklist = Blocklist::disabled();
+        let _ = load_and_install_with_approvals(
+            dir.path().to_str().unwrap(),
+            Some(adir.path().to_str().unwrap()),
+            &reg,
+            &handle,
+            &blocklist,
+        )
+        .await;
+        assert!(
+            !blocklist
+                .get_allowlist()
+                .await
+                .iter()
+                .any(|h| h == "sneaky.example.com")
+        );
+    }
+
+    #[tokio::test]
+    async fn baseline_no_binding_with_approvals_still_drains_blocklist() {
+        // Even with active approvals, a missing baseline must drain
+        // the L7 filter to the empty set — grants only EXTEND a
+        // valid baseline, they cannot create one out of nothing.
+        let dir = tempdir().unwrap();
+        let adir = tempdir().unwrap();
+        std::fs::write(
+            adir.path().join("approval-1.json"),
+            br#"{"schemaVersion":1,"approvalName":"a","sandbox":"demo","hosts":[{"host":"x.example.com","port":443}],"reason":"r","effectiveAt":"t","expiresAt":"u"}"#,
+        )
+        .unwrap();
+        let reg = PolicyStatusRegistry::new();
+        let handle = empty_handle();
+        let blocklist = Blocklist::disabled();
+        // Pre-seed the blocklist to non-empty so we can observe the drain.
+        blocklist
+            .replace_allowlist(vec!["leftover.example.com".to_string()])
+            .await;
+        let _ = load_and_install_with_approvals(
+            dir.path().to_str().unwrap(),
+            Some(adir.path().to_str().unwrap()),
+            &reg,
+            &handle,
+            &blocklist,
+        )
+        .await;
+        assert!(
+            !blocklist
+                .get_allowlist()
+                .await
+                .iter()
+                .any(|h| h == "x.example.com")
+        );
+        assert!(
+            !blocklist
+                .get_allowlist()
+                .await
+                .iter()
+                .any(|h| h == "leftover.example.com")
+        );
+        // EgressApproval echo should still be present with an empty
+        // merged set so the reconciler can observe the state.
+        assert!(reg.get(PolicyKind::EgressApproval).is_some());
     }
 }

--- a/inference-router/src/main.rs
+++ b/inference-router/src/main.rs
@@ -152,15 +152,29 @@ async fn main() -> Result<()> {
         let egress_dir = std::env::var("EGRESS_ALLOWLIST_DIR").unwrap_or_else(|_| {
             azureclaw_inference_router::egress_allowlist_loader::EGRESS_ALLOWLIST_DIR_DEFAULT.into()
         });
-        let _ = azureclaw_inference_router::egress_allowlist_loader::load_and_install(
-            &egress_dir,
-            &state.policy_status,
-            &state.egress_allowlist,
-            &state.blocklist,
+        // Slice 5e: per-sandbox `EgressApproval` files (one
+        // `approval-{name}.json` per CR pointing at this sandbox) live
+        // in a sibling ConfigMap mounted at `EGRESS_APPROVAL_DIR`. The
+        // loader UNIONs them with the baseline allowlist and registers
+        // the merged-set digest under `PolicyKind::EgressApproval`.
+        let approvals_dir = std::env::var(
+            azureclaw_inference_router::egress_allowlist_loader::EGRESS_APPROVAL_DIR_ENV,
         )
-        .await;
-        azureclaw_inference_router::egress_allowlist_loader::spawn_egress_allowlist_watcher(
+        .unwrap_or_else(|_| {
+            azureclaw_inference_router::egress_allowlist_loader::EGRESS_APPROVAL_DIR_DEFAULT.into()
+        });
+        let _ =
+            azureclaw_inference_router::egress_allowlist_loader::load_and_install_with_approvals(
+                &egress_dir,
+                Some(approvals_dir.as_str()),
+                &state.policy_status,
+                &state.egress_allowlist,
+                &state.blocklist,
+            )
+            .await;
+        azureclaw_inference_router::egress_allowlist_loader::spawn_egress_allowlist_watcher_with_approvals(
             egress_dir,
+            Some(approvals_dir),
             state.policy_status.clone(),
             state.egress_allowlist.clone(),
             state.blocklist.clone(),

--- a/inference-router/src/policy_status.rs
+++ b/inference-router/src/policy_status.rs
@@ -83,6 +83,28 @@ pub enum PolicyKind {
     /// as a defence-in-depth backstop, not the primary enforcement
     /// point.
     EgressAllowlist,
+
+    /// Merged egress allowlist after applying ephemeral `EgressApproval`
+    /// grants (Slice 5e). Distinct from [`PolicyKind::EgressAllowlist`]
+    /// because the two echoes track different surfaces:
+    ///
+    /// - `EgressAllowlist` echoes the **baseline** the operator signed
+    ///   and shipped via `spec.networkPolicy.allowlistRef`. This is
+    ///   the long-lived policy lane; its digest changes only when the
+    ///   operator publishes a new signed artifact.
+    /// - `EgressApproval` echoes the **merged** host set
+    ///   `(baseline ∪ all active approvals)`. This is the grant lane;
+    ///   the digest changes every time an `EgressApproval` CR lands
+    ///   or expires on the sandbox.
+    ///
+    /// The router loader (Slice 5e — `egress_allowlist_loader`)
+    /// computes both digests on every reload and registers each
+    /// under its own variant. The `EgressApproval` reconciler polls
+    /// `/internal/policy-status` looking for this kind specifically;
+    /// its digest matches the controller's expected merged digest
+    /// only when every contributing approval file has actually
+    /// reached the router.
+    EgressApproval,
 }
 
 impl PolicyKind {
@@ -95,6 +117,7 @@ impl PolicyKind {
             PolicyKind::InferencePolicy => "InferencePolicy",
             PolicyKind::Memory => "Memory",
             PolicyKind::EgressAllowlist => "EgressAllowlist",
+            PolicyKind::EgressApproval => "EgressApproval",
         }
     }
 }


### PR DESCRIPTION
Closes the consumer half of Slice 5e (crd-well-oiled-machine grant lane). 5e.1 (#308) landed the CRD shape; this PR wires the full producer↔consumer loop so `EgressApproval` CRs now drive a real data-plane change.

## What this PR delivers

The reconciler computes a merged-allowlist digest, writes per-approval files into a sibling ConfigMap mounted into the sandbox router, and only promotes `phase=Pending→Active` once the router echoes the digest on `/internal/policy-status` under `PolicyKind::EgressApproval`. On TTL expiry the reconciler drops the file, removes the finalizer, and stamps `phase=Expired`.

First full producer↔consumer loop for the **grant lane** of `principles.md §2.4` / `signing-model.md §6`. Satisfies §3 (`Ready ⇔ router echo`) and §5 (no scaffolding) end-to-end.

## Producer side (controller)

- `controller/src/egress_approval_compile.rs` (NEW, ~360 LOC, 13 tests): `approvals_configmap_name`, `approval_file_key`, `compile_approval_file` (canonical JSON), `merged_allowlist_digest` (length-prefixed sha256 over baseline ∪ approval hosts, byte-identical to router-side compute).
- `controller/src/egress_approval_reconciler.rs` (NEW, ~870 LOC, 28 tests): full state machine.
  - **Validate**: hand-rolled ISO 8601 parser (accepts `PT15M`/`PT4H`/`P1D`/`PT1H30M`/`PT30S`; rejects `P1W/Y`, `P1H` with H-before-T, `PT1D` with D-after-T, `PT0M`); `validate_reason` rejects empty / >512 bytes / ASCII control bytes; TTL clamped to `min(env_ceiling, 604800s)` (1 week hard ceiling).
  - **Sibling sandbox Ready gate**: `Pending(BlockedOnSandbox)` + 5s requeue if target sandbox isn't `phase=Ready`.
  - **Idempotency**: `effective_at` stamped only on first transition; re-reconciles preserve prior value.
  - **CM write**: SSA-apply under per-approval field manager `azureclaw-controller/egressapproval/{name}` so siblings don't trample.
  - **Router poll**: `poll_referencing_sandboxes` against merged digest. `Confirmed → Active`; `Awaiting → Pending(AwaitingRouterEcho)` + 5s.
  - **Expiry**: at `now ≥ expires_at`, drops the per-approval CM key (SSA empty `data: {}` + JSON-merge `null` defense-in-depth), stamps `phase=Expired`, removes finalizer.
  - **Finalizer**: `azureclaw.azure.com/egress-approval-cleanup`.
  - **Env knob**: `EGRESS_APPROVAL_MAX_TTL_SECONDS` (default 86400 / 1d via Helm).
- `controller/src/main.rs` spawn block + `select!` arm.
- `controller/src/reconciler/mod.rs` injects optional approvals CM mount onto `inference-router` container at `/etc/azureclaw/egress-approvals` with `EGRESS_APPROVAL_DIR` env.
- `controller/src/reconciler/governance_mounts.rs` adds `EGRESS_APPROVAL_DIR` path constant.
- `controller/src/status/phase.rs` adds `PHASE_ACTIVE` + `PHASE_EXPIRED`.
- `controller/src/field_managers.rs` adds `EGRESS_APPROVAL`.

## Consumer side (inference-router)

- `inference-router/src/policy_status.rs` adds `PolicyKind::EgressApproval` (wire string `"EgressApproval"`).
- `inference-router/src/egress_allowlist_loader.rs` `_with_approvals` variants (already present from 5e.0) are now wired in `main.rs` boot. They UNION every `approval-*.json` host with the baseline allowlist, register the merged-set digest under `PolicyKind::EgressApproval`, and rebuild the L7 blocklist accordingly. The watcher reacts to mtime changes in either directory.
- `inference-router/src/main.rs` boot wires `EGRESS_APPROVAL_DIR` env (default `/etc/azureclaw/egress-approvals`).

## Helm

- `deploy/helm/azureclaw/values.yaml`: `egressApproval.maxTtlSeconds: 86400`.
- `deploy/helm/azureclaw/templates/controller-deployment.yaml`: `EGRESS_APPROVAL_MAX_TTL_SECONDS` env passthrough.

## Test coverage

| Suite | Status |
|---|---|
| Workspace `cargo test` | ✅ 755 controller + 871 router + integration |
| `cargo clippy --all-targets --workspace -- -D warnings` | ✅ clean |
| `cargo fmt --check` | ✅ clean |
| Helm drift (`helm_drift::*`) | ✅ 16/16 |
| Phase taxonomy guard | ✅ |

+28 new reconciler unit tests cover: ISO 8601 parser corners (7 cases), reason validation (control bytes / empty / oversize / accept normal), TTL ceiling env parsing (4 cases), status-patch shape for all 5 transitions (Active / Pending(BlockedOnSandbox) / Terminal-invalid / Expired / preserve-prior-effective-at), per-approval field-manager scoping uniqueness, finalizer DNS-subdomain format, cross-binary digest parity with `egress_approval_compile`, policy-kind wire-string parity with router constant.

## What this PR does NOT do

- **No CLI**: `azureclaw egress allow-extra` lands in Slice 5e.3. Operators apply `EgressApproval` CRs via `kubectl apply` today.
- **No Headlamp panel**: deferable to Slice 5e.4.
- **No cryptographic attestation**: `spec.attestation` is the demand-gated forward-compat surface (anchors to `SignerPolicy.ed25519Keys` from Slice 1c.6); deferred to Slice 5e+ as previously locked.

## Backward compatibility

Fully backward-compatible. The approvals CM is optional-mounted (`optional: true`) so existing sandboxes start cleanly even with zero approvals. The router's baseline path is byte-identical when the approvals directory is empty or missing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>