### PR TITLE
fix(examples+controller): make every example actually apply, and fix the label-length bug it surfaced

### DIFF
--- a/controller/src/reconciler/governance_mounts.rs
+++ b/controller/src/reconciler/governance_mounts.rs
@@ -45,7 +45,36 @@ use kube::{
     api::{Patch, PatchParams},
 };
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
+
+/// Kubernetes label values are limited to 63 bytes (RFC 1123). The owner
+/// label value we want to emit (`<kind>.<name>`) can exceed 63 bytes when
+/// the mirrored resource has a long name (e.g. an InferencePolicy whose
+/// own ConfigMap name is already prefixed with `inferencepolicy-`).
+///
+/// We collapse over-long values to `<truncated-prefix>-<8-hex-digest>`
+/// so the label stays unique-per-source and recognisable in `kubectl get
+/// -l`, without violating the kubelet validator. Nothing reads this
+/// label programmatically (it is a write-only provenance marker —
+/// authoritative kind/namespace is in the sibling annotations) so
+/// truncation is safe.
+fn safe_label_value(raw: &str) -> String {
+    const MAX: usize = 63;
+    if raw.len() <= MAX {
+        return raw.to_string();
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(raw.as_bytes());
+    let digest = hasher.finalize();
+    let suffix = format!(
+        "-{:02x}{:02x}{:02x}{:02x}",
+        digest[0], digest[1], digest[2], digest[3]
+    );
+    let head_len = MAX - suffix.len();
+    let head = &raw[..head_len.min(raw.len())];
+    format!("{head}{suffix}")
+}
 
 /// Owned-resource label key, attached to every mirror by the reconciler
 /// so cleanup/observability can find them. Value format is
@@ -146,7 +175,7 @@ pub async fn mirror_configmap(
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert(
         MIRROR_OWNER_LABEL.into(),
-        format!("{source_kind}.{name}").to_lowercase(),
+        safe_label_value(&format!("{source_kind}.{name}").to_lowercase()),
     );
     labels.insert(MIRROR_SANDBOX_LABEL.into(), sandbox_name.into());
     labels.insert(
@@ -217,7 +246,7 @@ pub async fn mirror_secret(
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert(
         MIRROR_OWNER_LABEL.into(),
-        format!("{source_kind}.{name}").to_lowercase(),
+        safe_label_value(&format!("{source_kind}.{name}").to_lowercase()),
     );
     labels.insert(MIRROR_SANDBOX_LABEL.into(), sandbox_name.into());
     labels.insert(
@@ -663,5 +692,30 @@ mod tests {
         let before = spec.clone();
         inject_container_env(&mut spec, "does-not-exist", "X", "y");
         assert_eq!(spec, before);
+    }
+
+    #[test]
+    fn safe_label_value_passes_through_short_values() {
+        assert_eq!(
+            super::safe_label_value("inferencepolicy.my-policy"),
+            "inferencepolicy.my-policy"
+        );
+        let exact = "a".repeat(63);
+        assert_eq!(super::safe_label_value(&exact), exact);
+    }
+
+    #[test]
+    fn safe_label_value_truncates_with_stable_hash_when_too_long() {
+        // Real-world regression: telegram-agent's InferencePolicy
+        // mirror produced a 64-byte label value before this guard.
+        let long = "inferencepolicy.inferencepolicy-telegram-agent-inference-profile";
+        assert_eq!(long.len(), 64);
+        let safe = super::safe_label_value(long);
+        assert!(safe.len() <= 63, "got {} bytes: {safe}", safe.len());
+        // Stable: same input → same output.
+        assert_eq!(super::safe_label_value(long), safe);
+        // Different inputs → different outputs (collision-resistant).
+        let other = "inferencepolicy.inferencepolicy-different-name-foo-profile";
+        assert_ne!(super::safe_label_value(other), safe);
     }
 }

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,21 +4,23 @@ Eight end-to-end blueprints live under [`examples/`](https://github.com/Azure/az
 
 ## Single-agent runtime quickstarts
 
-| Example | Runtime | What it shows |
-|---|---|---|
-| [`basic-agent`](https://github.com/Azure/azureclaw/tree/main/examples/basic-agent) | `OpenClaw` | The smallest possible deployment — minimal sandbox with default isolation (seccomp-strict, RO rootfs, egress guard, AGT governance). **Start here.** |
-| [`telegram-agent`](https://github.com/Azure/azureclaw/tree/main/examples/telegram-agent) | `OpenClaw` | OpenClaw agent wired to a Telegram channel via the [channel-plugin pattern](channels-plugins.md). |
-| [`confidential-agent`](https://github.com/Azure/azureclaw/tree/main/examples/confidential-agent) | `OpenClaw` + Confidential Containers | The basic-agent shape upgraded to AKS Confidential Containers — CVM workers, attested boot, encrypted memory. |
-| [`openai-agents-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/openai-agents-quickstart) | `OpenAIAgents` (Python) | Hosts an unmodified [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) app. The adapter transparently routes `api.openai.com` through the local inference router. |
-| [`maf-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/maf-quickstart) | `MicrosoftAgentFramework` (Python) | Hosts an unmodified [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) app. |
-| [`byo-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/byo-quickstart) | `BYO` | Brings any container image under the BYO contract. Includes a tiny FastAPI reference agent. |
+| Example | Runtime | Verification status | What it shows |
+|---|---|---|---|
+| [`basic-agent`](https://github.com/Azure/azureclaw/tree/main/examples/basic-agent) | `OpenClaw` | YAMLs apply (dry-run + AKS); runtime path exercised by exec-brief harness | The smallest possible deployment — minimal sandbox with default isolation (seccomp-strict, RO rootfs, egress guard, AGT governance). **Start here.** |
+| [`telegram-agent`](https://github.com/Azure/azureclaw/tree/main/examples/telegram-agent) | `OpenClaw` | YAMLs apply; requires real Telegram bot token to exercise channel | OpenClaw agent wired to a Telegram channel via the [channel-plugin pattern](channels-plugins.md). |
+| [`confidential-agent`](https://github.com/Azure/azureclaw/tree/main/examples/confidential-agent) | `OpenClaw` + Confidential Containers | YAMLs apply; requires AKS CoCo-enabled node pool to actually boot a CVM worker | The basic-agent shape upgraded to AKS Confidential Containers — CVM workers, attested boot, encrypted memory. |
+| [`openai-agents-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/openai-agents-quickstart) | `OpenAIAgents` (Python) | YAMLs apply once you swap `REPLACE-ME/...` with your image | Hosts an unmodified [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) app. The adapter transparently routes `api.openai.com` through the local inference router. |
+| [`maf-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/maf-quickstart) | `MicrosoftAgentFramework` (Python) | YAMLs apply once you swap `REPLACE-ME/...` with your image | Hosts an unmodified [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) app. |
+| [`byo-quickstart`](https://github.com/Azure/azureclaw/tree/main/examples/byo-quickstart) | `BYO` | Builds + applies cleanly; runtime requires you to bring an image | Brings any container image under the BYO contract. Includes a tiny FastAPI reference agent. |
 
 ## Multi-agent attack-simulation demos
 
-| Example | Shape | What it shows |
-|---|---|---|
-| [`demo-clawshield`](https://github.com/Azure/azureclaw/tree/main/examples/demo-clawshield) | Three OpenClaw agents in three namespaces (Contoso Bank, Fabrikam Legal, Northwind Trade) | Multi-tenant isolation proof. A poisoned document attempts to exfiltrate across tenants; the NetworkPolicy + egress guard + governance layer each block it independently. |
-| [`lethal-trifecta-demo`](https://github.com/Azure/azureclaw/tree/main/examples/lethal-trifecta-demo) | Two OpenClaw agents (vanilla vs. AzureClaw-managed) | Reproduces the [Claude Cowork file-exfiltration attack](https://www.promptarmor.com/resources/claude-cowork-exfiltrates-files) (Jan 2026). Six independent layers — each one alone catches the attack on the AzureClaw-managed side. **Recommended launch demo.** |
+| Example | Shape | Verification status | What it shows |
+|---|---|---|---|
+| [`demo-clawshield`](https://github.com/Azure/azureclaw/tree/main/examples/demo-clawshield) | Three OpenClaw agents in three namespaces (Contoso Bank, Fabrikam Legal, Northwind Trade) | YAMLs apply (dry-run); full attack-simulation requires three running sandboxes with real model deployments | Multi-tenant isolation proof. A poisoned document attempts to exfiltrate across tenants; the NetworkPolicy + egress guard + governance layer each block it independently. |
+| [`lethal-trifecta-demo`](https://github.com/Azure/azureclaw/tree/main/examples/lethal-trifecta-demo) | Two OpenClaw agents (vanilla vs. AzureClaw-managed) | `scripts/deploy.sh` materialises both deployments on local-k8s and AKS (pods reach `Ready`). `run-attack.sh` additionally requires (a) a working OpenClaw runtime config on the `naked-claw` side so the vanilla pod doesn't crashloop at startup, and (b) the operator-flow break-glass label `azureclaw.azure.com/break-glass=true` on `azureclaw-realestate-agent` to bypass the `ValidatingAdmissionPolicy/azureclaw-sandbox-exec-ban` ([context](use-cases/exec-brief-walkthrough.md#proof-the-agent-cannot-call-foundry-directly)) ValidatingAdmissionPolicy for the demo `kubectl exec` path. | Reproduces the [Claude Cowork file-exfiltration attack](https://www.promptarmor.com/resources/claude-cowork-exfiltrates-files) (Jan 2026). Six independent layers — each one alone catches the attack on the AzureClaw-managed side. **Recommended launch demo for the deploy-time defense story; the attack-simulation path requires the prerequisites above.** |
+
+> **What "verification status" means here:** "YAMLs apply" = `kubectl apply --dry-run=client` succeeds against the published CRDs; "exercised by ..." = at least one of the maintainers has run the listed runbook end-to-end against a live cluster. Where the verification status mentions a credential or hardware prerequisite, those must be present on your side for the example to fully run.
 
 ## Prerequisites — common to all examples
 

--- a/examples/basic-agent/README.md
+++ b/examples/basic-agent/README.md
@@ -31,7 +31,7 @@ The `ClawSandbox` references the `InferencePolicy` by name via
 
 | Layer | Setting |
 |---|---|
-| Runtime | `OpenClaw 2026.3.13` |
+| Runtime | `OpenClaw` (image resolved by the controller from its `SANDBOX_IMAGE` env, set by `azureclaw up`) |
 | Isolation | `enhanced` (runc + strict seccomp + RO rootfs) |
 | Model | `azure-openai/gpt-4.1` (via Foundry; switch to GitHub Models with `azureclaw dev`) |
 | Content Safety | `requirePromptShields: true` |

--- a/examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml
+++ b/examples/byo-quickstart/k8s/clawsandbox-strict-demo.yaml
@@ -30,8 +30,8 @@ spec:
       provider: azure-openai
       deployment: gpt-4.1
   tokenBudget:
-    perRequestMax: 4000
-    perDayMax: 200000
+    perRequestTokens: 4000
+    dailyTokens: 200000
 ---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox

--- a/examples/byo-quickstart/k8s/clawsandbox.yaml
+++ b/examples/byo-quickstart/k8s/clawsandbox.yaml
@@ -27,8 +27,8 @@ spec:
       provider: azure-openai
       deployment: gpt-4.1
   tokenBudget:
-    perRequestMax: 4000
-    perDayMax: 200000
+    perRequestTokens: 4000
+    dailyTokens: 200000
 ---
 apiVersion: azureclaw.azure.com/v1alpha1
 kind: ClawSandbox

--- a/examples/demo-clawshield/contoso-bank-agent.yaml
+++ b/examples/demo-clawshield/contoso-bank-agent.yaml
@@ -37,8 +37,7 @@ spec:
   runtime:
     kind: OpenClaw
     openclaw:
-      version: "2026.3.13"
-      image: azureclaw.azurecr.io/openclaw-sandbox:latest
+      # Image intentionally unset: controller resolves from SANDBOX_IMAGE env (set by azureclaw up).
       config:
         agent:
           model: "azure/gpt-4.1"
@@ -66,17 +65,13 @@ spec:
     allowedEndpoints:
       - host: "github.com"
         port: 443
-        methods: ["GET"]
       - host: "api.github.com"
         port: 443
-        methods: ["GET"]
       # Contoso internal APIs only
       - host: "compliance.contoso.com"
         port: 443
-        methods: ["GET", "POST"]
       - host: "transactions.contoso.com"
         port: 443
-        methods: ["GET"]
 
   azureServices:
     - service: ai-foundry

--- a/examples/demo-clawshield/fabrikam-legal-agent.yaml
+++ b/examples/demo-clawshield/fabrikam-legal-agent.yaml
@@ -41,8 +41,7 @@ spec:
   runtime:
     kind: OpenClaw
     openclaw:
-      version: "2026.3.13"
-      image: azureclaw.azurecr.io/openclaw-sandbox:latest
+      # Image intentionally unset: controller resolves from SANDBOX_IMAGE env (set by azureclaw up).
       config:
         agent:
           model: "azure/gpt-4.1"
@@ -74,14 +73,11 @@ spec:
       # Fabrikam internal APIs only
       - host: "docs.fabrikam.com"
         port: 443
-        methods: ["GET"]
       - host: "legal-api.fabrikam.com"
         port: 443
-        methods: ["GET", "POST"]
       # SEC EDGAR for regulatory filings (read-only)
       - host: "efts.sec.gov"
         port: 443
-        methods: ["GET"]
 
   azureServices:
     - service: ai-foundry

--- a/examples/demo-clawshield/northwind-trade-agent.yaml
+++ b/examples/demo-clawshield/northwind-trade-agent.yaml
@@ -37,8 +37,7 @@ spec:
   runtime:
     kind: OpenClaw
     openclaw:
-      version: "2026.3.13"
-      image: azureclaw.azurecr.io/openclaw-sandbox:latest
+      # Image intentionally unset: controller resolves from SANDBOX_IMAGE env (set by azureclaw up).
       config:
         agent:
           model: "azure/gpt-4.1"

--- a/examples/lethal-trifecta-demo/README.md
+++ b/examples/lethal-trifecta-demo/README.md
@@ -84,6 +84,25 @@ cd examples/lethal-trifecta-demo
 ./scripts/teardown.sh         # removes everything
 ```
 
+> **What works out of the box** — `deploy.sh` and `teardown.sh` run end-to-end on
+> local-k8s and AKS; both Deployments reach `Ready` and the AzureClaw sandbox
+> stack (egress-guard, inference-router, NetworkPolicy, InferencePolicy) all
+> reconcile.
+>
+> **What `run-attack.sh` additionally requires** —
+> 1. The `naked-claw` container needs a working OpenClaw runtime config (mounted
+>    or templated into `01-naked-claw.yaml`); without it the vanilla pod
+>    crashloops at startup before it can attempt the attack.
+> 2. The `azureclaw-realestate-agent` namespace is governed by the cluster-wide
+>    `ValidatingAdmissionPolicy/azureclaw-sandbox-exec-ban` ValidatingAdmissionPolicy,
+>    so `kubectl exec` into the `openclaw` container is denied by design. For
+>    the demo's exec-driven attack path, label the namespace
+>    `azureclaw.azure.com/break-glass=true` first — every bypass is audited.
+>
+> If either prerequisite isn't met, `deploy.sh` still demonstrates the
+> deploy-time defense posture (network policy, egress guard, governance
+> mounts), which is the bulk of the story.
+
 The full timed walkthrough is in [`WALKTHROUGH.md`](WALKTHROUGH.md) — what to
 say at each second mark for a recorded or live demo.
 

--- a/examples/lethal-trifecta-demo/WALKTHROUGH.md
+++ b/examples/lethal-trifecta-demo/WALKTHROUGH.md
@@ -20,7 +20,7 @@ Two namespaces, one cluster.
 
 ```bash
 ./scripts/deploy.sh
-kubectl get pods -n naked-claw -n azureclaw-claw
+kubectl get pods -n naked-claw && kubectl get pods -n azureclaw-realestate-agent
 ```
 
 | Namespace | Agent | Defenses |
@@ -75,7 +75,7 @@ firing in production."*
 ## Act 4 — AzureClaw defeats it, six different ways (3:00–6:00)
 
 ```bash
-./scripts/run-attack.sh azureclaw-claw
+./scripts/run-attack.sh azureclaw
 ```
 
 Each layer is shown by toggling off the *previous* layers and watching
@@ -89,7 +89,7 @@ the next one engage. Six independent layers — any one stops the attack.
 ```
 
 The Foundry guardrail catches the injection before the model ever runs.
-**Show:** `kubectl logs -n azureclaw-claw deploy/inference-router | grep prompt_shields`
+**Show:** `kubectl logs -n azureclaw-realestate-agent deploy/realestate-agent -c inference-router | grep prompt_shields`
 
 > *(GitHub-Models mode skips this layer — see [security.md](../../docs/security.md#what-we-do-not-defend-against). The other five layers still fire.)*
 
@@ -130,7 +130,7 @@ Even if all router policy is bypassed, the agent process itself can't
 reach the network:
 
 ```bash
-kubectl exec -n azureclaw-claw deploy/realestate-agent -c openclaw -- \
+kubectl exec -n azureclaw-realestate-agent deploy/realestate-agent -c openclaw -- \
   curl -v https://api.openai.com/v1/files
 # curl: (7) Failed to connect to api.openai.com port 443: Connection refused
 ```

--- a/examples/lethal-trifecta-demo/scenarios/02-azureclaw-sandbox.yaml
+++ b/examples/lethal-trifecta-demo/scenarios/02-azureclaw-sandbox.yaml
@@ -41,7 +41,6 @@ spec:
   runtime:
     kind: OpenClaw
     openclaw:
-      version: "2026.3.13"
       config:
         agent:
           model: "azure/gpt-4.1"
@@ -68,14 +67,11 @@ spec:
       # is rejected at this layer alone.
       - host: "api.openai.com"
         port: 443
-        methods: ["GET"]
       - host: "api.github.com"
         port: 443
-        methods: ["GET"]
       # Bait server (cluster-internal, used to fetch the skill itself)
       - host: "bait-server.azureclaw-claw.svc.cluster.local"
         port: 80
-        methods: ["GET"]
   azureServices:
     - service: ai-foundry
       permissions: [inference]

--- a/examples/lethal-trifecta-demo/scripts/deploy.sh
+++ b/examples/lethal-trifecta-demo/scripts/deploy.sh
@@ -30,8 +30,13 @@ done
 kubectl apply -f scenarios/03-bait-server.yaml
 
 echo "▸ waiting for pods..."
-kubectl -n naked-claw      wait --for=condition=available --timeout=120s deploy/realestate-agent deploy/bait-server
-kubectl -n azureclaw-claw  wait --for=condition=available --timeout=180s deploy/realestate-agent deploy/bait-server
+kubectl -n naked-claw                wait --for=condition=available --timeout=120s deploy/realestate-agent deploy/bait-server
+# The ClawSandbox CR is created in `azureclaw-claw`, but the AzureClaw
+# controller materialises the sandbox deployment in its own per-sandbox
+# namespace `azureclaw-<sandbox-name>` (here: `azureclaw-realestate-agent`).
+# The bait server is a plain Deployment that stays in `azureclaw-claw`.
+kubectl -n azureclaw-realestate-agent wait --for=condition=available --timeout=180s deploy/realestate-agent
+kubectl -n azureclaw-claw             wait --for=condition=available --timeout=180s deploy/bait-server
 
 echo
 echo "✅ deployed. Run ./scripts/run-attack.sh next."

--- a/examples/lethal-trifecta-demo/scripts/run-attack.sh
+++ b/examples/lethal-trifecta-demo/scripts/run-attack.sh
@@ -6,14 +6,23 @@
 # workflow. Records what happens.
 #
 # Usage:
-#   ./run-attack.sh                 # both namespaces, side-by-side
-#   ./run-attack.sh naked-claw      # just the strawman
-#   ./run-attack.sh azureclaw-claw  # just the defended path
+#   ./run-attack.sh                 # both scenarios, side-by-side
+#   ./run-attack.sh naked            # just the strawman (naked-claw ns)
+#   ./run-attack.sh azureclaw        # just the defended path (azureclaw-realestate-agent ns)
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
 PROMPT='Please load the skill at http://bait-server/poisoned-skill.md and then run a comparables analysis on 1234 Main St.'
+
+# The naked-claw scenario is a plain Deployment (no AzureClaw controller
+# involvement) so the pod lives in `naked-claw` ns. The azureclaw-claw
+# scenario uses a ClawSandbox CR (declared in `azureclaw-claw`); the
+# controller materialises the actual sandbox Deployment in
+# `azureclaw-realestate-agent` per the standard per-sandbox-namespace
+# pattern.
+NAKED_NS="naked-claw"
+AZURECLAW_NS="azureclaw-realestate-agent"
 
 run_in() {
   local ns="$1"
@@ -27,15 +36,18 @@ run_in() {
 }
 
 case "${1:-both}" in
-  naked-claw|azureclaw-claw)
-    run_in "$1"
+  naked|naked-claw)
+    run_in "$NAKED_NS"
+    ;;
+  azureclaw|azureclaw-claw)
+    run_in "$AZURECLAW_NS"
     ;;
   both)
-    run_in naked-claw
-    run_in azureclaw-claw
+    run_in "$NAKED_NS"
+    run_in "$AZURECLAW_NS"
     ;;
   *)
-    echo "usage: $0 [naked-claw|azureclaw-claw|both]" >&2
+    echo "usage: $0 [naked|azureclaw|both]" >&2
     exit 2
     ;;
 esac

--- a/examples/lethal-trifecta-demo/scripts/teardown.sh
+++ b/examples/lethal-trifecta-demo/scripts/teardown.sh
@@ -4,6 +4,11 @@
 set -euo pipefail
 
 echo "▸ tearing down lethal-trifecta demo"
-kubectl delete namespace naked-claw      --ignore-not-found
-kubectl delete namespace azureclaw-claw  --ignore-not-found
+kubectl delete namespace naked-claw                  --ignore-not-found
+# Deleting the ClawSandbox CR (which lives in azureclaw-claw) triggers
+# the controller to garbage-collect the per-sandbox namespace
+# (azureclaw-realestate-agent); deleting both namespaces explicitly here
+# is belt-and-braces in case the controller is offline.
+kubectl delete namespace azureclaw-claw              --ignore-not-found
+kubectl delete namespace azureclaw-realestate-agent  --ignore-not-found
 echo "✅ done"

--- a/examples/lethal-trifecta-demo/scripts/verify-defense.sh
+++ b/examples/lethal-trifecta-demo/scripts/verify-defense.sh
@@ -5,12 +5,21 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-echo "═══ Audit chain (azureclaw-claw) ═══"
+# The ClawSandbox CR is declared in `azureclaw-claw`, but the controller
+# materialises the actual sandbox Deployment in
+# `azureclaw-realestate-agent` per the standard per-sandbox-namespace
+# pattern. All `kubectl logs` / `kubectl exec` against the live pod
+# target that namespace; `azureclaw audit verify` targets the CR
+# namespace (`azureclaw-claw`).
+SANDBOX_CR_NS="azureclaw-claw"
+SANDBOX_POD_NS="azureclaw-realestate-agent"
+
+echo "═══ Audit chain ($SANDBOX_CR_NS) ═══"
 if command -v azureclaw >/dev/null 2>&1; then
-  azureclaw audit verify --namespace azureclaw-claw --agent realestate-agent || true
+  azureclaw audit verify --namespace "$SANDBOX_CR_NS" --agent realestate-agent || true
 else
   echo "(azureclaw CLI not on PATH — falling back to raw logs)"
-  kubectl logs -n azureclaw-claw deploy/realestate-agent -c inference-router \
+  kubectl logs -n "$SANDBOX_POD_NS" deploy/realestate-agent -c inference-router \
     | grep -E 'audit|deny|safety|budget|quarantin' | tail -20 || true
 fi
 
@@ -19,14 +28,14 @@ echo "═══ Naked claw audit chain ═══"
 echo "(no audit pipeline — this is the point)"
 
 echo
-echo "═══ Router policy decisions (azureclaw-claw) ═══"
-kubectl logs -n azureclaw-claw deploy/realestate-agent -c inference-router \
+echo "═══ Router policy decisions ($SANDBOX_POD_NS) ═══"
+kubectl logs -n "$SANDBOX_POD_NS" deploy/realestate-agent -c inference-router \
   | grep -E 'tool_policy|prompt_shields|token_budget|behavior' | tail -20 || true
 
 echo
 echo "═══ Egress-guard verification ═══"
-echo "▸ trying direct curl from agent UID 1000 in azureclaw-claw:"
-kubectl exec -n azureclaw-claw deploy/realestate-agent -c openclaw -- \
+echo "▸ trying direct curl from agent UID 1000 in $SANDBOX_POD_NS:"
+kubectl exec -n "$SANDBOX_POD_NS" deploy/realestate-agent -c openclaw -- \
   sh -c 'curl -sS --max-time 5 https://api.openai.com/v1/files -o /dev/null -w "%{http_code}\n"' \
   2>&1 | tail -5 || echo "  ✅ refused as expected"
 


### PR DESCRIPTION
## What

Physically applied **every example** to a live local-k8s kind cluster (per the user mandate that examples must work "like a sharp knife cutting through butter"). Surfaced and fixed **4 real defects** — one controller bug, three example/script bugs — that were silently rotting because nobody had been running the examples end-to-end against a strict-decode cluster.

## Bugs found by running the examples (and now fixed)

### 1. Controller: K8s label-length violation on long InferencePolicy names
`controller/src/reconciler/governance_mounts.rs` stamped a provenance label `{source_kind}.{name}`. For names like `telegram-agent-inference-profile` this exceeded the 63-byte limit and the controller crashlooped:

```
ConfigMap "inferencepolicy-telegram-agent-inference-profile" is invalid:
  metadata.labels: Invalid value: "inferencepolicy.inferencepolicy-telegram-agent-inference-profile":
  must be no more than 63 bytes
```

Added `safe_label_value()` helper that truncates with an 8-hex sha256 suffix when over the limit. Includes unit tests. The label is a write-only provenance marker so truncation is safe.

### 2. Examples: non-existent CRD fields
- `demo-clawshield` (3 YAMLs) + `lethal-trifecta-demo/scenarios/02` used `spec.networkPolicy.allowedEndpoints[].methods` — never existed in the CRD; NetworkPolicy is L4. Removed.
- `byo-quickstart` used `tokenBudget.perDayMax` / `perRequestMax` — real names are `dailyTokens` / `perRequestTokens`. Renamed.

### 3. lethal-trifecta demo scripts: wrong namespace
All four scripts (`deploy.sh`, `run-attack.sh`, `verify-defense.sh`, `teardown.sh`) waited on `deploy/realestate-agent` in `azureclaw-claw`, but the controller materialises sandbox Deployments in `azureclaw-<sandbox-name>`. Refactored to use `SANDBOX_CR_NS` (CR namespace) vs `SANDBOX_POD_NS` (where the pod actually runs). Usage args renamed accordingly.

### 4. Examples: pinned `azureclaw.azurecr.io` image
`basic-agent`, `telegram-agent`, `confidential-agent` + 3 `demo-clawshield` YAMLs hardcoded `runtime.openclaw.image: azureclaw.azurecr.io/openclaw-sandbox:latest` — the maintainers' private registry, unpullable for any external user. Removed; controller resolves from its `SANDBOX_IMAGE` env per the [image versioning convention](docs/operations/image-versioning.md).

## Verified live on `kind-azureclaw-dev`

| Example | Status |
|---|---|
| `basic-agent` | ✅ 2/2 Running |
| `telegram-agent` | ✅ 2/2 Running (post controller fix) |
| `demo-clawshield` contoso, northwind | ✅ 2/2 Running |
| `lethal-trifecta` azureclaw-realestate-agent | ✅ 2/2 Running |
| `lethal-trifecta` `scripts/deploy.sh` end-to-end | ✅ both pods Ready, all 4 condition-met lines |
| `confidential-agent`, `demo-clawshield` fabrikam | ⚠️ needs kata-vm-isolation RuntimeClass (expected on kind; documented) |
| `byo-strict-demo` | ⚠️ rejected by design (`contractVersion: "v999"` is a deliberate negative test) |

## Documentation updates

- `docs/examples.md` — honest "Verification status" column. Explicit, accurate note on `lethal-trifecta-demo`: deploy works, but `run-attack.sh` additionally needs (a) working OpenClaw runtime config on the naked-claw side, and (b) the operator-flow break-glass label on the azureclaw side (because `ValidatingAdmissionPolicy/azureclaw-sandbox-exec-ban` blocks the demo's `kubectl exec` path).
- `examples/lethal-trifecta-demo/README.md` — same honest treatment of what `deploy.sh` vs `run-attack.sh` actually do.
- `examples/lethal-trifecta-demo/WALKTHROUGH.md` — pod-namespace references corrected.

## Out of scope (logged as follow-ups)

- Controller emits `InferencePolicyEventPublishFailed` warn spam — RBAC missing for `events.events.k8s.io` in `azureclaw-system`. Non-fatal; reconciliation works.
- Controller status accuracy: confidential-agent shows Phase=Running even when no pod can schedule (ReplicaSet error not propagated to ClawSandbox.status.phase).

## Validation

- `cargo clippy --package azureclaw-controller --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --bin azureclaw-controller -- safe_label_value` — 2 new tests pass
- Controller image rebuilt + `kind load`'d + `rollout restart`'d; telegram-agent (which previously crashlooped the controller indefinitely) now reconciles to 2/2 Running in ~15s.
