### PR TITLE
fix(operator+plugin): kind-node false positive, peer DID truncation, headlamp cmd

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -32,6 +32,7 @@ import { mcpCommand } from "./commands/mcp.js";
 import { memoryCommand } from "./commands/memory.js";
 import { inspectCommand } from "./commands/inspect.js";
 import { auditCommand } from "./commands/audit.js";
+import { headlampCommand } from "./commands/headlamp.js";
 
 export function createCli(): Command {
   const program = new Command();
@@ -69,6 +70,7 @@ export function createCli(): Command {
   program.addCommand(evalCommand());
   program.addCommand(operatorCommand());
   program.addCommand(auditCommand());
+  program.addCommand(headlampCommand());
 
   // Agent mobility
   program.addCommand(handoffCommand());
@@ -95,7 +97,7 @@ Command groups:
   Lifecycle       up, dev, add, push, destroy
   Operations      connect, status, list, logs, inspect
   Configuration   credentials, model, policy, egress, config
-  Observability   trace, eval, operator, audit
+  Observability   trace, eval, operator, audit, headlamp
   Agent mobility  handoff, mesh, pair
   Interop         convert, a2a, a2a-agent, migrate
   Governance      toolpolicy, inferencepolicy, mcp, memory

--- a/cli/src/commands/headlamp.ts
+++ b/cli/src/commands/headlamp.ts
@@ -128,6 +128,70 @@ export function headlampCommand(): Command {
         // Give the forward ~1.5s to bind before opening the browser.
         await new Promise((r) => setTimeout(r, 1500));
 
+        // Best-effort: if the cluster also has kube-prometheus-stack
+        // installed (which `azureclaw dev` ships out of the box), forward
+        // Prometheus on :19091 and Grafana on :3000 so the Headlamp
+        // AzureClaw plugin's metric panels (Mesh Topology, Token
+        // Budget, AGT decisions) light up without manual setup. The
+        // plugin reads `window.AZURECLAW_PROMETHEUS_URL` which defaults
+        // to http://127.0.0.1:19091.
+        const promPort = 19091;
+        const grafanaPort = 3000;
+        let promForwarded = false;
+        let grafanaForwarded = false;
+        try {
+          await execa(
+            "kubectl",
+            kctl(["get", "svc", "kps-kube-prometheus-stack-prometheus", "-n", "monitoring", "--no-headers"]),
+            { stdio: "pipe" },
+          );
+          await freePort(execa, promPort);
+          const pfProm = spawn(
+            "kubectl",
+            kctl([
+              "port-forward",
+              "-n",
+              "monitoring",
+              "service/kps-kube-prometheus-stack-prometheus",
+              `${promPort}:9090`,
+            ]),
+            { detached: true, stdio: "ignore" },
+          );
+          pfProm.unref();
+          promForwarded = true;
+        } catch {
+          // Prometheus not present — plugin panels will show the
+          // "Prometheus unreachable" hint, which is the correct UX
+          // for a cluster without monitoring.
+        }
+        try {
+          await execa(
+            "kubectl",
+            kctl(["get", "svc", "kps-grafana", "-n", "monitoring", "--no-headers"]),
+            { stdio: "pipe" },
+          );
+          await freePort(execa, grafanaPort);
+          const pfGraf = spawn(
+            "kubectl",
+            kctl([
+              "port-forward",
+              "-n",
+              "monitoring",
+              "service/kps-grafana",
+              `${grafanaPort}:80`,
+            ]),
+            { detached: true, stdio: "ignore" },
+          );
+          pfGraf.unref();
+          grafanaForwarded = true;
+        } catch {
+          // Grafana not present — fine.
+        }
+        if (promForwarded || grafanaForwarded) {
+          // Give the forwards a moment to bind.
+          await new Promise((r) => setTimeout(r, 1500));
+        }
+
         const url = `http://localhost:${options.port}/`;
         console.log("");
         console.log(chalk.bold("  Headlamp dashboard:"));
@@ -137,11 +201,17 @@ export function headlampCommand(): Command {
           console.log(chalk.bold("  Login token (paste into Headlamp):"));
           console.log(`    ${chalk.dim(token)}`);
         }
+        if (promForwarded || grafanaForwarded) {
+          console.log("");
+          console.log(chalk.bold("  Observability stack:"));
+          if (promForwarded) console.log(`    Prometheus: ${chalk.cyan(`http://localhost:${promPort}/`)}`);
+          if (grafanaForwarded) console.log(`    Grafana:    ${chalk.cyan(`http://localhost:${grafanaPort}/`)}`);
+        }
         console.log("");
         console.log(
           chalk.dim(
             `  Port-forward runs in the background (PID ${child.pid}).\n` +
-              `  Stop it later with: pkill -f 'port-forward.*headlamp'`,
+              `  Stop it later with: pkill -f 'port-forward.*(headlamp|prometheus|grafana)'`,
           ),
         );
 

--- a/cli/src/commands/headlamp.ts
+++ b/cli/src/commands/headlamp.ts
@@ -5,15 +5,15 @@ import { Command } from "commander";
 import chalk from "chalk";
 
 /**
- * `azureclaw headlamp` — open the Headlamp Kubernetes dashboard for the
+ * `kars headlamp` — open the Headlamp Kubernetes dashboard for the
  * current kubectl context (AKS, kind, anything kubectl can reach).
  *
- * Mirrors the UX of `azureclaw connect <name>`: best-effort port-forward
+ * Mirrors the UX of `kars connect <name>`: best-effort port-forward
  * + browser open + token print, with a single `--install` escape hatch
  * for clusters that don't have Headlamp installed yet.
  *
- * Headlamp is installed by `azureclaw dev --target local-k8s` out of
- * the box. For AKS / shared clusters, run `azureclaw headlamp --install`
+ * Headlamp is installed by `kars dev --target local-k8s` out of
+ * the box. For AKS / shared clusters, run `kars headlamp --install`
  * once per cluster.
  */
 export function headlampCommand(): Command {
@@ -24,7 +24,7 @@ export function headlampCommand(): Command {
     .option("--context <name>", "Kubernetes context to use (defaults to current-context)")
     .option("--port <port>", "Local port to bind", "4466")
     .option("--namespace <ns>", "Namespace where Headlamp is deployed", "headlamp")
-    .option("--install", "Install Headlamp + AzureClaw plugin into the cluster first", false)
+    .option("--install", "Install Headlamp + Kars plugin into the cluster first", false)
     .option("--no-browser", "Skip opening the browser; just port-forward + print URL")
     .option("--token-duration <dur>", "Token TTL passed to `kubectl create token`", "24h")
     .action(
@@ -78,7 +78,7 @@ export function headlampCommand(): Command {
           );
           console.error("");
           console.error(chalk.bold("  Install it first:"));
-          console.error(`    ${chalk.cyan(`azureclaw headlamp --install --context ${ctx}`)}`);
+          console.error(`    ${chalk.cyan(`kars headlamp --install --context ${ctx}`)}`);
           process.exitCode = 1;
           return;
         }
@@ -129,11 +129,11 @@ export function headlampCommand(): Command {
         await new Promise((r) => setTimeout(r, 1500));
 
         // Best-effort: if the cluster also has kube-prometheus-stack
-        // installed (which `azureclaw dev` ships out of the box), forward
+        // installed (which `kars dev` ships out of the box), forward
         // Prometheus on :19091 and Grafana on :3000 so the Headlamp
-        // AzureClaw plugin's metric panels (Mesh Topology, Token
+        // Kars plugin's metric panels (Mesh Topology, Token
         // Budget, AGT decisions) light up without manual setup. The
-        // plugin reads `window.AZURECLAW_PROMETHEUS_URL` which defaults
+        // plugin reads `window.KARS_PROMETHEUS_URL` which defaults
         // to http://127.0.0.1:19091.
         const promPort = 19091;
         const grafanaPort = 3000;
@@ -226,7 +226,7 @@ export function headlampCommand(): Command {
 
 /**
  * Best-effort: kill any process holding `port` so a fresh port-forward
- * can bind. Reuses the same lsof/kill dance used by `azureclaw dev`.
+ * can bind. Reuses the same lsof/kill dance used by `kars dev`.
  */
 async function freePort(execa: typeof import("execa").execa, port: number): Promise<void> {
   try {
@@ -263,8 +263,8 @@ async function openBrowser(execa: typeof import("execa").execa, url: string): Pr
 }
 
 /**
- * Install Headlamp + the AzureClaw plugin into the active cluster.
- * Pinned to the same Headlamp chart version that `azureclaw dev`
+ * Install Headlamp + the Kars plugin into the active cluster.
+ * Pinned to the same Headlamp chart version that `kars dev`
  * installs locally so the bundled plugin remains compatible.
  *
  * Idempotent — re-running re-applies the manifest. Works on AKS,

--- a/cli/src/commands/headlamp.ts
+++ b/cli/src/commands/headlamp.ts
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Command } from "commander";
+import chalk from "chalk";
+
+/**
+ * `azureclaw headlamp` — open the Headlamp Kubernetes dashboard for the
+ * current kubectl context (AKS, kind, anything kubectl can reach).
+ *
+ * Mirrors the UX of `azureclaw connect <name>`: best-effort port-forward
+ * + browser open + token print, with a single `--install` escape hatch
+ * for clusters that don't have Headlamp installed yet.
+ *
+ * Headlamp is installed by `azureclaw dev --target local-k8s` out of
+ * the box. For AKS / shared clusters, run `azureclaw headlamp --install`
+ * once per cluster.
+ */
+export function headlampCommand(): Command {
+  const cmd = new Command("headlamp");
+
+  cmd
+    .description("Open the Headlamp K8s dashboard for the current cluster")
+    .option("--context <name>", "Kubernetes context to use (defaults to current-context)")
+    .option("--port <port>", "Local port to bind", "4466")
+    .option("--namespace <ns>", "Namespace where Headlamp is deployed", "headlamp")
+    .option("--install", "Install Headlamp + AzureClaw plugin into the cluster first", false)
+    .option("--no-browser", "Skip opening the browser; just port-forward + print URL")
+    .option("--token-duration <dur>", "Token TTL passed to `kubectl create token`", "24h")
+    .action(
+      async (options: {
+        context?: string;
+        port: string;
+        namespace: string;
+        install: boolean;
+        browser: boolean;
+        tokenDuration: string;
+      }) => {
+        const { execa } = await import("execa");
+
+        // Resolve the effective context (so error messages name it).
+        let ctx = options.context;
+        if (!ctx) {
+          try {
+            const { stdout } = await execa("kubectl", ["config", "current-context"], { stdio: "pipe" });
+            ctx = stdout.trim();
+          } catch {
+            console.error(chalk.red("✖ kubectl has no current-context set."));
+            console.error(chalk.dim("  Try: kubectl config use-context <name>"));
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        const kctl = (args: string[]) => ["--context", ctx!, ...args];
+
+        // Optional install — works on any cluster kubectl can reach.
+        if (options.install) {
+          await installHeadlamp(execa, ctx!);
+          console.log("");
+        }
+
+        // Verify Headlamp is present.
+        let svcExists = false;
+        try {
+          await execa(
+            "kubectl",
+            kctl(["get", "svc", "headlamp", "-n", options.namespace, "--no-headers"]),
+            { stdio: "pipe" },
+          );
+          svcExists = true;
+        } catch {
+          // fall through
+        }
+        if (!svcExists) {
+          console.error(
+            chalk.red(`✖ Headlamp service '${options.namespace}/headlamp' not found in context '${ctx}'.`),
+          );
+          console.error("");
+          console.error(chalk.bold("  Install it first:"));
+          console.error(`    ${chalk.cyan(`azureclaw headlamp --install --context ${ctx}`)}`);
+          process.exitCode = 1;
+          return;
+        }
+
+        // Kill any stale port-forward bound to the local port (best-effort).
+        await freePort(execa, parseInt(options.port, 10));
+
+        // Mint a fresh service-account token so the user can log in.
+        // Headlamp uses bearer-token auth out of the box; the SA is
+        // created by the chart in the same namespace as the deployment.
+        let token = "";
+        try {
+          const { stdout } = await execa(
+            "kubectl",
+            kctl([
+              "create",
+              "token",
+              "headlamp",
+              "-n",
+              options.namespace,
+              `--duration=${options.tokenDuration}`,
+            ]),
+            { stdio: "pipe" },
+          );
+          token = stdout.trim();
+        } catch (err) {
+          console.warn(
+            chalk.yellow(
+              `  ⚠ could not mint Headlamp token (${(err as Error).message}). ` +
+                `You can mint one manually with:\n` +
+                `    kubectl --context ${ctx} create token headlamp -n ${options.namespace} --duration=24h`,
+            ),
+          );
+        }
+
+        // Start a detached port-forward so the process survives this
+        // command exiting. User stops it via `pkill -f 'port-forward.*headlamp'`.
+        console.log(chalk.bold(`  Connecting to Headlamp on context ${chalk.cyan(ctx!)}…`));
+        const { spawn } = await import("node:child_process");
+        const child = spawn(
+          "kubectl",
+          kctl(["port-forward", "-n", options.namespace, "service/headlamp", `${options.port}:80`]),
+          { detached: true, stdio: "ignore" },
+        );
+        child.unref();
+
+        // Give the forward ~1.5s to bind before opening the browser.
+        await new Promise((r) => setTimeout(r, 1500));
+
+        const url = `http://localhost:${options.port}/`;
+        console.log("");
+        console.log(chalk.bold("  Headlamp dashboard:"));
+        console.log(`    ${chalk.cyan(url)}`);
+        if (token) {
+          console.log("");
+          console.log(chalk.bold("  Login token (paste into Headlamp):"));
+          console.log(`    ${chalk.dim(token)}`);
+        }
+        console.log("");
+        console.log(
+          chalk.dim(
+            `  Port-forward runs in the background (PID ${child.pid}).\n` +
+              `  Stop it later with: pkill -f 'port-forward.*headlamp'`,
+          ),
+        );
+
+        if (options.browser) {
+          await openBrowser(execa, url);
+        }
+      },
+    );
+
+  return cmd;
+}
+
+/**
+ * Best-effort: kill any process holding `port` so a fresh port-forward
+ * can bind. Reuses the same lsof/kill dance used by `azureclaw dev`.
+ */
+async function freePort(execa: typeof import("execa").execa, port: number): Promise<void> {
+  try {
+    const { stdout } = await execa("lsof", ["-ti", `:${port}`], { stdio: "pipe" });
+    const pids = stdout.trim().split(/\s+/).filter(Boolean);
+    for (const pid of pids) {
+      try {
+        await execa("kill", [pid]);
+      } catch {
+        // process already gone — fine
+      }
+    }
+  } catch {
+    // lsof returns non-zero when nothing matches — fine
+  }
+}
+
+/**
+ * Cross-platform browser-open helper. Failure is non-fatal (the URL is
+ * printed for the user to click manually).
+ */
+async function openBrowser(execa: typeof import("execa").execa, url: string): Promise<void> {
+  const cmd =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "start"
+        : "xdg-open";
+  try {
+    await execa(cmd, [url], { stdio: "ignore" });
+  } catch {
+    // user can click the printed URL
+  }
+}
+
+/**
+ * Install Headlamp + the AzureClaw plugin into the active cluster.
+ * Pinned to the same Headlamp chart version that `azureclaw dev`
+ * installs locally so the bundled plugin remains compatible.
+ *
+ * Idempotent — re-running re-applies the manifest. Works on AKS,
+ * kind, and any other cluster kubectl can reach.
+ */
+async function installHeadlamp(execa: typeof import("execa").execa, ctx: string): Promise<void> {
+  const HEADLAMP_CHART_VERSION = "0.41.0"; // keep in lock-step with cli/src/commands/dev/local-k8s.ts
+  const kctl = (args: string[]) => ["--context", ctx, ...args];
+
+  console.log(chalk.bold(`  Installing Headlamp into context ${chalk.cyan(ctx)}…`));
+
+  // Ensure the namespace exists.
+  try {
+    await execa("kubectl", kctl(["create", "namespace", "headlamp"]), { stdio: "pipe" });
+  } catch {
+    // already exists — fine
+  }
+
+  // Add and update the chart repo.
+  try {
+    await execa("helm", ["repo", "add", "headlamp", "https://kubernetes-sigs.github.io/headlamp/"], {
+      stdio: "pipe",
+    });
+  } catch {
+    // already added — fine
+  }
+  await execa("helm", ["repo", "update", "headlamp"], { stdio: "pipe" });
+
+  // Render the chart and apply through kubectl --context so the install
+  // honours the user's --context flag (helm doesn't always thread it).
+  const { stdout: manifest } = await execa(
+    "helm",
+    [
+      "template",
+      "headlamp",
+      "headlamp/headlamp",
+      "--version",
+      HEADLAMP_CHART_VERSION,
+      "--namespace",
+      "headlamp",
+      "--set",
+      "config.useNodeInternalDNS=false",
+    ],
+    { stdio: "pipe" },
+  );
+  await execa(
+    "kubectl",
+    kctl(["apply", "-f", "-", "--server-side", "--force-conflicts"]),
+    { input: manifest, stdio: ["pipe", "inherit", "inherit"] },
+  );
+
+  // Wait for the deployment to come up (best-effort 90s).
+  try {
+    await execa(
+      "kubectl",
+      kctl(["rollout", "status", "deployment/headlamp", "-n", "headlamp", "--timeout=90s"]),
+      { stdio: "inherit" },
+    );
+  } catch {
+    console.warn(
+      chalk.yellow("  ⚠ Headlamp deployment didn't become ready within 90s; proceeding anyway."),
+    );
+  }
+
+  console.log(chalk.green("  ✓ Headlamp installed."));
+}

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -4,13 +4,28 @@
 import { Command } from "commander";
 import chalk from "chalk";
 
+interface ClusterTarget {
+  context: string;
+  label: string;
+}
+
+interface SandboxRow {
+  name: string;
+  phase: string;
+  runtime: string;
+  model: string;
+  isolation: string;
+  ns: string;
+}
+
 export function listCommand(): Command {
   const cmd = new Command("list");
 
   cmd
-    .description("List all Kars sandboxes (Docker + AKS)")
+    .description("List all AzureClaw sandboxes (Docker + every reachable kube context)")
     .option("--aks-only", "Only show AKS sandboxes")
     .option("--docker-only", "Only show local Docker sandboxes")
+    .option("--context <name>", "Limit kube query to a single context")
     .action(async (options) => {
       const { execa } = await import("execa");
       const blue = chalk.hex("#0078D4");
@@ -23,20 +38,34 @@ export function listCommand(): Command {
         try {
           const { stdout } = await execa("docker", [
             "ps", "-a",
-            "--filter", "name=kars-",
-            "--format", "{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}",
+            "--filter", "name=azureclaw-",
+            "--format",
+            "{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Label \"io.x-k8s.kind.cluster\"}}\t{{.Label \"io.x-k8s.kind.role\"}}",
           ], { stdio: "pipe" });
 
-          if (stdout.trim()) {
+          const rows: { name: string; status: string; image: string }[] = [];
+          for (const line of stdout.trim().split("\n").filter(Boolean)) {
+            const [name, status, image, kindCluster, kindRole] = line.split("\t");
+            if (!name?.startsWith("azureclaw-")) continue;
+            // Skip kind cluster nodes — they match name=azureclaw- when the
+            // local-k8s cluster is named "azureclaw-*" (default for
+            // `azureclaw dev --target local-k8s`). Detect via the kind
+            // labels rather than relying on the image name.
+            if (kindCluster || kindRole) continue;
+            // Skip AGT infrastructure containers
+            if (name.includes("agt-postgres") || name.includes("agt-relay") || name.includes("agt-registry")) continue;
+            rows.push({ name, status, image });
+          }
+
+          if (rows.length > 0) {
             console.log(chalk.bold("  Local (Docker)"));
             console.log(chalk.dim("  ─────────────────────────────────────────────────────────────────"));
-            for (const line of stdout.trim().split("\n")) {
-              const [name, status, image] = line.split("\t");
-              const agentName = name.replace(/^kars-/, "");
-              const isUp = status.toLowerCase().startsWith("up");
+            for (const r of rows) {
+              const agentName = r.name.replace(/^azureclaw-/, "");
+              const isUp = r.status.toLowerCase().startsWith("up");
               const icon = isUp ? chalk.green("●") : chalk.red("●");
-              const shortStatus = status.replace(/ \(.*\)/, "");
-              console.log(`  ${icon} ${chalk.bold(agentName.padEnd(24))} ${shortStatus.padEnd(20)} ${chalk.dim(image || "")}`);
+              const shortStatus = r.status.replace(/ \(.*\)/, "");
+              console.log(`  ${icon} ${chalk.bold(agentName.padEnd(24))} ${shortStatus.padEnd(20)} ${chalk.dim(r.image || "")}`);
               found = true;
             }
             console.log();
@@ -44,47 +73,37 @@ export function listCommand(): Command {
         } catch { /* docker not available */ }
       }
 
-      // ── AKS sandboxes (KarsSandbox CRDs) ──
+      // ── Kubernetes sandboxes (all reachable contexts) ──
+      // Discover every kubectl context once and query each separately
+      // so users see both their local-k8s kind cluster AND their AKS
+      // cluster in a single `azureclaw list`. Previously this section
+      // only queried the *current* context, which silently hid one or
+      // the other depending on which `kubectl config use-context` was
+      // last run.
       if (!options.dockerOnly) {
-        try {
-          const { stdout } = await execa("kubectl", [
-            "get", "karssandbox",
-            "-n", "kars-system",
-            "-o", "json",
-          ], { stdio: "pipe" });
+        const targets = await discoverKubeContexts(execa, options.context);
+        for (const tgt of targets) {
+          const rows = await fetchClusterSandboxes(execa, tgt.context);
+          if (rows.length === 0) continue;
 
-          const list = JSON.parse(stdout);
-          const items = list.items || [];
+          console.log(chalk.bold(`  ${tgt.label}`) + chalk.dim(`  (context: ${tgt.context})`));
+          console.log(chalk.dim("  ─────────────────────────────────────────────────────────────────"));
+          console.log(chalk.dim(`  ${"NAME".padEnd(22)} ${"STATUS".padEnd(12)} ${"RUNTIME".padEnd(22)} ${"MODEL".padEnd(14)} ${"ISO".padEnd(10)} NS`));
 
-          if (items.length > 0) {
-            console.log(chalk.bold("  AKS Cluster"));
-            console.log(chalk.dim("  ─────────────────────────────────────────────────────────────────"));
-            console.log(chalk.dim(`  ${"NAME".padEnd(22)} ${"STATUS".padEnd(12)} ${"RUNTIME".padEnd(22)} ${"MODEL".padEnd(14)} ${"ISO".padEnd(10)} NS`));
+          for (const r of rows) {
+            let icon: string;
+            if (r.phase === "Running") icon = chalk.green("●");
+            else if (r.phase === "Pending" || r.phase === "Creating") icon = chalk.yellow("●");
+            else icon = chalk.red("●");
 
-            for (const sb of items) {
-              const name = sb.metadata?.name || "unknown";
-              const phase = sb.status?.phase || "Unknown";
-              const model = sb.spec?.inference?.model || "gpt-4.1";
-              const isolation = sb.spec?.sandbox?.isolation || "enhanced";
-              const runtimeKind = sb.spec?.runtime?.kind || "OpenClaw";
-              const ns = `kars-${name}`;
-
-              let icon: string;
-              if (phase === "Running") icon = chalk.green("●");
-              else if (phase === "Pending" || phase === "Creating") icon = chalk.yellow("●");
-              else icon = chalk.red("●");
-
-              console.log(`  ${icon} ${chalk.bold(name.padEnd(22))} ${phase.padEnd(12)} ${runtimeKind.padEnd(22)} ${model.padEnd(14)} ${isolation.padEnd(10)} ${chalk.dim(ns)}`);
-              found = true;
-            }
-            console.log();
+            console.log(`  ${icon} ${chalk.bold(r.name.padEnd(22))} ${r.phase.padEnd(12)} ${r.runtime.padEnd(22)} ${r.model.padEnd(14)} ${r.isolation.padEnd(10)} ${chalk.dim(r.ns)}`);
+            found = true;
           }
-        } catch {
-          if (!options.aksOnly) {
-            // AKS not configured — only show if explicitly requested
-          } else {
-            console.log(chalk.dim("  No AKS cluster configured (kubectl not connected)\n"));
-          }
+          console.log();
+        }
+
+        if (!found && options.aksOnly) {
+          console.log(chalk.dim("  No AKS / kube sandboxes found (kubectl unreachable or no ClawSandbox CRs)\n"));
         }
       }
 
@@ -95,4 +114,117 @@ export function listCommand(): Command {
     });
 
   return cmd;
+}
+
+/**
+ * Resolve the set of kube contexts to query.
+ *
+ * - `--context <name>` → just that one
+ * - Otherwise: every context in kubeconfig that we can reach. A
+ *   context is "reachable" if `kubectl --context <name> get ns` returns
+ *   within a short timeout. Unreachable contexts are silently skipped
+ *   so a stale kubeconfig entry doesn't make `azureclaw list` hang.
+ *
+ * Returns a friendly label per context: `Local (kind)` for any
+ * `kind-*` context, `AKS Cluster` for everything else. This is a
+ * heuristic — it covers the documented `azureclaw dev --target
+ * local-k8s` (creates `kind-azureclaw-dev`) and `azureclaw up`
+ * (configures `azureclaw-aks`).
+ */
+async function discoverKubeContexts(
+  execa: typeof import("execa").execa,
+  pinned?: string,
+): Promise<ClusterTarget[]> {
+  if (pinned) {
+    return [{ context: pinned, label: pinned.startsWith("kind-") ? "Local (kind)" : "AKS Cluster" }];
+  }
+
+  let allContexts: string[] = [];
+  try {
+    const { stdout } = await execa("kubectl", ["config", "get-contexts", "-o", "name"], { stdio: "pipe" });
+    allContexts = stdout.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+
+  // Probe each context in parallel with a short timeout so a single
+  // unreachable AKS cluster doesn't block listing the local one.
+  const probed = await Promise.all(
+    allContexts.map(async (ctx): Promise<ClusterTarget | null> => {
+      try {
+        await execa(
+          "kubectl",
+          ["--context", ctx, "get", "ns", "--request-timeout=3s", "--no-headers"],
+          { stdio: "pipe", timeout: 5000 },
+        );
+        return { context: ctx, label: ctx.startsWith("kind-") ? "Local (kind)" : "AKS Cluster" };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return probed.filter((t): t is ClusterTarget => t !== null);
+}
+
+/**
+ * Query ClawSandbox CRs from one kube context, resolving the model
+ * via the modern `spec.inferenceRef → InferencePolicy.modelPreference`
+ * path (with legacy `spec.inference.model` fallback for pre-S10 CRs).
+ *
+ * This mirrors the same resolution order used by
+ * `cli/src/commands/operator/fetchers/sandboxes.ts:75-82`. Keeping the
+ * two in sync means `azureclaw list` and `azureclaw operator` agree
+ * on which model each sandbox is using.
+ */
+async function fetchClusterSandboxes(
+  execa: typeof import("execa").execa,
+  context: string,
+): Promise<SandboxRow[]> {
+  try {
+    const [sbRes, ipRes] = await Promise.allSettled([
+      execa(
+        "kubectl",
+        ["--context", context, "get", "clawsandbox", "-A", "-o", "json", "--request-timeout=5s"],
+        { stdio: "pipe", timeout: 8000 },
+      ),
+      execa(
+        "kubectl",
+        ["--context", context, "get", "inferencepolicy", "-A", "-o", "json", "--request-timeout=5s"],
+        { stdio: "pipe", timeout: 8000 },
+      ),
+    ]);
+    if (sbRes.status !== "fulfilled") return [];
+
+    const ipModel = new Map<string, string>();
+    if (ipRes.status === "fulfilled") {
+      try {
+        const ipData = JSON.parse((ipRes.value as any).stdout);
+        for (const it of (ipData.items || []) as any[]) {
+          const ns = it?.metadata?.namespace;
+          const nm = it?.metadata?.name;
+          const dep = it?.spec?.modelPreference?.primary?.deployment;
+          if (ns && nm && typeof dep === "string" && dep) {
+            ipModel.set(`${ns}/${nm}`, dep);
+          }
+        }
+      } catch { /* non-fatal */ }
+    }
+
+    const data = JSON.parse((sbRes.value as any).stdout);
+    const out: SandboxRow[] = [];
+    for (const sb of (data.items || []) as any[]) {
+      const name = sb.metadata?.name || "unknown";
+      const ns = sb.metadata?.namespace || "azureclaw-system";
+      const phase = sb.status?.phase || "Unknown";
+      const runtime = sb.spec?.runtime?.kind || "OpenClaw";
+      const isolation = sb.spec?.sandbox?.isolation || "enhanced";
+      const inferenceRefName = sb.spec?.inferenceRef?.name as string | undefined;
+      const ipKey = inferenceRefName ? `${ns}/${inferenceRefName}` : "";
+      const model = (ipKey && ipModel.get(ipKey)) || sb.spec?.inference?.model || "gpt-4.1";
+      out.push({ name, phase, runtime, model, isolation, ns });
+    }
+    return out;
+  } catch {
+    return [];
+  }
 }

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -22,7 +22,7 @@ export function listCommand(): Command {
   const cmd = new Command("list");
 
   cmd
-    .description("List all AzureClaw sandboxes (Docker + every reachable kube context)")
+    .description("List all Kars sandboxes (Docker + every reachable kube context)")
     .option("--aks-only", "Only show AKS sandboxes")
     .option("--docker-only", "Only show local Docker sandboxes")
     .option("--context <name>", "Limit kube query to a single context")
@@ -38,7 +38,7 @@ export function listCommand(): Command {
         try {
           const { stdout } = await execa("docker", [
             "ps", "-a",
-            "--filter", "name=azureclaw-",
+            "--filter", "name=kars-",
             "--format",
             "{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Label \"io.x-k8s.kind.cluster\"}}\t{{.Label \"io.x-k8s.kind.role\"}}",
           ], { stdio: "pipe" });
@@ -46,10 +46,10 @@ export function listCommand(): Command {
           const rows: { name: string; status: string; image: string }[] = [];
           for (const line of stdout.trim().split("\n").filter(Boolean)) {
             const [name, status, image, kindCluster, kindRole] = line.split("\t");
-            if (!name?.startsWith("azureclaw-")) continue;
-            // Skip kind cluster nodes — they match name=azureclaw- when the
-            // local-k8s cluster is named "azureclaw-*" (default for
-            // `azureclaw dev --target local-k8s`). Detect via the kind
+            if (!name?.startsWith("kars-")) continue;
+            // Skip kind cluster nodes — they match name=kars- when the
+            // local-k8s cluster is named "kars-*" (default for
+            // `kars dev --target local-k8s`). Detect via the kind
             // labels rather than relying on the image name.
             if (kindCluster || kindRole) continue;
             // Skip AGT infrastructure containers
@@ -61,7 +61,7 @@ export function listCommand(): Command {
             console.log(chalk.bold("  Local (Docker)"));
             console.log(chalk.dim("  ─────────────────────────────────────────────────────────────────"));
             for (const r of rows) {
-              const agentName = r.name.replace(/^azureclaw-/, "");
+              const agentName = r.name.replace(/^kars-/, "");
               const isUp = r.status.toLowerCase().startsWith("up");
               const icon = isUp ? chalk.green("●") : chalk.red("●");
               const shortStatus = r.status.replace(/ \(.*\)/, "");
@@ -76,7 +76,7 @@ export function listCommand(): Command {
       // ── Kubernetes sandboxes (all reachable contexts) ──
       // Discover every kubectl context once and query each separately
       // so users see both their local-k8s kind cluster AND their AKS
-      // cluster in a single `azureclaw list`. Previously this section
+      // cluster in a single `kars list`. Previously this section
       // only queried the *current* context, which silently hid one or
       // the other depending on which `kubectl config use-context` was
       // last run.
@@ -103,7 +103,7 @@ export function listCommand(): Command {
         }
 
         if (!found && options.aksOnly) {
-          console.log(chalk.dim("  No AKS / kube sandboxes found (kubectl unreachable or no ClawSandbox CRs)\n"));
+          console.log(chalk.dim("  No AKS / kube sandboxes found (kubectl unreachable or no KarsSandbox CRs)\n"));
         }
       }
 
@@ -123,13 +123,13 @@ export function listCommand(): Command {
  * - Otherwise: every context in kubeconfig that we can reach. A
  *   context is "reachable" if `kubectl --context <name> get ns` returns
  *   within a short timeout. Unreachable contexts are silently skipped
- *   so a stale kubeconfig entry doesn't make `azureclaw list` hang.
+ *   so a stale kubeconfig entry doesn't make `kars list` hang.
  *
  * Returns a friendly label per context: `Local (kind)` for any
  * `kind-*` context, `AKS Cluster` for everything else. This is a
- * heuristic — it covers the documented `azureclaw dev --target
- * local-k8s` (creates `kind-azureclaw-dev`) and `azureclaw up`
- * (configures `azureclaw-aks`).
+ * heuristic — it covers the documented `kars dev --target
+ * local-k8s` (creates `kind-kars-dev`) and `kars up`
+ * (configures `kars-aks`).
  */
 async function discoverKubeContexts(
   execa: typeof import("execa").execa,
@@ -167,13 +167,13 @@ async function discoverKubeContexts(
 }
 
 /**
- * Query ClawSandbox CRs from one kube context, resolving the model
+ * Query KarsSandbox CRs from one kube context, resolving the model
  * via the modern `spec.inferenceRef → InferencePolicy.modelPreference`
  * path (with legacy `spec.inference.model` fallback for pre-S10 CRs).
  *
  * This mirrors the same resolution order used by
  * `cli/src/commands/operator/fetchers/sandboxes.ts:75-82`. Keeping the
- * two in sync means `azureclaw list` and `azureclaw operator` agree
+ * two in sync means `kars list` and `kars operator` agree
  * on which model each sandbox is using.
  */
 async function fetchClusterSandboxes(
@@ -184,7 +184,7 @@ async function fetchClusterSandboxes(
     const [sbRes, ipRes] = await Promise.allSettled([
       execa(
         "kubectl",
-        ["--context", context, "get", "clawsandbox", "-A", "-o", "json", "--request-timeout=5s"],
+        ["--context", context, "get", "karssandbox", "-A", "-o", "json", "--request-timeout=5s"],
         { stdio: "pipe", timeout: 8000 },
       ),
       execa(
@@ -214,7 +214,7 @@ async function fetchClusterSandboxes(
     const out: SandboxRow[] = [];
     for (const sb of (data.items || []) as any[]) {
       const name = sb.metadata?.name || "unknown";
-      const ns = sb.metadata?.namespace || "azureclaw-system";
+      const ns = sb.metadata?.namespace || "kars-system";
       const phase = sb.status?.phase || "Unknown";
       const runtime = sb.spec?.runtime?.kind || "OpenClaw";
       const isolation = sb.spec?.sandbox?.isolation || "enhanced";

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -134,7 +134,7 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
     fg: "white",
     label: " Agents  [↑↓ navigate] ",
     columnSpacing: 1,
-    columnWidth: [3, 40, 14, 10, 18, 12, 5, 6],
+    columnWidth: [3, 32, 14, 10, 14, 10, 5, 6, 18],
     interactive: true,
     style: {
       border: { fg: "cyan" },
@@ -436,11 +436,21 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
         rk === "PydanticAi" ? "PydAI" :
         rk === "BYO" ? "BYO" :
         rk;
-      return [hIcon, displayName, statusStr, rkTag, s.model, s.isolation, s.channels, s.age];
+      // Compact cluster origin tag so the user can tell which cluster
+      // each row came from in a multi-cluster operator view. Docker
+      // sandboxes show "docker"; AKS-tagged sandboxes show the last
+      // segment of their kube context name (e.g. "azureclaw-aks" or
+      // "azureclaw-dev"). Empty when no context was tagged (single-
+      // cluster operator runs preserved the historical no-column view).
+      const clusterTag =
+        s.runtime === "docker" ? "docker" :
+        s.kubeContext ? s.kubeContext.replace(/^kind-/, "") :
+        "";
+      return [hIcon, displayName, statusStr, rkTag, s.model, s.isolation, s.channels, s.age, clusterTag];
     });
     (agentTable as any).setData({
-      headers: [" ", " Name", " Status", " Runtime", " Model", " Isolation", " Ch", " Age"],
-      data: agentData.length > 0 ? agentData : [["", "(no agents)", "", "", "", "", "", ""]],
+      headers: [" ", " Name", " Status", " Runtime", " Model", " Isolation", " Ch", " Age", " Cluster"],
+      data: agentData.length > 0 ? agentData : [["", "(no agents)", "", "", "", "", "", "", ""]],
     });
 
     // Egress list — filtered to selected agent, colored by status
@@ -519,14 +529,14 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
 
       if (fetchDetail) {
         promises.push(
-          Promise.allSettled(running.map((s) => fetchEgressDomains(s, kubeContext))).then((settled) => {
+          Promise.allSettled(running.map((s) => fetchEgressDomains(s, s.kubeContext ?? kubeContext))).then((settled) => {
             egressByAgent = new Map();
             for (let i = 0; i < running.length; i++) {
               const r = settled[i];
               if (r.status === "fulfilled") egressByAgent.set(running[i].name, r.value);
             }
           }),
-          Promise.allSettled(running.map((s) => fetchSecurityState(s, kubeContext))).then((settled) => {
+          Promise.allSettled(running.map((s) => fetchSecurityState(s, s.kubeContext ?? kubeContext))).then((settled) => {
             securityStates = new Map();
             for (let i = 0; i < running.length; i++) {
               const r = settled[i];
@@ -537,7 +547,7 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
       } else {
         // Fast AGT-only poll on non-detail cycles to keep mesh data alive
         promises.push(
-          Promise.allSettled(running.map((s) => fetchAgtQuick(s, securityStates.get(s.name), kubeContext))),
+          Promise.allSettled(running.map((s) => fetchAgtQuick(s, securityStates.get(s.name), s.kubeContext ?? kubeContext))),
         );
       }
 

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -27,7 +27,7 @@ import type {
   ClusterHealth,
   MeshHealth,
 } from "./operator/types.js";
-import { timeSince, kctl, platformTag } from "./operator/helpers.js";
+import { timeSince, kctl, platformTag, clusterOriginTag } from "./operator/helpers.js";
 import { fetchSandboxes } from "./operator/fetchers/sandboxes.js";
 import {
   fetchEgressDomains,
@@ -84,7 +84,6 @@ export function operatorCommand(): Command {
 }
 
 // Helper to build kubectl args with optional context
-
 
 async function startDashboard(refreshInterval: number, kubeContext?: string, devMode = false, panelOpts: { panels?: string; perSandbox?: boolean } = {}) {
   // ── Resolve cluster ───────────────────────────────────────────────
@@ -436,16 +435,7 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
         rk === "PydanticAi" ? "PydAI" :
         rk === "BYO" ? "BYO" :
         rk;
-      // Compact cluster origin: one-letter platform tag (D/K/C) +
-      // short cluster name. Lets the user tell at a glance whether a
-      // row came from Docker, kind, or a real cloud cluster, and
-      // which cluster specifically when more than one is present.
-      const tag = platformTag(s);
-      const clusterName =
-        s.runtime === "docker" ? "" :
-        s.kubeContext ? s.kubeContext.replace(/^kind-/, "") :
-        "";
-      const clusterTag = clusterName ? `${tag} ${clusterName}` : tag;
+      const clusterTag = clusterOriginTag(s);
       return [hIcon, displayName, statusStr, rkTag, s.model, s.isolation, s.channels, s.age, clusterTag];
     });
     (agentTable as any).setData({

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -27,7 +27,7 @@ import type {
   ClusterHealth,
   MeshHealth,
 } from "./operator/types.js";
-import { timeSince, kctl } from "./operator/helpers.js";
+import { timeSince, kctl, platformTag } from "./operator/helpers.js";
 import { fetchSandboxes } from "./operator/fetchers/sandboxes.js";
 import {
   fetchEgressDomains,
@@ -436,16 +436,16 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
         rk === "PydanticAi" ? "PydAI" :
         rk === "BYO" ? "BYO" :
         rk;
-      // Compact cluster origin tag so the user can tell which cluster
-      // each row came from in a multi-cluster operator view. Docker
-      // sandboxes show "docker"; AKS-tagged sandboxes show the last
-      // segment of their kube context name (e.g. "azureclaw-aks" or
-      // "azureclaw-dev"). Empty when no context was tagged (single-
-      // cluster operator runs preserved the historical no-column view).
-      const clusterTag =
-        s.runtime === "docker" ? "docker" :
+      // Compact cluster origin: one-letter platform tag (D/K/C) +
+      // short cluster name. Lets the user tell at a glance whether a
+      // row came from Docker, kind, or a real cloud cluster, and
+      // which cluster specifically when more than one is present.
+      const tag = platformTag(s);
+      const clusterName =
+        s.runtime === "docker" ? "" :
         s.kubeContext ? s.kubeContext.replace(/^kind-/, "") :
         "";
+      const clusterTag = clusterName ? `${tag} ${clusterName}` : tag;
       return [hIcon, displayName, statusStr, rkTag, s.model, s.isolation, s.channels, s.age, clusterTag];
     });
     (agentTable as any).setData({

--- a/cli/src/commands/operator/fetchers/sandboxes.ts
+++ b/cli/src/commands/operator/fetchers/sandboxes.ts
@@ -29,8 +29,8 @@ import { kctl, timeSince } from "../helpers.js";
  *
  * When `kubeContext` is undefined, every kube context in the user's
  * kubeconfig that's reachable within ~5s is queried in parallel. This
- * matches what `azureclaw list` already does and means a developer
- * with both `kind-azureclaw-dev` and `azureclaw-aks` configured sees
+ * matches what `kars list` already does and means a developer
+ * with both `kind-kars-dev` and `kars-aks` configured sees
  * both clusters' sandboxes in a single dashboard, without having to
  * `kubectl config use-context` between them.
  *
@@ -278,19 +278,19 @@ export async function fetchSandboxesDocker(): Promise<SandboxInfo[]> {
   try {
     const { stdout } = await execa("docker", [
       "ps", "-a", "--format",
-      "{{.Names}}|{{.Status}}|{{.Label \"azureclaw.parent\"}}|{{.Label \"azureclaw.spawned-by\"}}|{{.CreatedAt}}|{{.Label \"io.x-k8s.kind.cluster\"}}|{{.Label \"io.x-k8s.kind.role\"}}",
-      "--filter", "name=azureclaw-",
+      "{{.Names}}|{{.Status}}|{{.Label \"kars.parent\"}}|{{.Label \"kars.spawned-by\"}}|{{.CreatedAt}}|{{.Label \"io.x-k8s.kind.cluster\"}}|{{.Label \"io.x-k8s.kind.role\"}}",
+      "--filter", "name=kars-",
     ], { stdio: "pipe" });
 
     const results: SandboxInfo[] = [];
     for (const line of stdout.split("\n").filter(Boolean)) {
       const [containerName, status, parent, , createdAt, kindCluster, kindRole] = line.split("|");
-      if (!containerName?.startsWith("azureclaw-")) continue;
+      if (!containerName?.startsWith("kars-")) continue;
       // Skip kind cluster nodes: `kind` names control-plane / worker
       // containers `<cluster-name>-control-plane`, `<cluster-name>-worker`.
-      // When the kind cluster is named `azureclaw-dev` (default for
-      // `azureclaw dev --target local-k8s`) these containers match our
-      // `name=azureclaw-` filter and get misidentified as sandboxes.
+      // When the kind cluster is named `kars-dev` (default for
+      // `kars dev --target local-k8s`) these containers match our
+      // `name=kars-` filter and get misidentified as sandboxes.
       // Distinguishing label: `io.x-k8s.kind.cluster` is set by kind on
       // every node container; we drop any container that carries it.
       if (kindCluster || kindRole) continue;

--- a/cli/src/commands/operator/fetchers/sandboxes.ts
+++ b/cli/src/commands/operator/fetchers/sandboxes.ts
@@ -22,18 +22,80 @@ import type { HealthState, SandboxInfo } from "../types.js";
 import { kctl, timeSince } from "../helpers.js";
 
 /**
- * Unified Docker + AKS sandbox view (concatenated; deduplication is
- * intentionally avoided — same-named sandboxes in both runtimes are a
- * legitimate handoff state, e.g. dormant local + active-successor cloud).
+ * Unified Docker + multi-cluster sandbox view.
+ *
+ * When `kubeContext` is given (legacy `--context <name>` path), only
+ * that one context is queried — preserves the historical behaviour.
+ *
+ * When `kubeContext` is undefined, every kube context in the user's
+ * kubeconfig that's reachable within ~5s is queried in parallel. This
+ * matches what `azureclaw list` already does and means a developer
+ * with both `kind-azureclaw-dev` and `azureclaw-aks` configured sees
+ * both clusters' sandboxes in a single dashboard, without having to
+ * `kubectl config use-context` between them.
+ *
+ * Deduplication is intentionally avoided — same-named sandboxes in
+ * both runtimes are a legitimate handoff state (e.g. dormant local +
+ * active-successor cloud).
  */
 export async function fetchSandboxes(kubeContext?: string): Promise<SandboxInfo[]> {
-  const [dockerResult, aksResult] = await Promise.allSettled([
+  // Decide which kube contexts to query.
+  let contexts: (string | undefined)[];
+  if (kubeContext) {
+    contexts = [kubeContext];
+  } else {
+    contexts = await discoverReachableContexts();
+    // If discovery returned nothing (no kubeconfig / kubectl missing),
+    // fall back to a single undefined → current-context attempt so an
+    // existing kube user without explicit context names still sees
+    // their sandboxes.
+    if (contexts.length === 0) contexts = [undefined];
+  }
+
+  const [dockerResult, ...aksResults] = await Promise.allSettled([
     fetchSandboxesDocker(),
-    fetchSandboxesAKS(kubeContext),
+    ...contexts.map((c) => fetchSandboxesAKS(c)),
   ]);
   const docker = dockerResult.status === "fulfilled" ? dockerResult.value : [];
-  const aks = aksResult.status === "fulfilled" ? aksResult.value : [];
+  const aks = aksResults.flatMap((r) => (r.status === "fulfilled" ? r.value : []));
   return [...docker, ...aks];
+}
+
+/**
+ * List every kube context in the user's kubeconfig that responds to
+ * `kubectl get ns` within ~3 seconds. Probes run in parallel so a
+ * single unreachable AKS doesn't block the local kind cluster.
+ *
+ * Mirrors `cli/src/commands/list.ts:discoverKubeContexts`, but here we
+ * return raw context names (no labels) because the operator UI does
+ * not group by cluster.
+ */
+async function discoverReachableContexts(): Promise<string[]> {
+  let allContexts: string[] = [];
+  try {
+    const { stdout } = await execa("kubectl", ["config", "get-contexts", "-o", "name"], {
+      stdio: "pipe",
+      timeout: 5000,
+    });
+    allContexts = stdout.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+  const probed = await Promise.all(
+    allContexts.map(async (ctx) => {
+      try {
+        await execa(
+          "kubectl",
+          ["--context", ctx, "get", "ns", "--request-timeout=3s", "--no-headers"],
+          { stdio: "pipe", timeout: 5000 },
+        );
+        return ctx;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return probed.filter((c): c is string => c !== null);
 }
 
 export async function fetchSandboxesAKS(kubeContext?: string): Promise<SandboxInfo[]> {
@@ -177,6 +239,12 @@ export async function fetchSandboxesAKS(kubeContext?: string): Promise<SandboxIn
         role, parent: parentLabel, handoffState,
         runtime: "aks",
         runtimeKind: (item.spec?.runtime?.kind as string | undefined) || "OpenClaw",
+        // Tag every kube-sourced sandbox with its origin context so
+        // per-sandbox follow-up fetches (security/egress/agt-quick)
+        // target the same cluster instead of the current kubectl
+        // context. Critical when the operator aggregates multiple
+        // clusters in one view.
+        kubeContext,
       } as SandboxInfo;
     }));
 

--- a/cli/src/commands/operator/fetchers/sandboxes.ts
+++ b/cli/src/commands/operator/fetchers/sandboxes.ts
@@ -210,14 +210,22 @@ export async function fetchSandboxesDocker(): Promise<SandboxInfo[]> {
   try {
     const { stdout } = await execa("docker", [
       "ps", "-a", "--format",
-      "{{.Names}}|{{.Status}}|{{.Label \"kars.parent\"}}|{{.Label \"kars.spawned-by\"}}|{{.CreatedAt}}",
-      "--filter", "name=kars-",
+      "{{.Names}}|{{.Status}}|{{.Label \"azureclaw.parent\"}}|{{.Label \"azureclaw.spawned-by\"}}|{{.CreatedAt}}|{{.Label \"io.x-k8s.kind.cluster\"}}|{{.Label \"io.x-k8s.kind.role\"}}",
+      "--filter", "name=azureclaw-",
     ], { stdio: "pipe" });
 
     const results: SandboxInfo[] = [];
     for (const line of stdout.split("\n").filter(Boolean)) {
-      const [containerName, status, parent, , createdAt] = line.split("|");
-      if (!containerName?.startsWith("kars-")) continue;
+      const [containerName, status, parent, , createdAt, kindCluster, kindRole] = line.split("|");
+      if (!containerName?.startsWith("azureclaw-")) continue;
+      // Skip kind cluster nodes: `kind` names control-plane / worker
+      // containers `<cluster-name>-control-plane`, `<cluster-name>-worker`.
+      // When the kind cluster is named `azureclaw-dev` (default for
+      // `azureclaw dev --target local-k8s`) these containers match our
+      // `name=azureclaw-` filter and get misidentified as sandboxes.
+      // Distinguishing label: `io.x-k8s.kind.cluster` is set by kind on
+      // every node container; we drop any container that carries it.
+      if (kindCluster || kindRole) continue;
       // Skip AGT infrastructure containers
       if (containerName.includes("agt-postgres") || containerName.includes("agt-relay") || containerName.includes("agt-registry")) continue;
 

--- a/cli/src/commands/operator/helpers.ts
+++ b/cli/src/commands/operator/helpers.ts
@@ -120,8 +120,8 @@ export function platformLabel(s: {
 /**
  * Compact "<tag> <cluster-name>" used in the agent-table Cluster column
  * and the CRD snapshot status line. Docker sandboxes show just "D"
- * (no cluster name). Kube sandboxes show "K azureclaw-dev" or
- * "C azureclaw-aks" — the kubeContext with the `kind-` prefix stripped.
+ * (no cluster name). Kube sandboxes show "K kars-dev" or
+ * "C kars-aks" — the kubeContext with the `kind-` prefix stripped.
  */
 export function clusterOriginTag(s: {
   runtime: "docker" | "aks";

--- a/cli/src/commands/operator/helpers.ts
+++ b/cli/src/commands/operator/helpers.ts
@@ -116,3 +116,20 @@ export function platformLabel(s: {
   if (s.kubeContext && s.kubeContext.startsWith("kind-")) return "kind";
   return "cloud";
 }
+
+/**
+ * Compact "<tag> <cluster-name>" used in the agent-table Cluster column
+ * and the CRD snapshot status line. Docker sandboxes show just "D"
+ * (no cluster name). Kube sandboxes show "K azureclaw-dev" or
+ * "C azureclaw-aks" — the kubeContext with the `kind-` prefix stripped.
+ */
+export function clusterOriginTag(s: {
+  runtime: "docker" | "aks";
+  kubeContext?: string;
+}): string {
+  const tag = platformTag(s);
+  const clusterName = s.runtime === "docker"
+    ? ""
+    : s.kubeContext?.replace(/^kind-/, "") ?? "";
+  return clusterName ? `${tag} ${clusterName}` : tag;
+}

--- a/cli/src/commands/operator/helpers.ts
+++ b/cli/src/commands/operator/helpers.ts
@@ -76,3 +76,43 @@ export function sumPrometheusCounter(
   }
   return total;
 }
+
+/**
+ * Compact one-letter platform tag for a sandbox row.
+ *
+ * The TUI needs to fit the host type into a tiny column or a topology
+ * subtitle. The three values cover all the deployment surfaces the
+ * controller supports today:
+ *
+ *   D — Docker (local docker-engine sandbox; `runtime === "docker"`)
+ *   K — Kind  (local Kubernetes via kind; `runtime === "aks"` but
+ *              `kubeContext` starts with `kind-`)
+ *   C — Cloud (real AKS / any other kubernetes context;
+ *              `runtime === "aks"` and not kind)
+ *
+ * `runtime: "aks"` is a legacy field name from before kind support
+ * landed — it now means "any kubernetes context", not specifically
+ * Azure Kubernetes Service. The `kubeContext` tag added in the
+ * multi-cluster refactor is what distinguishes kind from real AKS.
+ */
+export function platformTag(s: {
+  runtime: "docker" | "aks";
+  kubeContext?: string;
+}): "D" | "K" | "C" {
+  if (s.runtime === "docker") return "D";
+  if (s.kubeContext && s.kubeContext.startsWith("kind-")) return "K";
+  return "C";
+}
+
+/**
+ * Full word for the platform — used where space allows (e.g. tooltips,
+ * status lines). Same mapping as `platformTag` above.
+ */
+export function platformLabel(s: {
+  runtime: "docker" | "aks";
+  kubeContext?: string;
+}): "docker" | "kind" | "cloud" {
+  if (s.runtime === "docker") return "docker";
+  if (s.kubeContext && s.kubeContext.startsWith("kind-")) return "kind";
+  return "cloud";
+}

--- a/cli/src/commands/operator/panels/layout.ts
+++ b/cli/src/commands/operator/panels/layout.ts
@@ -24,8 +24,9 @@
  */
 import type { Panel, ClusterState, PanelCategory } from "./types.js";
 import { bucketFromConditions } from "./util.js";
-import { clawSandboxPanel } from "./karssandbox.js";
-import { clawPairingPanel } from "./karspairing.js";
+import { platformTag } from "../helpers.js";
+import { clawSandboxPanel } from "./clawsandbox.js";
+import { clawPairingPanel } from "./clawpairing.js";
 import { mcpServerPanel } from "./mcpserver.js";
 import { toolPolicyPanel } from "./toolpolicy.js";
 import { inferencePolicyPanel } from "./inferencepolicy.js";
@@ -226,14 +227,15 @@ function buildRows(state: ClusterState): CrdRow[] {
     // Include cluster origin so multi-cluster aggregated views can
     // distinguish e.g. an `execbrief` on kind-azureclaw-dev from an
     // `execbrief` on azureclaw-aks — otherwise the two rows look
-    // identical except for AGE, which is misleading.
-    const clusterTag =
-      s.runtime === "docker" ? "docker" :
+    // identical except for AGE, which is misleading. Tag format is
+    // "<D|K|C> <cluster-name>" — D=Docker, K=Kind, C=Cloud.
+    const tag = platformTag(s);
+    const clusterName =
+      s.runtime === "docker" ? "" :
       s.kubeContext ? s.kubeContext.replace(/^kind-/, "") :
       "";
-    const parts = [s.model || "-", rk, s.isolation || "-", s.role];
-    if (clusterTag) parts.push(clusterTag);
-    const status = parts.join("  ·  ");
+    const clusterTag = clusterName ? `${tag} ${clusterName}` : tag;
+    const status = [s.model || "-", rk, s.isolation || "-", s.role, clusterTag].join("  ·  ");
     rows.push({
       index: next(),
       kind: "KarsSandbox",

--- a/cli/src/commands/operator/panels/layout.ts
+++ b/cli/src/commands/operator/panels/layout.ts
@@ -223,7 +223,17 @@ function buildRows(state: ClusterState): CrdRow[] {
   // KarsSandbox — uses SandboxInfo (no conditions; health field is authoritative).
   for (const s of state.sandboxes) {
     const rk = s.runtimeKind || "OpenClaw";
-    const status = `${s.model || "-"}  ·  ${rk}  ·  ${s.isolation || "-"}  ·  ${s.role}`;
+    // Include cluster origin so multi-cluster aggregated views can
+    // distinguish e.g. an `execbrief` on kind-azureclaw-dev from an
+    // `execbrief` on azureclaw-aks — otherwise the two rows look
+    // identical except for AGE, which is misleading.
+    const clusterTag =
+      s.runtime === "docker" ? "docker" :
+      s.kubeContext ? s.kubeContext.replace(/^kind-/, "") :
+      "";
+    const parts = [s.model || "-", rk, s.isolation || "-", s.role];
+    if (clusterTag) parts.push(clusterTag);
+    const status = parts.join("  ·  ");
     rows.push({
       index: next(),
       kind: "KarsSandbox",

--- a/cli/src/commands/operator/panels/layout.ts
+++ b/cli/src/commands/operator/panels/layout.ts
@@ -25,8 +25,8 @@
 import type { Panel, ClusterState, PanelCategory } from "./types.js";
 import { bucketFromConditions } from "./util.js";
 import { platformTag } from "../helpers.js";
-import { clawSandboxPanel } from "./clawsandbox.js";
-import { clawPairingPanel } from "./clawpairing.js";
+import { clawSandboxPanel } from "./karssandbox.js";
+import { clawPairingPanel } from "./karspairing.js";
 import { mcpServerPanel } from "./mcpserver.js";
 import { toolPolicyPanel } from "./toolpolicy.js";
 import { inferencePolicyPanel } from "./inferencepolicy.js";
@@ -225,8 +225,8 @@ function buildRows(state: ClusterState): CrdRow[] {
   for (const s of state.sandboxes) {
     const rk = s.runtimeKind || "OpenClaw";
     // Include cluster origin so multi-cluster aggregated views can
-    // distinguish e.g. an `execbrief` on kind-azureclaw-dev from an
-    // `execbrief` on azureclaw-aks — otherwise the two rows look
+    // distinguish e.g. an `execbrief` on kind-kars-dev from an
+    // `execbrief` on kars-aks — otherwise the two rows look
     // identical except for AGE, which is misleading. Tag format is
     // "<D|K|C> <cluster-name>" — D=Docker, K=Kind, C=Cloud.
     const tag = platformTag(s);

--- a/cli/src/commands/operator/render/security.ts
+++ b/cli/src/commands/operator/render/security.ts
@@ -133,9 +133,20 @@ export function renderAGTFull(
   if (!sec) return `{bold}${sb.name}{/}\n{gray-fg}Polling...{/}`;
   if (!sec.agtEnabled) return "{gray-fg}AGT not enabled{/}\n{gray-fg}Use --governance flag{/}";
 
-  const activePeerCount = sec.agtTrustScores.filter((t: any) =>
-    t.agent !== sb.name && sandboxes.some((s) => s.name === t.agent) && (t.interactions > 0 || t.lastSeen)
-  ).length;
+  // Strip DID prefix when comparing agent_ids to sandbox short names
+  // (router emits did:agentmesh:<name>; sandbox list uses short names).
+  // Also collapse the legacy truncated "did:agentmes" key — pre-PR-354
+  // openclaw plugin builds collapsed every unresolved peer into that
+  // single key, so it pollutes the trust store on already-running pods.
+  // Hide it from the operator view until the router restarts.
+  const shortAgentName = (id: string): string => id.replace(/^did:agentmesh:/, "");
+  const isBogusLegacyKey = (id: string): boolean => id === "did:agentmes";
+
+  const activePeerCount = sec.agtTrustScores.filter((t: any) => {
+    const a = shortAgentName(t.agent);
+    if (isBogusLegacyKey(t.agent) || a === sb.name) return false;
+    return sandboxes.some((s) => s.name === a) && (t.interactions > 0 || t.lastSeen);
+  }).length;
 
   const lines: string[] = [
     `{bold}${sb.name}{/}` + (sec.agtAmid ? ` {gray-fg}${sec.agtAmid}{/}` : ""),
@@ -194,17 +205,22 @@ export function renderAGTFull(
   }
 
   if (sec.agtTrustScores.length > 0) {
-    const self = sec.agtTrustScores.find((t) => t.agent === sb.name);
+    const self = sec.agtTrustScores.find((t) => shortAgentName(t.agent) === sb.name);
     // Show peers that are either known sandboxes OR recently active.
     // Sub-agents are spawned dynamically and may not appear in the
     // sandbox list; cloud-offload parents are identified only by AMID
     // prefix (no CR name) so they also don't match. For AMID-only peers
     // we require BOTH recent lastSeen AND interactions > 0 so stale
     // ghosts (failed KNOCKs, aged-out sessions) stay hidden.
+    // Bogus "did:agentmes" entries (legacy 12-char truncation from
+    // pre-PR-354 openclaw plugin builds) are filtered out — they will
+    // persist in the router's trust store until the pod restarts.
     const recentThreshold = Date.now() - 30 * 60_000;
     const peers = sec.agtTrustScores.filter((t) => {
-      if (t.agent === sb.name) return false;
-      if (sandboxes.some((s) => s.name === t.agent)) return true;
+      if (isBogusLegacyKey(t.agent)) return false;
+      const a = shortAgentName(t.agent);
+      if (a === sb.name) return false;
+      if (sandboxes.some((s) => s.name === a)) return true;
       if (!t.lastSeen || t.interactions <= 0) return false;
       const seen = new Date(/^\d+Z$/.test(t.lastSeen) ? Number(t.lastSeen.slice(0, -1)) * 1000 : t.lastSeen);
       return !isNaN(seen.getTime()) && seen.getTime() > recentThreshold;
@@ -226,7 +242,7 @@ export function renderAGTFull(
             else ago = `${Math.round(ms / 3_600_000)}h ago`;
           }
         }
-        const name = t.agent;
+        const name = shortAgentName(t.agent);
         lines.push(` {${c}-fg}${bar}{/} ${t.score} ${name}`);
         lines.push(`   ${t.tier} · ${t.interactions} msg${t.interactions !== 1 ? "s" : ""}${ago ? ` · ${ago}` : ""}`);
       }
@@ -276,14 +292,21 @@ export function renderAGT(ctx: SecurityRenderContext): void {
   }
 
   const mode = sec.egressMode === "enforcing" ? "{green-fg}enforcing{/}" : "{yellow-fg}learning{/}";
+  // Strip DID prefix and filter out the legacy "did:agentmes" truncation
+  // ghost. Same rationale as in renderSecurity above.
+  const shortAgentName = (id: string): string => id.replace(/^did:agentmesh:/, "");
+  const isBogusLegacyKey = (id: string): boolean => id === "did:agentmes";
+
   // Same filter as the full panel: include known-sandbox peers
   // unconditionally; include AMID-only peers (e.g. cloud-offload parents)
   // only if they have real traffic + recent activity, to avoid showing
   // stale ghosts from failed KNOCKs or aged-out sessions.
   const recentThreshold = Date.now() - 30 * 60_000;
   const peers = sec.agtTrustScores.filter((t) => {
-    if (t.agent === sb.name) return false;
-    if (sandboxes.some((s) => s.name === t.agent)) return t.interactions > 0 || !!t.lastSeen;
+    if (isBogusLegacyKey(t.agent)) return false;
+    const a = shortAgentName(t.agent);
+    if (a === sb.name) return false;
+    if (sandboxes.some((s) => s.name === a)) return t.interactions > 0 || !!t.lastSeen;
     if (!t.lastSeen || t.interactions <= 0) return false;
     const seen = new Date(/^\d+Z$/.test(t.lastSeen) ? Number(t.lastSeen.slice(0, -1)) * 1000 : t.lastSeen);
     return !isNaN(seen.getTime()) && seen.getTime() > recentThreshold;
@@ -299,7 +322,7 @@ export function renderAGT(ctx: SecurityRenderContext): void {
     const c = t.score >= 600 ? "green" : t.score >= 400 ? "yellow" : "red";
     const filled = Math.round(t.score / 100);
     const bar = "█".repeat(filled) + "░".repeat(4 - Math.min(filled, 4));
-    lines.push(` {${c}-fg}${bar}{/} ${t.score} ${t.agent}`);
+    lines.push(` {${c}-fg}${bar}{/} ${t.score} ${shortAgentName(t.agent)}`);
   }
 
   if (peers.length === 0) {

--- a/cli/src/commands/operator/render/topology.ts
+++ b/cli/src/commands/operator/render/topology.ts
@@ -94,9 +94,14 @@ export function renderTopology(ctx: TopologyRenderContext): void {
   // while sandbox names in the operator are the short form
   // ("execbrief", "analyst", ...). Without normalization the
   // sandboxes.some()/subs.some() lookups never match and the peer
-  // count is always 0.
+  // count is always 0. Also filter out the legacy "did:agentmes"
+  // truncation ghost (pre-PR-354 openclaw plugins collapsed every
+  // unresolved peer into that single key; persists until pod restart).
   function shortAgentName(id: string): string {
     return id.replace(/^did:agentmesh:/, "");
+  }
+  function isBogusLegacyKey(id: string): boolean {
+    return id === "did:agentmes";
   }
 
   for (const p of parents) {
@@ -106,6 +111,7 @@ export function renderTopology(ctx: TopologyRenderContext): void {
                  sec?.egressMode === "learning" ? "{yellow-fg}learn{/}" : "";
     const meshInfo = sec ? `↑${sec.agtMeshSent} ↓${sec.agtMeshReceived}` : "";
     const peerCount = sec?.agtTrustScores.filter((t) => {
+      if (isBogusLegacyKey(t.agent)) return false;
       const a = shortAgentName(t.agent);
       return a !== p.name && sandboxes.some((s) => s.name === a) && (t.interactions > 0 || t.lastSeen);
     }).length || 0;
@@ -188,6 +194,7 @@ export function renderTopology(ctx: TopologyRenderContext): void {
       for (const s of subs) {
         const childSec = securityStates.get(s.name);
         const peers = childSec?.agtTrustScores.filter((t) => {
+          if (isBogusLegacyKey(t.agent)) return false;
           const a = shortAgentName(t.agent);
           return a !== s.name && subs.some((sub) => sub.name === a) && t.interactions > 0;
         }) || [];

--- a/cli/src/commands/operator/render/topology.ts
+++ b/cli/src/commands/operator/render/topology.ts
@@ -7,6 +7,7 @@
 // `securityStates`, and `topologyBox` become an explicit context object.
 
 import type { SandboxInfo, SecurityState } from "../types.js";
+import { platformTag } from "../helpers.js";
 
 interface BlessedBox {
   setContent(content: string): void;
@@ -116,7 +117,7 @@ export function renderTopology(ctx: TopologyRenderContext): void {
       return a !== p.name && sandboxes.some((s) => s.name === a) && (t.interactions > 0 || t.lastSeen);
     }).length || 0;
 
-    const rtLabel = p.runtime === "docker" ? "D" : "C";
+    const rtLabel = platformTag(p);
     const pBox = makeBox(p.name, icon, `${rtLabel} ${p.model}  ${mode}`, `${peerCount} peer${peerCount !== 1 ? "s" : ""}  ${meshInfo}  ${p.age}`);
     for (const l of pBox) lines.push(`  ${l}`);
 
@@ -132,7 +133,7 @@ export function renderTopology(ctx: TopologyRenderContext): void {
         const childSec = securityStates.get(subs[0].name);
         const ci = statusIcon(subs[0].health);
         const cMesh = childSec ? `↑${childSec.agtMeshSent} ↓${childSec.agtMeshReceived}` : "";
-        const cBox = makeBox(subs[0].name, ci, subs[0].model, cMesh);
+        const cBox = makeBox(subs[0].name, ci, `${platformTag(subs[0])} ${subs[0].model}`, cMesh);
         // Center single child under parent
         const childIndent = Math.max(2, parentCenter - Math.floor(BOX_W / 2));
         for (const l of cBox) lines.push(" ".repeat(childIndent) + l);
@@ -177,7 +178,7 @@ export function renderTopology(ctx: TopologyRenderContext): void {
           const childSec = securityStates.get(s.name);
           const ci = statusIcon(s.health);
           const cMesh = childSec ? `↑${childSec.agtMeshSent} ↓${childSec.agtMeshReceived}` : "";
-          childBoxes.push(makeBox(s.name, ci, s.model, cMesh));
+          childBoxes.push(makeBox(s.name, ci, `${platformTag(s)} ${s.model}`, cMesh));
         }
         for (let row = 0; row < 5; row++) {
           let line = " ".repeat(groupStart);

--- a/cli/src/commands/operator/render/topology.ts
+++ b/cli/src/commands/operator/render/topology.ts
@@ -89,13 +89,26 @@ export function renderTopology(ctx: TopologyRenderContext): void {
     ];
   }
 
+  // Normalize agent_id to short name for peer matching. The router
+  // emits trust_states[].agent_id in DID format ("did:agentmesh:<name>")
+  // while sandbox names in the operator are the short form
+  // ("execbrief", "analyst", ...). Without normalization the
+  // sandboxes.some()/subs.some() lookups never match and the peer
+  // count is always 0.
+  function shortAgentName(id: string): string {
+    return id.replace(/^did:agentmesh:/, "");
+  }
+
   for (const p of parents) {
     const sec = securityStates.get(p.name);
     const icon = statusIcon(p.health);
     const mode = sec?.egressMode === "enforcing" ? "{green-fg}enforce{/}" :
                  sec?.egressMode === "learning" ? "{yellow-fg}learn{/}" : "";
     const meshInfo = sec ? `↑${sec.agtMeshSent} ↓${sec.agtMeshReceived}` : "";
-    const peerCount = sec?.agtTrustScores.filter((t) => t.agent !== p.name && sandboxes.some((s) => s.name === t.agent) && (t.interactions > 0 || t.lastSeen)).length || 0;
+    const peerCount = sec?.agtTrustScores.filter((t) => {
+      const a = shortAgentName(t.agent);
+      return a !== p.name && sandboxes.some((s) => s.name === a) && (t.interactions > 0 || t.lastSeen);
+    }).length || 0;
 
     const rtLabel = p.runtime === "docker" ? "D" : "C";
     const pBox = makeBox(p.name, icon, `${rtLabel} ${p.model}  ${mode}`, `${peerCount} peer${peerCount !== 1 ? "s" : ""}  ${meshInfo}  ${p.age}`);
@@ -174,15 +187,17 @@ export function renderTopology(ctx: TopologyRenderContext): void {
       const peerLinks: string[] = [];
       for (const s of subs) {
         const childSec = securityStates.get(s.name);
-        const peers = childSec?.agtTrustScores.filter((t) =>
-          t.agent !== s.name && subs.some((sub) => sub.name === t.agent) && t.interactions > 0
-        ) || [];
+        const peers = childSec?.agtTrustScores.filter((t) => {
+          const a = shortAgentName(t.agent);
+          return a !== s.name && subs.some((sub) => sub.name === a) && t.interactions > 0;
+        }) || [];
         for (const peer of peers) {
-          const key = [s.name, peer.agent].sort().join(":");
+          const peerShort = shortAgentName(peer.agent);
+          const key = [s.name, peerShort].sort().join(":");
           if (!peerLinks.includes(key)) {
             peerLinks.push(key);
             const c = peer.score >= 600 ? "green" : peer.score >= 400 ? "yellow" : "red";
-            lines.push(`         {${c}-fg}⟷{/} ${s.name} ↔ ${peer.agent} {gray-fg}(${peer.interactions} msg${peer.interactions !== 1 ? "s" : ""}, trust: ${peer.score}){/}`);
+            lines.push(`         {${c}-fg}⟷{/} ${s.name} ↔ ${peerShort} {gray-fg}(${peer.interactions} msg${peer.interactions !== 1 ? "s" : ""}, trust: ${peer.score}){/}`);
           }
         }
       }

--- a/cli/src/commands/operator/types.ts
+++ b/cli/src/commands/operator/types.ts
@@ -36,6 +36,16 @@ export interface SandboxInfo {
    * sandboxes that pre-date the `runtime` discriminator (S10).
    */
   runtimeKind?: string;
+  /**
+   * The kube context this sandbox lives in. `undefined` for Docker
+   * sandboxes (no context) and for sandboxes fetched from the current
+   * kubectl context when the operator wasn't given an explicit
+   * `--context` flag. Used by the multi-cluster aggregator (S15.f) so
+   * per-sandbox follow-up fetches (security, egress, agt-quick) target
+   * the SAME cluster the sandbox was discovered on, instead of
+   * silently falling back to the current kubectl context.
+   */
+  kubeContext?: string;
 }
 
 export interface EgressDomain {

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -883,10 +883,23 @@ async fn reconcile(sandbox: Arc<KarsSandbox>, ctx: Arc<Context>) -> Result<Actio
             "ports": [{"protocol": "TCP", "port": 8443}]
         }),
         // Allow AGT relay/registry egress: inference-router → self-hosted agentmesh services.
-        // Relay (WebSocket, port 8765) and registry (HTTP, port 8080) in the agentmesh namespace.
+        // Relay (WebSocket) and registry (HTTP) in the agentmesh namespace.
+        //
+        // Selector: agentmesh namespace by canonical name. kindnet
+        // (the local-k8s CNI) evaluates NetworkPolicy post-DNAT, so
+        // the destination port the policy sees is the *targetPort*
+        // of the Service (relay→8083, registry→8082), not the
+        // service-side ports (8765 / 8080). We allow both pairs so
+        // the policy is correct on both kindnet (post-DNAT) and CNIs
+        // that evaluate pre-DNAT.
         json!({
-            "to": [{"namespaceSelector": {"matchLabels": {"app.kubernetes.io/managed-by": "kars"}}}],
-            "ports": [{"protocol": "TCP", "port": 8765}, {"protocol": "TCP", "port": 8080}]
+            "to": [{"namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "agentmesh"}}}],
+            "ports": [
+                {"protocol": "TCP", "port": 8765},
+                {"protocol": "TCP", "port": 8080},
+                {"protocol": "TCP", "port": 8083},
+                {"protocol": "TCP", "port": 8082}
+            ]
         }),
     ];
 

--- a/deploy/helm/kars/templates/rbac.yaml
+++ b/deploy/helm/kars/templates/rbac.yaml
@@ -75,8 +75,16 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Events
+  # Events — Kubernetes ships two Event APIs: the legacy core v1
+  # Events ("" apiGroup) and the modern events.k8s.io/v1 Events.
+  # The controller writes to events.k8s.io (the kube-rs Recorder
+  # defaults to it on newer Kubernetes versions), so both groups
+  # need the create/patch verb or the recorder log-spams
+  # `events.events.k8s.io is forbidden` warnings on every reconcile.
   - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]
   # Manage spawner role bindings for sandbox sub-agent creation

--- a/docs/internal/security-audits/2026-05-26-operator-multi-cluster-and-headlamp.md
+++ b/docs/internal/security-audits/2026-05-26-operator-multi-cluster-and-headlamp.md
@@ -1,0 +1,79 @@
+# Security Audit — operator multi-cluster + headlamp + plugin DID fix + RBAC + netpol
+
+**Scope**: PR #354 — `fix/operator-headlamp-bugs`. Five commits across the operator TUI, OpenClaw plugin, K8s RBAC, and sandbox NetworkPolicy.
+
+Capability-introducing paths touched:
+
+- `controller/src/reconciler/mod.rs` (sandbox NetworkPolicy egress rule)
+- `cli/src/commands/connect.ts`, `list.ts`, `headlamp.ts` and operator/* (new + edited CLI commands; cli/src/commands/ is in the capability list)
+- `runtimes/openclaw/src/index.ts` (the OpenClaw plugin's KNOCK/onMessage handlers)
+
+All changes are either **bug fixes** for incorrect identifier propagation or **policy fixes** that loosen overly-restrictive defaults. No capability is added or weakened in a way that grants new authority to the agent.
+
+## 1. What changed
+
+### 1a. Sandbox NetworkPolicy now allows mesh egress to agentmesh ns
+
+`controller/src/reconciler/mod.rs` egress rule selecting the agentmesh namespace previously matched the label `app.kubernetes.io/managed-by=azureclaw`, which the AGT bundle in `deploy/agentmesh-agt.yaml` never set (it labels with `azureclaw.azure.com/managed: "true"` instead). The mismatch meant every sandbox lost mesh on kindnet. **Also**: kindnet evaluates NetworkPolicy post-DNAT, so the ports the policy must allow are the Service `targetPort` values (relay 8083, registry 8082), not the service-side ports (8765 / 8080).
+
+Both fixed. The selector now matches by canonical ns name (`kubernetes.io/metadata.name: agentmesh`); the allow-list includes both service ports and target ports.
+
+**Capability impact**: this is a fix, not a weakening. The pre-fix policy was unintentionally blocking required infrastructure traffic. The new policy still **only** allows egress to the agentmesh namespace and only on the four AGT-specific ports. No new network reachability.
+
+### 1b. Controller RBAC: `events.k8s.io` group added
+
+`deploy/helm/kars/templates/rbac.yaml` previously granted `create/patch` on the legacy core `events` ("" apiGroup) but not on `events.k8s.io`. kube-rs's `Recorder` writes to the modern API group on Kubernetes ≥1.19, so every reconcile spammed a 403 warning. Both groups now granted. Strictly additive — the controller can finally publish events the modern API expects.
+
+### 1c. OpenClaw plugin: peer DID truncation
+
+`runtimes/openclaw/src/index.ts` lines 580/658/710/731 fell back to `fromAmid.slice(0, 12)` when name resolution returned empty. That truncated literal — exactly `did:agentmes` for every AGT DID — was passed as the **trust-store key** to `pushTrustToRouter()` and as the inbox `from_agent` identifier, collapsing every distinct peer into a single key.
+
+Fixed: the 12-char short form stays in log strings (humans can read it), but identifier sites now fall back to the **full** AMID so distinct peers get distinct trust entries.
+
+**Capability impact**: tightens, doesn't loosen. Previously every unresolved peer inherited the same trust score; now each peer is scored independently and KNOCK threshold rejection works correctly.
+
+### 1d. Operator multi-cluster
+
+`cli/src/commands/list.ts` and `cli/src/commands/operator/fetchers/sandboxes.ts` now probe every kube context in the user's kubeconfig and query each in parallel (3s probe timeout). Each sandbox is tagged with its origin `kubeContext` so per-sandbox follow-up fetches (router probes for security/egress/agt-quick) target the correct cluster rather than silently falling back to whichever context is current.
+
+**Capability impact**: zero. The operator only reads the kubeconfig the user already has access to; cross-cluster *writes* still require explicit `--context`. The new `kars headlamp` command port-forwards Headlamp + optionally installs the chart on a single context.
+
+### 1e. CLI agent table 'Cluster' column
+
+`cli/src/commands/operator.ts` gained a `Cluster` column rendering the origin context via `clusterOriginTag(s)` (extracted into `cli/src/commands/operator/helpers.ts` for the §4.2 LOC budget). Purely display.
+
+## 2. Streaming / hot path
+
+Not touched. Edits are confined to non-streaming control-plane handlers (KNOCK, onMessage, NetworkPolicy compile, table render).
+
+## 3. CR/LF / header-injection safety
+
+`runtimes/openclaw/src/index.ts` falls back to the full AMID as `from_agent`; AMIDs are validated DID strings (`did:agentmesh:<name>`) with no CR/LF. Even if a malicious agent registered a registry entry with a name containing CR/LF, the AMID resolution layer enforces character class via the registry's input validation. No new sanitization needed.
+
+## 4. Defensive parsing
+
+All new code paths in `cli/src/commands/list.ts` and `sandboxes.ts` use `Promise.allSettled` with short timeouts — an unreachable AKS context does not block listing the local one. JSON parsing is wrapped in try/catch with no-op fallthrough.
+
+## 5. Crypto Surface
+
+No change. Mesh envelopes continue to be X3DH + Double Ratchet from the upstream `@microsoft/agent-governance-sdk`. This PR touches neither identity, key material, nor envelope layout.
+
+## 6. Secrets Handling
+
+Headlamp service-account tokens are minted via `kubectl create token --duration=24h` and printed to stdout for the user to paste into the Headlamp login UI. They are never written to disk by the CLI. Same TTL + provisioning pattern as `kars dev --target local-k8s` (PR #338).
+
+## 7. Test Coverage
+
+- `cargo test --package kars-controller` — 1 PASS (integration; the controller crate has no `--lib` target)
+- `cd cli && npm test` — **769/769 PASS**
+- `cd runtimes/openclaw && npm test` — **118/118 PASS**
+- Live verification on kind-kars-dev: exec-brief e2e harness **9/9 verification checks PASS** with the patched NetworkPolicy + plugin + RBAC
+
+## 8. Network / NetworkPolicy review
+
+The only network policy change is in §1a (sandbox → agentmesh egress). No new ingress allowance; no new external egress allowance. The fix is strictly within the same control-plane allow list the policy already documented.
+
+## 9. Sign-offs
+
+Signed-off-by: Pal Lakatos <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -10,6 +10,10 @@
 
 use agentmesh::AuditLogger;
 use agentmesh::identity::AgentIdentity;
+use agentmesh_mcp::rate_limit::{InMemoryRateLimitStore, McpSlidingRateLimiter};
+use agentmesh_mcp::redactor::{CredentialKind, CredentialRedactor};
+use agentmesh_mcp::response::{McpResponseScanner, McpResponseThreatType};
+use agentmesh_mcp::{InMemoryAuditSink, McpMetricsCollector, SystemClock};
 use agentmesh::policy::PolicyEngine;
 use agentmesh::trust::{TrustConfig, TrustManager};
 use agentmesh::types::PolicyDecision;

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -10,10 +10,6 @@
 
 use agentmesh::AuditLogger;
 use agentmesh::identity::AgentIdentity;
-use agentmesh_mcp::rate_limit::{InMemoryRateLimitStore, McpSlidingRateLimiter};
-use agentmesh_mcp::redactor::{CredentialKind, CredentialRedactor};
-use agentmesh_mcp::response::{McpResponseScanner, McpResponseThreatType};
-use agentmesh_mcp::{InMemoryAuditSink, McpMetricsCollector, SystemClock};
 use agentmesh::policy::PolicyEngine;
 use agentmesh::trust::{TrustConfig, TrustManager};
 use agentmesh::types::PolicyDecision;

--- a/runtimes/openclaw/src/index.ts
+++ b/runtimes/openclaw/src/index.ts
@@ -577,7 +577,12 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
     }
     agtMeshClient.onKnock(async (fromAmid: string, request: any) => {
       const intent = request?.intent?.capability || '*';
-      const fromName = await resolveAmidToName(fromAmid) || fromAmid.slice(0, 12);
+      // Use full AMID as identifier when name resolution fails — a truncated
+      // prefix (slice(0,12) = "did:agentmes") collapses every unresolved
+      // peer into the SAME trust-store key, producing nonsense
+      // "did:agentmes" entries in the operator's peer view.
+      // The 12-char short form is for **log readability only**.
+      const fromName = await resolveAmidToName(fromAmid) || fromAmid;
       log.info(`AGT KNOCK from ${fromName} (${fromAmid.slice(0, 12)}...) intent=${intent}`);
 
       // Trust score evaluation (when threshold > 0)
@@ -655,7 +660,9 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
 
     // Handle E2E decryption failures and KNOCK rejections — log and surface to operator
     agtMeshClient.onError((type: string, fromAmid: string, detail: string) => {
-      const fromName = amidToName.get(fromAmid) || fromAmid.slice(0, 12);
+      // Same rationale as onKnock above: full AMID as fallback identifier,
+      // not a 12-char prefix (which would conflate every unresolved peer).
+      const fromName = amidToName.get(fromAmid) || fromAmid;
       if (type === 'knock_rejected') {
         log.warn(`⛔ Message blocked from '${fromName}': KNOCK not accepted — ${detail}`);
         pushInbox({
@@ -707,7 +714,7 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
 
     // Log when E2E encrypted channel is verified with a peer
     agtMeshClient.onE2EVerified((peerAmid: string, isFirstPeer: boolean) => {
-      const peerName = amidToName.get(peerAmid) || peerAmid.slice(0, 12);
+      const peerName = amidToName.get(peerAmid) || peerAmid;
       if (isFirstPeer) {
         log.info(`✅ E2E encrypted channel UP — first verified peer: '${peerName}' (X3DH + Double Ratchet)`);
       } else {
@@ -728,7 +735,10 @@ async function initAGT(log: { info: (m: string) => void; warn: (m: string) => vo
       if (!fromName) {
         fromName = await resolveAmidToName(fromAmid);
       }
-      if (!fromName) fromName = fromAmid.slice(0, 12);
+      // Fallback to the full AMID, NOT a 12-char prefix — the truncated
+      // form would collapse every unresolved peer into the same
+      // "did:agentmes" trust-store key (and the same inbox.from_agent).
+      if (!fromName) fromName = fromAmid;
 
       // ── Transport layer: intercept chunked transfer messages ──
       // mesh:transfer_manifest and mesh:transfer_chunk are transport-level —


### PR DESCRIPTION
## Summary

Three independent operator-UX fixes plus a brand-new `azureclaw headlamp` command.

## 1. `operator` Docker fetcher misidentified kind cluster nodes as sandboxes

`fetchSandboxesDocker()` ran `docker ps --filter name=azureclaw-`. When the local-k8s dev cluster is named `azureclaw-dev` (default for `azureclaw dev --target local-k8s`), `kind` creates a container literally named `azureclaw-dev-control-plane` that matches the filter. The operator showed it as a sixth 'sandbox' called `dev-control-plane` with bogus state.

**Fix**: read the `io.x-k8s.kind.cluster` and `io.x-k8s.kind.role` labels in the docker-ps format string and skip any container that carries them.

## 2. Topology peer matching broken by DID format mismatch

`render/topology.ts` filtered `agtTrustScores` against sandbox short names (`analyst`, `viz`, ...), but the router emits `agent_id` in `did:agentmesh:<name>` format. Peer count was always 0; `⟷` peer-link lines never rendered.

**Fix**: `shortAgentName()` helper strips the `did:agentmesh:` prefix before comparing. Used in both peer-count and peer-link renderers.

## 3. OpenClaw plugin truncated peer DIDs to 12 chars, collapsing trust state (root cause of `did:agentmes`)

The plugin's KNOCK / onError / onE2EVerified / onMessage handlers each fell back to `fromAmid.slice(0, 12)` when name resolution returned empty. That truncated literal — exactly `"did:agentmes"` for every agentmesh DID — was then **passed as the trust-store key** to `pushTrustToRouter()` and as the inbox `from_agent` identifier.

The downstream effect was that every unresolved peer collapsed into **the same** trust state under key `"did:agentmes"`, inflating its interaction counter while every distinct peer disappeared. The operator's peer panel always showed exactly one mystery peer (`did:agentmes`) with thousands of interactions.

**Fix**: the 12-char prefix stays in **log strings** (humans can read the short form), but identifier-use sites (`pushTrustToRouter`, `pushInbox.from_agent`, peer-name lookups) now fall back to the **full** AMID so distinct peers get distinct trust entries. Lines 580, 658, 710, 731 in `runtimes/openclaw/src/index.ts`.

## 4. New: `azureclaw headlamp` command

Pattern-matches `azureclaw connect <agent>`: port-forwards the Headlamp `service/headlamp` to a local port, mints a fresh service-account token via `kubectl create token`, and opens the browser. Works on any context kubectl can reach.

For clusters without Headlamp installed (the typical AKS case), `--install` runs the Helm chart install pinned to the same version `azureclaw dev --target local-k8s` uses, so the bundled AzureClaw plugin remains compatible.

```
azureclaw headlamp                    # open dashboard for current context
azureclaw headlamp --install          # install Headlamp first (AKS)
azureclaw headlamp --context <name>   # override kubectl context
azureclaw headlamp --port <n>         # bind to a non-default port
azureclaw headlamp --no-browser       # port-forward + URL only
```

Verified live:
- `kind-azureclaw-dev`: dashboard up on localhost:4466, login token valid, HTTP 200
- `azureclaw-aks`: clean 'not installed' error with install hint printed

## Tests

- `cd cli && npm test` → **769/769 ✅**
- `cd cli && npm run typecheck` → clean
- `cd cli && npm run build && npm run lint` → clean
- `cd runtimes/openclaw && npm test` → **118/118 ✅**
- `cd runtimes/openclaw && npm run build` → clean
- Live: `azureclaw operator --snapshot --context kind-azureclaw-dev` now reports **5 agents** (was 6 — the bogus `dev-control-plane` is gone)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>