### PR TITLE
fix(docs): two mermaid parse errors (crd-reference + architecture-diagrams)

### DIFF
--- a/docs/api/crd-reference.md
+++ b/docs/api/crd-reference.md
@@ -71,7 +71,7 @@ sequenceDiagram
   CM-->>Rt: Volume-mount or hot-reload picks up new bytes
   Rt->>Rt: Re-canonicalise locally, POST {loaded_digest} to /internal/policy-status
   C->>Rt: Compare router's loaded_digest vs controller's compiled digest
-  C->>K: status.bundleRefDigest = digest; condition Ready=True only on match
+  C->>K: status.bundleRefDigest = digest. Condition Ready=True only on match
 ```
 
 Two crypto checks always fire, and both must pass:

--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -62,7 +62,7 @@ flowchart TB
   Router -->|exchange SA→AAD| WI
   WI -.->|no keys on disk| Router
   Router -->|HTTPS, AAD token| Foundry
-  Router -->|WS, opaque ciphertext (agent-sourced)| Mesh
+  Router -->|"WS, opaque ciphertext (agent-sourced)"| Mesh
   Router -->|HTTPS| A2A
 
   classDef cluster fill:#e6f0ff,stroke:#0078d4


### PR DESCRIPTION
Two Mermaid blocks in the docs fail to render. Found by running `mmdc` against every `\`\`\`mermaid` block in `docs/` (49 blocks total — these were the only two failures).

## #1 — `docs/api/crd-reference.md` (verification-path sequence diagram)

The line

```
C->>K: status.bundleRefDigest = digest; condition Ready=True only on match
```

contains a `;` inside the message text. Mermaid sequence diagrams treat `;` as a statement separator, so the parser cuts the line in half and chokes on the trailing fragment.

**Fix:** `;` → `.`.

## #2 — `docs/architecture-diagrams.md` (component diagram)

The flowchart edge label

```
Router -->|WS, opaque ciphertext (agent-sourced)| Mesh
```

contains unescaped parens. Mermaid sees the `(` and expects a shape-end token.

**Fix:** wrap the edge label in double quotes.

## Validation

```
$ for f in docs/api/crd-reference.md docs/architecture-diagrams.md; do
    python -c "..." extract every mermaid block
    npx mmdc -i ...
  done
Generating single mermaid chart
Generating single mermaid chart
```

No parse errors on either after the fix. Scanned all 49 mermaid blocks across `docs/`; these were the only two failures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
