### PR TITLE
feat(observability): mesh metrics + Headlamp plugin v0.5.1 + Grafana ops dashboard

### DIFF
--- a/.github/skills/agt-e2e-encryption/SKILL.md
+++ b/.github/skills/agt-e2e-encryption/SKILL.md
@@ -62,3 +62,31 @@ All originally fixed via patches in `vendor/` (removed in 2026-05). Listed here 
 - KNOCK handler evaluates peer trust score via registry lookup
 - Anonymous agents (no OAuth) have score 0 — fail open when registry lookup fails
 - Verified agents (Tier 1, GitHub OAuth) have score 600+
+
+## Mesh-message metrics
+
+The inference router exports two Prometheus counters that the
+Headlamp Mesh Topology and operator-CLI topology use:
+
+- `azureclaw_mesh_messages_sent_total`
+- `azureclaw_mesh_messages_received_total`
+
+Defined in `inference-router/src/metrics.rs` (`AGT_MESH_MESSAGES_*`) and
+incremented in `inference-router/src/routes/mesh.rs` next to the
+atomic `MeshMetrics::messages_{sent,received}` counters. The
+`sandbox=<name>` label is added at scrape time by
+`deploy/monitoring/podmonitor-sandbox-router.yaml`.
+
+**Counted**: KNOCK frames, X3DH bundle exchange, each `mesh_send`
+call, explicit `sendHeartbeat()` ticks (every 30 s, scheduled from
+`mesh-plugin/src/agt-transport.ts` — vanilla AGT doesn't auto-heartbeat).
+
+**Not counted**: WebSocket Ping/Pong keepalives (short-circuited with
+`continue` before the counter increments), and registry HTTP calls
+(`/v1/agents/...`, `/v1/agents/{did}/heartbeat`) which go over HTTP,
+not the WS relay.
+
+**Why sent ≫ received early on**: a fresh sandbox emits ≥ 1 KNOCK
+per known peer plus a 30 s heartbeat tick, but only receives back
+the relay's KNOCK-ack until a real bidirectional conversation
+starts. Counters live in the router process and **reset on pod restart**.

--- a/cli/src/commands/dev/local-k8s.ts
+++ b/cli/src/commands/dev/local-k8s.ts
@@ -1341,12 +1341,29 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
   await installAzureclawPlugin(tools, opts.clusterName);
   stepper.done("AzureClaw plugin installed");
 
+  // Phase 5b: Prometheus + Grafana stack so the Headlamp plugin's
+  // metric panels (mesh topology msg counts, token budgets, AGT decisions,
+  // policy bundle health) have data on first run — no manual helm dance.
+  stepper.step("Installing Prometheus + Grafana stack…");
+  await installPrometheus(tools, opts.clusterName);
+  stepper.done("Prometheus + Grafana installed");
+
   // Open Headlamp in the user's browser. Port-forward runs detached so
   // it survives the CLI command exiting; user kills it via `azureclaw dev down`
   // (Phase 6) or `pkill -f 'port-forward.*headlamp'`.
   const headlampPort = 4466;
   const headlampUrl = `http://localhost:${headlampPort}/`;
   await startHeadlampPortForward(tools, headlampPort);
+
+  // Grafana + Prometheus port-forwards so the Headlamp plugin embeds work
+  // out of the box. Grafana is exposed at :3000 (anonymous Viewer, allow_embedding
+  // enabled in the chart values below). Prometheus at :19091 for ad-hoc PromQL.
+  const grafanaPort = 3000;
+  const grafanaUrl = `http://localhost:${grafanaPort}/`;
+  const prometheusPort = 19091;
+  const prometheusUrl = `http://localhost:${prometheusPort}/`;
+  await startMonitoringPortForwards(tools, grafanaPort, prometheusPort);
+
   await openBrowser(headlampUrl);
 
   console.log("");
@@ -1356,6 +1373,16 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
   console.log(`    ${chalk.cyan(headlampUrl)}  (token printed below)`);
   console.log("");
   await printHeadlampToken(tools);
+  console.log("");
+  console.log(chalk.bold("  Observability stack:"));
+  console.log(`    Grafana:    ${chalk.cyan(grafanaUrl)}   (anonymous Viewer)`);
+  console.log(`    Prometheus: ${chalk.cyan(prometheusUrl)}`);
+  console.log(
+    chalk.dim(
+      `    Default dashboards: 'AzureClaw — Sandbox Fleet Overview' (uid azureclaw-fleet)\n` +
+        `                        'AzureClaw — Agent Fleet Operations' (uid azureclaw-ops)`,
+    ),
+  );
   console.log("");
 
   // ── Phase 9: auto-create sandbox + WebUI port-forward ─────────────
@@ -1526,6 +1553,280 @@ async function installHeadlamp(tools: Tooling, clusterName: string): Promise<voi
   // Headlamp's Helm chart already creates a ClusterRoleBinding 'headlamp-admin'
   // that binds the 'headlamp' ServiceAccount to cluster-admin, so we don't
   // need to create our own. We just need to mint tokens against that SA.
+}
+
+/**
+ * Install kube-prometheus-stack + apply our PodMonitor/json-exporter/dashboard
+ * manifests so observability is wired end-to-end on first run. Mirrors the
+ * Headlamp pattern (helm template → kubectl apply, idempotent).
+ *
+ * Defaults are tuned for a kind cluster:
+ *   - AlertManager off (no UI, no PVC)
+ *   - 2d retention (kind disks are ephemeral anyway)
+ *   - Grafana: anonymous Viewer + allow_embedding so the Headlamp iframe
+ *     works without auth
+ *   - podMonitorSelectorNilUsesHelmValues=false so our PodMonitor is
+ *     discovered without label gymnastics
+ *
+ * The chart version is pinned for reproducibility. The matching Headlamp
+ * plugin (tools/headlamp-plugin) reads
+ *   azureclaw_mesh_messages_{sent,received}_total
+ *   azureclaw_tokens_total
+ *   azureclaw_agt_policy_evaluations_total
+ *   agentmesh_relay_*
+ * which all light up once the PodMonitor + json-exporter manifests below
+ * are applied.
+ */
+async function installPrometheus(tools: Tooling, clusterName: string): Promise<void> {
+  const ctx = `kind-${clusterName}`;
+
+  // Ensure namespace exists + has the labels the sandbox NetworkPolicy
+  // ingress allows scraping from (app.kubernetes.io/name=azureclaw,
+  // component=system). Without these labels kindnet would block the
+  // PodMonitor scrape on :8443.
+  try {
+    await execa(tools.kubectl, ["--context", ctx, "create", "namespace", "monitoring"]);
+  } catch {
+    // already exists — fine
+  }
+  await execa(tools.kubectl, [
+    "--context",
+    ctx,
+    "label",
+    "namespace",
+    "monitoring",
+    "app.kubernetes.io/name=azureclaw",
+    "app.kubernetes.io/component=system",
+    "--overwrite",
+  ]);
+
+  // Add the prometheus-community helm repo (idempotent).
+  try {
+    await execa(tools.helm, [
+      "repo",
+      "add",
+      "prometheus-community",
+      "https://prometheus-community.github.io/helm-charts",
+    ]);
+  } catch {
+    // already added — fine
+  }
+  await execa(tools.helm, ["repo", "update", "prometheus-community"]);
+
+  // Write a tmp values file — kube-prometheus-stack has nested keys with
+  // dots ("grafana.ini") that are painful to express via --set. Yaml is
+  // clearer and survives chart upgrades.
+  const valuesYaml = `
+alertmanager:
+  enabled: false
+
+prometheus:
+  prometheusSpec:
+    retention: 2d
+    # Pick up PodMonitors created elsewhere in the cluster (our deploy/monitoring/*.yaml)
+    podMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+
+grafana:
+  adminPassword: admin
+  defaultDashboardsTimezone: browser
+  service:
+    type: ClusterIP
+  grafana.ini:
+    auth.anonymous:
+      enabled: true
+      org_role: Viewer
+    security:
+      allow_embedding: true
+      cookie_samesite: none
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: ALL
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+# Trim down for kind — full kube-state-metrics + node-exporter are kept
+# because the in-image Grafana dashboards reference them.
+defaultRules:
+  create: false
+
+kubeApiServer:
+  enabled: true
+kubelet:
+  enabled: true
+kubeControllerManager:
+  enabled: false
+coreDns:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+`.trimStart();
+
+  const KPS_CHART_VERSION = "85.3.3";
+  const tmpdir = mkdtempSync(path.join(os.tmpdir(), "azureclaw-kps-"));
+  const valuesPath = path.join(tmpdir, "values.yaml");
+  writeFileSync(valuesPath, valuesYaml);
+
+  try {
+    const { stdout } = await execa(tools.helm, [
+      "template",
+      "kps",
+      "prometheus-community/kube-prometheus-stack",
+      "--version",
+      KPS_CHART_VERSION,
+      "--namespace",
+      "monitoring",
+      "--include-crds",
+      "--values",
+      valuesPath,
+    ]);
+    await execa(
+      tools.kubectl,
+      [
+        "--context",
+        ctx,
+        "apply",
+        "-f",
+        "-",
+        "--server-side",
+        "--force-conflicts",
+      ],
+      { input: stdout, stdio: ["pipe", "inherit", "inherit"] },
+    );
+  } finally {
+    try {
+      rmSync(tmpdir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+
+  // Wait for Grafana to be ready (best-effort 180s — kube-prometheus-stack
+  // pulls several images on first install). Don't fail the whole dev
+  // command if it overruns; the Operator may still be reconciling Prometheus.
+  try {
+    await execa(
+      tools.kubectl,
+      [
+        "--context",
+        ctx,
+        "rollout",
+        "status",
+        "deployment/kps-grafana",
+        "-n",
+        "monitoring",
+        "--timeout=180s",
+      ],
+      { stdio: "inherit" },
+    );
+  } catch {
+    console.warn(
+      chalk.yellow(
+        "  ⚠ Grafana deployment did not become ready within 180s — observability panels may be empty until 'kubectl get pods -n monitoring' shows kps-grafana Ready.",
+      ),
+    );
+  }
+
+  // Apply our AzureClaw-specific monitoring manifests: PodMonitor for
+  // every sandbox router, prometheus-json-exporter for the AGT relay
+  // /health endpoint, and the two Grafana dashboards (fleet + ops).
+  const repoRoot = findRepoRoot(process.cwd());
+  const monitoringDir = path.join(repoRoot, "deploy", "monitoring");
+  for (const f of [
+    "podmonitor-sandbox-router.yaml",
+    "agentmesh-json-exporter.yaml",
+    "grafana-dashboard-configmap.yaml",
+  ]) {
+    const p = path.join(monitoringDir, f);
+    if (!existsSync(p)) {
+      console.warn(chalk.yellow(`  ⚠ missing ${f} — skipping`));
+      continue;
+    }
+    await execa(
+      tools.kubectl,
+      [
+        "--context",
+        ctx,
+        "apply",
+        "-f",
+        p,
+        "--server-side",
+        "--force-conflicts",
+      ],
+      { stdio: "inherit" },
+    );
+  }
+}
+
+/**
+ * Start detached `kubectl port-forward` for Grafana (3000) and Prometheus
+ * (19091) so the Headlamp plugin's iframe + ad-hoc PromQL just work
+ * after `azureclaw dev`. Same kill-existing-then-spawn pattern as the
+ * Headlamp port-forward.
+ */
+async function startMonitoringPortForwards(
+  tools: Tooling,
+  grafanaLocalPort: number,
+  prometheusLocalPort: number,
+): Promise<void> {
+  const { spawn } = await import("node:child_process");
+  const startOne = async (
+    localPort: number,
+    target: string,
+    targetPort: number,
+  ): Promise<void> => {
+    try {
+      const { stdout } = await execa("lsof", ["-ti", `:${localPort}`]);
+      for (const pid of stdout.trim().split(/\s+/).filter(Boolean)) {
+        try {
+          await execa("kill", [pid]);
+        } catch {
+          // process already gone
+        }
+      }
+    } catch {
+      // lsof returns non-zero when nothing matches — fine
+    }
+    const child = spawn(
+      tools.kubectl,
+      [
+        "port-forward",
+        "-n",
+        "monitoring",
+        target,
+        `${localPort}:${targetPort}`,
+      ],
+      {
+        detached: true,
+        stdio: "ignore",
+      },
+    );
+    child.unref();
+  };
+
+  // kps-grafana service is on :80, kps-kube-prometheus-stack-prometheus on :9090.
+  await startOne(grafanaLocalPort, "service/kps-grafana", 80);
+  await startOne(prometheusLocalPort, "service/kps-kube-prometheus-stack-prometheus", 9090);
+
+  // Give the forwards a moment to bind.
+  await new Promise((r) => setTimeout(r, 1500));
 }
 
 /**

--- a/deploy/monitoring/agentmesh-json-exporter.yaml
+++ b/deploy/monitoring/agentmesh-json-exporter.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentmesh-json-exporter-config
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: agentmesh-json-exporter
+data:
+  config.yml: |
+    modules:
+      default:
+        metrics:
+          - name: agentmesh_relay_connected_agents
+            type: value
+            help: Number of agents currently connected to the relay WebSocket
+            path: '{ .connected_agents }'
+          - name: agentmesh_relay_messages_routed_total
+            type: value
+            help: Total messages routed by the relay since startup
+            path: '{ .stats.messages_routed }'
+          - name: agentmesh_relay_messages_stored_total
+            type: value
+            help: Messages stored offline (peer unreachable when sent)
+            path: '{ .stats.messages_stored }'
+          - name: agentmesh_relay_messages_delivered_total
+            type: value
+            help: Stored messages delivered after peer reconnected
+            path: '{ .stats.messages_delivered }'
+          - name: agentmesh_relay_up
+            type: object
+            help: Relay /health status (1=healthy)
+            path: '{ .status }'
+            valuetype: untyped
+            values:
+              healthy: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentmesh-json-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: agentmesh-json-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentmesh-json-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agentmesh-json-exporter
+    spec:
+      containers:
+      - name: exporter
+        image: quay.io/prometheuscommunity/json-exporter:v0.7.0
+        args:
+          - --config.file=/config/config.yml
+        ports:
+        - name: metrics
+          containerPort: 7979
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        resources:
+          limits: {cpu: 100m, memory: 64Mi}
+          requests: {cpu: 10m, memory: 16Mi}
+      volumes:
+      - name: config
+        configMap:
+          name: agentmesh-json-exporter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentmesh-json-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: agentmesh-json-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: agentmesh-json-exporter
+  ports:
+  - name: metrics
+    port: 7979
+    targetPort: 7979
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: agentmesh-relay-health
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: agentmesh-json-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentmesh-json-exporter
+  endpoints:
+  - port: metrics
+    interval: 10s
+    path: /probe
+    params:
+      target:
+        - http://agentmesh-relay.agentmesh.svc:8765/health
+    relabelings:
+    - sourceLabels: [__param_target]
+      targetLabel: target
+    - sourceLabels: [__address__]
+      targetLabel: instance

--- a/deploy/monitoring/dashboards.md
+++ b/deploy/monitoring/dashboards.md
@@ -57,3 +57,46 @@ InsightsMetrics
     Tokens * 0.001 / 1000)
 | summarize TotalCost = sum(CostUSD) by sandbox, model, bin(TimeGenerated, 1d)
 ```
+
+## Mesh message counters
+
+The router exports two `IntCounter` metrics, scraped by the
+`azureclaw-sandbox-router` PodMonitor:
+
+- `azureclaw_mesh_messages_sent_total`
+- `azureclaw_mesh_messages_received_total`
+
+The `sandbox=<name>` label is injected at scrape time (relabel from
+`__meta_kubernetes_pod_label_azureclaw_azure_com_sandbox`). Each
+counter ticks **once per WebSocket frame proxied through the relay**
+(KNOCK, X3DH bundle, encrypted `mesh_send`, and the explicit
+30 s `sendHeartbeat()` tick). WebSocket Ping/Pong keepalives and
+registry HTTP calls (`/v1/agents/...`) are **not** counted.
+
+Counters live in the router process and reset on pod restart.
+A fresh sandbox typically shows `sent ≫ received` because it emits
+≥ 1 KNOCK per known peer + a 30 s heartbeat tick, while inbound is
+just the relay's KNOCK-ack until a real conversation starts.
+
+```promql
+# Per-sandbox sent rate (PromQL)
+sum by (sandbox) (rate(azureclaw_mesh_messages_sent_total[5m]))
+
+# Per-sandbox received rate
+sum by (sandbox) (rate(azureclaw_mesh_messages_received_total[5m]))
+
+# Fleet totals over 24 h
+sum(increase(azureclaw_mesh_messages_sent_total[24h]))
+sum(increase(azureclaw_mesh_messages_received_total[24h]))
+```
+
+For per-peer message attribution (sender→receiver pairs) the Rust
+router currently only exposes this via the in-process atomic
+counters reported on `/agt/status` (`trust_states[].interactions`)
+— there is no Prometheus per-pair metric yet. The Headlamp Mesh
+Topology and operator CLI both fall back to:
+
+1. **Children count** from the `azureclaw.azure.com/parent=<name>`
+   label on sub-agent CRs (deterministic, derived from the K8s API).
+2. **Trust-graph size** = `azureclaw_agt_known_agents` (populates
+   only after live traffic; resets on pod restart).

--- a/deploy/monitoring/grafana-dashboard-azureclaw-fleet.json
+++ b/deploy/monitoring/grafana-dashboard-azureclaw-fleet.json
@@ -1,0 +1,368 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Active sandboxes scraped",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "count(count by (sandbox) (azureclaw_tokens_total{sandbox=~\"$sandbox\"}))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total tokens (all sandboxes, lifetime)",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(azureclaw_tokens_total{sandbox=~\"$sandbox\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "AGT policy evaluations (allow)",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(azureclaw_agt_policy_evaluations_total{decision=\"allow\",sandbox=~\"$sandbox\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "AGT denies / approvals / rate-limited",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(azureclaw_agt_policy_evaluations_total{decision!=\"allow\",sandbox=~\"$sandbox\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "yellow"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "barchart",
+      "title": "Tokens per sandbox (input vs output)",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox, direction) (azureclaw_tokens_total{sandbox=~\"$sandbox\"})",
+          "refId": "A",
+          "legendFormat": "{{sandbox}} / {{direction}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Token rate per sandbox (tokens/sec, 5m avg)",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox) (rate(azureclaw_tokens_total{sandbox=~\"$sandbox\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{sandbox}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "tps"
+        }
+      }
+    },
+    {
+      "type": "barchart",
+      "title": "Tokens per model (cross-sandbox)",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (model, direction) (azureclaw_tokens_total{sandbox=~\"$sandbox\"})",
+          "refId": "A",
+          "legendFormat": "{{model}} / {{direction}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "barchart",
+      "title": "AGT policy decisions per sandbox",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox, decision) (azureclaw_agt_policy_evaluations_total{sandbox=~\"$sandbox\"})",
+          "refId": "A",
+          "legendFormat": "{{sandbox}} / {{decision}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Policy bundle health (1=healthy)",
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "azureclaw_policy_bundle_healthy{sandbox=~\"$sandbox\"}",
+          "refId": "A",
+          "legendFormat": "{{sandbox}} / {{kind}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "AGT eval latency p99 (per sandbox)",
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (sandbox, le) (rate(azureclaw_agt_eval_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "{{sandbox}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "azureclaw"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "sandbox",
+        "label": "Sandbox",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(azureclaw_tokens_total, sandbox)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        }
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "AzureClaw \u2014 Sandbox Fleet Overview",
+  "uid": "azureclaw-fleet",
+  "version": 1
+}

--- a/deploy/monitoring/grafana-dashboard-azureclaw-ops.json
+++ b/deploy/monitoring/grafana-dashboard-azureclaw-ops.json
@@ -1,0 +1,1421 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "type": "row",
+      "id": 100,
+      "title": "\ud83e\ude7a  Fleet Health \u2014 Single Pane of Glass",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Active sandboxes",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "count(count by (sandbox) (azureclaw_inference_requests_total{sandbox=~\"$sandbox\"}))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Requests / sec (5m)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(azureclaw_inference_requests_total{sandbox=~\"$sandbox\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Error rate (5m)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(azureclaw_inference_requests_total{status!=\"ok\",sandbox=~\"$sandbox\"}[5m])) / clamp_min(sum(rate(azureclaw_inference_requests_total{sandbox=~\"$sandbox\"}[5m])), 1) * 100",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "P95 inference latency",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(azureclaw_inference_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m])))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1.2
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Tokens (last 24h)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(azureclaw_tokens_total{sandbox=~\"$sandbox\"}[24h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Est. cost 24h (USD)",
+      "description": "Indicative only \u2014 uses $price_input_per_1k / $price_output_per_1k dashboard variables. Adjust to your contract.",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "(sum(increase(azureclaw_tokens_total{direction=\"input\",sandbox=~\"$sandbox\"}[24h])) / 1000) * $price_input_per_1k + (sum(increase(azureclaw_tokens_total{direction=\"output\",sandbox=~\"$sandbox\"}[24h])) / 1000) * $price_output_per_1k",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "row",
+      "id": 200,
+      "title": "\ud83d\udcb0  Token & Cost Economy",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokens / sec \u2014 stacked by sandbox",
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 0,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox) (rate(azureclaw_tokens_total{sandbox=~\"$sandbox\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{sandbox}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "stacking": {
+              "mode": "normal"
+            },
+            "lineWidth": 1
+          }
+        }
+      }
+    },
+    {
+      "type": "table",
+      "title": "Top spenders \u2014 input vs output (selected range)",
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 14,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox) (increase(azureclaw_tokens_total{direction=\"input\",sandbox=~\"$sandbox\"}[$__range]))",
+          "refId": "A",
+          "format": "table",
+          "instant": true,
+          "interval": "1m"
+        },
+        {
+          "expr": "sum by (sandbox) (increase(azureclaw_tokens_total{direction=\"output\",sandbox=~\"$sandbox\"}[$__range]))",
+          "refId": "B",
+          "format": "table",
+          "instant": true,
+          "interval": "1m"
+        },
+        {
+          "expr": "(sum by (sandbox) (increase(azureclaw_tokens_total{direction=\"input\",sandbox=~\"$sandbox\"}[$__range])) / 1000) * $price_input_per_1k + (sum by (sandbox) (increase(azureclaw_tokens_total{direction=\"output\",sandbox=~\"$sandbox\"}[$__range])) / 1000) * $price_output_per_1k",
+          "refId": "C",
+          "format": "table",
+          "instant": true,
+          "interval": "1m"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "sandbox",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
+            "renameByName": {
+              "Value #A": "Input tokens",
+              "Value #B": "Output tokens",
+              "Value #C": "Est. $",
+              "sandbox": "Sandbox"
+            },
+            "indexByName": {
+              "Sandbox": 0,
+              "Input tokens": 1,
+              "Output tokens": 2,
+              "Est. $": 3
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Input tokens",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Input tokens"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient",
+                  "valueDisplayMode": "color"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Output tokens"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient",
+                  "valueDisplayMode": "color"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Est. $"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              },
+              {
+                "id": "decimals",
+                "value": 4
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": true,
+          "reducer": [
+            "sum"
+          ],
+          "fields": [
+            "Input tokens",
+            "Output tokens",
+            "Est. $"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cost burn-rate ($/hr) vs hourly budget",
+      "description": "Derived from $price_input/$price_output dashboard vars. Horizontal line = hourly_budget_usd.",
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 0,
+        "y": 15
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(azureclaw_tokens_total{direction=\"input\",sandbox=~\"$sandbox\"}[5m])) * 3600 / 1000 * $price_input_per_1k + sum(rate(azureclaw_tokens_total{direction=\"output\",sandbox=~\"$sandbox\"}[5m])) * 3600 / 1000 * $price_output_per_1k",
+          "refId": "A",
+          "legendFormat": "current $/hr"
+        },
+        {
+          "expr": "vector($hourly_budget_usd)",
+          "refId": "B",
+          "legendFormat": "hourly budget"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        }
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Tokens per sandbox (selected range)",
+      "description": "Bar gauges per sandbox, sized by total tokens consumed in the selected time range. Hover for input vs output breakdown.",
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 14,
+        "y": 15
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox) (increase(azureclaw_tokens_total{sandbox=~\"$sandbox\"}[$__range]))",
+          "refId": "A",
+          "instant": true,
+          "legendFormat": "{{sandbox}}"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "valueMode": "color",
+        "minVizWidth": 0,
+        "minVizHeight": 16,
+        "namePlacement": "auto",
+        "sizing": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "id": 300,
+      "title": "\u26a1  Latency & Throughput SLO",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Inference latency \u2014 P50 / P95 / P99",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(azureclaw_inference_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(azureclaw_inference_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(azureclaw_inference_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m])))",
+          "refId": "C",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        }
+      }
+    },
+    {
+      "type": "heatmap",
+      "title": "Latency heatmap (all models)",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (le) (rate(azureclaw_inference_latency_seconds_bucket{sandbox=~\"$sandbox\"}[1m]))",
+          "refId": "A",
+          "format": "heatmap",
+          "legendFormat": "{{le}}"
+        }
+      ],
+      "options": {
+        "yAxis": {
+          "unit": "s"
+        },
+        "color": {
+          "mode": "scheme",
+          "scheme": "Spectral",
+          "steps": 64
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests / sec \u2014 by status",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(azureclaw_inference_requests_total{sandbox=~\"$sandbox\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "P95 latency per sandbox",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (sandbox, le) (rate(azureclaw_inference_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "{{sandbox}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 2
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "id": 400,
+      "title": "\ud83d\udee1\ufe0f  Governance, Safety & Compliance",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "AGT policy decisions over time",
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 0,
+        "y": 43
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (decision) (rate(azureclaw_agt_policy_evaluations_total{sandbox=~\"$sandbox\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{decision}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "stacking": {
+              "mode": "normal"
+            },
+            "lineWidth": 1
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "allow"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "deny"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "approval"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rate_limit"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "piechart",
+      "title": "Decision mix",
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 14,
+        "y": 43
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (decision) (azureclaw_agt_policy_evaluations_total{sandbox=~\"$sandbox\"})",
+          "refId": "A",
+          "legendFormat": "{{decision}}"
+        }
+      ],
+      "options": {
+        "pieType": "pie",
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "allow"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "deny"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "approval"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "table",
+      "title": "Top sandboxes by deny rate (last 1h)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (sandbox) (rate(azureclaw_agt_policy_evaluations_total{decision=\"deny\",sandbox=~\"$sandbox\"}[1h])) / clamp_min(sum by (sandbox) (rate(azureclaw_agt_policy_evaluations_total{sandbox=~\"$sandbox\"}[1h])), 1e-9))",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.001
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "custom": {
+            "cellOptions": {
+              "type": "color-background",
+              "mode": "gradient"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "AGT eval latency P50/P95/P99 (\u00b5s)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(azureclaw_agt_eval_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m]))) * 1e6",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(azureclaw_agt_eval_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m]))) * 1e6",
+          "refId": "B",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(azureclaw_agt_eval_latency_seconds_bucket{sandbox=~\"$sandbox\"}[5m]))) * 1e6",
+          "refId": "C",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Behavior alerts (active)",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(azureclaw_agt_behavior_alerts_total{sandbox=~\"$sandbox\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Audit entries (24h)",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(azureclaw_agt_audit_entries_total{sandbox=~\"$sandbox\"}[24h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Policy rules loaded",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(azureclaw_agt_policy_rules{sandbox=~\"$sandbox\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Known mesh agents",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(azureclaw_agt_known_agents{sandbox=~\"$sandbox\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "teal"
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "id": 500,
+      "title": "\ud83c\udf10  Bundle Health & Operational Hygiene",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "title": "Policy bundle health matrix (sandbox \u00d7 kind)",
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 66
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "azureclaw_policy_bundle_healthy{sandbox=~\"$sandbox\"}",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "pod": true,
+              "sandbox_namespace": true
+            }
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "kind",
+            "rowField": "sandbox",
+            "valueField": "Value"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "cellOptions": {
+              "type": "color-background"
+            },
+            "align": "center"
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "\u2716 UNHEALTHY",
+                  "color": "red",
+                  "index": 0
+                },
+                "1": {
+                  "text": "\u2713 healthy",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Bundle reloads / hour",
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 14,
+        "y": 66
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox, kind) (rate(azureclaw_policy_bundle_reload_total{sandbox=~\"$sandbox\"}[1h])) * 3600",
+          "refId": "A",
+          "legendFormat": "{{sandbox}} / {{kind}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokens / sec per sandbox \u2014 input (above) vs output (below, negated)",
+      "description": "Stream-style chart: input plotted positive, output plotted negative for visual contrast.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (sandbox) (rate(azureclaw_tokens_total{direction=\"input\",sandbox=~\"$sandbox\"}[1m]))",
+          "refId": "A",
+          "legendFormat": "{{sandbox}} in"
+        },
+        {
+          "expr": "-sum by (sandbox) (rate(azureclaw_tokens_total{direction=\"output\",sandbox=~\"$sandbox\"}[1m]))",
+          "refId": "B",
+          "legendFormat": "{{sandbox}} out"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "lineWidth": 1,
+            "spanNulls": true
+          }
+        }
+      }
+    },
+    {
+      "type": "text",
+      "title": "\ud83d\udd78\ufe0f  Mesh Topology \u2014 now in Headlamp",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 83
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "The live mesh-topology view (agents \u2194 relay, with per-agent \u2191sent / \u2193received counts, animated pulses, and parent\u2192sub-agent hierarchy) lives in the **AzureClaw Headlamp plugin** (*sidebar \u2192 AzureClaw \u2192 Mesh Topology*).\n\nUnderlying Prometheus metrics (still queryable here): `azureclaw_mesh_messages_sent_total`, `azureclaw_mesh_messages_received_total`, `azureclaw_agt_known_agents`, `agentmesh_relay_{connected_agents,messages_routed_total,messages_stored_total,messages_delivered_total}`."
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "azureclaw",
+    "ops"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "sandbox",
+        "label": "Sandbox",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(azureclaw_tokens_total, sandbox)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "price_input_per_1k",
+        "label": "$ / 1k input tokens",
+        "type": "constant",
+        "query": "0.005",
+        "current": {
+          "text": "0.005",
+          "value": "0.005"
+        },
+        "hide": 0
+      },
+      {
+        "name": "price_output_per_1k",
+        "label": "$ / 1k output tokens",
+        "type": "constant",
+        "query": "0.015",
+        "current": {
+          "text": "0.015",
+          "value": "0.015"
+        },
+        "hide": 0
+      },
+      {
+        "name": "hourly_budget_usd",
+        "label": "$ / hour budget",
+        "type": "constant",
+        "query": "5",
+        "current": {
+          "text": "5",
+          "value": "5"
+        },
+        "hide": 0
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "AzureClaw \u2014 Agent Fleet Operations",
+  "uid": "azureclaw-ops",
+  "version": 2
+}

--- a/deploy/monitoring/grafana-dashboard-configmap.yaml
+++ b/deploy/monitoring/grafana-dashboard-configmap.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+data:
+  azureclaw-fleet.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Active sandboxes scraped",
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "count(count by (sandbox) (azureclaw_tokens_total))", "refId": "A"}],
+          "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "blue"}]}}}
+        },
+        {
+          "type": "stat",
+          "title": "Total tokens (all sandboxes, lifetime)",
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "sum(azureclaw_tokens_total)", "refId": "A"}],
+          "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green"}]}}}
+        },
+        {
+          "type": "stat",
+          "title": "AGT policy evaluations (allow)",
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "sum(azureclaw_agt_policy_evaluations_total{decision=\"allow\"})", "refId": "A"}],
+          "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green"}]}}}
+        },
+        {
+          "type": "stat",
+          "title": "AGT denies / approvals / rate-limited",
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "sum(azureclaw_agt_policy_evaluations_total{decision!=\"allow\"})", "refId": "A"}],
+          "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "yellow"}, {"color": "red", "value": 1}]}}}
+        },
+        {
+          "type": "barchart",
+          "title": "Tokens per sandbox (input vs output)",
+          "gridPos": {"h": 9, "w": 12, "x": 0, "y": 4},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "sum by (sandbox, direction) (azureclaw_tokens_total)", "refId": "A", "legendFormat": "{{sandbox}} / {{direction}}"}
+          ],
+          "fieldConfig": {"defaults": {"unit": "short"}}
+        },
+        {
+          "type": "timeseries",
+          "title": "Token rate per sandbox (tokens/sec, 5m avg)",
+          "gridPos": {"h": 9, "w": 12, "x": 12, "y": 4},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "sum by (sandbox) (rate(azureclaw_tokens_total[5m]))", "refId": "A", "legendFormat": "{{sandbox}}"}
+          ],
+          "fieldConfig": {"defaults": {"unit": "tps"}}
+        },
+        {
+          "type": "barchart",
+          "title": "Tokens per model (cross-sandbox)",
+          "gridPos": {"h": 9, "w": 12, "x": 0, "y": 13},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "sum by (model, direction) (azureclaw_tokens_total)", "refId": "A", "legendFormat": "{{model}} / {{direction}}"}
+          ],
+          "fieldConfig": {"defaults": {"unit": "short"}}
+        },
+        {
+          "type": "barchart",
+          "title": "AGT policy decisions per sandbox",
+          "gridPos": {"h": 9, "w": 12, "x": 12, "y": 13},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "sum by (sandbox, decision) (azureclaw_agt_policy_evaluations_total)", "refId": "A", "legendFormat": "{{sandbox}} / {{decision}}"}
+          ],
+          "fieldConfig": {"defaults": {"unit": "short"}}
+        },
+        {
+          "type": "stat",
+          "title": "Policy bundle health (1=healthy)",
+          "gridPos": {"h": 5, "w": 12, "x": 0, "y": 22},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "azureclaw_policy_bundle_healthy", "refId": "A", "legendFormat": "{{sandbox}} / {{kind}}"}
+          ],
+          "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "red"}, {"color": "green", "value": 1}]}}}
+        },
+        {
+          "type": "timeseries",
+          "title": "AGT eval latency p99 (per sandbox)",
+          "gridPos": {"h": 5, "w": 12, "x": 12, "y": 22},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "histogram_quantile(0.99, sum by (sandbox, le) (rate(azureclaw_agt_eval_latency_seconds_bucket[5m])))", "refId": "A", "legendFormat": "{{sandbox}}"}
+          ],
+          "fieldConfig": {"defaults": {"unit": "s"}}
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 39,
+      "tags": ["azureclaw"],
+      "templating": {"list": []},
+      "time": {"from": "now-1h", "to": "now"},
+      "timepicker": {},
+      "timezone": "",
+      "title": "AzureClaw — Sandbox Fleet Overview",
+      "uid": "azureclaw-fleet",
+      "version": 1
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"azureclaw-fleet.json":"{\n  \"annotations\": {\"list\": []},\n  \"editable\": true,\n  \"fiscalYearStartMonth\": 0,\n  \"graphTooltip\": 0,\n  \"id\": null,\n  \"links\": [],\n  \"liveNow\": false,\n  \"panels\": [\n    {\n      \"type\": \"stat\",\n      \"title\": \"Active sandboxes scraped\",\n      \"gridPos\": {\"h\": 4, \"w\": 6, \"x\": 0, \"y\": 0},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [{\"expr\": \"count(count by (sandbox) (azureclaw_tokens_total))\", \"refId\": \"A\"}],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"short\", \"color\": {\"mode\": \"thresholds\"}, \"thresholds\": {\"steps\": [{\"color\": \"blue\"}]}}}\n    },\n    {\n      \"type\": \"stat\",\n      \"title\": \"Total tokens (all sandboxes, lifetime)\",\n      \"gridPos\": {\"h\": 4, \"w\": 6, \"x\": 6, \"y\": 0},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [{\"expr\": \"sum(azureclaw_tokens_total)\", \"refId\": \"A\"}],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"short\", \"color\": {\"mode\": \"thresholds\"}, \"thresholds\": {\"steps\": [{\"color\": \"green\"}]}}}\n    },\n    {\n      \"type\": \"stat\",\n      \"title\": \"AGT policy evaluations (allow)\",\n      \"gridPos\": {\"h\": 4, \"w\": 6, \"x\": 12, \"y\": 0},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [{\"expr\": \"sum(azureclaw_agt_policy_evaluations_total{decision=\\\"allow\\\"})\", \"refId\": \"A\"}],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"short\", \"color\": {\"mode\": \"thresholds\"}, \"thresholds\": {\"steps\": [{\"color\": \"green\"}]}}}\n    },\n    {\n      \"type\": \"stat\",\n      \"title\": \"AGT denies / approvals / rate-limited\",\n      \"gridPos\": {\"h\": 4, \"w\": 6, \"x\": 18, \"y\": 0},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [{\"expr\": \"sum(azureclaw_agt_policy_evaluations_total{decision!=\\\"allow\\\"})\", \"refId\": \"A\"}],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"short\", \"color\": {\"mode\": \"thresholds\"}, \"thresholds\": {\"steps\": [{\"color\": \"yellow\"}, {\"color\": \"red\", \"value\": 1}]}}}\n    },\n    {\n      \"type\": \"barchart\",\n      \"title\": \"Tokens per sandbox (input vs output)\",\n      \"gridPos\": {\"h\": 9, \"w\": 12, \"x\": 0, \"y\": 4},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [\n        {\"expr\": \"sum by (sandbox, direction) (azureclaw_tokens_total)\", \"refId\": \"A\", \"legendFormat\": \"{{sandbox}} / {{direction}}\"}\n      ],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"short\"}}\n    },\n    {\n      \"type\": \"timeseries\",\n      \"title\": \"Token rate per sandbox (tokens/sec, 5m avg)\",\n      \"gridPos\": {\"h\": 9, \"w\": 12, \"x\": 12, \"y\": 4},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [\n        {\"expr\": \"sum by (sandbox) (rate(azureclaw_tokens_total[5m]))\", \"refId\": \"A\", \"legendFormat\": \"{{sandbox}}\"}\n      ],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"tps\"}}\n    },\n    {\n      \"type\": \"barchart\",\n      \"title\": \"Tokens per model (cross-sandbox)\",\n      \"gridPos\": {\"h\": 9, \"w\": 12, \"x\": 0, \"y\": 13},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [\n        {\"expr\": \"sum by (model, direction) (azureclaw_tokens_total)\", \"refId\": \"A\", \"legendFormat\": \"{{model}} / {{direction}}\"}\n      ],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"short\"}}\n    },\n    {\n      \"type\": \"barchart\",\n      \"title\": \"AGT policy decisions per sandbox\",\n      \"gridPos\": {\"h\": 9, \"w\": 12, \"x\": 12, \"y\": 13},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [\n        {\"expr\": \"sum by (sandbox, decision) (azureclaw_agt_policy_evaluations_total)\", \"refId\": \"A\", \"legendFormat\": \"{{sandbox}} / {{decision}}\"}\n      ],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"short\"}}\n    },\n    {\n      \"type\": \"stat\",\n      \"title\": \"Policy bundle health (1=healthy)\",\n      \"gridPos\": {\"h\": 5, \"w\": 12, \"x\": 0, \"y\": 22},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [\n        {\"expr\": \"azureclaw_policy_bundle_healthy\", \"refId\": \"A\", \"legendFormat\": \"{{sandbox}} / {{kind}}\"}\n      ],\n      \"fieldConfig\": {\"defaults\": {\"color\": {\"mode\": \"thresholds\"}, \"thresholds\": {\"steps\": [{\"color\": \"red\"}, {\"color\": \"green\", \"value\": 1}]}}}\n    },\n    {\n      \"type\": \"timeseries\",\n      \"title\": \"AGT eval latency p99 (per sandbox)\",\n      \"gridPos\": {\"h\": 5, \"w\": 12, \"x\": 12, \"y\": 22},\n      \"datasource\": {\"type\": \"prometheus\", \"uid\": \"prometheus\"},\n      \"targets\": [\n        {\"expr\": \"histogram_quantile(0.99, sum by (sandbox, le) (rate(azureclaw_agt_eval_latency_seconds_bucket[5m])))\", \"refId\": \"A\", \"legendFormat\": \"{{sandbox}}\"}\n      ],\n      \"fieldConfig\": {\"defaults\": {\"unit\": \"s\"}}\n    }\n  ],\n  \"refresh\": \"10s\",\n  \"schemaVersion\": 39,\n  \"tags\": [\"azureclaw\"],\n  \"templating\": {\"list\": []},\n  \"time\": {\"from\": \"now-1h\", \"to\": \"now\"},\n  \"timepicker\": {},\n  \"timezone\": \"\",\n  \"title\": \"AzureClaw — Sandbox Fleet Overview\",\n  \"uid\": \"azureclaw-fleet\",\n  \"version\": 1\n}\n"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"grafana_dashboard":"1"},"name":"azureclaw-fleet-dashboard","namespace":"monitoring"}}
+  labels:
+    grafana_dashboard: "1"
+  name: azureclaw-fleet-dashboard

--- a/deploy/monitoring/podmonitor-sandbox-router.yaml
+++ b/deploy/monitoring/podmonitor-sandbox-router.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: azureclaw-sandbox-router
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: azureclaw
+    release: kps
+spec:
+  # Scrape every azureclaw sandbox pod across all azureclaw-* namespaces.
+  # The router /metrics is on port 8443 (HTTP, cluster-internal — the
+  # TLS-terminating ingress is loopback-only).
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      azureclaw.azure.com/component: sandbox
+  podMetricsEndpoints:
+    - port: inference        # container port name on the router container
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      scheme: http
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_label_azureclaw_azure_com_sandbox]
+          targetLabel: sandbox
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: sandbox_namespace

--- a/docs/internal/security-audits/2026-05-26-observability-bundle.md
+++ b/docs/internal/security-audits/2026-05-26-observability-bundle.md
@@ -1,0 +1,138 @@
+# Security Audit — observability bundle (mesh metrics + Prometheus dev bundle)
+
+**Scope**: PR #338 — `feat/observability-bundle`. Adds Prometheus
+counters for mesh traffic in the inference-router, bundles
+kube-prometheus-stack into `azureclaw dev` local-k8s, and ships the
+Headlamp plugin v0.5.1 + Grafana ops dashboard.
+
+Two paths trip the capability-introducing file list:
+
+- `inference-router/src/routes/mesh.rs`
+- `cli/src/commands/dev/local-k8s.ts`
+
+Both edits are observability-only — neither introduces, removes, or
+weakens a security capability. This audit documents that.
+
+## 1. What changed
+
+### 1a. `inference-router/src/routes/mesh.rs`
+
+Added two `IntCounter` increments inside the existing mesh routes:
+
+```rust
+state.metrics.mesh_messages_sent_total
+    .with_label_values(&[message_type]).inc();
+state.metrics.mesh_messages_received_total
+    .with_label_values(&[message_type]).inc();
+```
+
+`message_type` is one of the existing AGT envelope kinds (`knock`,
+`x3dh`, `mesh_send`, `heartbeat`). The counters are declared in
+`inference-router/src/metrics.rs` and surface on the existing
+`/metrics` Prometheus endpoint that the PodMonitor scrapes.
+
+No new endpoints. No new auth-bypassing surface. No new env vars
+consumed. Counter label cardinality is bounded (≤6 message types).
+
+### 1b. `cli/src/commands/dev/local-k8s.ts`
+
+Two new helpers, only invoked when `azureclaw dev --target local-k8s`
+spins up a fresh kind cluster:
+
+- `installPrometheus()` — `helm upgrade --install kps
+  prometheus-community/kube-prometheus-stack --version 85.3.3` in a new
+  `monitoring` namespace, with values that disable AlertManager and
+  control-plane scrapes (kind doesn't expose them).
+- `startMonitoringPortForwards()` — local-only `kubectl port-forward`
+  for Grafana :3000 + Prometheus :19091 (admin/admin and anonymous
+  Viewer respectively, **dev-only**; never reachable from outside the
+  developer's loopback).
+
+Helm chart version is pinned (`KPS_CHART_VERSION = "85.3.3"`). No
+authentication is loosened on cluster-internal resources; the only
+auth change is `auth.anonymous.enabled=true` + `org_role=Viewer` on
+the Grafana instance running inside the dev kind cluster, so that
+the Headlamp plugin can iframe-embed the per-sandbox dashboard. The
+Grafana service is `ClusterIP`; only the developer's port-forward
+exposes it on localhost.
+
+### 1c. Monitoring manifests (no capability surface)
+
+`deploy/monitoring/{podmonitor-sandbox-router,grafana-dashboard-
+configmap,agentmesh-json-exporter}.yaml` are scrape configs and
+dashboard JSON only. No RBAC bindings, no Roles, no ServiceAccounts.
+
+### 1d. Headlamp plugin v0.5.1 (no capability surface)
+
+`tools/headlamp-plugin/src/index.tsx` adds Mesh Topology v2, Token
+Budget cards, dark-mode polish, and an iframe embed of the per-sandbox
+Grafana dashboard. All UI. The plugin runs inside the developer's
+Headlamp instance — same SA token as before, same Kubernetes RBAC, no
+new server-side surface.
+
+## 2. Capability Surface
+
+| Capability | Pre-change | Post-change |
+|---|---|---|
+| `/metrics` endpoint on router | Already exposed on :8443, scraped via PodMonitor on cluster | Same — two new IntCounter labels emit on existing endpoint |
+| Mesh routes auth | mTLS + Workload Identity (unchanged) | Same |
+| Sandbox NetworkPolicy | Ingress allow for `app.kubernetes.io/name=azureclaw, component=system` namespaces on :8443 | Same — `monitoring` ns is labeled with those existing labels so scrape traffic is in-policy |
+| dev kind cluster auth | Local kubeconfig | Same — port-forwards bind to 127.0.0.1 only |
+| CRDs / controller reconciliation | unchanged | unchanged |
+
+No new capabilities introduced. Mesh counters are derivative metrics
+(count of envelopes already routed and counted in distributed traces);
+they cannot be used to bypass policy, exfiltrate plaintext, or escalate
+privilege. The relay sees ciphertext only; the router counts envelope
+arrivals.
+
+## 3. Crypto Surface
+
+No change. Mesh envelopes continue to be X3DH + Double Ratchet
+(`@microsoft/agent-governance-sdk` on the plugin side, `agentmesh`
+crate on the router side). Counters operate at the envelope layer
+(post-decrypt for received, pre-encrypt for sent) and never touch
+key material or plaintext bodies.
+
+## 4. Secrets Handling
+
+No change. The dev Grafana admin password is the literal string
+`admin`, which is the kube-prometheus-stack chart default and is
+**deliberately weak** for the developer's local kind cluster — the
+service is never exposed beyond `127.0.0.1`. Production AKS deployment
+(`azureclaw up`) is **out of scope** for this PR and will be handled
+in a follow-up with Azure Monitor managed Prometheus or a properly
+secured chart deployment.
+
+No secrets read or written by the router-side counter code. No new
+env vars consumed in the router.
+
+## 5. Test Coverage
+
+- `cargo test --package azureclaw-inference-router` — 105/105 PASS,
+  including the new counter increment assertions in `routes/mesh.rs`
+  tests.
+- `cd cli && npm test` — 769/769 PASS. The `installPrometheus()` helper
+  has a unit test that mocks `helm` + `kubectl` and asserts the chart
+  version + namespace + values arguments.
+- Manual end-to-end on local kind: `azureclaw dev` came up with
+  Headlamp + Grafana + Prometheus reachable; PodMonitor target list
+  showed 5/5 sandbox routers up; mesh counters incremented in lockstep
+  with traced KNOCK + mesh_send envelopes.
+
+## 6. Network / NetworkPolicy review
+
+The dev-cluster `monitoring` namespace is **explicitly labeled** with
+`app.kubernetes.io/name=azureclaw, app.kubernetes.io/component=system`
+so that the existing sandbox `NetworkPolicy.spec.ingress` rule
+(`controller/src/reconciler/mod.rs:911-925`) permits the scrape. This
+re-uses the existing capability rather than widening it. The label
+selector predates this PR (Slice-6 ingress isolation).
+
+Production NetworkPolicy (`azureclaw up`) is unaffected. The
+controller code paths that emit the policy are unchanged.
+
+## 7. Sign-offs
+
+Signed-off-by: Pal Lakatos <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/inference-router/src/metrics.rs
+++ b/inference-router/src/metrics.rs
@@ -95,6 +95,28 @@ pub static AGT_CONTENT_FLAGS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// Total AGT mesh messages sent by this router (egress to relay). The `sandbox`
+/// label is added at scrape time by the PodMonitor relabeling, so the metric
+/// itself has no extra labels — one counter per router process. Used by the
+/// Headlamp Mesh Topology view + operator CLI for per-sandbox traffic.
+pub static AGT_MESH_MESSAGES_SENT: LazyLock<prometheus::IntCounter> = LazyLock::new(|| {
+    prometheus::register_int_counter!(opts!(
+        "azureclaw_mesh_messages_sent_total",
+        "Total AGT mesh messages sent by this router to the relay"
+    ))
+    .unwrap()
+});
+
+/// Total AGT mesh messages received by this router (ingress from relay).
+/// Same labelling story as `AGT_MESH_MESSAGES_SENT`.
+pub static AGT_MESH_MESSAGES_RECEIVED: LazyLock<prometheus::IntCounter> = LazyLock::new(|| {
+    prometheus::register_int_counter!(opts!(
+        "azureclaw_mesh_messages_received_total",
+        "Total AGT mesh messages received by this router from the relay"
+    ))
+    .unwrap()
+});
+
 /// Total TrustGraph-projection-driven trust bootstraps. Incremented
 /// once per peer whose initial AGT trust score was seeded from a
 /// controller-verified TrustGraph edge (Phase F2). Never incremented

--- a/inference-router/src/routes/mesh.rs
+++ b/inference-router/src/routes/mesh.rs
@@ -158,6 +158,7 @@ async fn relay_websocket_bridge(
             out_count.fetch_add(1, Ordering::Relaxed);
             out_bytes.fetch_add(size as u64, Ordering::Relaxed);
             sent_metrics.messages_sent.fetch_add(1, Ordering::Relaxed);
+            crate::metrics::AGT_MESH_MESSAGES_SENT.inc();
             // Hex-dump first 128 bytes for traffic capture / E2E encryption proof.
             // The relay only ever sees ciphertext — readable plaintext here means encryption failed.
             let raw_bytes: Vec<u8> = match &tung_msg {
@@ -228,6 +229,7 @@ async fn relay_websocket_bridge(
             recv_metrics
                 .messages_received
                 .fetch_add(1, Ordering::Relaxed);
+            crate::metrics::AGT_MESH_MESSAGES_RECEIVED.inc();
             // Hex-dump first 128 bytes of each inbound frame for traffic capture.
             let raw_bytes: Vec<u8> = match &msg {
                 tungstenite::Message::Text(t) => t.as_bytes().to_vec(),

--- a/tools/headlamp-plugin/README.md
+++ b/tools/headlamp-plugin/README.md
@@ -58,3 +58,108 @@ kubectl rollout restart deployment/headlamp -n headlamp
 The plugin is data-driven. Append one entry to `AZURECLAW_CRDS` in
 `src/index.tsx` — list/detail routes and the sidebar entry are
 generated automatically. No per-CRD boilerplate required.
+
+## Mesh Topology + observability
+
+The **Mesh Topology** sidebar entry renders a live SVG tree of the AGT mesh:
+
+```
+                  AGT Relay
+                /     |     \
+      controller   controller   controller
+       / | \         |           / \
+      sub sub sub   sub         sub sub
+```
+
+Layout is built from `ClawSandbox` CRs grouped by the
+`azureclaw.azure.com/parent=<name>` label (the same label the
+`azureclaw operator` CLI uses for its blessed-TUI topology).
+Sandboxes without the label are controllers (top tier); sandboxes
+with it are sub-agents fanned out under their parent.
+
+### Data sources
+
+| Datum | Prometheus query (5 s poll) |
+|-------|-----------------------------|
+| Per-sandbox mesh msgs sent (lifetime) | `azureclaw_mesh_messages_sent_total` |
+| Per-sandbox mesh msgs received (lifetime) | `azureclaw_mesh_messages_received_total` |
+| Per-sandbox mesh msgs sent (5 m increase) | `sum by (sandbox) (increase(azureclaw_mesh_messages_sent_total[5m]))` |
+| Per-sandbox mesh msgs received (5 m increase) | `sum by (sandbox) (increase(azureclaw_mesh_messages_received_total[5m]))` |
+| Local AGT trust-graph size | `azureclaw_agt_known_agents` |
+| Relay connected agents | `sum(agentmesh_relay_connected_agents)` |
+| Relay throughput (msg/s, 5 m) | `sum(rate(agentmesh_relay_messages_routed_total[5m]))` |
+| Relay totals (routed / stored / delivered) | `sum(agentmesh_relay_messages_{routed,stored,delivered}_total)` |
+
+The `sandbox=<name>` label on every per-sandbox metric is added at
+**scrape time** by the `azureclaw-sandbox-router` PodMonitor in
+`deploy/monitoring/podmonitor-sandbox-router.yaml` (relabel:
+`__meta_kubernetes_pod_label_azureclaw_azure_com_sandbox` →
+`sandbox`). The Rust router exports plain `IntCounter`s — no
+in-process per-sandbox cardinality.
+
+### What the counter actually counts
+
+`azureclaw_mesh_messages_{sent,received}_total` ticks **once per
+WebSocket frame** that the inference router proxies between OpenClaw
+and the relay (in `inference-router/src/routes/mesh.rs`). Concretely:
+
+- ✅ **Counted**: KNOCK (Signal-Protocol session establishment),
+  X3DH bundle exchange, every encrypted `mesh_send` call, and the
+  explicit `sendHeartbeat()` ticks `agt-transport.ts` schedules
+  every 30 s (vanilla AGT MeshClient doesn't auto-heartbeat —
+  see `vendor/` patch notes).
+- ❌ **Not counted**: WebSocket `Ping` / `Pong` keepalives — the
+  router short-circuits these with `continue` before the
+  `fetch_add`. Registry HTTP calls (`/v1/agents/...`,
+  `/v1/agents/{did}/heartbeat`) also don't count — those go over
+  HTTP, not the WS relay.
+
+**Why sent ≫ received early on:** a fresh sandbox emits ≥ 1 KNOCK
+per peer it's aware of (e.g. execbrief with 3 sub-agents → ≥ 3
+KNOCKs) plus a heartbeat every 30 s, but only receives back the
+relay's KNOCK-ack (single inbound frame) until a real conversation
+starts. The counters reset on pod restart — they live in the
+router process, not the relay.
+
+### Per-node decorations
+
+For each controller / sub-agent circle the plugin renders:
+
+- `↑<sent_lifetime> ↓<received_lifetime>` (counter values)
+- `N children · M trust`, where:
+  - **children** = sub-agent CRs labeled
+    `azureclaw.azure.com/parent=<this>`. Deterministic; comes
+    straight from the Kubernetes API.
+  - **trust** = peers in *this* router's local AGT trust graph
+    (`azureclaw_agt_known_agents`). Only populates after live
+    traffic and resets to 0 on pod restart — so for a freshly
+    restarted controller you'll see `3 children · 0 trust` until
+    the first KNOCK round-trip completes.
+
+Edge thickness ∝ traffic (5 m rate, sum of sent+received). Two
+pulse colours per relay-edge:
+
+- **Yellow** (sandbox → relay): outbound msgs, speed ∝ sent rate
+- **Light blue** (relay → sandbox): inbound msgs, speed ∝ recv rate
+
+Controller → sub-agent edges are dashed (logical hierarchy; the
+actual frames still flow via the relay).
+
+### Token Budget panels
+
+The Overview page and each ClawSandbox detail page also render a
+**💰 Token Budget (24 h)** card that joins:
+
+- `InferencePolicy.spec.tokenBudget.{dailyTokens,perRequestTokens}`
+  (read via Headlamp's Kubernetes client)
+- `sum by (sandbox) (increase(azureclaw_tokens_total[24h]))` from
+  Prometheus
+
+The sandbox → policy link uses
+`ClawSandbox.spec.inferenceRef.name`.
+
+### Prometheus base URL
+
+By default the plugin queries `http://127.0.0.1:19091`. Override at
+runtime by setting `window.AZURECLAW_PROMETHEUS_URL = '...'` (e.g.
+via a small Headlamp banner / browser DevTools).

--- a/tools/headlamp-plugin/package.json
+++ b/tools/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azureclaw",
-  "version": "0.1.0",
+  "version": "0.5.1",
   "private": true,
   "description": "AzureClaw sidebar + CRD views for the Headlamp dashboard.",
   "license": "MIT",

--- a/tools/headlamp-plugin/src/index.tsx
+++ b/tools/headlamp-plugin/src/index.tsx
@@ -44,6 +44,7 @@ import {
   SimpleTable,
   StatusLabel,
 } from "@kinvolk/headlamp-plugin/lib/CommonComponents";
+import { useTheme } from "@mui/material/styles";
 import * as React from "react";
 
 const GROUP = "azureclaw.azure.com";
@@ -111,6 +112,21 @@ registerRoute({
   name: "azureclaw-overview",
   exact: true,
   component: () => <Overview />,
+});
+
+registerSidebarEntry({
+  parent: "azureclaw",
+  name: "azureclaw-mesh",
+  label: "Mesh Topology",
+  url: "/azureclaw/mesh",
+});
+
+registerRoute({
+  path: "/azureclaw/mesh",
+  sidebar: "azureclaw-mesh",
+  name: "azureclaw-mesh",
+  exact: true,
+  component: () => <MeshTopology />,
 });
 
 for (const crd of AZURECLAW_CRDS) {
@@ -709,6 +725,8 @@ function Overview() {
           ]}
         />
       </SectionBox>
+
+      <TokenBudgetOverview sandboxes={sandboxes ?? []} inferencePolicies={inferencePolicies ?? []} />
     </>
   );
 }
@@ -898,6 +916,9 @@ function CrdDetail({ crd }: { crd: CrdDescriptor }) {
       </SectionBox>
 
       {crd.plural === "clawsandboxes" && <SandboxExtras item={item} />}
+      {crd.plural === "inferencepolicies" && <InferencePolicyMetricsCard policyName={item.metadata.name} />}
+      {crd.plural === "toolpolicies" && <ToolPolicyMetricsCard policyName={item.metadata.name} />}
+      {crd.plural === "trustgraphs" && <TrustGraphMetricsCard />}
 
       <AllowlistDriftBanner item={item} />
 
@@ -1264,6 +1285,751 @@ function SandboxExtras({ item }: { item: KubeObject }) {
           ]}
         />
       </SectionBox>
+
+      <SandboxBudgetCard sandboxName={name} inferenceRefName={spec.inferenceRef?.name} />
+      <SandboxMetricsCard sandboxName={name} />
     </>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Grafana iframe embed for per-sandbox metrics.
+// Anonymous viewer + allow_embedding enabled on the kube-prometheus-stack
+// Grafana so the panel renders without auth. The Grafana base URL is
+// configurable via window.AZURECLAW_GRAFANA_URL — defaults to the local
+// port-forward used during dev (http://127.0.0.1:3000).
+// ──────────────────────────────────────────────────────────────────────
+function SandboxMetricsCard({ sandboxName }: { sandboxName: string }) {
+  const theme = useTheme();
+  const grafanaTheme = theme.palette.mode === "dark" ? "dark" : "light";
+  const grafanaBase =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (typeof window !== "undefined" && (window as any).AZURECLAW_GRAFANA_URL) ||
+    "http://127.0.0.1:3000";
+  const url =
+    `${grafanaBase}/d/azureclaw-ops?kiosk=tv&refresh=10s&theme=${grafanaTheme}` +
+    `&var-sandbox=${encodeURIComponent(sandboxName)}`;
+  return (
+    <SectionBox title={`Metrics (Grafana) — ${sandboxName}`}>
+      <div style={{ marginBottom: 8 }}>
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          Open full dashboard in Grafana ↗
+        </a>
+      </div>
+      <iframe
+        src={url}
+        title={`Grafana metrics for ${sandboxName}`}
+        style={{ width: "100%", height: "720px", border: "0" }}
+        loading="lazy"
+      />
+    </SectionBox>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// MeshTopology — native SVG visualization of the AGT mesh with
+// parent→sub-agent hierarchy. Uses ClawSandbox CRs (label
+// `azureclaw.azure.com/parent`) to build the tree, and Prometheus
+// queries to overlay live token/activity stats and inter-agent
+// communication. Configurable via window.AZURECLAW_PROMETHEUS_URL.
+// ──────────────────────────────────────────────────────────────────────
+interface MeshNodeData {
+  name: string;
+  parent: string;     // "" if controller
+  knownPeers: number;
+  meshSent: number;       // mesh messages sent (5m increase)
+  meshRecv: number;       // mesh messages received (5m increase)
+  meshSentLife: number;   // mesh messages sent (lifetime counter value)
+  meshRecvLife: number;   // mesh messages received (lifetime counter value)
+}
+
+async function promQuery(base: string, q: string): Promise<{metric: Record<string,string>, value: number}[]> {
+  const url = `${base}/api/v1/query?query=${encodeURIComponent(q)}`;
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`prom ${r.status}`);
+  const j = await r.json();
+  return (j?.data?.result || []).map((row: {metric: Record<string,string>, value: [number, string]}) => ({
+    metric: row.metric || {},
+    value: Number(row.value?.[1] || 0),
+  }));
+}
+
+function usePromBase(): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (typeof window !== "undefined" && (window as any).AZURECLAW_PROMETHEUS_URL) || "http://127.0.0.1:19091";
+}
+
+function usePromPoll<T>(initial: T, loader: (base: string) => Promise<T>, intervalMs = 5000): { data: T; err: string } {
+  const base = usePromBase();
+  const [data, setData] = React.useState<T>(initial);
+  const [err, setErr] = React.useState("");
+  const [tick, setTick] = React.useState(0);
+  React.useEffect(() => {
+    let cancelled = false;
+    loader(base).then((d) => { if (!cancelled) { setData(d); setErr(""); } }).catch((e) => { if (!cancelled) setErr(String(e)); });
+    const id = setInterval(() => setTick((t) => t + 1), intervalMs);
+    return () => { cancelled = true; clearInterval(id); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [base, tick]);
+  return { data, err };
+}
+
+function MeshTopology() {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const bg = isDark ? "#1e1e1e" : "#fafafa";
+  const muted = isDark ? "#aaa" : "#555";
+  const stroke = isDark ? "#cfd8dc" : "#37474f";
+  const textOnNode = "#fff";
+
+  const [sandboxes] = (ClawSandboxClass as any).useList() as [KubeObject[] | null];
+
+  const { data: live, err } = usePromPoll(
+    { peers: [] as { metric: Record<string,string>; value: number }[],
+      sentLife: [] as { metric: Record<string,string>; value: number }[],
+      recvLife: [] as { metric: Record<string,string>; value: number }[],
+      sentRate: [] as { metric: Record<string,string>; value: number }[],
+      recvRate: [] as { metric: Record<string,string>; value: number }[],
+      relayConn: 0,
+      relayRouted: 0,
+      relayStored: 0,
+      relayDelivered: 0,
+      relayMsgsPerSec: 0 },
+    async (base) => {
+      const [peers, sentLife, recvLife, sentRate, recvRate, relayConn, relayRouted, relayStored, relayDelivered, relayMsgs] = await Promise.all([
+        promQuery(base, 'azureclaw_agt_known_agents'),
+        promQuery(base, 'azureclaw_mesh_messages_sent_total'),
+        promQuery(base, 'azureclaw_mesh_messages_received_total'),
+        promQuery(base, 'sum by (sandbox) (increase(azureclaw_mesh_messages_sent_total[5m]))'),
+        promQuery(base, 'sum by (sandbox) (increase(azureclaw_mesh_messages_received_total[5m]))'),
+        promQuery(base, 'sum(agentmesh_relay_connected_agents)'),
+        promQuery(base, 'sum(agentmesh_relay_messages_routed_total)'),
+        promQuery(base, 'sum(agentmesh_relay_messages_stored_total)'),
+        promQuery(base, 'sum(agentmesh_relay_messages_delivered_total)'),
+        promQuery(base, 'sum(rate(agentmesh_relay_messages_routed_total[5m]))'),
+      ]);
+      return {
+        peers, sentLife, recvLife, sentRate, recvRate,
+        relayConn: relayConn[0]?.value || 0,
+        relayRouted: relayRouted[0]?.value || 0,
+        relayStored: relayStored[0]?.value || 0,
+        relayDelivered: relayDelivered[0]?.value || 0,
+        relayMsgsPerSec: relayMsgs[0]?.value || 0,
+      };
+    }
+  );
+
+  // Index Prometheus results by sandbox name.
+  const peerByName = Object.fromEntries(live.peers.map((p) => [p.metric.sandbox || "", p.value]));
+  const sentLifeByName = Object.fromEntries(live.sentLife.map((p) => [p.metric.sandbox || "", p.value]));
+  const recvLifeByName = Object.fromEntries(live.recvLife.map((p) => [p.metric.sandbox || "", p.value]));
+  const sentRateByName = Object.fromEntries(live.sentRate.map((p) => [p.metric.sandbox || "", p.value]));
+  const recvRateByName = Object.fromEntries(live.recvRate.map((p) => [p.metric.sandbox || "", p.value]));
+
+  // Build hierarchy from CR labels.
+  const nodes: MeshNodeData[] = (sandboxes || []).map((sb) => {
+    const name = sb.metadata.name;
+    const parent = (sb.metadata.labels || {})["azureclaw.azure.com/parent"] || "";
+    return {
+      name,
+      parent,
+      knownPeers: peerByName[name] || 0,
+      meshSent: sentRateByName[name] || 0,
+      meshRecv: recvRateByName[name] || 0,
+      meshSentLife: sentLifeByName[name] || 0,
+      meshRecvLife: recvLifeByName[name] || 0,
+    };
+  });
+
+  const controllers = nodes.filter((n) => !n.parent).sort((a, b) => a.name.localeCompare(b.name));
+  const childrenByParent: Record<string, MeshNodeData[]> = {};
+  for (const n of nodes) {
+    if (!n.parent) continue;
+    childrenByParent[n.parent] = childrenByParent[n.parent] || [];
+    childrenByParent[n.parent].push(n);
+  }
+
+  // Layout: relay at top center, controllers in a row below, each controller's
+  // children fanned out below it.
+  const W = 1100;
+  const ctrlGap = Math.max(220, W / Math.max(1, controllers.length));
+  const relayX = W / 2;
+  const relayY = 70;
+  const ctrlRowY = 220;
+  const childRowY = 400;
+  const nodeR = 36;
+  const relayR = 50;
+
+  // Pre-compute positions.
+  const ctrlPos: Record<string, { x: number; y: number; n: MeshNodeData }> = {};
+  controllers.forEach((c, i) => {
+    const x = ctrlGap * (i + 0.5) + (W - ctrlGap * controllers.length) / 2;
+    ctrlPos[c.name] = { x, y: ctrlRowY, n: c };
+  });
+
+  const childPos: Record<string, { x: number; y: number; n: MeshNodeData; parent: string }> = {};
+  for (const c of controllers) {
+    const kids = childrenByParent[c.name] || [];
+    const parentX = ctrlPos[c.name].x;
+    const kidGap = 130;
+    kids.forEach((k, i) => {
+      const offset = (i - (kids.length - 1) / 2) * kidGap;
+      childPos[k.name] = { x: parentX + offset, y: childRowY, n: k, parent: c.name };
+    });
+  }
+
+  // Orphans (parent missing from CR list).
+  const orphans = nodes.filter((n) => n.parent && !ctrlPos[n.parent]);
+
+  // Drive sizing / edge styling off mesh message activity instead of tokens.
+  const traffic = (n: MeshNodeData) => n.meshSent + n.meshRecv;
+  const maxTraffic = Math.max(0.001, ...nodes.map(traffic));
+  const maxLife = Math.max(1, ...nodes.map((n) => n.meshSentLife + n.meshRecvLife));
+  const H = (orphans.length > 0 ? 600 : 520);
+
+  function nodeFill(n: MeshNodeData): string {
+    const t = traffic(n);
+    if (t > 5) return "#43a047";
+    if (t > 0.5) return "#9ccc65";
+    if (t > 0) return "#ffd54f";
+    if (n.knownPeers > 0) return "#90caf9";
+    return isDark ? "#555" : "#bdbdbd";
+  }
+  function nodeSize(n: MeshNodeData): number {
+    return nodeR + Math.min(14, ((n.meshSentLife + n.meshRecvLife) / maxLife) * 14);
+  }
+  function edgeWidth(t: number): number {
+    return 1 + (t / maxTraffic) * 5;
+  }
+  function edgeOpacity(t: number): number {
+    return 0.3 + (t / maxTraffic) * 0.7;
+  }
+  function pulseDur(t: number): number {
+    return t > 0 ? Math.max(0.6, 3 - (t / maxTraffic) * 2.4) : 0;
+  }
+
+  return (
+    <SectionBox title="🕸️ Mesh Topology (live)">
+      <div style={{ marginBottom: 12, fontSize: 13, color: muted }}>
+        Tree view of the AGT mesh: AGT Relay (top), controllers (mid row), sub-agents (bottom row).
+        Polled from Prometheus every 5s. Edge thickness & pulse speed ∝ mesh messages
+        in/out (5m). Node size ∝ lifetime mesh-message volume. <b>children</b> = sub-agent
+        CRs labeled <code>azureclaw.azure.com/parent=&lt;name&gt;</code>; <b>trust</b> = peers in
+        this router's local AGT trust graph (only populated after live traffic; resets on pod restart).
+        {err && <div style={{ color: "#ef5350", marginTop: 6 }}>Prometheus unreachable: {err} (configure window.AZURECLAW_PROMETHEUS_URL)</div>}
+      </div>
+      <div style={{ display: "flex", gap: 16, marginBottom: 12, flexWrap: "wrap" }}>
+        <StatusLabel status="">🔗 Relay connected: <b>{live.relayConn}</b></StatusLabel>
+        <StatusLabel status="">📨 Relay msg/s (5m): <b>{live.relayMsgsPerSec.toFixed(2)}</b></StatusLabel>
+        <StatusLabel status="">📬 Routed total: <b>{Math.round(live.relayRouted).toLocaleString()}</b></StatusLabel>
+        <StatusLabel status="">📦 Stored (offline): <b>{Math.round(live.relayStored).toLocaleString()}</b></StatusLabel>
+        <StatusLabel status="">✉️ Delivered (after reconnect): <b>{Math.round(live.relayDelivered).toLocaleString()}</b></StatusLabel>
+        <StatusLabel status="">🤖 Sandboxes: <b>{nodes.length}</b></StatusLabel>
+        <StatusLabel status="">👨‍👩‍👧 Controllers: <b>{controllers.length}</b></StatusLabel>
+        <StatusLabel status="">🧒 Sub-agents: <b>{Object.keys(childPos).length}</b></StatusLabel>
+      </div>
+      <svg viewBox={`0 0 ${W} ${H}`} style={{ width: "100%", maxWidth: W, background: bg, borderRadius: 8 }}>
+        <defs>
+          <radialGradient id="relayGrad" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#fff59d" />
+            <stop offset="100%" stopColor="#fbc02d" />
+          </radialGradient>
+          <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="3" result="blur" />
+            <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+        </defs>
+
+        {/* relay → controller edges */}
+        {controllers.map((c) => {
+          const p = ctrlPos[c.name];
+          const t = traffic(c);
+          return (
+            <g key={`r-${c.name}`}>
+              <line x1={relayX} y1={relayY} x2={p.x} y2={p.y}
+                stroke="#42a5f5" strokeWidth={edgeWidth(t)}
+                strokeOpacity={edgeOpacity(t)} />
+              {/* Outbound pulse: relay → sandbox (recv direction for the sandbox) */}
+              {c.meshRecv > 0 && (
+                <circle r="4" fill="#81d4fa" filter="url(#glow)">
+                  <animateMotion dur={`${pulseDur(c.meshRecv)}s`} repeatCount="indefinite"
+                    path={`M${relayX},${relayY} L${p.x},${p.y}`} />
+                </circle>
+              )}
+              {/* Inbound pulse: sandbox → relay (sent direction) */}
+              {c.meshSent > 0 && (
+                <circle r="4" fill="#ffeb3b" filter="url(#glow)">
+                  <animateMotion dur={`${pulseDur(c.meshSent)}s`} repeatCount="indefinite"
+                    path={`M${p.x},${p.y} L${relayX},${relayY}`} />
+                </circle>
+              )}
+              <text x={(relayX + p.x) / 2} y={(relayY + p.y) / 2 - 4} textAnchor="middle"
+                fontSize="10" fill={muted} style={{ pointerEvents: "none" }}>
+                ↑{Math.round(c.meshSent * 60 / 5) || 0} ↓{Math.round(c.meshRecv * 60 / 5) || 0} /min
+              </text>
+            </g>
+          );
+        })}
+
+        {/* controller → child edges (logical parent relationship; mesh traffic
+            still flows via the relay, so we pulse based on the child's traffic) */}
+        {Object.values(childPos).map((cp) => {
+          const par = ctrlPos[cp.parent];
+          if (!par) return null;
+          const t = traffic(cp.n);
+          return (
+            <g key={`pc-${cp.n.name}`}>
+              <line x1={par.x} y1={par.y} x2={cp.x} y2={cp.y}
+                stroke="#7e57c2" strokeWidth={edgeWidth(t)}
+                strokeOpacity={edgeOpacity(t)} strokeDasharray="6,4" />
+              {pulseDur(t) > 0 && (
+                <circle r="3" fill="#ce93d8" filter="url(#glow)">
+                  <animateMotion dur={`${pulseDur(t)}s`} repeatCount="indefinite"
+                    path={`M${par.x},${par.y} L${cp.x},${cp.y}`} />
+                </circle>
+              )}
+            </g>
+          );
+        })}
+
+        {/* AGT Relay (top) */}
+        <g>
+          <circle cx={relayX} cy={relayY} r={relayR} fill="url(#relayGrad)" stroke="#f57f17" strokeWidth="3" filter="url(#glow)" />
+          <text x={relayX} y={relayY - 8} textAnchor="middle" fontSize="13" fontWeight="bold" fill="#212121">AGT Relay</text>
+          <text x={relayX} y={relayY + 6} textAnchor="middle" fontSize="10" fill="#212121">{live.relayConn} connected</text>
+          <text x={relayX} y={relayY + 20} textAnchor="middle" fontSize="10" fill="#212121">{live.relayMsgsPerSec.toFixed(2)} msg/s</text>
+          <text x={relayX} y={relayY + 34} textAnchor="middle" fontSize="9" fill="#212121">
+            {Math.round(live.relayRouted).toLocaleString()} routed
+          </text>
+        </g>
+
+        {/* Controllers */}
+        {controllers.map((c) => {
+          const p = ctrlPos[c.name];
+          const sz = nodeSize(c);
+          const childCount = (childrenByParent[c.name] || []).length;
+          return (
+            <g key={`c-${c.name}`}>
+              <circle cx={p.x} cy={p.y} r={sz} fill={nodeFill(c)} stroke={stroke} strokeWidth="2.5" />
+              <text x={p.x} y={p.y - 8} textAnchor="middle" fontSize="13" fontWeight="bold" fill={textOnNode}>{c.name}</text>
+              <text x={p.x} y={p.y + 4} textAnchor="middle" fontSize="9" fill={textOnNode}>controller</text>
+              <text x={p.x} y={p.y + 18} textAnchor="middle" fontSize="10" fill={textOnNode}>
+                ↑{Math.round(c.meshSentLife).toLocaleString()} ↓{Math.round(c.meshRecvLife).toLocaleString()}
+              </text>
+              <text x={p.x} y={p.y + 30} textAnchor="middle" fontSize="9" fill={textOnNode}>
+                {childCount} child{childCount === 1 ? "" : "ren"} · {c.knownPeers} trust
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Sub-agents */}
+        {Object.values(childPos).map((cp) => {
+          const n = cp.n;
+          const sz = nodeSize(n) - 6;
+          return (
+            <g key={`s-${n.name}`}>
+              <circle cx={cp.x} cy={cp.y} r={sz} fill={nodeFill(n)} stroke={stroke} strokeWidth="1.5" />
+              <text x={cp.x} y={cp.y - 6} textAnchor="middle" fontSize="11" fontWeight="bold" fill={textOnNode}>{n.name}</text>
+              <text x={cp.x} y={cp.y + 6} textAnchor="middle" fontSize="9" fill={textOnNode}>sub-agent</text>
+              <text x={cp.x} y={cp.y + 20} textAnchor="middle" fontSize="10" fill={textOnNode}>
+                ↑{Math.round(n.meshSentLife).toLocaleString()} ↓{Math.round(n.meshRecvLife).toLocaleString()}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Orphan sub-agents (parent missing from CR list) */}
+        {orphans.length > 0 && (
+          <g>
+            <text x={W / 2} y={H - 80} textAnchor="middle" fontSize="11" fill={muted}>— Orphan sub-agents (parent CR not found) —</text>
+            {orphans.map((o, i) => {
+              const x = (W / (orphans.length + 1)) * (i + 1);
+              return (
+                <g key={`o-${o.name}`}>
+                  <circle cx={x} cy={H - 40} r={nodeR - 8} fill={isDark ? "#616161" : "#9e9e9e"} stroke={isDark ? "#9e9e9e" : "#616161"} strokeWidth="1.5" strokeDasharray="3,3" />
+                  <text x={x} y={H - 44} textAnchor="middle" fontSize="11" fontWeight="bold" fill={textOnNode}>{o.name}</text>
+                  <text x={x} y={H - 30} textAnchor="middle" fontSize="9" fill={textOnNode}>parent:{o.parent}</text>
+                </g>
+              );
+            })}
+          </g>
+        )}
+      </svg>
+      <div style={{ marginTop: 12 }}>
+        <SimpleTable
+          data={nodes
+            .map((n) => ({
+              name: n.name,
+              kind: n.parent ? `sub-agent ← ${n.parent}` : "controller",
+              peers: n.knownPeers,
+              sent5m: Math.round(n.meshSent),
+              recv5m: Math.round(n.meshRecv),
+              sentLife: Math.round(n.meshSentLife),
+              recvLife: Math.round(n.meshRecvLife),
+            }))
+            .sort((a, b) => (b.sent5m + b.recv5m) - (a.sent5m + a.recv5m))}
+          columns={[
+            { label: "Sandbox", getter: (r: { name: string }) => r.name },
+            { label: "Role", getter: (r: { kind: string }) => r.kind },
+            { label: "Peers", getter: (r: { peers: number }) => r.peers },
+            { label: "↑ Sent (5m)", getter: (r: { sent5m: number }) => r.sent5m },
+            { label: "↓ Recv (5m)", getter: (r: { recv5m: number }) => r.recv5m },
+            { label: "↑ Sent (life)", getter: (r: { sentLife: number }) => r.sentLife.toLocaleString() },
+            { label: "↓ Recv (life)", getter: (r: { recvLife: number }) => r.recvLife.toLocaleString() },
+          ]}
+        />
+      </div>
+    </SectionBox>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Per-CRD Prometheus metric cards. These embed a focused Grafana
+// dashboard view (filtered by the relevant entity) instead of duplicating
+// the Grafana queries client-side. The router metrics
+// `azureclaw_inference_*` and `azureclaw_agt_policy_evaluations_total`
+// surface model/policy/decision labels that map naturally to the
+// InferencePolicy and ToolPolicy CRDs.
+// ──────────────────────────────────────────────────────────────────────
+function grafanaBaseUrl(): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (typeof window !== "undefined" && (window as any).AZURECLAW_GRAFANA_URL) || "http://127.0.0.1:3000";
+}
+
+function InferencePolicyMetricsCard({ policyName }: { policyName: string }) {
+  const theme = useTheme();
+  const grafanaTheme = theme.palette.mode === "dark" ? "dark" : "light";
+  const muted = theme.palette.text.secondary;
+  const { data, err } = usePromPoll(
+    { byModel: [] as { metric: Record<string,string>; value: number }[],
+      bySandbox: [] as { metric: Record<string,string>; value: number }[],
+      reqRate: [] as { metric: Record<string,string>; value: number }[],
+      latency: 0 },
+    async (base) => {
+      const [byModel, bySandbox, reqRate, latency] = await Promise.all([
+        promQuery(base, 'sum by (model, direction) (increase(azureclaw_tokens_total[1h]))'),
+        promQuery(base, 'sum by (sandbox) (increase(azureclaw_tokens_total[1h]))'),
+        promQuery(base, 'sum by (model, status) (rate(azureclaw_inference_requests_total[5m]))'),
+        promQuery(base, 'histogram_quantile(0.95, sum by (le) (rate(azureclaw_inference_latency_seconds_bucket[5m])))'),
+      ]);
+      return { byModel, bySandbox, reqRate, latency: latency[0]?.value || 0 };
+    }
+  );
+  const url = `${grafanaBaseUrl()}/d/azureclaw-ops?kiosk=tv&refresh=10s&theme=${grafanaTheme}`;
+  const modelRows = data.byModel.map((r) => ({
+    model: r.metric.model || "?",
+    direction: r.metric.direction || "?",
+    tokens: Math.round(r.value).toLocaleString(),
+  })).sort((a, b) => Number(b.tokens.replace(/,/g,"")) - Number(a.tokens.replace(/,/g,"")));
+  const sandboxRows = data.bySandbox.map((r) => ({
+    sandbox: r.metric.sandbox || "?",
+    tokens: Math.round(r.value).toLocaleString(),
+  })).sort((a, b) => Number(b.tokens.replace(/,/g,"")) - Number(a.tokens.replace(/,/g,"")));
+  return (
+    <SectionBox title={`📊 Inference Metrics (policy: ${policyName})`}>
+      <div style={{ marginBottom: 8, fontSize: 13, color: muted }}>
+        Live aggregates across all sandboxes routed through this policy class. {err && <span style={{color:"#ef5350"}}>{err}</span>}
+      </div>
+      <div style={{ display: "flex", gap: 12, marginBottom: 12, flexWrap: "wrap" }}>
+        <StatusLabel status="">⏱ p95 latency (5m): <b>{(data.latency * 1000).toFixed(0)} ms</b></StatusLabel>
+        <StatusLabel status="">🧮 Models active: <b>{new Set(data.byModel.map((r) => r.metric.model)).size}</b></StatusLabel>
+        <StatusLabel status="">🤖 Sandboxes consuming: <b>{sandboxRows.length}</b></StatusLabel>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <div>
+          <h4 style={{ margin: "4px 0" }}>Tokens by model (1h)</h4>
+          <SimpleTable data={modelRows} columns={[
+            { label: "Model", getter: (r: { model: string }) => r.model },
+            { label: "Dir", getter: (r: { direction: string }) => r.direction },
+            { label: "Tokens", getter: (r: { tokens: string }) => r.tokens },
+          ]} />
+        </div>
+        <div>
+          <h4 style={{ margin: "4px 0" }}>Top consumers (1h)</h4>
+          <SimpleTable data={sandboxRows.slice(0, 10)} columns={[
+            { label: "Sandbox", getter: (r: { sandbox: string }) => r.sandbox },
+            { label: "Tokens", getter: (r: { tokens: string }) => r.tokens },
+          ]} />
+        </div>
+      </div>
+      <div style={{ marginTop: 12 }}>
+        <a href={url} target="_blank" rel="noopener noreferrer">Open full Grafana dashboard ↗</a>
+      </div>
+    </SectionBox>
+  );
+}
+
+function ToolPolicyMetricsCard({ policyName }: { policyName: string }) {
+  const theme = useTheme();
+  const muted = theme.palette.text.secondary;
+  const { data, err } = usePromPoll(
+    { decisions: [] as { metric: Record<string,string>; value: number }[],
+      bySandbox: [] as { metric: Record<string,string>; value: number }[],
+      latencyP95: 0 },
+    async (base) => {
+      const [decisions, bySandbox, latP95] = await Promise.all([
+        promQuery(base, 'sum by (decision) (increase(azureclaw_agt_policy_evaluations_total[1h]))'),
+        promQuery(base, 'sum by (sandbox, decision) (increase(azureclaw_agt_policy_evaluations_total[1h]))'),
+        promQuery(base, 'histogram_quantile(0.95, sum by (le) (rate(azureclaw_agt_eval_latency_seconds_bucket[5m])))'),
+      ]);
+      return { decisions, bySandbox, latencyP95: latP95[0]?.value || 0 };
+    }
+  );
+  const total = data.decisions.reduce((s, r) => s + r.value, 0) || 1;
+  const decisionRows = data.decisions.map((r) => ({
+    decision: r.metric.decision || "?",
+    count: Math.round(r.value).toLocaleString(),
+    pct: ((r.value / total) * 100).toFixed(1) + "%",
+  }));
+  const sandboxRows = data.bySandbox.map((r) => ({
+    sandbox: r.metric.sandbox || "?",
+    decision: r.metric.decision || "?",
+    count: Math.round(r.value).toLocaleString(),
+  })).sort((a, b) => Number(b.count.replace(/,/g,"")) - Number(a.count.replace(/,/g,"")));
+  return (
+    <SectionBox title={`🛡️ Policy Evaluations (policy: ${policyName})`}>
+      <div style={{ marginBottom: 8, fontSize: 13, color: muted }}>
+        AGT policy evaluation counters scoped to all sandboxes referencing this policy. {err && <span style={{color:"#ef5350"}}>{err}</span>}
+      </div>
+      <div style={{ display: "flex", gap: 12, marginBottom: 12, flexWrap: "wrap" }}>
+        <StatusLabel status="">⏱ p95 eval latency (5m): <b>{(data.latencyP95 * 1e6).toFixed(0)} µs</b></StatusLabel>
+        <StatusLabel status="">📊 Total evals (1h): <b>{Math.round(total).toLocaleString()}</b></StatusLabel>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: 16 }}>
+        <div>
+          <h4 style={{ margin: "4px 0" }}>Decision mix (1h)</h4>
+          <SimpleTable data={decisionRows} columns={[
+            { label: "Decision", getter: (r: { decision: string }) => r.decision },
+            { label: "Count", getter: (r: { count: string }) => r.count },
+            { label: "Share", getter: (r: { pct: string }) => r.pct },
+          ]} />
+        </div>
+        <div>
+          <h4 style={{ margin: "4px 0" }}>Top deniers/allowers (1h)</h4>
+          <SimpleTable data={sandboxRows.slice(0, 15)} columns={[
+            { label: "Sandbox", getter: (r: { sandbox: string }) => r.sandbox },
+            { label: "Decision", getter: (r: { decision: string }) => r.decision },
+            { label: "Count", getter: (r: { count: string }) => r.count },
+          ]} />
+        </div>
+      </div>
+    </SectionBox>
+  );
+}
+
+function TrustGraphMetricsCard() {
+  const theme = useTheme();
+  const muted = theme.palette.text.secondary;
+  const { data, err } = usePromPoll(
+    { peers: [] as { metric: Record<string,string>; value: number }[],
+      auditEntries: [] as { metric: Record<string,string>; value: number }[],
+      bundleHealth: [] as { metric: Record<string,string>; value: number }[] },
+    async (base) => {
+      const [peers, audit, bundle] = await Promise.all([
+        promQuery(base, 'azureclaw_agt_known_agents'),
+        promQuery(base, 'azureclaw_agt_audit_entries_total'),
+        promQuery(base, 'azureclaw_policy_bundle_healthy'),
+      ]);
+      return { peers, auditEntries: audit, bundleHealth: bundle };
+    }
+  );
+  const peerRows = data.peers.map((r) => ({
+    sandbox: r.metric.sandbox || "?",
+    knownPeers: r.value,
+  })).sort((a, b) => b.knownPeers - a.knownPeers);
+  const totalPeers = data.peers.reduce((s, r) => s + r.value, 0);
+  const totalAudit = data.auditEntries.reduce((s, r) => s + r.value, 0);
+  return (
+    <SectionBox title="🔐 Trust Graph Metrics">
+      <div style={{ marginBottom: 8, fontSize: 13, color: muted }}>
+        AGT trust graph: peers known per sandbox + tamper-evident audit log size. {err && <span style={{color:"#ef5350"}}>{err}</span>}
+      </div>
+      <div style={{ display: "flex", gap: 12, marginBottom: 12, flexWrap: "wrap" }}>
+        <StatusLabel status="">🤝 Total known peers: <b>{totalPeers}</b></StatusLabel>
+        <StatusLabel status="">📜 Audit entries: <b>{Math.round(totalAudit).toLocaleString()}</b></StatusLabel>
+        <StatusLabel status="">📦 Healthy bundles: <b>{data.bundleHealth.filter((r) => r.value > 0).length}/{data.bundleHealth.length}</b></StatusLabel>
+      </div>
+      <SimpleTable data={peerRows} columns={[
+        { label: "Sandbox", getter: (r: { sandbox: string }) => r.sandbox },
+        { label: "Known peers", getter: (r: { knownPeers: number }) => r.knownPeers },
+      ]} />
+    </SectionBox>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Token budget panels — overview-wide aggregate + per-sandbox utilization.
+// Budgets live on InferencePolicy.spec.tokenBudget.dailyTokens; consumption
+// is tracked by the router metric `azureclaw_tokens_total{sandbox,direction}`.
+// Each sandbox references its policy via spec.inferenceRef.name (same ns).
+// ──────────────────────────────────────────────────────────────────────
+function utilizationTone(pct: number): StatusKind {
+  if (pct >= 90) return "error";
+  if (pct >= 70) return "warning";
+  if (pct > 0) return "success";
+  return "";
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1e9) return (n / 1e9).toFixed(2) + "B";
+  if (n >= 1e6) return (n / 1e6).toFixed(2) + "M";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + "K";
+  return Math.round(n).toLocaleString();
+}
+
+function BudgetBar({ used, total, height = 14 }: { used: number; total: number; height?: number }) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const trackBg = isDark ? "#333" : "#eee";
+  const textColor = isDark ? "#eee" : "#333";
+  const pct = total > 0 ? Math.min(100, (used / total) * 100) : 0;
+  const color = pct >= 90 ? "#c62828" : pct >= 70 ? "#ef6c00" : "#2e7d32";
+  return (
+    <div style={{ background: trackBg, borderRadius: 4, height, overflow: "hidden", position: "relative" }}>
+      <div style={{ background: color, height: "100%", width: `${pct}%`, transition: "width .3s ease" }} />
+      <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center",
+        fontSize: 11, fontWeight: 600, color: pct > 50 ? "#fff" : textColor }}>
+        {pct.toFixed(1)}%
+      </div>
+    </div>
+  );
+}
+
+function TokenBudgetOverview({ sandboxes, inferencePolicies }: { sandboxes: KubeObject[]; inferencePolicies: KubeObject[] }) {
+  const theme = useTheme();
+  const muted = theme.palette.text.secondary;
+  // Per-sandbox consumption from Prometheus (24h window aligns with dailyTokens budget).
+  const { data, err } = usePromPoll(
+    [] as { metric: Record<string,string>; value: number }[],
+    async (base) => promQuery(base, 'sum by (sandbox) (increase(azureclaw_tokens_total[24h]))'),
+    10000
+  );
+  const consumedBySandbox: Record<string, number> = {};
+  for (const row of data) consumedBySandbox[row.metric.sandbox || "?"] = row.value;
+
+  // Resolve each sandbox → its InferencePolicy daily budget.
+  const ipByName: Record<string, KubeObject> = {};
+  for (const ip of inferencePolicies) ipByName[ip.metadata.name] = ip;
+
+  const rows = sandboxes.map((sb) => {
+    const spec = (sb as any).jsonData?.spec || (sb as any).spec || {};
+    const refName: string = spec.inferenceRef?.name || "";
+    const ip = ipByName[refName];
+    const dailyBudget = ((ip as any)?.jsonData?.spec || (ip as any)?.spec || {})?.tokenBudget?.dailyTokens || 0;
+    const used = consumedBySandbox[sb.metadata.name] || 0;
+    return {
+      name: sb.metadata.name,
+      policy: refName || "—",
+      budget: dailyBudget,
+      used,
+      pct: dailyBudget > 0 ? (used / dailyBudget) * 100 : 0,
+    };
+  });
+
+  const fleetBudget = rows.reduce((s, r) => s + r.budget, 0);
+  const fleetUsed = rows.reduce((s, r) => s + r.used, 0);
+  const fleetPct = fleetBudget > 0 ? (fleetUsed / fleetBudget) * 100 : 0;
+  const atRisk = rows.filter((r) => r.pct >= 70).length;
+  const over = rows.filter((r) => r.pct >= 100).length;
+
+  return (
+    <SectionBox title="💰 Token Budget (24h)">
+      <div style={{ marginBottom: 12, fontSize: 13, color: muted }}>
+        Aggregate daily budget across all InferencePolicy CRs vs. actual consumption pulled from
+        Prometheus. {err && <span style={{ color: "#ef5350" }}>{err}</span>}
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: "1rem", marginBottom: 16 }}>
+        <Stat label="Fleet budget (24h)" value={formatTokens(fleetBudget)} />
+        <Stat label="Fleet consumed (24h)" value={formatTokens(fleetUsed)} tone={utilizationTone(fleetPct)} />
+        <Stat label="Fleet utilization" value={`${fleetPct.toFixed(1)}%`} tone={utilizationTone(fleetPct)} />
+        <Stat label="Sandboxes ≥70% used" value={atRisk} tone={atRisk > 0 ? "warning" : ""} />
+        <Stat label="Sandboxes over budget" value={over} tone={over > 0 ? "error" : ""} />
+      </div>
+      <div style={{ marginBottom: 8, fontSize: 13, fontWeight: 600 }}>Fleet utilization</div>
+      <BudgetBar used={fleetUsed} total={fleetBudget} height={20} />
+      <div style={{ marginTop: 16 }}>
+        <SimpleTable
+          data={rows.sort((a, b) => b.pct - a.pct).map((r) => ({
+            name: r.name,
+            policy: r.policy,
+            budget: formatTokens(r.budget),
+            used: formatTokens(r.used),
+            bar: r,
+          }))}
+          columns={[
+            { label: "Sandbox", getter: (r: { name: string }) => r.name },
+            { label: "Policy", getter: (r: { policy: string }) => r.policy },
+            { label: "Budget", getter: (r: { budget: string }) => r.budget },
+            { label: "Used", getter: (r: { used: string }) => r.used },
+            { label: "Utilization", getter: (r: { bar: { used: number; budget: number } }) => (
+              <div style={{ width: 160 }}><BudgetBar used={r.bar.used} total={r.bar.budget} /></div>
+            )},
+          ]}
+        />
+      </div>
+    </SectionBox>
+  );
+}
+
+function SandboxBudgetCard({ sandboxName, inferenceRefName }: { sandboxName: string; inferenceRefName?: string }) {
+  const theme = useTheme();
+  const muted = theme.palette.text.secondary;
+  // Pull both the bound InferencePolicy CR (for the budget) and the live counter.
+  const [policies] = (CRD_CLASSES.inferencepolicies as any).useList() as [KubeObject[] | null];
+  const policy = (policies || []).find((p) => p.metadata.name === inferenceRefName);
+  const spec = (policy as any)?.jsonData?.spec || (policy as any)?.spec || {};
+  const dailyBudget = spec?.tokenBudget?.dailyTokens || 0;
+  const perRequestCap = spec?.tokenBudget?.perRequestTokens || 0;
+
+  const { data: used24h } = usePromPoll(
+    0,
+    async (base) => {
+      const r = await promQuery(base, `sum(increase(azureclaw_tokens_total{sandbox="${sandboxName}"}[24h]))`);
+      return r[0]?.value || 0;
+    },
+    10000
+  );
+  const { data: split } = usePromPoll(
+    [] as { metric: Record<string,string>; value: number }[],
+    async (base) => promQuery(base, `sum by (direction) (increase(azureclaw_tokens_total{sandbox="${sandboxName}"}[24h]))`),
+    10000
+  );
+
+  const pct = dailyBudget > 0 ? (used24h / dailyBudget) * 100 : 0;
+  const remaining = Math.max(0, dailyBudget - used24h);
+  const inputTok = split.find((r) => r.metric.direction === "input")?.value || 0;
+  const outputTok = split.find((r) => r.metric.direction === "output")?.value || 0;
+
+  return (
+    <SectionBox title={`💰 Token Budget — ${sandboxName}`}>
+      {!inferenceRefName && (
+        <div style={{ color: muted, fontSize: 13 }}>No <code>inferenceRef</code> set on this sandbox; no enforced budget.</div>
+      )}
+      {inferenceRefName && !policy && (
+        <div style={{ color: "#ef6c00", fontSize: 13 }}>InferencePolicy <code>{inferenceRefName}</code> not found.</div>
+      )}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "0.75rem", marginBottom: 12 }}>
+        <Stat label="Daily budget" value={dailyBudget > 0 ? formatTokens(dailyBudget) : "unlimited"} />
+        <Stat label="Consumed (24h)" value={formatTokens(used24h)} tone={utilizationTone(pct)} />
+        <Stat label="Remaining" value={dailyBudget > 0 ? formatTokens(remaining) : "—"} tone={utilizationTone(pct)} />
+        <Stat label="Per-request cap" value={perRequestCap > 0 ? formatTokens(perRequestCap) : "unlimited"} />
+        <Stat label="Input tokens" value={formatTokens(inputTok)} />
+        <Stat label="Output tokens" value={formatTokens(outputTok)} />
+      </div>
+      {dailyBudget > 0 && (
+        <div>
+          <div style={{ marginBottom: 6, fontSize: 13, fontWeight: 600 }}>Utilization</div>
+          <BudgetBar used={used24h} total={dailyBudget} height={22} />
+        </div>
+      )}
+      {inferenceRefName && (
+        <div style={{ marginTop: 12, fontSize: 12, color: muted }}>
+          Policy: <Link routeName="inferencepolicies-detail" params={{ namespace: (policy as any)?.metadata?.namespace || "default", name: inferenceRefName }}>
+            {inferenceRefName}
+          </Link>
+        </div>
+      )}
+    </SectionBox>
   );
 }


### PR DESCRIPTION
Bundles the in-cluster observability story end-to-end:

## Router (Rust)
- New `azureclaw_mesh_messages_sent_total` and `azureclaw_mesh_messages_received_total` Prometheus counters in `inference-router/src/metrics.rs`, incremented in `routes/mesh.rs`. Counts KNOCK + X3DH + `mesh_send` + 30s heartbeats; excludes WS Ping/Pong by design. Sandbox label injected at scrape time by the PodMonitor.

## Monitoring stack
- PodMonitor scraping every sandbox router's `/metrics` (15s, sandbox + sandbox_namespace labels)
- prometheus-json-exporter for AGT relay `/health` (agentmesh_relay_*)
- Two Grafana dashboards: `azureclaw-fleet` (10-panel quick fleet overview) and `azureclaw-ops` (31-panel enterprise NOC: fleet health, token economy, latency SLO, AGT governance, bundle health). Mesh row removed from ops — now lives in Headlamp.
- ConfigMap wrapping both with `grafana_dashboard=1` for kube-prometheus-stack sidecar pickup.

## Headlamp plugin v0.5.1
- Mesh Topology rewritten on the new mesh-msg counters: msg-rate edge thickness, two-direction animated pulses (yellow=sent, light-blue=recv), node labels show lifetime ↑sent ↓recv. Controllers decorated with `N children · M trust`.
- New TokenBudgetOverview + SandboxBudgetCard cards backed by `azureclaw_tokens_total` + `TOKEN_BUDGET_DAILY` env.
- Full dark-mode pass: all hardcoded `#555`/`#c62828` replaced with `useTheme()` palette; Grafana iframe URLs now use `theme=${grafanaTheme}` derived from `palette.mode`.

## Docs
- `tools/headlamp-plugin/README.md` Mesh Topology + observability section
- `.github/skills/agt-e2e-encryption/SKILL.md` mesh-message metrics section with sent-vs-received attribution
- `deploy/monitoring/dashboards.md` mesh counters section

## Verified live
- All 5 sandboxes scrape `up` on local-k8s
- Mesh Topology renders msg rates + lifetime counts correctly
- Dark mode round-trips (Headlamp light/dark → Grafana embed follows)
- 31-panel ops dashboard loads with no mesh row