### PR TITLE
release: publish CLI to npmjs as kars-runtime + robust installer

### DIFF
--- a/.github/workflows/release-public-interim.yml
+++ b/.github/workflows/release-public-interim.yml
@@ -760,7 +760,7 @@ jobs:
         with:
           subject-path: 'cli/*.tgz'
 
-      # Publish @kars/cli to npmjs so `npm i -g @kars/cli` works — only for
+      # Publish kars-runtime to npmjs so `npm i -g kars-runtime` works — only for
       # clean (non-interim) release tags, and only when an NPM_TOKEN secret is
       # configured (so the workflow no-ops cleanly until npm publishing is set
       # up). `--provenance` records a signed npm provenance attestation (needs
@@ -845,7 +845,7 @@ jobs:
               {"name": "kars-sandbox-base",      "ghcr": "${{ env.REGISTRY }}/kars-sandbox-base:${{ env.VERSION }}",      "digest": "${{ needs.merge-sandbox.outputs.sandbox_base_digest }}"},
               {"name": "openclaw-sandbox",       "ghcr": "${{ env.REGISTRY }}/openclaw-sandbox:${{ env.VERSION }}",       "digest": "${{ needs.merge-sandbox.outputs.sandbox_digest }}"}
             ],
-            "cli_install": "npm i -g https://github.com/${{ github.repository }}/releases/latest/download/${{ steps.cli.outputs.tarball }}",
+            "cli_install": "curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | bash   (or: npm i -g kars-runtime)",
             "additional_registries_planned": "crates.io / npmjs / MCR publishing is in progress — see docs/PUBLISHING.md. The GHCR images + CLI tarball above are signed and usable today."
           }
           EOF
@@ -871,7 +871,8 @@ jobs:
             no AGT clone**:
 
             ```bash
-            npm i -g https://github.com/${{ github.repository }}/releases/latest/download/${{ steps.cli.outputs.tarball }}
+            # install the CLI (or: npm i -g kars-runtime, once on npmjs)
+            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | bash
             kars dev --release
             ```
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ or `kars up` for a managed AKS cluster (see [below](#when-you-are-ready-for-the-
 # Pin a specific release
 KARS_VERSION=v0.1.0 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh)"
 
-# Or install the signed tarball directly with npm (what install.sh does under the hood)
-npm i -g https://github.com/Azure/kars/releases/latest/download/kars-cli-0.1.0.tgz
+# Or install from npmjs (once published):
+npm i -g kars-runtime
 
 # Or build from source — to hack on the controller / router / plugin (needs Rust 1.88+)
 git clone https://github.com/Azure/kars.git && cd kars

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@kars/cli",
+  "name": "kars-runtime",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@kars/cli",
+      "name": "kars-runtime",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kars/cli",
+  "name": "kars-runtime",
   "version": "0.1.0",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,8 +113,9 @@ No Rust toolchain, no AGT checkout, no GitHub auth, no waiting on a local build.
 **You need only:** Docker (or a Docker-compatible runtime like Podman) · Node.js 22+.
 
 ```bash
-# 1. Install the kars CLI — always the latest published release
-npm i -g https://github.com/Azure/kars/releases/latest/download/kars-cli-0.1.0.tgz
+# 1. Install the kars CLI — public, signed, always the latest release
+curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
+# (or, once on npmjs:  npm i -g kars-runtime)
 
 # 2. Launch a sandbox from the published images (defaults to :latest)
 kars dev --release

--- a/install.sh
+++ b/install.sh
@@ -2,11 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# install.sh — public, no-auth installer for the kars CLI.
+# install.sh — public, no-auth installer for the kars CLI (`kars-runtime` on npm).
 #
 #   curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
 #
-# Installs the latest signed public release of @kars/cli from the GitHub
+# Installs the latest signed public release of the kars CLI from the GitHub
 # Release. No GitHub login, no Azure account, no org membership — every
 # artefact is cosign-signed + SBOM'd + SLSA-attested.
 #
@@ -18,17 +18,28 @@ set -euo pipefail
 
 REPO="${KARS_REPO:-Azure/kars}"
 VERSION="${KARS_VERSION:-latest}"
-CLI_TARBALL="kars-cli-0.1.0.tgz"
 
-if ! command -v npm >/dev/null 2>&1; then
-  echo "ERR: npm not found. Install Node.js 22+ first (https://nodejs.org)." >&2
-  exit 1
-fi
+command -v npm  >/dev/null 2>&1 || { echo "ERR: npm not found. Install Node.js 22+ (https://nodejs.org)." >&2; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo "ERR: curl not found." >&2; exit 1; }
 
 if [ "$VERSION" = "latest" ]; then
-  URL="https://github.com/${REPO}/releases/latest/download/${CLI_TARBALL}"
+  API="https://api.github.com/repos/${REPO}/releases/latest"
 else
-  URL="https://github.com/${REPO}/releases/download/${VERSION}/${CLI_TARBALL}"
+  API="https://api.github.com/repos/${REPO}/releases/tags/${VERSION}"
+fi
+
+# Resolve the CLI tarball asset URL dynamically (asset name carries the
+# version, and may be kars-runtime-*.tgz or an older kars-cli-*.tgz).
+URL="$(curl -fsSL "$API" \
+  | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*\.tgz"' \
+  | grep -iE 'kars' \
+  | head -1 \
+  | sed -E 's/.*"(https[^"]+)".*/\1/')"
+
+if [ -z "${URL:-}" ]; then
+  echo "ERR: could not find a CLI tarball in the ${VERSION} release of ${REPO}." >&2
+  echo "     See https://github.com/${REPO}/releases" >&2
+  exit 1
 fi
 
 echo "Installing the kars CLI from:"


### PR DESCRIPTION
Publishes the CLI to npmjs as unscoped **`kars-runtime`** (the `@kars` org is taken; unscoped needs no org). `npm i -g kars-runtime` once live. The `kars` command is unchanged. install.sh now resolves the release tarball dynamically via the GitHub API (no hardcoded filename → never breaks across versions). README/getting-started/release-notes updated. The npmjs publish step (added in #412) fires on clean v* tags when the `NPM_TOKEN` secret is set.