### PR TITLE
docs: record AGT PR #2719 merged upstream — Entra mesh-trust hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Upstream alignment — AGT mesh-identity hardening merged
+
+[microsoft/agent-governance-toolkit#2719](https://github.com/microsoft/agent-governance-toolkit/pull/2719)
+merged into AGT main on 2026-05-31 (+2289 / −560 across 14 files,
+upstream commit `a8a96bf4`). This was the Phase 6 Entra-signed mesh-trust
+work kars upstreamed:
+
+- **mesh-relay**: opt-in Entra-signed JWT verification on the connect
+  frame. `entra_verifier.py` (330 LOC) — JWKS fetcher + RS256/RS384/RS512
+  verifier + `aud`/`tid`/`exp`/`iat` claim enforcement. Opt-in via
+  `AGENTMESH_ENTRA_AUDIENCE` + `AGENTMESH_ENTRA_TENANT_ID`; rejects
+  empty/missing tokens with WebSocket code 4003 (no silent fallback).
+- **mesh-registry**: per-agent session counters
+  (`total_sessions` / `successful_sessions` / `failed_sessions` /
+  `timeout_sessions`) + derived `completion_rate` reputation field.
+  Bumped by both `/v1/registry/reputation/session` and the simple
+  heartbeat path.
+- **mesh-registry**: `POST /v1/registry/verify` endpoint surfacing
+  the per-agent verification status for cross-cluster trust decisions.
+- Plus 49 new tests across `tests/test_entra_verifier.py`,
+  `tests/test_relay.py`, `tests/test_registry.py`; CHANGELOG +
+  agent-mesh/README + security-audit doc additions.
+
+**kars impact**: from this point on, the kars Phase 6 verified-tier
+mesh stack consumes vanilla upstream AGT — no vendored fork required.
+
 ### Slice 5e.4 — `EgressApproval` E2E coverage + docs
 
 Closes the Slice 5e arc with operator-facing documentation and Kind-based

--- a/docs/architecture/agt-boundary.md
+++ b/docs/architecture/agt-boundary.md
@@ -12,12 +12,12 @@ AGT ships the governance engine. kars is the AKS operator and data plane that fe
 
 - **Policy evaluation** — `PolicyEngine.decide(request) -> verdict`. Policy-profile schema is AGT's. We emit profiles from CRDs; we do not redefine the schema.
 - **Signal Protocol primitives** — X3DH key exchange, Double Ratchet, prekey lifecycle, session state machine.
+- **Mesh-relay + mesh-registry** — including **opt-in Entra-signed JWT verification on the connect frame** (audience + tenant + issuer enforcement), **per-agent session counters** + `completion_rate` reputation surface, and the `POST /v1/registry/verify` endpoint. Upstreamed by kars in [microsoft/agent-governance-toolkit#2719](https://github.com/microsoft/agent-governance-toolkit/pull/2719); kars now consumes this as a regular AGT dependency rather than a vendored fork.
 - **Audit chain** — `AuditLogger.append(event) -> ReceiptId`. Storage, retention SLA, queryability API. The runtime uses AGT's linear SHA-256 hash chain today; Merkle anchoring and signed roots are a planned extension (the library exists in `inference-router/src/audit/merkle.rs` but is not yet wired into the live pipeline).
 - **Trust scoring** — `TrustManager`. Per-peer trust scores, transitive evaluation, decay functions, negative-signal ingestion.
 - **Behavior anomaly detection** — `BehaviorMonitor`. Baseline capture, deviation detection, Shadow-MCP behavioral signals.
 - **Rate-limit token bucket** — per-identity, per-tool, per-mesh counters. We configure caps; AGT enforces.
 - **Signing keys** — HSM / HW-backed key custody, key rotation, signing primitives for A2A cards and AP2 transfers.
-- **A2A 1.0.0 Signed Agent Card signing** — when AGT ships this primitive. Until then we implement via the `SigningProvider` seam and document the gap.
 - **AP2 policy grammar** — if AGT defines it. Until then kars defines a private schema designed to be portable to a future AGT definition.
 
 ### kars owns

--- a/docs/architecture/entra-agent-id/06-mesh-trust-design.md
+++ b/docs/architecture/entra-agent-id/06-mesh-trust-design.md
@@ -27,7 +27,7 @@ handshake is the only gate.
 |-------|-------|--------|
 | (a) CRD field + auth chain shape | kars controller | ✅ `KarsAuthConfig.spec.meshAuthBackend` enum live |
 | (b) Sandbox entrypoint mints token via shared sidecar | kars sandbox image | ✅ `inference-router /v1/mesh-token` + `entrypoint.sh` MESH_AUTH_BACKEND branch |
-| (c) AGT relay/registry JWKS verification | Microsoft AGT | ✅ Patches `66b6e006…5971f901` upstreamed in PR (`/v1/registry/verify` + `connect` JWT verification) |
+| (c) AGT relay/registry JWKS verification | Microsoft AGT | ✅ **Merged upstream as [microsoft/agent-governance-toolkit#2719](https://github.com/microsoft/agent-governance-toolkit/pull/2719)** — `agent-governance-python/agent-mesh/src/agentmesh/identity/entra_verifier.py` (330 LOC JWKS verifier), `POST /v1/registry/verify` endpoint, per-agent session counters + `completion_rate`, opt-in via `AGENTMESH_ENTRA_AUDIENCE` + `AGENTMESH_ENTRA_TENANT_ID`. Merged 2026-05-31, +2289/-560 across 14 files (commit `a8a96bf4`). |
 | (d) CLI operator switch | kars CLI | ✅ Single `--mesh-trust=anonymous\|entra` flag on `kars up` |
 
 ## Per-sandbox identity lifecycle (Phase 5b)


### PR DESCRIPTION
## 🎉 Upstream AGT merge confirmed

[microsoft/agent-governance-toolkit#2719](https://github.com/microsoft/agent-governance-toolkit/pull/2719) **merged into AGT main 2026-05-31 17:33 UTC** — the Phase 6 Entra-signed mesh-trust work kars has been driving for the past two days.

| Stat | Value |
|---|---|
| Squash merge SHA | `a8a96bf4` |
| Files changed | 14 |
| Additions | +2289 |
| Deletions | −560 |

## Verified

Fetched AGT main + confirmed the artefacts are live:
- `agent-governance-python/agent-mesh/src/agentmesh/identity/entra_verifier.py` — 330 LOC JWKS verifier ✅
- `POST /v1/registry/verify` endpoint in `registry/app.py:568` ✅
- Per-agent session counters in `store.py:49` (`total_sessions`, `successful_sessions`, `failed_sessions`, `timeout_sessions`, `completion_rate`) ✅

## Docs updated

1. **`docs/architecture/entra-agent-id/06-mesh-trust-design.md`** row (c) — replaced *"Patches 66b6e006…5971f901 upstreamed in PR"* with the actual merged PR number, merge SHA, file list, and stats
2. **`docs/architecture/agt-boundary.md`** §AGT owns:
   - Added explicit **"Mesh-relay + mesh-registry"** bullet covering Entra JWT verification + session counters + verify endpoint
   - Noted kars upstreamed it and now consumes vanilla upstream AGT (no vendored fork)
   - Dropped the stale "A2A 1.0.0 Signed Agent Card signing — when AGT ships this" line (we ship 494 LOC ourselves — addressed separately in PR #372)
3. **`CHANGELOG.md`** [Unreleased]: new top-of-section *"Upstream alignment — AGT mesh-identity hardening merged"* entry with full provenance

## Scope

3 files, 28 insertions, 2 deletions. Markdown only.