### PR TITLE
docs: make npm (@kars-runtime/cli) the default install

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Same CRDs. Same router code path. Same audit format. Same governance profiles. T
 You need only **Docker** (or Podman) and **Node.js 22+**:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
+npm i -g @kars-runtime/cli
 kars dev --release
 ```
 
@@ -146,6 +146,9 @@ image is multi-arch (`amd64` + `arm64`, native on Apple Silicon). On first
 launch you pick an inference provider — **GitHub Copilot** is easiest (one
 device-code login, no Azure account).
 
+The CLI on npm is **build-provenance attested** (SLSA) — verify with
+`npm audit signatures` after install.
+
 Run on Kubernetes instead with `kars dev --release --target local-k8s` (kind),
 or `kars up` for a managed AKS cluster (see [below](#when-you-are-ready-for-the-real-thing)).
 
@@ -153,11 +156,11 @@ or `kars up` for a managed AKS cluster (see [below](#when-you-are-ready-for-the-
 <summary>Other ways to install</summary>
 
 ```bash
-# Pin a specific release
-KARS_VERSION=v0.1.0 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh)"
+# One-line installer (no Node required up front — fetches the signed CLI tarball)
+curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
 
-# Or install from npmjs (once published):
-npm i -g @kars-runtime/cli
+# Pin a specific release with the installer
+KARS_VERSION=v0.1.1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh)"
 
 # Or build from source — to hack on the controller / router / plugin (needs Rust 1.88+)
 git clone https://github.com/Azure/kars.git && cd kars
@@ -303,7 +306,7 @@ The full site index is in **[`docs/README.md`](docs/README.md)**.
 
 > 📌 **NOTE: This is not an officially supported Microsoft product.** kars is an open-source reference implementation maintained under the Azure GitHub organization. No SLA, support contract, or product roadmap commitment is attached — see [SUPPORT.md](SUPPORT.md), [TRADEMARKS.md](TRADEMARKS.md), and [LICENSE](LICENSE).
 
-> ✅ **Every published artefact is signed.** All container images on `ghcr.io/azure` are **cosign keyless-signed** (verifiable in the Sigstore Rekor transparency log), carry an **SPDX SBOM**, and a **GitHub build-provenance (SLSA) attestation** — verify with `cosign verify` / `gh attestation verify`. The CLI tarball on each GitHub Release is build-provenance attested too. Install with no compile via the [Try it in five minutes](#try-it-in-five-minutes) quick-start. *(We're additionally working on publishing to crates.io / npmjs / MCR — see [`docs/PUBLISHING.md`](docs/PUBLISHING.md); the GHCR artefacts above are signed and usable today.)*
+> ✅ **Every published artefact is signed.** All container images on `ghcr.io/azure` are **cosign keyless-signed** (verifiable in the Sigstore Rekor transparency log), carry an **SPDX SBOM**, and a **GitHub build-provenance (SLSA) attestation** — verify with `cosign verify` / `gh attestation verify`. The CLI is published to **npmjs as [`@kars-runtime/cli`](https://www.npmjs.com/package/@kars-runtime/cli)** with an SLSA build-provenance attestation (verify with `npm audit signatures`), and the CLI tarball on each GitHub Release is attested too. Install with no compile via the [Try it in five minutes](#try-it-in-five-minutes) quick-start. *(We're additionally working on publishing to crates.io / MCR — see [`docs/PUBLISHING.md`](docs/PUBLISHING.md); the GHCR + npm artefacts above are signed and usable today.)*
 
 `v0.1.0`. The core data path (router, controller, A2A gateway, mesh) is feature-complete and exercised by CI (Kind E2E, chaos-tier fault injection, CNCF conformance self-assessment, plus a documented manual matrix on AKS — see [`tests/`](tests/)). The CRD surface is served at `v1alpha1` and may change between minor releases; the data path, security model, and audit chain are stable. See **[`CHANGELOG.md`](CHANGELOG.md)** for the change log and **[`docs/roadmap.md`](docs/roadmap.md)** for what's next.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ The sandbox YAML you wrote in step 1 runs unchanged in step 2. That is the whole
 | Local mode from source (GitHub Models) | Docker Desktop, Node.js 22+, Rust 1.88+, a GitHub PAT with `models:read` scope. **No Azure account needed.** |
 | AKS mode | The above, plus the [Azure CLI](https://learn.microsoft.com/cli/azure/) (`az`), [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [Helm 3.14+](https://helm.sh/), and an Azure subscription where you can create resource groups. |
 
-> **Just want it running?** Use the [fastest path](#10-fastest-path--no-compile-published-images-) — `npm i -g <release-tarball>` then `kars dev --release <tag>`. Everything below about building from source and cloning AGT is **only** for contributors hacking on kars itself.
+> **Just want it running?** Use the [fastest path](#10-fastest-path--no-compile-published-images-) — `npm i -g @kars-runtime/cli` then `kars dev --release`. Everything below about building from source and cloning AGT is **only** for contributors hacking on kars itself.
 
 > **AGT mesh prerequisite — source builds only.** Inter-agent E2E
 > messaging uses the [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)
@@ -113,13 +113,15 @@ No Rust toolchain, no AGT checkout, no GitHub auth, no waiting on a local build.
 **You need only:** Docker (or a Docker-compatible runtime like Podman) · Node.js 22+.
 
 ```bash
-# 1. Install the kars CLI — public, signed, always the latest release
-curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash
-# (or, once on npmjs:  npm i -g @kars-runtime/cli)
+# 1. Install the kars CLI from npm — public, signed (SLSA provenance), always the latest release
+npm i -g @kars-runtime/cli
 
 # 2. Launch a sandbox from the published images (defaults to :latest)
 kars dev --release
 ```
+
+> Prefer not to use npm? A one-line installer fetches the signed CLI tarball
+> directly: `curl -fsSL https://raw.githubusercontent.com/Azure/kars/main/install.sh | bash`.
 
 That's it. `kars dev --release` pulls the `openclaw-sandbox` agent image plus
 the AGT mesh relay + registry and runs them — skipping the AGT clone and every
@@ -144,7 +146,7 @@ kars dev --release --target local-k8s   # local kind cluster, real K8s posture
 > sub-agents, E2E-encrypted relay) passes on a stock M-series Mac and on AKS.
 
 > **Pin a specific build (optional).** `kars dev --release` follows the newest
-> release; pass a tag — `kars dev --release v0.1.0-interim.10` — to pin a
+> release; pass a tag — `kars dev --release v0.1.1` — to pin a
 > specific build for reproducibility.
 
 Want to hack on the controller / router / plugin? Build from source —


### PR DESCRIPTION
Now that `@kars-runtime/cli@0.1.1` is live on npm with an **SLSA build-provenance attestation**, promote the npm one-liner to the primary install path.

## Changes
- **README** "Try it in five minutes" → leads with `npm i -g @kars-runtime/cli`; `curl | bash` installer demoted to *Other ways to install*. Adds a note to verify provenance with `npm audit signatures`.
- **README** project-status note → npm is live + signed *today* (was "once published").
- **docs/getting-started.md** fastest-path → npm-first; pin examples refreshed to `v0.1.1`.

Docs-only.