### PR TITLE
chore: scrub stale amitayks/agentmesh comment from openclaw runtime

### DIFF
--- a/runtimes/openclaw/src/index.ts
+++ b/runtimes/openclaw/src/index.ts
@@ -134,7 +134,7 @@ export { routerBase, routerWsBase, routerUrl, routerWsUrl };
 export { redactSecrets };
 
 // ---------------------------------------------------------------------------
-// AGT SDK — AgentMesh (amitayks/agentmesh)
+// AGT (Microsoft Agent Governance Toolkit) — `@microsoft/agent-governance-sdk`
 // Full E2E encrypted inter-agent communication via self-hosted relay/registry.
 // Also: tool-level policy, trust scoring, audit logging.
 // Infrastructure controls (NetworkPolicy, token budgets) stay in Rust router.


### PR DESCRIPTION
Tiny follow-up to #328. The `runtimes/openclaw/src/index.ts` header comment still said `// AGT SDK — AgentMesh (amitayks/agentmesh)` even though the runtime hasn't imported `@agentmesh/sdk` since Phase 5.2 (see CHANGELOG entry: "The OpenClaw runtime and mesh-plugin no longer depend on @agentmesh/sdk"). Updated to name the actual SDK we ship with: `@microsoft/agent-governance-sdk`.

No code paths change.