### PR TITLE
release: scope CLI npm package as @kars-runtime/cli

### DIFF
--- a/.github/workflows/release-public-interim.yml
+++ b/.github/workflows/release-public-interim.yml
@@ -733,7 +733,7 @@ jobs:
 
   # ─── Stage 3: pack @kars/cli for GitHub Release distribution ───
   cli-pack:
-    name: Pack + publish kars-runtime CLI
+    name: Pack + publish @kars-runtime/cli
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -760,7 +760,7 @@ jobs:
 
       # Publish to npmjs via OIDC TRUSTED PUBLISHING — NO stored NPM_TOKEN.
       # The workflow authenticates with a short-lived OIDC id-token. Authorize
-      # it ONCE on npmjs: kars-runtime → Settings → Trusted Publisher →
+      # it ONCE on npmjs: @kars-runtime/cli → Settings → Trusted Publisher →
       # "GitHub Actions", org/repo = Azure/kars, workflow file =
       # release-public-interim.yml. (Works with org 2FA.)
       # Only clean (non-interim) tags publish; continue-on-error so the release
@@ -768,12 +768,12 @@ jobs:
       - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
         if: ${{ !contains(env.VERSION, 'interim') }}
         run: npm install -g npm@latest
-      - name: Publish kars-runtime to npmjs (OIDC trusted publishing)
+      - name: Publish @kars-runtime/cli to npmjs (OIDC trusted publishing)
         if: ${{ !contains(env.VERSION, 'interim') }}
         continue-on-error: true
         working-directory: cli
         run: |
-          echo "Publishing kars-runtime@$(node -p "require('./package.json').version") via OIDC trusted publishing…"
+          echo "Publishing @kars-runtime/cli@$(node -p "require('./package.json').version") via OIDC trusted publishing…"
           npm publish --provenance --access public
 
       - name: Upload CLI tarball
@@ -846,7 +846,7 @@ jobs:
               {"name": "kars-sandbox-base",      "ghcr": "${{ env.REGISTRY }}/kars-sandbox-base:${{ env.VERSION }}",      "digest": "${{ needs.merge-sandbox.outputs.sandbox_base_digest }}"},
               {"name": "openclaw-sandbox",       "ghcr": "${{ env.REGISTRY }}/openclaw-sandbox:${{ env.VERSION }}",       "digest": "${{ needs.merge-sandbox.outputs.sandbox_digest }}"}
             ],
-            "cli_install": "curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | bash   (or: npm i -g kars-runtime)",
+            "cli_install": "curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | bash   (or: npm i -g @kars-runtime/cli)",
             "additional_registries_planned": "crates.io / npmjs / MCR publishing is in progress — see docs/PUBLISHING.md. The GHCR images + CLI tarball above are signed and usable today."
           }
           EOF
@@ -872,7 +872,7 @@ jobs:
             no AGT clone**:
 
             ```bash
-            # install the CLI (or: npm i -g kars-runtime, once on npmjs)
+            # install the CLI (or: npm i -g @kars-runtime/cli, once on npmjs)
             curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | bash
             kars dev --release
             ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ or `kars up` for a managed AKS cluster (see [below](#when-you-are-ready-for-the-
 KARS_VERSION=v0.1.0 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh)"
 
 # Or install from npmjs (once published):
-npm i -g kars-runtime
+npm i -g @kars-runtime/cli
 
 # Or build from source — to hack on the controller / router / plugin (needs Rust 1.88+)
 git clone https://github.com/Azure/kars.git && cd kars

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kars-runtime",
+  "name": "@kars-runtime/cli",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kars-runtime",
+      "name": "@kars-runtime/cli",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kars-runtime",
+  "name": "@kars-runtime/cli",
   "version": "0.1.0",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,7 +115,7 @@ No Rust toolchain, no AGT checkout, no GitHub auth, no waiting on a local build.
 ```bash
 # 1. Install the kars CLI — public, signed, always the latest release
 curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
-# (or, once on npmjs:  npm i -g kars-runtime)
+# (or, once on npmjs:  npm i -g @kars-runtime/cli)
 
 # 2. Launch a sandbox from the published images (defaults to :latest)
 kars dev --release

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# install.sh — public, no-auth installer for the kars CLI (`kars-runtime` on npm).
+# install.sh — public, no-auth installer for the kars CLI (`@kars-runtime/cli` on npm).
 #
 #   curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
 #


### PR DESCRIPTION
The npm package lives under the `kars-runtime` org → scoped name `@kars-runtime/cli` (`npm i -g @kars-runtime/cli`). `kars` command unchanged. Scoped name also avoids the 24h cooldown on the unscoped name. Updates README/getting-started/install.sh/release-workflow install hints.