### PR TITLE
headlamp: reason-aware chip + MCP fleet card; memory store docs refresh

### DIFF
--- a/controller/src/claw_memory_reconciler.rs
+++ b/controller/src/claw_memory_reconciler.rs
@@ -41,15 +41,31 @@
 //! When binding write fails, `phase=Failed`, `Ready=False`,
 //! `Degraded=True`.
 //!
-//! ## What is *still* deferred (Slice 3b+)
+//! ## What landed in Slice 3b / 3c (no longer deferred)
 //!
-//! - Auto-provisioning of the upstream Foundry Memory Store on first
-//!   use (today the CLI plugin path / chart env still drive this).
-//! - `AuthMisconfigured` condition emission on 403 from Memory Store.
-//! - Memory MCP tool rewire to read from the binding (instead of the
-//!   chart-fed `FOUNDRY_MEMORY_STORE_ID` env). Slice 3a is additive —
-//!   the binding loads and the digest echoes, but no behavior
-//!   changes in the data plane yet.
+//! - **Slice 3b.4** — `AuthMisconfigured` Degraded reason: the router echoes
+//!   403 on the memory tool call back through `status.observedRouters[]`,
+//!   the reconciler elevates phase to `Degraded` with reason
+//!   `AuthMisconfigured` and an actionable message pointing at the project
+//!   MI / RBAC fix.
+//! - **Slice 3b.5** — `MemoryStoreMissing` Degraded reason: same echo path,
+//!   distinct reason so operators don't confuse "wrong RBAC" with "store
+//!   never created".
+//! - **Slice 3c.1** — router-side auto-provisioning. On first 404 from
+//!   `/memory_stores/{id}`, the inference router POSTs to `/memory_stores`
+//!   to create the store, then retries. See
+//!   [`inference-router/src/mcp/platform.rs`] `ensure_memory_store`. The
+//!   *controller* does NOT provision the upstream Foundry resource — that
+//!   remains an operator/`azure-prepare` job — but the store *inside* a
+//!   provisioned AI Services account is now self-healing.
+//!
+//! ## What is *still* operator-driven
+//!
+//! - Upstream Foundry **AI Services account** + **Project** lifecycle
+//!   (not in scope for the operator; `azure-prepare` handles it).
+//! - RBAC pre-grants: project MI needs `Azure AI User` on the resource
+//!   group for the internal model calls that Memory Store makes — see
+//!   `docs/operations/secret-rotation.md`.
 //!
 //! ## Reuse map (no-duplication rule, §0.2/§0.3)
 //!

--- a/docs/api/crd-reference.md
+++ b/docs/api/crd-reference.md
@@ -336,16 +336,27 @@ spec:
 | `spec.deleteOnSandboxDelete` | When `true` (default), runtime calls `delete_scope` on this scope when the sandbox or CR is deleted. |
 | `spec.bundleRef` | Signed OCI artifact alternative to inline content (mutex with `storeName` / `scope` / `retentionDays` / `deleteOnSandboxDelete` / `displayName`). `sandboxRef` is always CR-owned. |
 
-> **Provisioning is operator-driven today.** The CRD reconciler compiles
-> the binding into `/etc/azureclaw/memory/binding.json` and confirms the
-> router loaded it (`Ready ⇔ router echo`), but it does **not** create
-> the Foundry Memory Store, assign RBAC, or probe auth. You are
-> responsible for:
-> 1. Creating the Memory Store on the project (Portal or `azure-prepare`).
-> 2. Enabling system-assigned MI on the **project** (not the AI Services account).
-> 3. Granting `Azure AI User` to the project MI on the **resource group**.
+> **Provisioning split.** The CRD reconciler compiles the binding into
+> `/etc/azureclaw/memory/binding.json` and confirms the router loaded it
+> (`Ready ⇔ router echo`). It does **not** create the upstream **Foundry
+> AI Services account / Project** — that is operator-driven (Portal or
+> `azure-prepare`). The Memory **Store** *inside* a provisioned project,
+> however, is **router-auto-provisioned**: on the first `404` from
+> `/memory_stores/{id}` the inference router POSTs to `/memory_stores` to
+> create it and retries (`inference-router/src/mcp/platform.rs` ::
+> `ensure_memory_store`).
 >
-> Token audience must be `https://ai.azure.com/` (not `cognitiveservices.azure.com`). Auto-provisioning is on the roadmap — see [`docs/roadmap.md`](../roadmap.md#v11--topology--signed-crd-upgrades). While provisioning is pending, the controller stamps `Ready=False / reason=AwaitingFoundryProvisioning`.
+> Pre-flight checklist for the human operator:
+> 1. AI Services account + Project exist (`azure-prepare`).
+> 2. System-assigned MI enabled on the **project** (not the AI Services account).
+> 3. `Azure AI User` granted to the project MI on the **resource group**.
+>
+> Token audience must be `https://ai.azure.com/` (not
+> `cognitiveservices.azure.com`). The reconciler surfaces three distinct
+> Degraded reasons when echoes come back unhealthy:
+> `AwaitingFoundryProvisioning` (no project), `MemoryStoreMissing` (project
+> exists but auto-provision failed / disabled), `AuthMisconfigured` (403 on
+> the memory tool call — usually missing project-MI RBAC).
 
 ---
 

--- a/tools/headlamp-plugin/README.md
+++ b/tools/headlamp-plugin/README.md
@@ -17,13 +17,18 @@ Detail panes show `.spec`, `.status`, and a typed Conditions table with
 status colouring (Ready / Provisioned → green, Degraded / Failed → red,
 everything else → amber).
 
-> **Known gaps (v1).** The status chip is **phase-only** — an amber chip
-> on a policy-lane CRD does not differentiate "signature failed" from
-> "compiled but router-drifted". For `McpServer`, the detail pane
-> renders only the **first/primary** server when a sandbox uses
-> `governance.mcpServerRefs[]` plural — a fleet panel showing all
-> referenced servers is deferred. Both are tracked in
-> [`docs/roadmap.md`](../../docs/roadmap.md).
+> **Status chip semantics.** Chips are **reason-aware**: when the
+> `Ready` condition carries a hard-failure reason
+> (`SignatureMismatch`, `BundleVerifyFailed`, `AuthMisconfigured`,
+> `MemoryStoreMissing`, `RuntimeAdapterMissing`, `ShapeInvalid`,
+> `AllowlistDrift`, `PolicyCompileFailed`) the chip renders **red**;
+> transient reasons (`AwaitingRouterEnforcement`,
+> `AwaitingFoundryProvisioning`, `NoSandboxesReferencing`, `Pending`)
+> render **amber**. The reason is appended as a secondary muted label.
+> The ClawSandbox detail pane renders **all** servers referenced by
+> `governance.mcpServerRefs[]` via `McpServerFleetCard` (per-server
+> phase + reason + JWKS digest + tool count + `MISSING` chip for
+> dangling refs).
 
 ## Build
 

--- a/tools/headlamp-plugin/src/index.tsx
+++ b/tools/headlamp-plugin/src/index.tsx
@@ -144,7 +144,43 @@ for (const crd of AZURECLAW_CRDS) {
 
 type StatusKind = "success" | "error" | "warning" | "";
 
-function phaseToStatus(phase: string | undefined): StatusKind {
+// Reasons that mean "the policy is broken; needs human attention, not patience".
+// Sourced from `controller/src/status/conditions.rs` (`reason::*`) — kept in
+// sync by audit (`docs/internal/crd-well-oiled-machine/honest-audit.md`).
+// Distinguishing these from `Awaiting*` reasons is the difference between an
+// amber chip (working as designed, just settling) and a red chip (operator
+// action required). The plain phase enum can't tell them apart on its own.
+const HARD_FAILURE_REASONS = new Set<string>([
+  "SignatureMismatch",
+  "BundleVerifyFailed",
+  "AuthMisconfigured",
+  "MemoryStoreMissing",
+  "RuntimeAdapterMissing",
+  "AdapterMissing",
+  "ShapeInvalid",
+  "AllowlistDrift",
+  "PolicyCompileFailed",
+]);
+
+const SOFT_PENDING_REASONS = new Set<string>([
+  "AwaitingRouterEnforcement",
+  "AwaitingFoundryProvisioning",
+  "NoSandboxesReferencing",
+  "Pending",
+]);
+
+function readyReason(item: KubeObject): string | undefined {
+  const conds = (getStatus(item).conditions as Array<Record<string, any>> | undefined) ?? [];
+  const ready = conds.find(c => c.type === "Ready");
+  return ready?.reason as string | undefined;
+}
+
+function phaseToStatus(phase: string | undefined, reason?: string): StatusKind {
+  // Reason wins when present — a `Degraded` phase with reason
+  // `AwaitingRouterEnforcement` is amber (transient), but a `Pending` phase
+  // with reason `SignatureMismatch` is red (operator action required).
+  if (reason && HARD_FAILURE_REASONS.has(reason)) return "error";
+  if (reason && SOFT_PENDING_REASONS.has(reason)) return "warning";
   if (!phase) return "";
   if (phase === "Ready" || phase === "Provisioned" || phase === "Active") return "success";
   if (phase === "Degraded" || phase === "Failed" || phase === "Error") return "error";
@@ -174,10 +210,29 @@ function shortModel(m: string | undefined): string {
   return idx >= 0 ? m.slice(idx + 1) : m;
 }
 
-function phaseChip(phase: string | undefined) {
+function phaseChip(phase: string | undefined, reason?: string) {
   if (!phase) return <span>—</span>;
-  const status = phaseToStatus(phase);
-  return <StatusLabel status={status as any}>{phase}</StatusLabel>;
+  const status = phaseToStatus(phase, reason);
+  // When the reason carries actionable signal, append it as a secondary
+  // muted label so operators see both at a glance. e.g.
+  //   [Degraded] AllowlistDrift   — red, action required
+  //   [Pending]  AwaitingRouterEnforcement — amber, settling
+  const showReason = reason && (HARD_FAILURE_REASONS.has(reason) || SOFT_PENDING_REASONS.has(reason));
+  return (
+    <span>
+      <StatusLabel status={status as any}>{phase}</StatusLabel>
+      {showReason && (
+        <span style={{ marginLeft: "0.4rem", fontSize: "0.85em", color: "#888" }}>
+          {reason}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function chipForItem(item: KubeObject, phaseField: string) {
+  const phase = (getStatus(item) as any)[phaseField] as string | undefined;
+  return phaseChip(phase, readyReason(item));
 }
 
 function urlParams(re: RegExp): RegExpMatchArray | null {
@@ -638,7 +693,7 @@ function Overview() {
             { label: "Namespace", getter: (r: KubeObject) => r.metadata?.namespace ?? "—" },
             { label: "Runtime", getter: (r: KubeObject) => getSpec(r).runtime?.kind ?? "—" },
             { label: "Model", getter: recentModel },
-            { label: "Phase", getter: (r: KubeObject) => phaseChip(getStatus(r).phase as string) },
+            { label: "Phase", getter: (r: KubeObject) => phaseChip(getStatus(r).phase as string, readyReason(r)) },
             {
               label: "Egress",
               getter: (r: KubeObject) => {
@@ -776,7 +831,7 @@ function CrdList({ crd }: { crd: CrdDescriptor }) {
   if (crd.phaseField) {
     columns.push({
       label: "Phase",
-      getter: (r: KubeObject) => phaseChip(getStatus(r)[crd.phaseField!] as string),
+      getter: (r: KubeObject) => phaseChip(getStatus(r)[crd.phaseField!] as string, readyReason(r)),
     });
   }
   columns.push({
@@ -831,7 +886,7 @@ function CrdDetail({ crd }: { crd: CrdDescriptor }) {
         <SimpleTable
           data={[
             { k: "Namespace", v: namespace },
-            { k: "Phase", v: phaseChip(status.phase as string) },
+            { k: "Phase", v: phaseChip(status.phase as string, readyReason(item)) },
             { k: "Created", v: item.metadata?.creationTimestamp ?? "—" },
             { k: "UID", v: item.metadata?.uid ?? "—" },
           ]}
@@ -961,6 +1016,64 @@ function SandboxEgressApprovalsCard({
         means the router has echoed the merged digest. Grants auto-expire at{" "}
         <code>status.expiresAt</code>; revoke early with <code>azureclaw egress revoke</code>.
       </p>
+    </SectionBox>
+  );
+}
+
+function McpServerFleetCard({ refs }: { refs: Array<{ name?: string }> }) {
+  // Per-MCP-server live status on the ClawSandbox detail. Each server gets a
+  // row showing phase + reason chip, JWKS digest (router-echoed), and tool
+  // count. Previously the operator had to click each server to see drift —
+  // now you see the whole referenced fleet at a glance.
+  const [servers] = (CRD_CLASSES.mcpservers as any).useList() as [
+    KubeObject[] | null,
+  ];
+  if (refs.length === 0) return null;
+  const byName = new Map<string, KubeObject>();
+  (servers ?? []).forEach(s => {
+    const n = s.metadata?.name;
+    if (n) byName.set(n, s);
+  });
+  const rows = refs.map(r => {
+    const obj = r.name ? byName.get(r.name) : undefined;
+    const status = obj ? getStatus(obj) : {};
+    const spec = obj ? getSpec(obj) : {};
+    const tools = Array.isArray(spec.tools) ? spec.tools.length : (status.toolCount ?? 0);
+    return {
+      name: r.name ?? "—",
+      phase: (status.phase as string | undefined),
+      reason: obj ? readyReason(obj) : undefined,
+      digest: (status.jwksDigest as string | undefined) ?? (status.bundleDigest as string | undefined),
+      tools,
+      missing: !obj,
+    };
+  });
+  return (
+    <SectionBox title={`MCP Servers (${rows.length})`}>
+      <SimpleTable
+        data={rows}
+        columns={[
+          {
+            label: "Name",
+            getter: (r: any) =>
+              r.missing ? (
+                <span>
+                  {r.name} <StatusLabel status="error">MISSING</StatusLabel>
+                </span>
+              ) : (
+                <Link
+                  routeName="mcpservers-detail"
+                  params={{ namespace: "azureclaw-system", name: r.name }}
+                >
+                  {r.name}
+                </Link>
+              ),
+          },
+          { label: "Phase", getter: (r: any) => phaseChip(r.phase, r.reason) },
+          { label: "Tools", getter: (r: any) => r.tools },
+          { label: "JWKS digest", getter: (r: any) => shortDigest(r.digest) },
+        ]}
+      />
     </SectionBox>
   );
 }
@@ -1096,6 +1209,8 @@ function SandboxExtras({ item }: { item: KubeObject }) {
           />
         </SectionBox>
       )}
+
+      <McpServerFleetCard refs={mcpRefs} />
 
       <SandboxEgressApprovalsCard sandboxName={name} sandboxNamespace={namespace} />
 


### PR DESCRIPTION
Picks up the two nice-to-haves from the well-oiled-machine honest audit.

## Headlamp polish

**Reason-aware status chip.** `phaseToStatus(phase, reason)` now inspects
the `Ready` condition's reason. Hard failures render **red**:
`SignatureMismatch`, `BundleVerifyFailed`, `AuthMisconfigured`,
`MemoryStoreMissing`, `RuntimeAdapterMissing`, `ShapeInvalid`,
`AllowlistDrift`, `PolicyCompileFailed`. Awaiting reasons render
**amber**: `AwaitingRouterEnforcement`, `AwaitingFoundryProvisioning`,
`NoSandboxesReferencing`, `Pending`. The reason is rendered as a muted
secondary label next to the phase chip so operators see both at a glance.

Before: amber `[Degraded]` chip on every non-green CRD — could be
'signature failed', 'compiled but router-drifted', or 'just settling'.
After: red `[Degraded] SignatureMismatch` vs. amber
`[Pending] AwaitingRouterEnforcement` — operator action vs. patience.

**McpServerFleetCard.** New section on the ClawSandbox detail pane that
iterates `spec.mcpServerRefs[]` and renders per-server **phase chip +
reason + JWKS digest + tool count**, plus a `MISSING` chip when a ref
points at a non-existent CR. Replaces the single detail-link in 'Related
Resources' for the multi-MCP case.

## Memory Store docs honesty pass

The module-doc in `claw_memory_reconciler.rs` was still claiming
`AuthMisconfigured` emission and auto-provisioning were 'deferred to
Slice 3b+'. Both shipped:
- **Slice 3b.4**: `AuthMisconfigured` Degraded reason from router 403 echo.
- **Slice 3b.5**: `MemoryStoreMissing` Degraded reason from router 404 echo.
- **Slice 3c.1**: router auto-creates the Memory Store on first 404
  (`inference-router/src/mcp/platform.rs :: ensure_memory_store` + 5 tests).

`docs/api/crd-reference.md §ClawMemory` rewritten with the real split:
controller does **not** provision the Foundry account/project (operator
/ `azure-prepare` job), but the router auto-creates the Memory Store
*inside* a provisioned project on first 404. The three Degraded reasons
the reconciler surfaces (`AwaitingFoundryProvisioning`,
`MemoryStoreMissing`, `AuthMisconfigured`) are now documented inline.

## README

`tools/headlamp-plugin/README.md` known-gaps note retracted — both gaps
just got filled.

## Verification

- `cargo check --package azureclaw-controller` ✅
- `npm run build` in `tools/headlamp-plugin` ✅ (vite + tsc clean)
- No behavior changes outside the plugin chip + docs.