### PR TITLE
slice 6.5 follow-up: CLI help, claweval doc, E2E ownerRefs, CI prebuild cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,11 @@ jobs:
     # to keep PR signal fast — the path filter is the gate.
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      # Required by docker/build-push-action GHA cache backend
+      # (cache-to: type=gha) used by the image pre-build steps below.
+      actions: write
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
@@ -434,6 +439,36 @@ jobs:
           docker system prune -af --volumes >/dev/null 2>&1 || true
           df -h
 
+      # Pre-build controller + router images with buildx GHA cache so that
+      # the `cargo build --release` layer inside the Dockerfile is reused
+      # across PRs. Cache scope is shared with image-cache-publish.yml so
+      # dev-branch builds warm the same cache.
+      - name: Set up Docker Buildx
+        if: steps.paths.outputs.run == 'true'
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+
+      - name: Pre-build controller image (buildx + GHA cache)
+        if: steps.paths.outputs.run == 'true'
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+        with:
+          context: .
+          file: controller/Dockerfile
+          tags: azureclaw-controller:e2e
+          load: true
+          cache-from: type=gha,scope=image-controller
+          cache-to: type=gha,scope=image-controller,mode=max
+
+      - name: Pre-build inference-router image (buildx + GHA cache)
+        if: steps.paths.outputs.run == 'true'
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+        with:
+          context: .
+          file: inference-router/Dockerfile
+          tags: azureclaw-inference-router:e2e
+          load: true
+          cache-from: type=gha,scope=image-inference-router
+          cache-to: type=gha,scope=image-inference-router,mode=max
+
       - name: Run e2e
         if: steps.paths.outputs.run == 'true'
         env:
@@ -446,6 +481,10 @@ jobs:
           # leader lease so the test environment is deterministic.
           AZURECLAW_E2E_CONTROLLER_REPLICAS: "1"
           AZURECLAW_E2E_DISABLE_LEADER_ELECTION: "1"
+          # Both images were pre-built with buildx GHA cache above —
+          # tell the harness to skip its in-process `docker build` and
+          # just `kind load` the existing tags.
+          AZURECLAW_E2E_SKIP_IMAGE_BUILD: "1"
         run: |
           set -euo pipefail
           make test-e2e

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -94,11 +94,11 @@ export function createCli(): Command {
 Command groups:
   Lifecycle       up, dev, add, push, destroy
   Operations      connect, status, list, logs, inspect
-  Configuration   credentials, model, policy, egress
+  Configuration   credentials, model, policy, egress, config
   Observability   trace, eval, operator, audit
   Agent mobility  handoff, mesh, pair
   Interop         convert, a2a, a2a-agent, migrate
-  Governance      toolpolicy, inferencepolicy, mcp
+  Governance      toolpolicy, inferencepolicy, mcp, memory
   Attestation     attest
 
 Quick start:

--- a/controller/src/claw_eval_reconciler.rs
+++ b/controller/src/claw_eval_reconciler.rs
@@ -157,8 +157,10 @@ async fn reconcile(eval: Arc<ClawEval>, ctx: Arc<Ctx>) -> Result<Action, Reconci
     };
 
     // -------- 2. Ensure corpus ConfigMap --------------------------
+    let eval_uid = eval.metadata.uid.as_deref();
     let cm_name = format!("claweval-{name}-corpus");
-    if let Err(e) = ensure_corpus_configmap(&configmaps, &cm_name, &name, &resolved).await {
+    if let Err(e) = ensure_corpus_configmap(&configmaps, &cm_name, &name, eval_uid, &resolved).await
+    {
         tracing::warn!(claweval = %name, error_class = e.class(), "ClawEvalCorpusWriteFailed");
         return write_degraded(
             &evals_api,
@@ -194,7 +196,7 @@ async fn reconcile(eval: Arc<ClawEval>, ctx: Arc<Ctx>) -> Result<Action, Reconci
             &jobs,
             &job_name,
             &name,
-            eval.metadata.uid.as_deref(),
+            eval_uid,
             &cm_name,
             &runner_image,
             &target_url,
@@ -221,7 +223,7 @@ async fn reconcile(eval: Arc<ClawEval>, ctx: Arc<Ctx>) -> Result<Action, Reconci
             &cronjobs,
             &cj_name,
             &name,
-            eval.metadata.uid.as_deref(),
+            eval_uid,
             schedule,
             &cm_name,
             &runner_image,
@@ -432,6 +434,7 @@ async fn ensure_corpus_configmap(
     api: &Api<ConfigMap>,
     cm_name: &str,
     owner: &str,
+    eval_uid: Option<&str>,
     resolved: &ResolvedCorpus,
 ) -> Result<(), ReconcileError> {
     let mut data: BTreeMap<String, String> = BTreeMap::new();
@@ -453,6 +456,13 @@ async fn ensure_corpus_configmap(
         "azureclaw.azure.com/claweval-corpus-label".into(),
         resolved.label.clone(),
     );
+    let owner_refs =
+        eval_uid.and_then(|uid| {
+            serde_json::from_value::<
+                Vec<k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference>,
+            >(claweval_owner_refs(owner, uid))
+            .ok()
+        });
     let cm = ConfigMap {
         metadata: ObjectMeta {
             name: Some(cm_name.into()),
@@ -468,6 +478,7 @@ async fn ensure_corpus_configmap(
                     "claw-eval-corpus".into(),
                 ),
             ])),
+            owner_references: owner_refs,
             ..Default::default()
         },
         data: Some(data),

--- a/controller/src/claw_eval_reconciler.rs
+++ b/controller/src/claw_eval_reconciler.rs
@@ -456,13 +456,12 @@ async fn ensure_corpus_configmap(
         "azureclaw.azure.com/claweval-corpus-label".into(),
         resolved.label.clone(),
     );
-    let owner_refs =
-        eval_uid.and_then(|uid| {
-            serde_json::from_value::<
-                Vec<k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference>,
-            >(claweval_owner_refs(owner, uid))
-            .ok()
-        });
+    let owner_refs = eval_uid.and_then(|uid| {
+        serde_json::from_value::<
+            Vec<k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference>,
+        >(claweval_owner_refs(owner, uid))
+        .ok()
+    });
     let cm = ConfigMap {
         metadata: ObjectMeta {
             name: Some(cm_name.into()),

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -50,6 +50,7 @@
 # API & policy
 
 - [CRD reference](api/crd-reference.md)
+- [ClawEval (operator guide)](api/claweval.md)
 - [Lifecycle & reconciliation](api/lifecycle.md)
 - [Conditions](api/conditions.md)
 - [Backwards compatibility](api/backwards-compatibility.md)

--- a/docs/api/claweval.md
+++ b/docs/api/claweval.md
@@ -1,0 +1,250 @@
+# `ClawEval` — Policy Conformance Runner
+
+`ClawEval` is the **operator-facing surface** for replaying a signed
+corpus of attack prompts (jailbreak, prompt-injection, banned-tool,
+egress, memory-isolation) against a running `ClawSandbox` and stamping
+a verifiable pass/fail verdict on the CR.
+
+This page is the **operator guide** — what to run, what status to
+look at, what each phase means. The schema lives in
+[`crd-reference.md#claweval`](crd-reference.md#claweval--reproducible-evaluation-run).
+For corpus authoring + signing, see
+[`docs/cli-reference.md#azureclaw-policy`](../cli-reference.md#azureclaw-policy).
+
+---
+
+## What it does
+
+```
+operator   ──►   ClawEval CR   ──►   controller   ──►   Job / CronJob
+                                          │                  │
+                                          │                  ▼
+                                          │            conformance-runner
+                                          │              container
+                                          │                  │
+                                          │       hits sandbox router on :8443
+                                          │       runs each case in the corpus
+                                          │                  │
+                                          ▼                  ▼
+                                   status patch  ◄──   pod log: RunReport JSON
+                                   (per-case verdicts +
+                                    pass/fail counts)
+```
+
+The controller owns both the spawned `Job`/`CronJob` (via
+`ownerReferences`, so they GC with the parent) and the materialised
+corpus `ConfigMap`. The runner image is pinned globally via the Helm
+chart (`AZURECLAW_CONFORMANCE_RUNNER_IMAGE`); per-CR override exists
+for in-cluster dev only.
+
+---
+
+## Builtin corpora
+
+Five corpora ship compiled into the controller binary and are
+referenced by name via `spec.corpus.builtin`:
+
+| Name | What it tests |
+|---|---|
+| `jailbreak-baseline` | Classic LLM jailbreak prompts (DAN, role-reversal, system-prompt extraction). Default if `spec.corpus` is omitted. |
+| `prompt-injection-2026q1` | Indirect prompt injection via tool outputs, retrieved documents, and crafted user input. |
+| `banned-tools` | Asserts the sandbox refuses calls to denylisted MCP tools (filesystem write outside `/sandbox/workspace`, raw shell, etc.). |
+| `egress-known-bad` | Asserts the inference router blocks egress to known-bad hosts even when the agent is convinced to make the call. |
+| `memory-isolation` | Asserts memory-store reads/writes can't cross sandbox boundaries. |
+
+Source of truth: `eval-corpus/src/lib.rs::BUILTIN_NAMES`. Operators
+can list them at runtime by reading the controller's `--help` or
+sourcing a CR with `kubectl explain claweval.spec.corpus`.
+
+For an external (signed) corpus, swap `builtin:` for `bundleRef:`
+(`{ registry, repository, digest }`) — the controller verifies the
+artifact's signature via the same path policies use; signing flow is
+covered in the CLI reference under `azureclaw policy sign`.
+
+---
+
+## Triggering a run
+
+There are exactly two ways to start a run:
+
+1. **Scheduled** — set `spec.schedule` to a 5-token cron expression.
+   The reconciler ensures a `CronJob` owned by the eval. Editing
+   `spec.schedule` updates the `CronJob.spec.schedule` in-place; no
+   recreate.
+2. **Run-now** — set the `azureclaw.azure.com/run-now=true`
+   annotation (or run `azureclaw eval run <name>`, which sets the
+   annotation for you). The reconciler ensures a one-shot `Job`,
+   then clears the annotation so re-setting it triggers another
+   run. Idempotent.
+
+A CR with **both** a schedule and the run-now annotation will produce
+both a `CronJob` and a one-shot `Job`. They run independently.
+
+---
+
+## Status — what to read
+
+```
+$ kubectl get claweval -A
+NAMESPACE              NAME                SANDBOX     SCHEDULE      PHASE     LASTRUN   PASSED  FAILED  AGE
+azureclaw-my-agent     nightly-regression  my-agent    0 3 * * *     Ready     12h       41      1       3d
+```
+
+The printer columns (`Sandbox`, `Schedule`, `Phase`, `LastRun`,
+`Passed`, `Failed`, `Age`) come straight off `status` and are the
+fastest way to see "is my eval doing its job?".
+
+### `status.phase`
+
+Stamped by the reconciler from `(have-last-result, drifted)`:
+
+| Phase | Meaning |
+|---|---|
+| `Pending` | CR has been admitted; no run has completed yet. Either the first run is in flight or `run-now` hasn't been set and there's no schedule. |
+| `Ready` | At least one run has completed and the most recent one had `failed == 0`. |
+| `Degraded` | The most recent run had `failed > 0` (drift). When `spec.failSandboxOnDrift=true` the target `ClawSandbox` is also patched to `Degraded` with reason `ConformanceDrift` via the `azureclaw-controller/claweval-drift` field manager. |
+
+### `status.conditions`
+
+Three standard plus one ClawEval-specific:
+
+| Type | When it goes `True` |
+|---|---|
+| `Ready` | Same trigger as phase=Ready. |
+| `Progressing` | A run is in flight (Job exists and hasn't completed). |
+| `Degraded` | Same trigger as phase=Degraded. |
+| `ConformanceDrift` | Most recent run reported `failed > 0`. This is the operator's drift signal; it does not by itself patch the sandbox unless `failSandboxOnDrift=true`. |
+
+Reasons used on each condition are listed in
+[`docs/api/conditions.md#claweval`](conditions.md#claweval).
+
+### `status.lastResult` and `status.history`
+
+- `lastResult` carries the **full** summary of the most recent run:
+  `schemaVersion`, `corpusLabel`, `corpusDigest`, `jobName`, and the
+  pass/fail/errored counts. The reconciler reads the runner pod log,
+  parses the `RunReport` JSON, and stamps it.
+- `history` carries the last 20 (`MAX_HISTORY`) **summaries** in
+  newest-first order. The reconciler trims older entries so the
+  whole CR comfortably fits etcd's 1 MiB object cap. The 0-th entry
+  always equals `lastResult`.
+
+To diff the two most recent runs:
+
+```bash
+azureclaw eval diff nightly-regression
+```
+
+For the per-case detail (which prompt failed and why), grab the runner
+pod log directly — the reconciler keeps the spawning `Job.metadata.name`
+in `status.lastResult.jobName`:
+
+```bash
+kubectl logs -n azureclaw-system job/$(kubectl get claweval -n azureclaw-system \
+  nightly-regression -o jsonpath='{.status.lastResult.jobName}')
+```
+
+### Corpus digest drift
+
+`status.corpusDigest` is the SHA-256 of the resolved corpus bytes
+**as the controller saw them**. If a builtin corpus is updated by a
+controller upgrade, or a signed bundle in the registry rotates to a
+new digest, this field will change on the next reconcile. Combined
+with `lastResult.corpusDigest` this lets operators answer
+"did the corpus drift, or did the sandbox drift?" without leaving
+`kubectl`.
+
+The corpus is materialised into a `ConfigMap` (pointer in
+`status.corpusConfigMapRef`) and mounted into the runner pod; the
+runner re-hashes the bytes and refuses to start if the in-pod digest
+disagrees with the CR-stamped one.
+
+---
+
+## CLI ergonomics
+
+Four read-mostly subcommands:
+
+```bash
+azureclaw eval list                  # tabular across the controller namespace
+azureclaw eval show <name>           # spec + last-run summary + drift status + conditions
+azureclaw eval run <name>            # set run-now annotation
+azureclaw eval diff <name>           # diff status.history[0] vs status.history[1]
+```
+
+All four hit the apiserver via `kubectl`; no router admin token
+required. They work even when the router is unhealthy — useful for
+finding out *why* a sandbox is Degraded.
+
+Full reference: [`docs/cli-reference.md#azureclaw-eval`](../cli-reference.md#azureclaw-eval).
+
+---
+
+## Common workflows
+
+### "Block CI on a known-good corpus"
+
+Create one `ClawEval` per sandbox you want gated, with
+`failSandboxOnDrift: true` and a low-frequency schedule (or run-now
+in pre-merge CI). The sandbox flips to `Degraded` on the first failed
+case; downstream callers see the condition and refuse to route new
+sessions.
+
+```yaml
+apiVersion: azureclaw.azure.com/v1alpha1
+kind: ClawEval
+metadata:
+  name: ci-gate
+  namespace: azureclaw-my-agent
+spec:
+  targetSandboxRef:
+    name: my-agent
+  corpus:
+    builtin: jailbreak-baseline
+  failSandboxOnDrift: true
+```
+
+### "Run a custom corpus signed by my team"
+
+```yaml
+spec:
+  corpus:
+    bundleRef:
+      registry: myacr.azurecr.io
+      repository: eval-corpora/my-team-redteam
+      digest: sha256:1f3a…
+```
+
+The controller verifies the OCI signature via the same path used for
+ToolPolicies, refuses to materialise the `ConfigMap` if the signature
+is missing/invalid, and stamps `Degraded` with reason
+`SignatureVerificationFailed`. Sign with `azureclaw policy sign --kind
+eval-corpus` before pushing to the registry.
+
+### "Smoke test a sandbox after a controller upgrade"
+
+```bash
+azureclaw eval run nightly-regression   # one-shot
+kubectl wait claweval/nightly-regression \
+  -n azureclaw-my-agent --for=condition=Ready --timeout=5m
+```
+
+---
+
+## Garbage collection
+
+The controller sets `ownerReferences` (`controller=true`,
+`blockOwnerDeletion=true`) on every spawned `Job`, `CronJob`, and
+the corpus `ConfigMap`. Deleting the `ClawEval` deletes all three.
+Deleting the parent `ClawSandbox` does **not** cascade to `ClawEval`s
+that reference it — those land in `phase=Pending` until the sandbox
+is recreated or the `ClawEval` itself is deleted.
+
+---
+
+## See also
+
+- [`docs/api/crd-reference.md#claweval`](crd-reference.md#claweval--reproducible-evaluation-run) — schema.
+- [`docs/api/conditions.md`](conditions.md) — reason constants.
+- [`docs/api/lifecycle.md`](lifecycle.md) — `Ready ⇔ router echo` invariant and how it applies to ClawEval (corpus digest match).
+- [`docs/cli-reference.md#azureclaw-eval`](../cli-reference.md#azureclaw-eval) — CLI subcommand reference.

--- a/docs/api/crd-reference.md
+++ b/docs/api/crd-reference.md
@@ -351,7 +351,7 @@ spec:
 
 ## `ClawEval` — reproducible evaluation run
 
-Replays a corpus of jailbreak / prompt-injection / banned-tool / egress / memory-isolation prompts against a sandbox. Builtin corpora ship in the controller binary (`azureclaw_eval_corpus::builtin::ALL_NAMES`): `jailbreak-baseline`, `prompt-injection-2026q1`, `banned-tools`, `egress-known-bad`, `memory-isolation`.
+Replays a corpus of jailbreak / prompt-injection / banned-tool / egress / memory-isolation prompts against a sandbox. Builtin corpora ship in the controller binary (`azureclaw_eval_corpus::BUILTIN_NAMES`): `jailbreak-baseline`, `prompt-injection-2026q1`, `banned-tools`, `egress-known-bad`, `memory-isolation`. For an operator-focused walkthrough see [`docs/api/claweval.md`](claweval.md).
 
 ```yaml
 apiVersion: azureclaw.azure.com/v1alpha1
@@ -367,7 +367,7 @@ spec:
   schedule: "0 3 * * *"                                   # optional cron; absent = run-now annotation only
   failSandboxOnDrift: false                               # when true, drift patches sandbox Degraded
 status:
-  phase: Completed
+  phase: Ready
   observedGeneration: 1
   lastRunAt: "2026-05-14T03:00:00Z"
   cronJobName: claweval-nightly-regression

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1202,7 +1202,7 @@ azureclaw eval diff nightly-regression
 ```
 
 Authoring new corpora and signing them is covered separately:
-- **[`docs/guides/eval-corpus-signing.md`](guides/eval-corpus-signing.md)** — `policy sign --kind eval-corpus` walkthrough.
+- **[`docs/api/claweval.md`](api/claweval.md)** — operator workflows (run-now, schedule, drift, GC).
 - **[`docs/api/crd-reference.md#claweval`](api/crd-reference.md#claweval--reproducible-evaluation-run)** — the CRD schema.
 
 ---

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -54,6 +54,24 @@ setup_cluster() {
 }
 
 build_images() {
+    # CI optimisation: if `AZURECLAW_E2E_SKIP_IMAGE_BUILD=1` and the
+    # required tags are already present in the local docker daemon
+    # (a previous CI step did the buildx-cached build), skip the build
+    # entirely and only do the `kind load` step. Saves ~5-8 min/run.
+    local skip="${AZURECLAW_E2E_SKIP_IMAGE_BUILD:-0}"
+    if [ "$skip" = "1" ] || [ "$skip" = "true" ]; then
+        info "AZURECLAW_E2E_SKIP_IMAGE_BUILD=1 — using pre-loaded images"
+        if ! docker image inspect azureclaw-controller:e2e >/dev/null 2>&1; then
+            warn "azureclaw-controller:e2e not present; falling back to building"
+        elif ! docker image inspect azureclaw-inference-router:e2e >/dev/null 2>&1; then
+            warn "azureclaw-inference-router:e2e not present; falling back to building"
+        else
+            kind load docker-image azureclaw-controller:e2e --name "$CLUSTER_NAME"
+            kind load docker-image azureclaw-inference-router:e2e --name "$CLUSTER_NAME"
+            return 0
+        fi
+    fi
+
     # Retry docker pulls/builds to absorb transient MCR registry flakes
     # (e.g., 403/404 on pinned digests during MCR rollouts).
     docker_build_retry() {
@@ -591,13 +609,30 @@ EOF
     fi
 
     # The Job must be owned by the ClawEval CR for cascade cleanup.
-    local owner_kind
+    local owner_kind owner_controller owner_block
     owner_kind=$(kubectl get job "$job_name" -n azureclaw-system \
         -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null || true)
-    if [ "$owner_kind" = "ClawEval" ]; then
-        pass "ClawEval lifecycle: Job has ownerReference → ClawEval"
+    owner_controller=$(kubectl get job "$job_name" -n azureclaw-system \
+        -o jsonpath='{.metadata.ownerReferences[0].controller}' 2>/dev/null || true)
+    owner_block=$(kubectl get job "$job_name" -n azureclaw-system \
+        -o jsonpath='{.metadata.ownerReferences[0].blockOwnerDeletion}' 2>/dev/null || true)
+    if [ "$owner_kind" = "ClawEval" ] && [ "$owner_controller" = "true" ] && [ "$owner_block" = "true" ]; then
+        pass "ClawEval lifecycle: Job has ownerReference → ClawEval (controller=true, blockOwnerDeletion=true)"
     else
-        fail "ClawEval lifecycle: Job missing ClawEval ownerReference (got '$owner_kind')"
+        fail "ClawEval lifecycle: Job ownerReference mismatch (kind='$owner_kind' controller='$owner_controller' block='$owner_block')"
+    fi
+
+    # The corpus ConfigMap must also carry the same ownerReference so it
+    # GCs with the parent even if the controller is down. (The reconciler
+    # also has an explicit finalizer-driven cleanup path; ownerRef is
+    # defence-in-depth.)
+    local cm_owner_kind
+    cm_owner_kind=$(kubectl get configmap claweval-e2e-claweval-lc-corpus -n azureclaw-system \
+        -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null || true)
+    if [ "$cm_owner_kind" = "ClawEval" ]; then
+        pass "ClawEval lifecycle: corpus ConfigMap has ownerReference → ClawEval"
+    else
+        fail "ClawEval lifecycle: corpus ConfigMap missing ClawEval ownerReference (got '$cm_owner_kind')"
     fi
 
     # ---- schedule ensures a CronJob ----------------------------
@@ -612,6 +647,16 @@ EOF
             pass "ClawEval lifecycle: schedule → CronJob created with correct schedule"
         else
             fail "ClawEval lifecycle: CronJob schedule mismatch (got '$cron_sched')"
+        fi
+        local cj_owner_kind cj_owner_controller
+        cj_owner_kind=$(kubectl get cronjob claweval-e2e-claweval-lc -n azureclaw-system \
+            -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null || true)
+        cj_owner_controller=$(kubectl get cronjob claweval-e2e-claweval-lc -n azureclaw-system \
+            -o jsonpath='{.metadata.ownerReferences[0].controller}' 2>/dev/null || true)
+        if [ "$cj_owner_kind" = "ClawEval" ] && [ "$cj_owner_controller" = "true" ]; then
+            pass "ClawEval lifecycle: CronJob has ownerReference → ClawEval (controller=true)"
+        else
+            fail "ClawEval lifecycle: CronJob ownerReference mismatch (kind='$cj_owner_kind' controller='$cj_owner_controller')"
         fi
     else
         dump_cr_diagnostics claweval e2e-claweval-lc azureclaw-system

--- a/tools/headlamp-plugin/README.md
+++ b/tools/headlamp-plugin/README.md
@@ -17,6 +17,14 @@ Detail panes show `.spec`, `.status`, and a typed Conditions table with
 status colouring (Ready / Provisioned → green, Degraded / Failed → red,
 everything else → amber).
 
+> **Known gaps (v1).** The status chip is **phase-only** — an amber chip
+> on a policy-lane CRD does not differentiate "signature failed" from
+> "compiled but router-drifted". For `McpServer`, the detail pane
+> renders only the **first/primary** server when a sandbox uses
+> `governance.mcpServerRefs[]` plural — a fleet panel showing all
+> referenced servers is deferred. Both are tracked in
+> [`docs/roadmap.md`](../../docs/roadmap.md).
+
 ## Build
 
 ```bash


### PR DESCRIPTION
Follow-up to #316 covering the four items deferred from slice 6.5.

## d1 — CLI help groups (`cli/src/cli.ts`)
List `config` under **Configuration** and `memory` under **Governance** in the long help blurb. Both commands were registered but absent from the curated index.

## d2 — Standalone ClawEval operator doc (`docs/api/claweval.md`)
New page: protocol diagram, builtin corpora table, run-now vs schedule workflows, status interpretation against the real phase enum (`Pending` | `Ready` | `Degraded`), drift handling, GC semantics. Linked from `docs/SUMMARY.md`, `docs/api/crd-reference.md`, `docs/cli-reference.md`. Drive-by fixes:
- broken link to non-existent `docs/guides/eval-corpus-signing.md` replaced
- stale `Completed` phase in crd-reference.md YAML example → `Ready`
- `ALL_NAMES` → `BUILTIN_NAMES` (matches `eval-corpus/src/lib.rs:815`)

## d3 — Corpus ConfigMap ownerReferences + E2E
Controller stamps `ownerReferences` on the ClawEval corpus ConfigMap (previously only Jobs/CronJobs). Tightens K8s GC — corpus CM gets reaped if the explicit finalizer path is skipped (controller crash mid-delete). Reuses `eval.metadata.uid` via a single binding to avoid lookups.

E2E (`tests/e2e/run.sh::test_crd_claw_eval_lifecycle`) extended to assert:
- Job ownerRef has `controller=true` and `blockOwnerDeletion=true`
- CronJob ownerRef stamped on the scheduled path
- Corpus ConfigMap ownerRef stamped

## d4 — CI pre-build cache (`.github/workflows/ci.yml`, `tests/e2e/run.sh`)
`e2e-kind` now pre-builds the controller + inference-router images with `docker/build-push-action` + buildx + GHA cache. Cache scope (`image-controller` / `image-inference-router`) is **shared with `image-cache-publish.yml`** so dev-branch pushes warm the same cache.

The e2e harness honours `AZURECLAW_E2E_SKIP_IMAGE_BUILD=1` to skip its in-process `docker build` and just `kind load` the pre-loaded tags. Falls back to building if the tags are missing (local dev path unaffected).

Expected savings: **~5-8 min/run** on a warm cache (the `cargo build --release` layer in each Dockerfile is the dominant cost).

## Verification
- `cargo fmt --all` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --package azureclaw-controller claw_eval` → 31 passed
- `npm --prefix cli run typecheck && npm --prefix cli run lint` clean (only pre-existing warnings)
- `bash -n tests/e2e/run.sh` clean