### PR TITLE
feat(release): --release defaults to latest + public for-everyone quick-start

### DIFF
--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -30,7 +30,7 @@ jobs:
           - a2a-module-isolation
           - copyright-headers
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # full history so BASE_REF diffs work
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           file ./bin/amd64/*
           ( cd ./bin && sha256sum amd64/* | tee SHA256SUMS )
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: kars-binaries-${{ github.sha }}
           path: ./bin/
@@ -548,7 +548,7 @@ jobs:
       # Result: each image build is ~30s instead of ~8min.
       - name: Download pre-built kars binaries
         if: steps.paths.outputs.run == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: kars-binaries-${{ github.sha }}
           path: ./bin/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/.github/workflows/image-cache-publish.yml
+++ b/.github/workflows/image-cache-publish.yml
@@ -59,7 +59,7 @@ jobs:
           cp target/release/kars-a2a-gateway        ./bin/amd64/
           cp target/release/kars-conformance-runner ./bin/amd64/
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: kars-binaries-${{ github.sha }}
           path: ./bin/
@@ -99,7 +99,7 @@ jobs:
 
       - name: Download pre-built binaries
         if: matrix.image.needs_binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: kars-binaries-${{ github.sha }}
           path: ./bin/

--- a/.github/workflows/image-sign-sbom.yml
+++ b/.github/workflows/image-sign-sbom.yml
@@ -51,7 +51,7 @@ jobs:
           cp target/release/kars-a2a-gateway        ./bin/amd64/
           cp target/release/kars-conformance-runner ./bin/amd64/
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: kars-binaries-${{ github.sha }}
           path: ./bin/
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download pre-built binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: kars-binaries-${{ github.sha }}
           path: ./bin/

--- a/.github/workflows/release-public-interim.yml
+++ b/.github/workflows/release-public-interim.yml
@@ -806,11 +806,14 @@ jobs:
         with:
           tag_name: ${{ env.VERSION }}
           name: ${{ env.VERSION }} (Public Interim)
-          # Interim builds bundle a kars build of AGT pending upstream
-          # microsoft/agent-governance-toolkit#3128 — keep them out of
-          # "latest" until the ESRP-signed release supersedes them.
-          prerelease: true
-          make_latest: 'false'
+          # These public interim builds are the current install target for
+          # everyone (the README's no-compile quick-start points at
+          # /releases/latest/download/…), so mark them as the repo's "latest"
+          # release. `/releases/latest/` only serves non-prerelease releases,
+          # hence prerelease:false. When the ESRP-signed release line lands it
+          # supersedes these as latest.
+          prerelease: false
+          make_latest: 'true'
           generate_release_notes: true
           files: ./release-artefacts/**/*
           body: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -39,6 +39,6 @@ jobs:
           publish_results: true
 
       - name: Upload Results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -132,25 +132,39 @@ Same CRDs. Same router code path. Same audit format. Same governance profiles. T
 
 ## Try it in five minutes
 
-**Fastest path — published images, no compile (macOS & Linux, Intel & Apple Silicon).**
-On any host with Docker (amd64 Linux, Intel Mac, or Apple Silicon M-series),
-two commands get you a running agent — no Rust toolchain, no AGT checkout, no
-local image build:
+**Fastest path — no compile, works for everyone (macOS & Linux · Intel & Apple Silicon).**
+Two commands. No Azure account, no Rust toolchain, no AGT checkout, no image
+build — just Docker (or a Docker-compatible runtime such as Podman) and Node.js 22+:
 
 ```bash
-# 1. Install the CLI from the latest interim release
-npm i -g https://github.com/Azure/kars/releases/download/v0.1.0-interim.9/kars-cli-0.1.0.tgz
+# 1. Install the CLI — always the latest published release (public, signed)
+npm i -g https://github.com/Azure/kars/releases/latest/download/kars-cli-0.1.0.tgz
 
-# 2. Launch a sandbox from the published, cosign-signed images
-kars dev --release v0.1.0-interim.9
+# 2. Launch a sandbox from the published, cosign-signed images (defaults to :latest)
+kars dev --release
 ```
 
-> Use the newest tag from the [Releases page](https://github.com/Azure/kars/releases) — the `npm i -g …` URL and the `--release` flag must match.
+That's it. `kars dev --release` pulls the published `openclaw-sandbox` agent
+image plus the AGT mesh relay + registry and runs them — no compile, no clone.
+The images are public on `ghcr.io/azure`, so **anyone** can pull them; no GitHub
+auth or org membership required. Pin a specific build for reproducibility with
+`kars dev --release v0.1.0-interim.10`.
 
-> **Apple Silicon (M-series) Macs:** fully supported. The published images are
-> multi-arch (`linux/amd64` + `linux/arm64`), built on native arm64 runners,
-> and `kars dev --release` automatically pulls the image matching your host
-> architecture — no Rosetta, no extra flags.
+Prefer Kubernetes over plain Docker? Same published images, same one flag:
+
+```bash
+# Local Kubernetes (kind) — real K8s posture (NetworkPolicy, CRDs, controller)
+kars dev --release --target local-k8s
+```
+
+For a managed cluster, `kars up` provisions AKS + ACR + Foundry + the full
+stack — see **[When you are ready for the real thing](#)** below.
+
+> **Apple Silicon (M-series) Macs:** fully supported. Every published image —
+> sandbox, controller, router, relay, registry — is multi-arch
+> (`linux/amd64` + `linux/arm64`, built on native arm64 runners), and
+> `kars dev --release` pulls the variant matching your host automatically —
+> no Rosetta, no flags. Verified end-to-end on both arm64 and amd64.
 
 On first launch you'll pick an inference provider (see below). **GitHub Copilot** is the easiest — one device-code login, no Azure account.
 
@@ -172,9 +186,11 @@ The first source build of `kars dev` builds + caches the sandbox base image (~10
 </details>
 
 <details>
-<summary><strong>For Microsoft / Azure-org members: skip the build</strong></summary>
+<summary><strong>Microsoft / Azure-org contributors: internal pre-release channel</strong></summary>
 
-While ESRP is still being wired up, internal preview releases live on the private GitHub Releases page + private GHCR. If you have Azure-org access:
+Separate from the public release above, contributors with Azure-org access can
+install from the **private** internal-release channel (private GitHub Release +
+private GHCR), which tracks unreleased work:
 
 ```bash
 brew install gh node@22
@@ -183,11 +199,10 @@ curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
 kars dev
 ```
 
-Pin a specific release: `KARS_VERSION=v0.1.0-internal.2 …`.
+Pin a specific internal release: `KARS_VERSION=v0.1.0-internal.2 …`.
 Pre-pull all container images: `KARS_PULL_IMAGES=1 …`.
-See [`install.sh`](./install.sh) header for the **personal / non-managed device** path (PAT pre-blessed on a company device, used from anywhere).
-
-This path goes away when ESRP-signed images land on MCR + npmjs.com + crates.io.
+See [`install.sh`](./install.sh) header for the **personal / non-managed device** path.
+Most users should use the public `kars dev --release` path above instead — it needs no auth.
 </details>
 
 On first run `kars dev` shows a 3-way provider picker:

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -173,8 +173,8 @@ NOT overwrite your saved credentials.
     )
     // ── Image build ────────────────────────────────────────────────────
     .option(
-      "--release <version>",
-      "Run from PUBLISHED images instead of building. Pulls ghcr.io/azure/* at the given release tag (e.g. v0.1.0-interim.5) — no AGT clone, no local compile. Skips --build.",
+      "--release [version]",
+      "Run from PUBLISHED images instead of building. Pulls ghcr.io/azure/* — no AGT clone, no local compile. Defaults to the latest release (`:latest`); pass a tag (e.g. v0.1.0-interim.9) to pin. Skips --build.",
     )
     .option(
       "--image <image>",
@@ -276,8 +276,15 @@ Notes:
       // given tag: the openclaw-sandbox, the AGT relay + registry, and any
       // selected runtime image. It forces build OFF so we never compile or
       // clone the AGT toolkit. An explicit --build is contradictory.
-      const releaseMode = typeof options.release === "string" && options.release.length > 0;
-      const releaseVersion: string | undefined = releaseMode ? options.release : undefined;
+      // `--release` (optional value): bare flag → latest published images
+      // (`:latest`); `--release <tag>` pins a specific release.
+      const releaseMode = options.release === true ||
+        (typeof options.release === "string" && options.release.length > 0);
+      const releaseVersion: string | undefined = !releaseMode
+        ? undefined
+        : (typeof options.release === "string" && options.release.length > 0)
+          ? options.release
+          : "latest";
       if (releaseMode) {
         if (options.build === true || options.buildBase === true) {
           console.error(chalk.red(`\n  Error: --release pulls published images; it cannot be combined with --build/--build-base.\n`));
@@ -1165,7 +1172,11 @@ Notes:
               const ref = releaseImage(name, releaseVersion!);
               stepper.update(`Pulling published ${name}...`);
               try {
-                await execa("docker", ["pull", "--platform", "linux/amd64", ref], { stdio: "pipe" });
+                // No --platform: pull the host-arch variant for multi-arch
+                // images (relay/registry are multi-arch from interim.10 /
+                // :latest), falling back to amd64 (emulated) for older
+                // amd64-only pinned tags.
+                await execa("docker", ["pull", ref], { stdio: "pipe" });
                 await execa("docker", ["tag", ref, devTag], { stdio: "pipe" });
               } catch {
                 stepper.fail(`Could not pull ${ref}`);

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,41 +103,48 @@ If you'd rather skip provisioning by hand, jump to **[Step 2 — Deploy to AKS](
 
 ## Step 1 — Local (five minutes)
 
-### 1.0 Fastest path — no compile (published images, macOS & Linux) ⭐
+### 1.0 Fastest path — no compile, works for everyone (macOS & Linux) ⭐
 
 The quickest way to a running agent **on any host with Docker — amd64 Linux,
-Intel Mac, or Apple Silicon (M-series)**: install the CLI from a published
-release and launch from **pre-built, cosign-signed images**. No Rust toolchain,
-no AGT checkout, no waiting on a local image build.
+Intel Mac, or Apple Silicon (M-series)**: install the CLI from the latest
+published release and launch from **pre-built, cosign-signed, public images**.
+No Rust toolchain, no AGT checkout, no GitHub auth, no waiting on a local build.
 
-**You need only:** Docker (running) · Node.js 22+.
+**You need only:** Docker (or a Docker-compatible runtime like Podman) · Node.js 22+.
 
 ```bash
-# 1. Install the kars CLI from the latest interim release (one command)
-npm i -g https://github.com/Azure/kars/releases/download/v0.1.0-interim.9/kars-cli-0.1.0.tgz
+# 1. Install the kars CLI — always the latest published release
+npm i -g https://github.com/Azure/kars/releases/latest/download/kars-cli-0.1.0.tgz
 
-# 2. Launch a sandbox from the published images for that same release
-kars dev --release v0.1.0-interim.9
+# 2. Launch a sandbox from the published images (defaults to :latest)
+kars dev --release
 ```
 
-That's it. `--release` pulls the `openclaw-sandbox` agent image plus the AGT
-mesh relay + registry and runs them — skipping the AGT clone and every local
-build. The first run downloads the images once (a few minutes); afterwards it
-launches near-instantly. On first launch you'll pick an inference provider —
+That's it. `kars dev --release` pulls the `openclaw-sandbox` agent image plus
+the AGT mesh relay + registry and runs them — skipping the AGT clone and every
+local build. The images are public on `ghcr.io/azure`, so anyone can pull them
+with no auth. The first run downloads the images once (a few minutes); afterwards
+it launches near-instantly. On first launch you'll pick an inference provider —
 see the [provider picker](#12-launch-a-sandbox) below (**GitHub Copilot** is
 the easiest: one device-code login, no Azure account).
 
-> **Apple Silicon (M-series) Macs:** fully supported. The published images are
-> multi-arch (`linux/amd64` + `linux/arm64`, built on native arm64 runners) and
-> `kars dev --release` automatically pulls the variant matching your host
-> architecture — no Rosetta, no extra flags. Verified end-to-end on arm64:
-> the full multi-agent exec-brief scenario (parent + 3 mesh sub-agents,
-> E2E-encrypted relay) passes on a stock M-series Mac.
+Run the same published images on Kubernetes instead of plain Docker:
 
-> **Use matching versions.** The `npm i -g …` tarball URL and the `--release`
-> flag must reference the **same** tag. Browse the
-> [Releases page](https://github.com/Azure/kars/releases) for the newest
-> `v0.1.0-interim.N`.
+```bash
+kars dev --release --target local-k8s   # local kind cluster, real K8s posture
+```
+
+> **Apple Silicon (M-series) Macs:** fully supported. Every published image
+> (sandbox, controller, router, relay, registry) is multi-arch
+> (`linux/amd64` + `linux/arm64`, built on native arm64 runners) and
+> `kars dev --release` automatically pulls the variant matching your host
+> architecture — no Rosetta, no extra flags. Verified end-to-end on both arm64
+> and amd64: the full multi-agent exec-brief scenario (parent + 3 mesh
+> sub-agents, E2E-encrypted relay) passes on a stock M-series Mac and on AKS.
+
+> **Pin a specific build (optional).** `kars dev --release` follows the newest
+> release; pass a tag — `kars dev --release v0.1.0-interim.10` — to pin a
+> specific build for reproducibility.
 
 Want to hack on the controller / router / plugin? Build from source —
 **[1.1 Build the CLI](#11-build-the-cli)**.

--- a/docs/internal/security-audits/2026-06-23-release-latest-default.md
+++ b/docs/internal/security-audits/2026-06-23-release-latest-default.md
@@ -1,0 +1,70 @@
+# Security Audit — `kars dev --release` defaults to latest + public quick-start
+
+PR: Azure/kars#411 (branch `feat/release-latest-default`)
+
+## Scope
+
+A follow-up to #408 (`docs/internal/security-audits/2026-06-23-cli-dev-release-published-images.md`).
+The capability-introducing change is in `cli/src/commands/dev.ts`:
+
+- `--release` becomes an **optional-value** flag. Bare `--release` now resolves
+  to the latest published images (the `:latest` tag); `--release <tag>` still
+  pins a specific release. `releaseImage(name, "latest")` → `ghcr.io/azure/<name>:latest`.
+- The relay/registry pull drops the hardcoded `--platform linux/amd64` so the
+  host-arch variant is pulled for multi-arch images (relay/registry became
+  multi-arch in interim.10), falling back to amd64 (emulated) for older
+  amd64-only pinned tags.
+
+Non-capability changes in the same PR (not the subject of this audit, but
+noted): the release workflow marks public-interim releases as the repo's
+`latest` release; README/getting-started lead with the public, no-auth
+`/releases/latest/download/` install + `kars dev --release`; 12 GitHub-owned
+actions pinned by SHA (Scorecard Pinned-Dependencies).
+
+## Threat model
+
+### T1: `:latest` is mutable — does defaulting to latest enable image substitution? (MITIGATED)
+`:latest` is pushed by the **same protected org CI** that pushes `:VERSION`,
+to the same `ghcr.io/azure` packages, and every image (including the manifest
+`:latest` points at) is **cosign keyless signed + GitHub build-provenance
+attested + SBOM'd** — identical posture to the pinned-tag path audited in #408.
+A mutable tag is a *reproducibility* tradeoff, not a trust downgrade: consumers
+who need pinning use `--release <tag>` (documented). The default favours
+"always get the latest security fixes" for the grandma/no-pin audience, which
+is the safer default for unattended consumers.
+
+### T2: Dropping `--platform linux/amd64` on the relay/registry pull (NOT A REGRESSION)
+Previously the CLI force-pulled the amd64 relay/registry and ran them emulated
+on arm64. Now `docker pull` (no `--platform`) selects the host-arch variant for
+multi-arch images and still resolves amd64 for amd64-only tags. The image
+**contents/signatures are unchanged**; only the arch of the pulled variant
+changes. Native arm64 removes the Rosetta/QEMU emulation layer (a strict
+reduction in moving parts), and the relay forwards only opaque encrypted
+frames either way — no security control depends on the arch.
+
+### T3: Public "for everyone" framing — does it expose anything new? (NO)
+The runtime images referenced by the docker quick-start
+(`openclaw-sandbox`, `kars-agentmesh-relay`, `kars-agentmesh-registry`) are
+**already public** on `ghcr.io/azure` and already signed/attested. The docs
+change is descriptive (point users at the existing public artefacts + the
+stable `/releases/latest/` URL); it grants no new access and changes no
+package visibility. `kars-controller`/`kars-inference-router` remain private —
+the K8s (`--target local-k8s`) released path needs them public, called out in
+the PR as a separate one-time maintainer action.
+
+## What this audit does NOT cover
+
+- Image **contents** (covered by the controller/router/sandbox build audits and
+  the patched AGT SDK in microsoft/agent-governance-toolkit#3128).
+- The ESRP-signed public path (MCR + npmjs + crates.io) that supersedes the
+  interim GHCR release line — tracked in `docs/PUBLISHING.md`.
+
+## Verdict
+
+No new capability or trust boundary is introduced. The change makes the
+already-signed published-image path easier to consume (latest-by-default,
+native-arch) without weakening signing, provenance, sandbox isolation, or the
+mesh trust model.
+
+Signed-off-by: Pal Lakatos <plakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Summary

Two install-UX improvements requested after reviewing the published quick-start, plus a Scorecard Pinned-Dependencies win.

### 1. `kars dev --release` defaults to **latest**
- `--release` (bare flag) → pulls the latest published images (`:latest`); `--release <tag>` still pins a build.
- Drops the hardcoded `--platform linux/amd64` on the relay/registry pull so multi-arch (interim.10+/`:latest`) images run natively on arm64.

### 2. Public, always-latest quick-start (for **everyone**, not just Azure-org members)
- README + getting-started lead with the stable latest URL:
  `npm i -g https://github.com/Azure/kars/releases/latest/download/kars-cli-0.1.0.tgz` + `kars dev --release`.
- Documented on docker **and** `--target local-k8s` (kind); all runtime images are public on `ghcr.io/azure` — no GitHub auth, no org membership.
- The internal `install.sh` path is demoted to a clearly-labelled "Azure-org contributors" channel.
- Release workflow marks public-interim releases as the repo's **latest** (`prerelease:false`, `make_latest:true`) so `/releases/latest/` serves them. `v0.1.0-interim.10` re-marked as latest; the URL resolves (HTTP 200).

### 3. Scorecard: pin remaining GitHub-owned actions by SHA
- Pinned the 12 `@v4` GitHub-owned actions across 7 workflows (Pinned-Dependencies 88/100 → 100/100 for GitHub-owned), reusing the SHAs the repo already uses.

Remaining Scorecard items (token-permissions, signed-release tarballs, vuln triage, container-image digests, CII badge) tracked in #410.

### Verification
- 801 CLI tests pass; `--release` help shows the optional/latest default; `cargo`/typecheck clean.
- `/releases/latest/download/kars-cli-0.1.0.tgz` → HTTP 200 (serves interim.10).

> Note: the kind/AKS `--release` path additionally pulls `kars-controller` + `kars-inference-router`, which are still **private** GHCR packages — they need a one-time Public toggle in org package settings for the K8s path to work for external users (docker `--release` already works for everyone today).
