### PR TITLE
fix(ci): add missing copyright header to exec-brief/config.sh

### DIFF
--- a/tools/e2e-harness/scenarios/exec-brief/config.sh
+++ b/tools/e2e-harness/scenarios/exec-brief/config.sh
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
 # scenarios/exec-brief/config.sh — exec-brief-specific knobs the
 # generic driver picks up via `source $SCENARIO_DIR/config.sh`.
 #


### PR DESCRIPTION
ci-gates copyright-headers gate has been red on main for the last 3 commits — pre-existing miss that landed with #339. Brings the file in line with every other shell file in `tools/e2e-harness/`. Locally: `./ci/check-copyright-headers.sh` → ✅ All 462 source files carry the header.