### PR TITLE
docs: clarify mesh ownership (plugin not router) + document OpenClaw plugin tools

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,8 +21,9 @@ kars has four code components, two languages, and one rule that ties them togeth
 | Component | Language | Crate / package | Responsibility |
 |---|---|---|---|
 | **Controller** | Rust (kube-rs) | `kars-controller` | Watches `KarsSandbox` and its eight peer workload CRDs, plus the infrastructure CRDs `KarsAuthConfig` and (controller-internal) `KarsPairing`; reconciles them into namespaces, pods, services, NetworkPolicies, ConfigMaps, federated identities. |
-| **Inference router** | Rust (axum) | `kars-inference-router` | Sits in the data path of every external call. Identity, content safety, governance, audit, mesh, A2A — all of it. |
+| **Inference router** | Rust (axum) | `kars-inference-router` | Sits in the data path of every external call — identity, content safety, governance, audit, A2A. **Mesh**: WebSocket-bridges opaque Signal-Protocol ciphertext for the agent (the Signal session is plugin-owned; see [The mesh](#the-mesh)). |
 | **A2A gateway** | Rust (axum) | `kars-a2a-gateway` + `kars-a2a-core` | Public-ingress entry point for A2A 1.0.0 peer traffic. Verifies signed `AgentCard`s, routes to the correct sandbox, emits audit. |
+| **kars OpenClaw plugin** | TypeScript | `runtimes/openclaw/` (id `kars`) | The agent-side surface: registers 24 governance-aware tools with OpenClaw (`kars_spawn`, `kars_mesh_send`, `kars_mesh_transfer_file`, `foundry_web_search`, `foundry_code_execute`, `foundry_image_generation`, …) and owns the Signal Protocol session via `@microsoft/agent-governance-sdk`. Catalogued in [Channels & plugins](channels-plugins.md). |
 | **CLI** | TypeScript | `@kars/cli` | Lifecycle of clusters, sandboxes, policies. 30+ commands. The CLI is convenience; everything it does is achievable with `az` + `helm` + `kubectl`. |
 
 The rule that ties them together: **the agent has no network of its own**. The router is the only process in the sandbox pod that can talk to the outside. Every other property of kars is a downstream consequence of holding that line.

--- a/docs/channels-plugins.md
+++ b/docs/channels-plugins.md
@@ -2,6 +2,63 @@
 
 Messaging channels and third-party plugins extend your kars agent with external communication and search capabilities. Configuration is handled via CLI flags — the sandbox entrypoint auto-configures everything from environment variables at startup.
 
+This page also documents the **kars OpenClaw plugin** itself — the agent-side surface that registers the runtime's governance-aware tools and owns the AGT mesh session.
+
+---
+
+## kars OpenClaw plugin (`runtimes/openclaw/`)
+
+When the sandbox image boots, OpenClaw auto-discovers and loads the **`kars` plugin** from `~/.openclaw-data/extensions/kars/`. The plugin is the agent's runtime contract with kars — it registers governance-aware tools that route through the inference router, owns the AGT mesh session (Signal Protocol via `@microsoft/agent-governance-sdk`), and ships skill manifests (`SKILL.md`) that teach the agent when to use each tool.
+
+> The plugin lives in the **sandbox container under UID 1000**. The inference router (UID 1001) is its only network egress. Plugin source: `runtimes/openclaw/src/`; tool manifest: `runtimes/openclaw/openclaw.plugin.json`.
+
+### Registered tools (24 total)
+
+The plugin replaces every privileged OpenClaw built-in with a governance-aware equivalent. Categories:
+
+| Category | Tools | What they do |
+|---|---|---|
+| **Mesh + sub-agents** | `kars_discover`, `kars_spawn`, `kars_spawn_list`, `kars_spawn_status`, `kars_spawn_destroy`, `kars_mesh_send`, `kars_mesh_inbox`, `kars_mesh_await`, `kars_mesh_transfer_file` | Discover sibling agents on the mesh, spawn governed sub-agents (each becomes its own `KarsSandbox`), and exchange E2E-encrypted messages + files via Signal Protocol. The mesh session is plugin-owned end-to-end; the router only WebSocket-bridges opaque ciphertext. |
+| **Handoff** | `kars_handoff_request`, `kars_handoff_confirm`, `kars_handoff_status` | Transfer ownership of a running session to another sandbox (e.g., escalate to a more-privileged peer). |
+| **Network** | `http_fetch` | Single governance-gated outbound HTTP; subject to L7 egress allowlist + blocklist. |
+| **Foundry data plane** | `foundry_code_execute`, `foundry_image_generation`, `foundry_web_search`, `foundry_file_search`, `foundry_memory`, `foundry_conversations`, `foundry_evaluations`, `foundry_deployments`, `foundry_agents`, `foundry_download_file` | Direct access to Azure AI Foundry hosted tools (code-exec containers, image gen via `gpt-image-1`, Bing Grounding web search, RAG, persistent memory store, conversation API, evaluations, deployment discovery, file management). All calls flow through the inference router which adds Entra Agent ID auth, content-safety inspection, audit chaining, and token-budget enforcement. |
+| **Channels** | `telegram_status` | Emit a status update to the configured Telegram channel. |
+
+Authoritative tool list is `runtimes/openclaw/openclaw.plugin.json` → `contracts.tools[]`. The plugin enforces this contract at startup — OpenClaw refuses to register tools not declared here.
+
+### Skills (10 — agent-facing how-to)
+
+Each skill is a `SKILL.md` markdown file that documents the agent-facing contract for a group of tools. OpenClaw exposes them as a discovery surface so the LLM knows when to invoke each tool:
+
+| Skill | Tools it covers |
+|---|---|
+| `kars-spawn` | `kars_spawn`, `kars_spawn_*`, `kars_mesh_*`, `kars_handoff_*`, `kars_discover` |
+| `agt-governance` | `http_fetch` + the AGT decision contract for every tool call |
+| `foundry-web-search` | `foundry_web_search` (Bing Grounding) |
+| `foundry-code` | `foundry_code_execute` (Python container) |
+| `foundry-memory` | `foundry_memory` (persistent long-term memory) |
+| `foundry-knowledge` | `foundry_file_search`, RAG patterns |
+| `foundry-conversations` | `foundry_conversations` (multi-turn state) |
+| `foundry-evaluations` | `foundry_evaluations` |
+| `foundry-agents` | `foundry_agents` (prompt-agent inspection) |
+| `foundry-deployments` | `foundry_deployments` (discover models, connections, indexes) |
+
+Skills directory: `runtimes/openclaw/skills/`. Each subdirectory contains `SKILL.md` plus the agent-facing examples.
+
+### The `@kars/mesh` companion plugin
+
+For users who run **OpenClaw on their laptop** and want to delegate heavy work to a governed AKS sandbox, the separate **`@kars/mesh`** plugin (`mesh-plugin/`, npm name `@kars/mesh`) installs into the local OpenClaw and pairs it with a kars cluster:
+
+- Registers the local agent on AGT (via a one-time pairing token from `kars pair generate`)
+- Exposes `mesh_offload`, `mesh_send`, `mesh_transfer_file` so the local agent can delegate to remote governed sandboxes
+- Includes a `mesh-federation` skill for cross-cluster federation patterns
+
+Manifest: `mesh-plugin/openclaw.plugin.json` (id `kars-mesh`). See also [Runtimes → Local-OpenClaw-with-mesh pattern](runtimes.md#local-openclaw-with-mesh-pattern) and [Blueprint 05 — Cross-org federation](blueprints/05-cross-org-federation.md).
+
+### How OpenClaw loads the plugin
+
+`sandbox-images/openclaw/entrypoint.sh` (around line 784, `cat > "$OPENCLAW_CONFIG"`) writes the openclaw.json with the kars provider config; the plugin then auto-loads from `~/.openclaw-data/extensions/kars/` via OpenClaw's standard extension-discovery contract. See [Upstream alignment](upstream-alignment.md) for why kars uses this mechanism rather than forking OpenClaw.
+
 ---
 
 ## Messaging Channels

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -225,7 +225,7 @@ In AKS mode the sandbox is a multi-container pod, **not** a single container:
 
 - `init: egress-guard` — installs iptables rules so only the router can reach the cluster network.
 - `agent` — your runtime (OpenClaw, OpenAI Agents, MAF, LangGraph, Anthropic, Pydantic-AI, or BYO), running as **UID 1000** with no direct egress.
-- `inference-router` — the Rust router, running as **UID 1001** on `127.0.0.1:8443`. It is the only container in the pod that can talk to Foundry, the mesh, or A2A peers.
+- `inference-router` — the Rust router, running as **UID 1001** on `127.0.0.1:8443`. It is the only container in the pod with network egress — it brokers identity/auth for Foundry calls and **WebSocket-bridges opaque mesh ciphertext** between the agent and the AgentMesh relay (the Signal session itself is owned plugin-side inside the agent container — see [Architecture → The mesh](architecture.md#the-mesh)).
 
 A NetworkPolicy on the namespace pins the pod's allowed egress to exactly: cluster DNS, Foundry, the AgentMesh relay, the A2A gateway. Nothing else. See **[Architecture diagrams](architecture-diagrams.md)** for the full picture.
 


### PR DESCRIPTION
## Summary

Two real gaps the user spotted:

### 1. Stale claim: "router does the mesh"

`docs/architecture.md` Components table line 24 said the inference router does *"Identity, content safety, governance, audit, **mesh**, A2A — all of it"*.

The **mesh** part is misleading. The Signal Protocol session (X3DH + Double Ratchet + KNOCK) is owned plugin-side by `@microsoft/agent-governance-sdk` inside the agent container (UID 1000). The router only WebSocket-bridges opaque ciphertext between the agent and the relay; it holds no session keys and performs no encryption/decryption.

This is what §The mesh of the same file already says (and what security.md Layer 8 says). The Components table was just out of sync.

**Fix:** Updated Components table row + added a fifth component row for the kars OpenClaw plugin. Tightened `getting-started.md:228` from *"can talk to ... the mesh"* → *"WebSocket-bridges opaque mesh ciphertext"*.

### 2. Missing: OpenClaw plugin (`runtimes/openclaw/`) was not documented

The plugin registers **24 governance-aware tools** and ships **10 skills** but only appeared in passing references.

**Fix:** Added a comprehensive new section to `docs/channels-plugins.md` covering:
- Why the plugin exists + where it lives (UID 1000, sandbox container)
- All **24 registered tools** categorised:
  - Mesh + sub-agents (`kars_spawn`, `kars_mesh_send`, `kars_mesh_transfer_file`, …)
  - Handoff (`kars_handoff_request`, `_confirm`, `_status`)
  - Network (`http_fetch`)
  - Foundry data plane (`foundry_code_execute`, `foundry_image_generation`, `foundry_web_search`, `foundry_file_search`, `foundry_memory`, `foundry_conversations`, `foundry_evaluations`, `foundry_deployments`, `foundry_agents`, `foundry_download_file`)
  - Channels (`telegram_status`)
- All **10 skills** (`kars-spawn`, `agt-governance`, `foundry-web-search`, `foundry-code`, `foundry-memory`, `foundry-knowledge`, `foundry-conversations`, `foundry-evaluations`, `foundry-agents`, `foundry-deployments`)
- The companion `@kars/mesh` plugin for local OpenClaw + mesh-federation skill (`mesh-plugin/`)
- How OpenClaw auto-loads the plugin via standard extension discovery

## Verified

- `runtimes/openclaw/openclaw.plugin.json` → `contracts.tools[]` lists exactly 24 tools (verified count)
- `runtimes/openclaw/skills/*/SKILL.md` → 10 skill files with descriptions
- `mesh-plugin/openclaw.plugin.json` → id `kars-mesh`; `mesh-plugin/skills/mesh-federation` exists
- `inference-router/src/routes/mesh.rs` → WS proxy only, no decryption (consistent with the corrected Components row)

## Scope

Markdown-only, 3 files changed: 60 insertions, 2 deletions.

| File | Change |
|---|---|
| `docs/architecture.md` | Components table: clarified router's mesh role + added OpenClaw plugin row |
| `docs/channels-plugins.md` | New 60-line "kars OpenClaw plugin" section (tools + skills + companion mesh plugin) |
| `docs/getting-started.md` | One sentence at line 228 tightened |