### PR TITLE
docs+examples: make every example actually applicable, surface the catalogue in docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Operator TUI](operator-tui.md)
 - [Permissions model](permissions.md)
 - [Demo script](demo-script.md)
+- [Examples catalogue](examples.md)
 
 # Operations
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,57 @@
+# Examples catalogue
+
+Eight end-to-end blueprints live under [`examples/`](https://github.com/Azure/azureclaw/tree/main/examples). Each one is a self-contained `kubectl apply -f` after `azureclaw up`. All examples share the same control-plane install and isolation guarantees — only the agent runtime image changes.
+
+## Single-agent runtime quickstarts
+
+| Example | Runtime | What it shows |
+|---|---|---|
+| [`basic-agent`](https://github.com/Azure/azureclaw/tree/main/examples/basic-agent) | `OpenClaw` | The smallest possible deployment — minimal sandbox with default isolation (seccomp-strict, RO rootfs, egress guard, AGT governance). **Start here.** |
+| [`telegram-agent`](https://github.com/Azure/azureclaw/tree/main/examples/telegram-agent) | `OpenClaw` | OpenClaw agent wired to a Telegram channel via the [channel-plugin pattern](channels-plugins.md). |
+| [`confidential-agent`](https://github.com/Azure/azureclaw/tree/main/examples/confidential-agent) | `OpenClaw` + Confidential Containers | The basic-agent shape upgraded to AKS Confidential Containers — CVM workers, attested boot, encrypted memory. |
+| [`openai-agents-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/openai-agents-quickstart) | `OpenAIAgents` (Python) | Hosts an unmodified [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) app. The adapter transparently routes `api.openai.com` through the local inference router. |
+| [`maf-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/maf-quickstart) | `MicrosoftAgentFramework` (Python) | Hosts an unmodified [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) app. |
+| [`byo-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/byo-quickstart) | `BYO` | Brings any container image under the BYO contract. Includes a tiny FastAPI reference agent. |
+
+## Multi-agent attack-simulation demos
+
+| Example | Shape | What it shows |
+|---|---|---|
+| [`demo-clawshield`](https://github.com/Azure/azureclaw/tree/main/examples/demo-clawshield) | Three OpenClaw agents in three namespaces (Contoso Bank, Fabrikam Legal, Northwind Trade) | Multi-tenant isolation proof. A poisoned document attempts to exfiltrate across tenants; the NetworkPolicy + egress guard + governance layer each block it independently. |
+| [`lethal-trifecta-demo`](https://github.com/Azure/azureclaw/tree/main/examples/lethal-trifecta-demo) | Two OpenClaw agents (vanilla vs. AzureClaw-managed) | Reproduces the [Claude Cowork file-exfiltration attack](https://www.promptarmor.com/resources/claude-cowork-exfiltrates-files) (Jan 2026). Six independent layers — each one alone catches the attack on the AzureClaw-managed side. **Recommended launch demo.** |
+
+## Prerequisites — common to all examples
+
+Every example assumes:
+
+1. `azureclaw up` (or `azureclaw dev` for the laptop path) has been run.
+2. Your control plane has resolved the sandbox image (the controller sets `SANDBOX_IMAGE` to the image it built or pulled — see [Operations → Image versioning](operations/image-versioning.md)).
+3. For Foundry-backed runs, the `InferencePolicy` references a model deployment that actually exists in your Foundry project.
+
+The YAMLs intentionally do **not** pin `runtime.openclaw.image` or `runtime.openclaw.version` — the controller's `SANDBOX_IMAGE` default is the authoritative source. Pinning here would override that and likely break the example for anyone not running our internal registry.
+
+## What you'll need to replace
+
+The two SDK quickstarts (`openai-agents-quickstart`, `maf-quickstart`) reference a placeholder agent image:
+
+```yaml
+runtime:
+  openaiAgents:                  # or microsoftAgentFramework
+    agentCode:
+      oci:
+        image: REPLACE-ME/your-agent:latest
+```
+
+There is no published agent image for these — you supply your own. The README in each directory shows the exact swap. (The BYO quickstart has the same `REPLACE_ME` pattern for the same reason.)
+
+## What none of these examples cover
+
+- **Real cross-org A2A traffic** — that's the [A2A gateway](architecture/a2a-gateway.md) operations runbook, not a single-YAML demo.
+- **Production-grade observability wiring** — the demos rely on `kubectl logs` and `kubectl describe`. For real ops, see [Operations → Observability](operations/README.md).
+- **GitOps rollout** — see the [GitOps blueprint](operations/gitops.md) for Argo/Flux + signed-image rollout.
+
+## See also
+
+- [Runtimes](runtimes.md) — what each runtime kind does and which adapter image powers it
+- [`examples/README.md`](https://github.com/Azure/azureclaw/blob/main/examples/README.md) — the same catalogue, in-repo
+- [Use cases](use-cases.md) — patterns these examples are concrete instances of

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -133,7 +133,22 @@ spec:
 
 ### Reference example
 
-A reference BYO image (a tiny FastAPI agent) is in `examples/byo-agent/`. The README walks through building it locally, pushing it to ACR, and applying a `ClawSandbox` against it.
+A reference BYO image (a tiny FastAPI agent) is in [`examples/byo-quickstart/`](../examples/byo-quickstart/). The README walks through building it locally, pushing it to a registry, and applying a `ClawSandbox` against it.
+
+### Worked examples — full catalogue
+
+Eight end-to-end examples ship under [`examples/`](../examples/README.md) — one per runtime, plus two multi-tenant attack-simulation demos:
+
+| Example | Runtime | Shows |
+|---|---|---|
+| [`basic-agent`](../examples/basic-agent/) | OpenClaw | Minimal sandbox with default isolation |
+| [`telegram-agent`](../examples/telegram-agent/) | OpenClaw | Channel-plugin wiring (Telegram bot) |
+| [`confidential-agent`](../examples/confidential-agent/) | OpenClaw + Confidential Containers | CVM workers + attested boot |
+| [`openai-agents-quickstart`](../examples/openai-agents-quickstart/) | OpenAIAgents | Unmodified OpenAI Agents SDK app |
+| [`maf-quickstart`](../examples/maf-quickstart/) | MicrosoftAgentFramework | Unmodified MAF Python app |
+| [`byo-quickstart`](../examples/byo-quickstart/) | BYO | Any container image under the BYO contract |
+| [`demo-clawshield`](../examples/demo-clawshield/) | OpenClaw ×3 | Multi-tenant isolation proof (poisoned doc, two victim tenants) |
+| [`lethal-trifecta-demo`](../examples/lethal-trifecta-demo/) | OpenClaw ×2 | Reproduces the Jan-2026 Claude Cowork file-exfiltration attack against vanilla OpenClaw vs. an AzureClaw-managed agent — six independent layers each catch the attack. **Recommended launch demo.** |
 
 ---
 

--- a/examples/basic-agent/clawsandbox.yaml
+++ b/examples/basic-agent/clawsandbox.yaml
@@ -32,8 +32,10 @@ spec:
   runtime:
     kind: OpenClaw
     openclaw:
-      version: "2026.3.13"
-      image: azureclaw.azurecr.io/openclaw-sandbox:latest
+      # Image and version intentionally unset: the controller resolves
+      # the sandbox image from its SANDBOX_IMAGE env (set by `azureclaw
+      # up`). Pinning a registry path here breaks the example for users
+      # who haven't pushed to the same registry.
       config:
         agent:
           model: "azure/gpt-4.1"

--- a/examples/confidential-agent/clawsandbox.yaml
+++ b/examples/confidential-agent/clawsandbox.yaml
@@ -32,8 +32,10 @@ spec:
   runtime:
     kind: OpenClaw
     openclaw:
-      version: "2026.3.13"
-      image: azureclaw.azurecr.io/openclaw-sandbox:latest
+      # Image and version intentionally unset: the controller resolves
+      # the sandbox image from its SANDBOX_IMAGE env (set by `azureclaw
+      # up`). Pinning a registry path here breaks the example for users
+      # who haven't pushed to the same registry.
       config:
         agent:
           model: "azure/gpt-4.1"

--- a/examples/maf-quickstart/clawsandbox.yaml
+++ b/examples/maf-quickstart/clawsandbox.yaml
@@ -13,9 +13,10 @@
 #   - AzureClaw control plane installed (`azureclaw up`)
 #   - InferencePolicy below references an Azure OpenAI deployment named
 #     `gpt-4.1`. Adjust if needed.
-#   - Your MAF agent code is published to a public OCI image. The example
-#     uses `ghcr.io/microsoft/maf-quickstart:latest` as a placeholder —
-#     swap for your image, or use `git:` for dev iteration.
+#   - You publish your MAF agent code to an OCI registry and replace the
+#     `REPLACE-ME/your-maf-agent:latest` placeholder below. There is no
+#     upstream image — this YAML will not pull as-is. Use `git:` instead
+#     of `oci:` for dev iteration without a container build.
 
 ---
 apiVersion: azureclaw.azure.com/v1alpha1
@@ -52,7 +53,11 @@ spec:
       language: python
       agentCode:
         oci:
-          image: ghcr.io/microsoft/maf-quickstart:latest
+          # REPLACE this with the image you built and pushed for your
+          # MAF agent. There is no upstream `ghcr.io/microsoft/maf-quickstart`
+          # image — this is a placeholder. Use `git:` instead of `oci:` for
+          # in-repo iteration without rebuilding a container.
+          image: REPLACE-ME/your-maf-agent:latest
       # entrypoint: ["python", "-u", "agent.py"]
       extraEnv:
         AGENT_LOG_LEVEL: "INFO"

--- a/examples/openai-agents-quickstart/clawsandbox.yaml
+++ b/examples/openai-agents-quickstart/clawsandbox.yaml
@@ -14,8 +14,9 @@
 #   - InferencePolicy below references an Azure OpenAI deployment named
 #     `gpt-4.1` reachable through your project. Adjust if needed.
 #   - Your agent code is published to a public OCI image. The example uses
-#     `ghcr.io/openai/openai-agents-quickstart:latest` as a placeholder —
-#     swap for your image, or use `git:` instead of `oci:` for dev iteration.
+#     `REPLACE-ME/your-openai-agents-app:latest` as a placeholder — there
+#     is no upstream image, this YAML will not pull as-is. Replace with
+#     your own image, or use `git:` instead of `oci:` for dev iteration.
 
 ---
 # S13 phase2-config-authority-refs — InferencePolicy is referenced from
@@ -56,7 +57,12 @@ spec:
       # `git`: dev iteration path — controller clones at pod start.
       agentCode:
         oci:
-          image: ghcr.io/openai/openai-agents-quickstart:latest
+          # REPLACE this with the image you built and pushed for your
+          # OpenAI Agents app. There is no upstream
+          # `ghcr.io/openai/openai-agents-quickstart` image — this is
+          # a placeholder. Use `git:` instead of `oci:` for in-repo
+          # iteration without rebuilding a container.
+          image: REPLACE-ME/your-openai-agents-app:latest
       # Optional: override the entrypoint. Default is `python -u agent.py`.
       # entrypoint: ["python", "-u", "agent.py"]
       extraEnv:

--- a/examples/telegram-agent/clawsandbox.yaml
+++ b/examples/telegram-agent/clawsandbox.yaml
@@ -47,8 +47,10 @@ spec:
   runtime:
     kind: OpenClaw
     openclaw:
-      version: "2026.3.13"
-      image: azureclaw.azurecr.io/openclaw-sandbox:latest
+      # Image and version intentionally unset: the controller resolves
+      # the sandbox image from its SANDBOX_IMAGE env (set by `azureclaw
+      # up`). Pinning a registry path here breaks the example for users
+      # who haven't pushed to the same registry.
       config:
         agent:
           model: "azure/gpt-4.1"


### PR DESCRIPTION
Closes out the "validate every demo/example on the site" follow-up from #348.

## Problem

Walked the docs ↔ examples link graph; three real bugs:

1. **`docs/runtimes.md:136` references `examples/byo-agent/`** — directory does not exist. Real example is `examples/byo-quickstart/`.
2. **`docs/SUMMARY.md` (mdbook TOC) had no link to `examples/` at all.** The catalogue at `examples/README.md` was unreachable from the rendered docs site.
3. **Five `clawsandbox.yaml` files pin images that won't pull for any external user:**

| File | Pin | Reality |
|---|---|---|
| `basic-agent`, `telegram-agent`, `confidential-agent` | `image: azureclaw.azurecr.io/openclaw-sandbox:latest` | Our private ACR — external users hit `ImagePullBackOff`. |
| same three | `version: "2026.3.13"` | Verified the controller does **not** read `OpenClawConfig.version`. `plan_openclaw()` at `controller/src/reconciler/runtime.rs:407` only reads `.image`. Dead field, misleading. |
| `maf-quickstart` | `ghcr.io/microsoft/maf-quickstart:latest` | No such image. |
| `openai-agents-quickstart` | `ghcr.io/openai/openai-agents-quickstart:latest` | No such image. |

## Fix

| File | Change |
|---|---|
| `docs/runtimes.md` | Fix stale `byo-agent` → `byo-quickstart`. Add a "Worked examples — full catalogue" table covering all 8 examples. |
| `docs/SUMMARY.md` | Link the new `docs/examples.md` under "Agent capabilities". |
| `docs/examples.md` (new) | Full catalogue with prereqs, image-resolution explainer, "what you'll need to replace" callout, and an honest "what these examples do **not** cover" section (real cross-org A2A, production observability, GitOps rollout). |
| `examples/{basic,telegram,confidential}-agent/clawsandbox.yaml` | Drop dead `version:` + private-registry `image:` pins. Controller's `SANDBOX_IMAGE` default (set by `azureclaw up`) is authoritative. |
| `examples/{maf,openai-agents}-quickstart/clawsandbox.yaml` | Rename placeholder OCI image to `REPLACE-ME/...` so an accidental `kubectl apply` fails clearly at admission rather than at ImagePull. Update YAML headers to be explicit that no upstream image exists. |

## Verified

| Check | Result |
|---|---|
| `kubectl --dry-run=client apply -f` on all 19 example YAMLs | all green |
| `mdbook build` | clean |
| `OpenClawConfig.version` dead-code check | `grep -rn "openclaw.*version\|cfg.version" controller/src` returns no read sites (only the struct field declaration) |

## Out of scope

- `examples/byo-quickstart/k8s/clawsandbox.yaml` already uses `REPLACE_ME` style — no change needed.
- `examples/lethal-trifecta-demo` and `examples/demo-clawshield` YAMLs already use sensible defaults — verified, no change.
- `examples/README.md` already lists all 8 correctly — left as-is.
