### PR TITLE
fix(deps): bump agentmesh 3.1.0 → 3.7.0 (CredentialRedactor::new is now infallible)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "agentmesh"
-version = "3.3.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbaef94069c2dee3cc60357a787e65b9f875bb326f782181753e1b250189fc38"
+checksum = "c8aad669165e6bd20bdbf06c31f095ea96102586e6c99ed0f64f18e202fe0760"
 dependencies = [
  "base64 0.22.1",
  "cedar-policy",
@@ -2740,7 +2740,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4107,9 +4107,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656c9768f1d2113590ebc05e2e342a9f76baa97a445f2928f24eec9ae1fb14ac"
+checksum = "63642e663bb81698ab7160735bdc831f580022194922d3f24d5c40a913ff3fab"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -4118,7 +4118,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "spin",
+ "spin 0.10.0",
  "thiserror 2.0.18",
 ]
 
@@ -4941,6 +4941,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 
 # AGT governance (native — replaces former Python sidecar)
-agentmesh = "3.1.0"
+agentmesh = "3.7.0"
 
 # Benchmarking (S16 — chaos tier perf baselines). Used by `controller/benches/`
 # and `inference-router/benches/`. Kept out of the binary builds via dev-deps.

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -175,18 +175,17 @@ impl Governance {
         let policy = PolicyEngine::new();
         let policy_rule_count = AtomicU64::new(0);
 
-        // AGT MCP modules (from agentmesh 3.1.0)
-        let redactor = CredentialRedactor::new().unwrap_or_else(|e| {
-            tracing::warn!("CredentialRedactor init failed ({e}), using fallback");
-            CredentialRedactor::new().expect("redactor must initialize")
-        });
+        // AGT MCP modules. As of agentmesh 3.7, `CredentialRedactor::new()` is
+        // infallible — regex literals are validated at compile time via
+        // `.expect()` inside the constructor. See agentmesh-3.7.0
+        // src/mcp/redactor.rs.
+        let redactor = CredentialRedactor::new();
         let mcp_clock: std::sync::Arc<dyn agentmesh::mcp::Clock> = std::sync::Arc::new(SystemClock);
-        let mcp_audit: std::sync::Arc<dyn agentmesh::mcp::McpAuditSink> = std::sync::Arc::new(
-            InMemoryAuditSink::new(CredentialRedactor::new().expect("redactor for audit sink")),
-        );
+        let mcp_audit: std::sync::Arc<dyn agentmesh::mcp::McpAuditSink> =
+            std::sync::Arc::new(InMemoryAuditSink::new(CredentialRedactor::new()));
         let mcp_metrics = McpMetricsCollector::default();
         let response_scanner = McpResponseScanner::new(
-            CredentialRedactor::new().expect("redactor for scanner"),
+            CredentialRedactor::new(),
             mcp_audit,
             mcp_metrics,
             mcp_clock.clone(),


### PR DESCRIPTION
Supersedes #334 (Dependabot couldn't auto-merge because the major API change needed call-site updates).

## Root cause

In agentmesh 3.7.0, `CredentialRedactor::new()` was changed from `Result<Self, McpError>` → `Self`. Regex literals are now validated at compile time via `.expect()` inside the constructor (see `agentmesh-3.7.0/src/mcp/redactor.rs`).

Our four call sites in `inference-router/src/governance/mod.rs:179-189` were still threading the `Result`, so the build broke with E0599:

```
error[E0599]: no method named `unwrap_or_else` found for struct `agentmesh::CredentialRedactor`
error[E0599]: no method named `expect` found for struct `agentmesh::CredentialRedactor`
```

## Fix

Drop the `.unwrap_or_else(...)` and `.expect(...)` from the four call sites. Behaviour is unchanged — the old code's "fallback" path also called `new().expect(...)` after warning-logging, so we were never going to actually recover from an Err in production.

## Workspace bump 3.1.0 → 3.7.0

Workspace was on `agentmesh = "3.1.0"` (Cargo.toml:82); 3.3.0 was a transitive bump in the lockfile. Going straight to 3.7.0 brings dep and lockfile in sync.

## Verified

| Check | Result |
|---|---|
| `cargo build --package azureclaw-inference-router` | clean |
| `cargo build --package azureclaw-controller` | clean (no direct dep) |
| `cargo test --package azureclaw-inference-router --lib` | **884 passed**, 0 failed |

## Out of scope

60 new deprecation warnings about `agentmesh::mcp::*` re-exports moving to a future `agentmesh-mcp` crate (upstream issue #2013, next major). Migration is out of scope for this minor bump.

Closes #334.
