### PR TITLE
docs: audit follow-ups — outcome-first README, expanded troubleshooting, mesh-plugin offload pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ It is built for three audiences:
 - **Security teams** — one opinionated, layered control plane for identity, egress, content safety, governance, mesh trust.
 - **Agent builders** — build the agent, not the boring-but-load-bearing infrastructure underneath it.
 
+> **Status — pre-launch (v0.1.0).** AzureClaw is an open-source project from Microsoft. We don't yet have public reference customers to list — if your team is running governed agents on AKS and wants to be one, we'd love to hear from you ([SUPPORT.md](SUPPORT.md)). The design assumes platform teams operating roughly ten or more agents on AKS with an Azure-AI-Foundry-or-Copilot model backend; below that, `azureclaw dev` on a laptop is probably the right shape.
+
 ### What makes it different
 
-- **The router is the security boundary, not the agent process.** Every external call is mediated by a typed Rust proxy under a different UID, with credentials the agent never sees and a CRD-driven allowlist on every request. iptables + NetworkPolicy are safety nets, not the policy layer.
-- **Governance is a first-class CRD layer.** Approval gates, rate limits, tool allowlists, content-safety floors, token budgets, and trust topology are all declarative Kubernetes resources you commit to a repo and reconcile with Argo / Flux — no out-of-band config store.
-- **End-to-end encrypted agent-to-agent mesh.** Signal Protocol (X3DH + Double Ratchet) with KNOCK trust gating. The relay sees only ciphertext.
-- **Provider- and runtime-agnostic.** Seven first-class runtimes (OpenClaw, OpenAI Agents SDK, Microsoft Agent Framework, LangGraph in Python and TypeScript, Anthropic, Pydantic-AI) plus BYO; GitHub Copilot, Azure AI Foundry, Azure OpenAI, and GitHub Models as backends; native Anthropic-shape passthrough for Claude.
-- **Same code path in dev and prod.** `azureclaw dev` runs the same router, the same audit chain, the same governance profile as `azureclaw up`. The dev-to-prod jump is one CLI command, not a re-architecture.
+- **A prompt-injected agent cannot leak your Azure credentials** — because the agent process runs under a different UID than the Rust router that holds them, on a different network, and never sees the bearer token. (iptables + NetworkPolicy back this up; they are not the primary control.)
+- **Your security and platform teams review YAML, not Python.** Approval gates, rate limits, tool allowlists, content-safety floors, token budgets, and trust topology are declarative Kubernetes resources — commit them to a repo, reconcile with Argo / Flux, audit with `git log`. No out-of-band config store, no per-agent code review for policy.
+- **Two agents that talk cannot be eavesdropped by you, by us, or by the relay.** Agent-to-agent messaging is end-to-end encrypted with Signal Protocol (X3DH + Double Ratchet) and KNOCK trust gating. The relay sees only ciphertext.
+- **You are not locked to one runtime or one model provider.** Seven first-class runtimes (OpenClaw, OpenAI Agents SDK, Microsoft Agent Framework, LangGraph in Python and TypeScript, Anthropic, Pydantic-AI) plus BYO. GitHub Copilot, Azure AI Foundry, Azure OpenAI, and GitHub Models as backends — switching is a one-field CRD change, not a re-architecture. Native Anthropic-shape passthrough for Claude.
+- **What runs on your laptop is what runs in production.** `azureclaw dev` and `azureclaw up` share the same router binary, the same audit chain, the same governance profile. The dev-to-prod jump is one CLI command — no separate stack to learn or debug.
 
 ---
 

--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -93,9 +93,14 @@ sequenceDiagram
   Gov-->>Router: allow + decision audit
   Router->>WI: exchange SA token → AAD
   WI-->>Router: bearer token
-  Router->>Foundry: POST /openai/… + bearer<br/>(Content Safety enforced server-side)
-  Foundry-->>Router: completion + prompt_filter_results
-  Router->>Router: parse prompt_filter_results — block if jailbreak / category > threshold
+  alt provider == Foundry / Azure OpenAI
+    Router->>Foundry: POST /openai/… + bearer<br/>(Content Safety enforced server-side)
+    Foundry-->>Router: completion + prompt_filter_results
+    Router->>Router: parse prompt_filter_results — block if jailbreak / category > threshold
+  else provider == Copilot or GitHub Models
+    Router->>Foundry: POST upstream + bearer<br/>(no inline Content Safety returned)
+    Foundry-->>Router: completion (no prompt_filter_results)
+  end
   Router-->>Agent: completion
   Note over Router: audit record:<br/>hash-chained, append-only<br/>(detection, not signing)
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ In prose:
 
 > **More providers later.** Copilot, Foundry, and GitHub Models are the three backends wired in today. Adding more (direct Anthropic, Bedrock, AWS Q, third-party OpenAI-compatible gateways) is mostly a matter of an endpoint+auth recipe in `inference-router/src/proxy.rs::build_upstream_url` plus a CLI prompt branch. We're tracking provider-expansion through GitHub issues — please open a feature request describing the provider, auth model, and which Foundry-only features (if any) you'd want preserved.
 
-Every other external call (web fetch, MCP tool, sub-agent spawn, A2A peer message) goes through the same shape with a different policy module. Code: `inference-router/src/routes/chat_completions.rs:27-100`.
+Every other external call (web fetch, MCP tool, sub-agent spawn, A2A peer message) goes through the same shape with a different policy module. The handler is `chat_completions_handler` in [`inference-router/src/routes/chat_completions.rs`](../inference-router/src/routes/chat_completions.rs).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -269,8 +269,12 @@ Then submit `ClawSandbox` resources directly with `kubectl apply`. The CLI is co
 |---|---|---|
 | `azureclaw dev` hangs on first run | Docker Desktop is not running | Start Docker. |
 | `azureclaw up` fails on `az login` | Stale CLI session | `az logout && az login --use-device-code`. |
+| `azureclaw connect` fails with `address already in use` | Leftover `kubectl port-forward` from a previous session is still holding the local port | `lsof -ti:18789 \| xargs kill` (or restart your terminal). Then retry. |
+| `azureclaw dev` errors with `Unsupported engine` on `npm ci` | Node.js < 22 | Install Node 22+ (we test against the LTS line; see [`cli/package.json`](../cli/package.json) for the exact engines pin). |
+| `kind create cluster` fails with `cluster "kind" already exists` | A previous `azureclaw dev --target local-k8s` run did not clean up | `kind delete cluster --name <name>` and retry. |
+| GitHub Copilot provider returns `401` | The token is a classic PAT, not a Copilot-enabled OAuth token; or your Copilot seat is inactive | Verify your seat at [github.com/settings/copilot](https://github.com/settings/copilot). See [`cli-reference.md#azureclaw-dev`](cli-reference.md#azureclaw-dev) for the OAuth flow. |
 | Sandbox stays `Pending` | Foundry quota / model not deployed | `kubectl describe clawsandbox <name>` — the controller surfaces the cause as a `Condition`. |
-| Agent gets `403` on tool call | `ToolPolicy` denies it | `azureclaw policy show <name>` and adjust. |
+| Agent gets `403` on tool call | `ToolPolicy` denies it | `azureclaw policy show <name>` and adjust. See [`cli-reference.md#azureclaw-policy`](cli-reference.md#azureclaw-policy). |
 | Mesh KNOCK fails | Trust score below threshold | See **[AGT boundary](architecture/agt-boundary.md#trust-scoring)**. |
 
 The complete operational runbook is in **[`docs/operations/`](operations/)**.

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -163,6 +163,19 @@ The existing adapters are the reference. CrewAI is tracked in the [roadmap](road
 
 ---
 
+## Running OpenClaw locally and offloading to AzureClaw (no in-cluster runtime)
+
+The runtimes above describe agents that run **inside** an AzureClaw sandbox pod. There is a second, complementary shape: a local OpenClaw (or OpenClaw variant, e.g. NVIDIA's `nemoclaw`) running on your laptop or a non-AzureClaw host that uses the AzureClaw **mesh-plugin** to delegate heavy work to a governed AKS sandbox over the encrypted mesh.
+
+- **The local OpenClaw is not operated by AzureClaw.** You install it yourself, configure it yourself, run it under your shell. AzureClaw governs only the cloud-side environment that receives the offloaded task.
+- **The mesh-plugin (`@azureclaw/mesh`) installs into your local OpenClaw.** It registers the local agent on AGT, pairs to your AzureClaw cluster with a one-time token, and exposes tools (`mesh_send`, `mesh_offload`, `mesh_transfer_file`, etc.) that your agent can call.
+- **All traffic is E2E encrypted.** The relay sees only ciphertext (same Signal Protocol stack as in-cluster mesh, see [`architecture.md` → The mesh](architecture.md#the-mesh)).
+- **Variants ship as flavored builds of the same plugin.** `mesh-plugin/` is the canonical `@azureclaw/mesh` for stock OpenClaw; `mesh-plugin/nemoclaw/` is the NVIDIA NeMo / `nemoclaw` flavored build (policy presets + `setup.sh` that fits the nemoclaw container shape). The `sandbox-images/nemoclaw/Dockerfile` is the convenience image that bundles nemoclaw + the plugin together for users who want a pre-wired local container.
+
+Setup, pairing, and troubleshooting for the local-OpenClaw-with-offload pattern live in **[`mesh-plugin/README.md`](../mesh-plugin/README.md)** — that is the operator-facing reference for this shape.
+
+---
+
 ## See also
 
 - **[CRD reference — `ClawSandbox`](api/crd-reference.md#clawsandbox--the-agent)** — the spec field structure for each runtime.


### PR DESCRIPTION
Executes the items left as "deferred" after #347, per user pushback ("can someone explain me why always defer?").

## What changed

| File | Change |
|---|---|
| `README.md` | "What makes it different" rewritten **outcome-first** (lead with the user-visible guarantee, mechanism in parentheses). Honest pre-launch adoption callout — no fabricated customer names; points at SUPPORT.md for would-be reference customers; states the design assumption (≥10 agents on AKS with Foundry/Copilot backend). |
| `docs/getting-started.md` | Troubleshooting table expanded from 5 → 9 rows. New entries: `azureclaw connect` port conflict (the exact symptom we hit live this session), Node 22+ engine mismatch, leftover `kind` cluster, inactive Copilot seat. Anchor links to `cli-reference.md#azureclaw-dev` and `#azureclaw-policy`. |
| `docs/runtimes.md` | New section **"Running OpenClaw locally and offloading to AzureClaw"** — documents the mesh-plugin shape: a local OpenClaw (or `nemoclaw` variant) on your laptop using `@azureclaw/mesh` to delegate heavy work to a governed AKS sandbox over the encrypted mesh. Clarifies that `sandbox-images/nemoclaw/` is the convenience image bundling nemoclaw + plugin, **not** an AzureClaw-operated runtime — points readers at the existing `mesh-plugin/README.md` for the operator runbook. |
| `docs/architecture.md` | Stale line range `chat_completions.rs:27-100` → replaced with function name `chat_completions_handler` + repo-relative link. |
| `docs/architecture-diagrams.md` | Diagram 3 (one model call) shows provider branching explicitly with `alt`/`else` — Foundry path parses `prompt_filter_results`; Copilot / GitHub Models path does not. The caveat that was prose-only is now visible in the diagram itself. |

## Verified before edits

- `mesh-plugin/README.md` is already the operator-facing reference for the local-OpenClaw offload pattern (315 lines, real Quickstart, real troubleshooting) — `docs/runtimes.md` now surfaces it instead of duplicating.
- `mesh-plugin/nemoclaw/` exists with `policies/` + `setup.sh` (nemoclaw-flavored mesh-plugin build).
- `sandbox-images/nemoclaw/Dockerfile` builds nemoclaw + plugin together as a convenience image — not an AzureClaw runtime.
- `cli-reference.md` headings `### \`azureclaw dev\`` (line 164) and `### \`azureclaw policy\`` (line 1009) verified to match the anchors used.
- Existing 5-row troubleshooting table was found at lines 266-275 (not absent as the audit claimed — auditor missed it; we expand it).
- `chat_completions_handler` confirmed to be the function in `inference-router/src/routes/chat_completions.rs`.

## Verification

```
mdbook build (docs/site)   → clean, 0 warnings
git diff --stat            → 5 files, +34 -10
```

## Out of scope (still deferred — needs runtime validation or separate scope)

- New `examples/mesh-quickstart/` directory — shipping an untested 2-agent demo would violate the no-hallucination directive; `mesh-plugin/README.md` Quickstart is the tested path that already exists.
- Phase 3 structural splits (`cli-reference.md` 1705 lines, `use-cases.md` 886 lines, CHANGELOG, blueprint-03 hardware-isolation extraction).
- Phase 4 branch-protection widening 4 → 11 required checks (needs admin action outside repo).