### PR TITLE
docs: close audit §3 brittle counters

### DIFF
--- a/docs/api/backwards-compatibility.md
+++ b/docs/api/backwards-compatibility.md
@@ -79,5 +79,5 @@ Every release includes the standard sections (see [`r5-changelog`](../../CHANGEL
 
 ## Forward-looking notes
 
-- A CRD `v1alpha2` is planned for v1.1 (additive only). The conversion webhook ships at the same time. Existing `v1alpha1` clients keep working without change.
+- A CRD `v1alpha2` is on the roadmap (additive only) alongside a conversion webhook so existing `v1alpha1` clients keep working without change. See [`docs/roadmap.md`](../roadmap.md) for the current target window.
 - The provider-trait surface is internal and *will* change between minor versions. External consumers should integrate at the CRD or CLI level, not the trait level.

--- a/docs/blueprints/02-enterprise-self-hosted.md
+++ b/docs/blueprints/02-enterprise-self-hosted.md
@@ -285,7 +285,7 @@ azureclaw trace research-bot --network
 - **Multi-runtime, single governance plane.** Teams can run `OpenClaw`, `OpenAIAgents`, or `MicrosoftAgentFramework` agents side-by-side on the same cluster with identical `InferencePolicy` + `ToolPolicy` governance and the same audit chain. Switch runtimes by changing `spec.runtime.kind`.
 - **Signed OCI egress allowlist as the production network policy path.** Inline `allowedEndpoints` are fine for day-0; sign and pin allowlist artifacts in CI for auditable, GitOps-managed network policy. The `SignerPolicy` ConfigMap in `azureclaw-system` pins the authoritative signer identity; the controller fails closed if the policy is absent or the signature doesn't match.
 - **You can scale Confidential Containers in.** AKS supports kata + AMD SEV-SNP node pools today. Set `ClawSandbox.spec.sandbox.isolation: confidential` per-agent for sensitive workloads; sub-agents inherit and cannot downgrade.
-- **CNCF Kubernetes AI Conformance v1.35+.** The cluster and all nine CRDs pass the CNCF AI Conformance suite (`tests/cncf-conformance/`). This gives you a reproducible, vendor-neutral benchmark and audit evidence for your security reviewers.
+- **CNCF Kubernetes AI Conformance.** The cluster and all CRDs are validated against the CNCF AI Conformance suite (`tests/cncf-conformance/`); the README pins the exact upstream tag the suite tracks. This gives you a reproducible, vendor-neutral benchmark and audit evidence for your security reviewers.
 
 ## Operator polish
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,13 +26,13 @@ If you have a GitHub Copilot seat — Individual, Business, or Enterprise — `a
 
 1. Run `azureclaw dev`. The CLI prints a **device code** and a URL.
 2. Open <https://github.com/login/device> in your browser, paste the code, approve the AzureClaw client.
-3. Pick a model from the catalogue the CLI shows you — **Claude Opus 4.7**, **Claude Sonnet 4.5**, **GPT-5**, **GPT-4.1**, **Gemini 2.5 Pro**, **o4-mini**, etc. The router will use it for every chat completion the agent makes.
+3. Pick a model from the catalogue the CLI shows you — current Claude, GPT, Gemini, and reasoning-class models are exposed; run `azureclaw models` to see today's list. The router will use the selected model for every chat completion the agent makes.
 
 That's it. No PAT to rotate, no API key on disk, no subscription to provision. The OAuth token is stored in `~/.azureclaw/` and refreshed automatically.
 
 **Why we recommend Copilot for the inner loop:**
 
-- **Frontier models, large contexts.** Claude Opus 4.7 / GPT-5 / Gemini 2.5 Pro through one auth surface — exactly the catalogue you'd compose by hand against three vendors.
+- **Frontier models, large contexts.** Current Claude, GPT, and Gemini frontier tiers through one auth surface — exactly the catalogue you'd compose by hand against three vendors.
 - **Native Anthropic shape for Claude.** AzureClaw routes Claude requests to Copilot's `/v1/messages` endpoint with no shape translation, preserving full tool-calling fidelity (no lossy OpenAI-to-Anthropic rewrites).
 - **One credential, no key sprawl.** The same OAuth token works for the parent agent and every sub-agent it spawns; the router refreshes it on its own.
 - **Sub-agent inheritance.** Spawned sub-agents automatically inherit the parent's provider, model, and credentials — no per-agent wiring.

--- a/docs/operations/supply-chain.md
+++ b/docs/operations/supply-chain.md
@@ -84,9 +84,11 @@ helm install azureclaw deploy/helm/azureclaw \
   --set controller.image.tag="@sha256:<digest>"
 ```
 
-CNCF conformance criterion **C9** (`tests/cncf-conformance`) enforces
+The CNCF AI Conformance suite under `tests/cncf-conformance/` enforces
 the minimum bar: every `image:` reference must declare an explicit
-tag or digest. Implicit `:latest` (no tag at all) is forbidden.
+tag or digest. Implicit `:latest` (no tag at all) is forbidden. The
+exact criterion identifier tracks the upstream conformance release the
+suite is pinned to — see the suite's README for the current mapping.
 
 ## SBOM
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -105,7 +105,7 @@ When `spec.governance.enabled: true`, AGT governance runs **natively inside the 
 | `TrustManager` | Ed25519 identities, 0–1000 trust score, 5 tiers, clamped ±200/update. |
 | `AuditLogger` | SHA-256 hash-chained log. Tamper-detectable. Append-only. |
 | `RateLimiter` | 500 req/sec global, 50/sec per-agent default. Token bucket with burst. |
-| `BehaviorMonitor` | Burst detection (100/60s), failure tracking (20), denial tracking (10/60s). |
+| `BehaviorMonitor` | Burst detection, failure tracking, denial tracking — thresholds configured per deployment; see `inference-router/src/behavior_monitor.rs`. |
 
 Governance evaluation is on the router hot path, written in Rust, and short-circuits on the first deny so the cost is dominated by the cheapest rule that matches. Plugin-side AGT only handles E2E-encrypted mesh transport through `@microsoft/agent-governance-sdk`; every governance decision goes through the router.
 


### PR DESCRIPTION
Closes the 6 remaining §3 brittle-counter items from the docs audit. With this, **Phase 1 + Phase 2** of the audit are complete. Only Phase 3 (structural splits) and Phase 4 (CI widening) remain — both consciously deferred.

Changes:
- `docs/security.md` BehaviorMonitor numbers → adjective + Rust source link
- `docs/getting-started.md` model list → adjective + `azureclaw models` pointer (×2)
- `docs/blueprints/02-enterprise-self-hosted.md` CNCF v1.35+ → drop version
- `docs/operations/supply-chain.md` C9 → suite README pointer
- `docs/api/backwards-compatibility.md` v1.1 date claim → roadmap link

VM SKU in blueprints/03 left as-is (mermaid label + CLI example; concrete usage is fine).

mdbook build clean.