### PR TITLE
fix(cli): drop blessed-contrib → clean npm audit; safe GHCR tag cleanup

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/keyvault-secrets": "^4.8.0",
         "blessed": "^0.1.81",
-        "blessed-contrib": "^4.11.0",
         "chalk": "^5.3.0",
         "commander": "^13.0.0",
         "execa": "^9.0.0",
@@ -346,16 +345,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1840,12 +1829,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC"
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1853,27 +1836,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
-      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -1890,21 +1852,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/ansi-term": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ansi-term/-/ansi-term-0.0.2.tgz",
-      "integrity": "sha512-jLnGE+n8uAjksTJxiWZf/kcUmXq+cRWSl550B9NmQ8YiqaTM+lILcSe5dHdp8QkJPhaOghDjnMKwyYSMjosgAA==",
-      "license": "ISC",
-      "dependencies": {
-        "x256": ">=0.0.1"
-      }
-    },
-    "node_modules/ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
-      "license": "MIT"
     },
     "node_modules/ansis": {
       "version": "4.2.0",
@@ -1966,81 +1913,11 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/blessed-contrib": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/blessed-contrib/-/blessed-contrib-4.11.0.tgz",
-      "integrity": "sha512-P00Xji3xPp53+FdU9f74WpvnOAn/SS0CKLy4vLAf5Ps7FGDOTY711ruJPZb3/7dpFuP+4i7f4a/ZTZdLlKG9WA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-term": ">=0.0.2",
-        "chalk": "^1.1.0",
-        "drawille-canvas-blessed-contrib": ">=0.1.3",
-        "lodash": "~>=4.17.21",
-        "map-canvas": ">=0.1.5",
-        "marked": "^4.0.12",
-        "marked-terminal": "^5.1.1",
-        "memory-streams": "^0.1.0",
-        "memorystream": "^0.3.1",
-        "picture-tuber": "^1.0.1",
-        "sparkline": "^0.1.1",
-        "strip-ansi": "^3.0.0",
-        "term-canvas": "0.0.5",
-        "x256": ">=0.0.1"
-      }
-    },
-    "node_modules/blessed-contrib/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/blessed-contrib/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/blessed-contrib/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/bresenham": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/bresenham/-/bresenham-0.0.3.tgz",
-      "integrity": "sha512-wbMxoJJM1p3+6G7xEFXYNCJ30h2qkwmVxebkbwIl4OcnWtno5R3UT9VuYLfStlVNAQCmRjkGwjPFdfaPd4iNXw==",
-      "license": "MIT"
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "engines": {
-        "node": ">=0.2.0"
-      }
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -2065,19 +1942,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/cardinal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
-      "license": "MIT",
-      "dependencies": {
-        "ansicolors": "~0.3.2",
-        "redeyed": "~2.1.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
       }
     },
     "node_modules/chai": {
@@ -2108,12 +1972,6 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
     },
-    "node_modules/charm": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
-      "integrity": "sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==",
-      "license": "MIT/X11"
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -2139,21 +1997,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-table3": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-width": {
@@ -2197,12 +2040,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -2291,25 +2128,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/drawille-blessed-contrib": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/drawille-blessed-contrib/-/drawille-blessed-contrib-1.0.0.tgz",
-      "integrity": "sha512-WnHMgf5en/hVOsFhxLI8ZX0qTJmerOsVjIMQmn4cR1eI8nLGu+L7w5ENbul+lZ6w827A3JakCuernES5xbHLzQ==",
-      "license": "MIT"
-    },
-    "node_modules/drawille-canvas-blessed-contrib": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/drawille-canvas-blessed-contrib/-/drawille-canvas-blessed-contrib-0.1.3.tgz",
-      "integrity": "sha512-bdDvVJOxlrEoPLifGDPaxIzFh3cD7QH05ePoQ4fwnqfi08ZSxzEhOUpI5Z0/SQMlWgcCQOEtuw0zrwezacXglw==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-term": ">=0.0.2",
-        "bresenham": "0.0.3",
-        "drawille-blessed-contrib": ">=0.0.1",
-        "gl-matrix": "^2.1.0",
-        "x256": ">=0.0.1"
       }
     },
     "node_modules/dts-resolver": {
@@ -2407,28 +2225,6 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2437,29 +2233,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/event-stream": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.9.8.tgz",
-      "integrity": "sha512-o5h0Mp1bkoR6B0i7pTCAzRy+VzdsRWH997KQD4Psb0EOPoKEIiaRx/EsOdUl7p1Ktjw7aIWvweI/OY1R9XrlUg==",
-      "dependencies": {
-        "optimist": "0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/event-stream/node_modules/optimist": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
-      "integrity": "sha512-Wy7E3cQDpqsTIFyW7m22hSevyTLxw850ahYv7FWsw4G6MIKVTZ8NSA95KBrQ95a4SMsMr1UGUUnwEFKhVaSzIg==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": ">=0.0.1 <0.1.0"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/execa": {
@@ -2587,39 +2360,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/gl-matrix": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz",
-      "integrity": "sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw==",
-      "license": "MIT"
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/here": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/here/-/here-0.0.2.tgz",
-      "integrity": "sha512-U7VYImCTcPoY27TSmzoiFsmWLEqQFaYNdpsPb9K0dXJhE6kufUqycaz51oR09CW85dDU9iWyy7At8M+p7hb3NQ==",
-      "license": "MIT"
-    },
     "node_modules/hookable": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
@@ -2690,12 +2430,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
     },
     "node_modules/inquirer": {
       "version": "12.11.1",
@@ -2827,12 +2561,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3157,12 +2885,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -3243,65 +2965,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/map-canvas": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/map-canvas/-/map-canvas-0.1.5.tgz",
-      "integrity": "sha512-f7M3sOuL9+up0NCOZbb1rQpWDLZwR/ftCiNbyscjl9LUUEwrRaoumH4sz6swgs58lF21DQ0hsYOCw5C6Zz7hbg==",
-      "license": "ISC",
-      "dependencies": {
-        "drawille-canvas-blessed-contrib": ">=0.0.1",
-        "xml2js": "^0.4.5"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/marked-terminal": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.2.0.tgz",
-      "integrity": "sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^6.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^5.2.0",
-        "cli-table3": "^0.6.3",
-        "node-emoji": "^1.11.0",
-        "supports-hyperlinks": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/memory-streams": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
-      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.0.2"
-      }
-    },
-    "node_modules/memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -3354,15 +3017,6 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
-    "node_modules/node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node_modules/node-pty": {
       "version": "1.2.0-beta.12",
       "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
@@ -3371,18 +3025,6 @@
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^7.1.0"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-      "integrity": "sha512-x8vXm7BZ2jE1Txrxh/hO74HTuYZQEbo8edoRcANgdZ4+PCV+pbjd/xdummkmjjC7LU5EjPzlu8zEq/oxWylnKA==",
-      "license": "MIT",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
       }
     },
     "node_modules/npm-run-path": {
@@ -3455,15 +3097,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
       }
     },
     "node_modules/ora": {
@@ -3614,31 +3247,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/picture-tuber": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/picture-tuber/-/picture-tuber-1.0.2.tgz",
-      "integrity": "sha512-49/xq+wzbwDeI32aPvwQJldM8pr7dKDRuR76IjztrkmiCkAQDaWFJzkmfVqCHmt/iFoPFhHmI9L0oKhthrTOQw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "charm": "~0.1.0",
-        "event-stream": "~0.9.8",
-        "optimist": "~0.3.4",
-        "png-js": "~0.1.0",
-        "x256": "~0.0.1"
-      },
-      "bin": {
-        "picture-tube": "bin/tube.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/png-js": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz",
-      "integrity": "sha512-NTtk2SyfjBm+xYl2/VZJBhFnTQ4kU5qWC7VC4/iGbrgiU4FuB4xC+74erxADYJIqZICOR1HCvRA7EBHkpjTg9g=="
-    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -3699,27 +3307,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/redeyed": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "esprima": "~4.0.0"
-      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -3883,15 +3470,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3954,21 +3532,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sparkline": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/sparkline/-/sparkline-0.1.2.tgz",
-      "integrity": "sha512-t//aVOiWt9fi/e22ea1vXVWBDX+gp18y+Ch9sKqmHl828bRfvP2VtfTJVEcgWFBQHd0yDPNQRiHdqzCvbcYSDA==",
-      "dependencies": {
-        "here": "0.0.2",
-        "nopt": "~2.1.2"
-      },
-      "bin": {
-        "sparkline": "bin/sparkline"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3994,12 +3557,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4036,18 +3593,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -4059,36 +3604,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/term-canvas": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/term-canvas/-/term-canvas-0.0.5.tgz",
-      "integrity": "sha512-eZ3rIWi5yLnKiUcsW8P79fKyooaLmyLWAGqBhFspqMxRNUiB4GmHHk5AzQ4LxvFbJILaXqQZLwbbATLOhCFwkw=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4830,15 +4345,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -4887,37 +4393,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/x256": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/x256/-/x256-0.0.2.tgz",
-      "integrity": "sha512-ZsIH+sheoF8YG9YG+QKEEIdtqpHRA9FYuD7MqhfyB1kayXU43RUNBFSxBEnF8ywSUxdg+8no4+bPr5qLbyxKgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/yaml": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {
@@ -27,7 +27,6 @@
     "@azure/identity": "^4.0.0",
     "@azure/keyvault-secrets": "^4.8.0",
     "blessed": "^0.1.81",
-    "blessed-contrib": "^4.11.0",
     "chalk": "^5.3.0",
     "commander": "^13.0.0",
     "execa": "^9.0.0",

--- a/cli/src/commands/operator.ts
+++ b/cli/src/commands/operator.ts
@@ -13,7 +13,7 @@
 import { Command } from "commander";
 import { execa } from "execa";
 import blessed from "blessed";
-import contrib from "blessed-contrib";
+import { makeGrid, makeTable } from "../lib/operator-tui.js";
 import { listSecretVariants } from "../config.js";
 import {
   statusBarForAgents,
@@ -134,7 +134,7 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
 
   // ── Layout (12×12 grid) ───────────────────────────────────────────
 
-  const grid = new contrib.grid({ rows: 12, cols: 12, screen });
+  const grid = makeGrid(screen, 12, 12);
 
   // Row 0: Header
   const header = grid.set(0, 0, 1, 12, blessed.box, {
@@ -144,7 +144,7 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
   });
 
   // Rows 1–4: Agent table (full width)
-  const agentTable = grid.set(1, 0, 4, 12, contrib.table, {
+  const agentTable = grid.set(1, 0, 4, 12, makeTable, {
     keys: false,
     vi: false,
     fg: "white",
@@ -194,7 +194,7 @@ async function startDashboard(refreshInterval: number, kubeContext?: string, dev
   });
 
   // Rows 5–6: Activity log (cols 8–11)
-  const activityLog = grid.set(5, 8, 2, 4, contrib.log, {
+  const activityLog = grid.set(5, 8, 2, 4, blessed.log, {
     fg: "green",
     label: " Log ",
     tags: true,

--- a/cli/src/lib/operator-tui.ts
+++ b/cli/src/lib/operator-tui.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// operator-tui.ts — minimal grid + table widgets backed by plain `blessed`.
+//
+// These replace the only three `blessed-contrib` widgets the operator
+// dashboard used (`grid`, `table`, `log`). `blessed-contrib` pulls in
+// vulnerable transitive dependencies (lodash code-injection / prototype
+// pollution via GHSA-r5fr-rjxr-66jc + GHSA-f23m-r3pf-42rh, and xml2js
+// prototype pollution via `map-canvas` → GHSA-776f-qx25-q3cc) that have no
+// consumer-applicable fix — `overrides` in a published package are ignored
+// when it is installed as a dependency, so the only durable remedy is to
+// stop depending on `blessed-contrib`. `blessed` alone has zero advisories.
+//
+// The widgets reproduce exactly the surface operator.ts relies on:
+//   makeGrid(screen).set(row,col,rowSpan,colSpan, factory, opts) → widget
+//   makeTable(opts) → box with .setData({headers,data}), .rows (inner list
+//                     exposing .selected/.select/.focus), .show/.hide/.style
+// For the activity log, operator.ts uses `blessed.log` directly (its `.log()`
+// method matches contrib.log 1:1).
+
+import blessed from "blessed";
+
+type AnyOpts = Record<string, any>;
+
+/** Factory signature shared by blessed.box/list/log and makeTable. */
+type WidgetFactory = (opts: AnyOpts) => any;
+
+export interface GridLike {
+  set(
+    row: number,
+    col: number,
+    rowSpan: number,
+    colSpan: number,
+    factory: WidgetFactory,
+    opts: AnyOpts,
+  ): any;
+}
+
+/**
+ * Replacement for `new contrib.grid({rows, cols, screen})`. Computes the same
+ * percentage-based geometry contrib.grid does and adds a line border by
+ * default (contrib.grid borders every cell), then constructs the widget via
+ * the supplied factory parented to the screen.
+ */
+export function makeGrid(screen: any, rows = 12, cols = 12): GridLike {
+  const pct = (n: number, d: number): string => `${(n / d) * 100}%`;
+  return {
+    set(row, col, rowSpan, colSpan, factory, opts = {}) {
+      const borderFg = opts?.style?.border?.fg;
+      return factory({
+        ...opts,
+        parent: screen,
+        top: pct(row, rows),
+        left: pct(col, cols),
+        width: pct(colSpan, cols),
+        height: pct(rowSpan, rows),
+        border: opts.border ?? { type: "line", fg: borderFg },
+      });
+    },
+  };
+}
+
+/**
+ * Replacement for `contrib.table`. Renders a bordered box containing a fixed
+ * header line plus a scrollable `blessed.list` of data rows — the same
+ * structure contrib.table uses internally, where the inner list is exposed as
+ * `.rows`. Columns are fixed-width (cells are plain strings in the operator,
+ * so simple pad/truncate is exact).
+ */
+export function makeTable(opts: AnyOpts = {}): any {
+  const columnWidth: number[] = opts.columnWidth ?? [];
+  const columnSpacing: number = opts.columnSpacing ?? 2;
+  const sep = " ".repeat(columnSpacing);
+
+  const fmt = (cells: any[]): string =>
+    cells
+      .map((c, i) => {
+        const s = String(c ?? "");
+        const w = columnWidth[i];
+        if (typeof w !== "number") return s;
+        return s.length > w ? s.slice(0, w) : s.padEnd(w);
+      })
+      .join(sep);
+
+  const box = blessed.box({
+    ...opts,
+    tags: true,
+    border: opts.border ?? { type: "line", fg: opts?.style?.border?.fg },
+  });
+
+  const headerLine = blessed.box({
+    parent: box,
+    top: 0,
+    left: 1,
+    right: 1,
+    height: 1,
+    tags: true,
+    style: opts?.style?.header ?? { fg: "cyan", bold: true },
+  });
+
+  const list = blessed.list({
+    parent: box,
+    top: 1,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    keys: opts.keys ?? false,
+    vi: opts.vi ?? false,
+    mouse: true,
+    tags: true,
+    interactive: opts.interactive ?? true,
+    style: {
+      fg: opts.fg ?? "white",
+      selected: opts?.style?.cell?.selected ?? { bg: "blue", fg: "white" },
+    },
+  });
+
+  (box as any).rows = list;
+  (box as any).setData = ({
+    headers,
+    data,
+  }: {
+    headers: any[];
+    data: any[][];
+  }): void => {
+    headerLine.setContent(fmt(headers ?? []));
+    const prev = (list as any).selected ?? 0;
+    list.setItems((data ?? []).map(fmt) as any);
+    const max = Math.max(0, (data?.length ?? 0) - 1);
+    (list as any).select(Math.min(prev, max));
+  };
+
+  return box;
+}

--- a/docs/internal/security-audits/2026-06-23-operator-tui-drop-blessed-contrib.md
+++ b/docs/internal/security-audits/2026-06-23-operator-tui-drop-blessed-contrib.md
@@ -1,0 +1,75 @@
+# Security Audit — operator TUI: drop `blessed-contrib` (npm-audit clean)
+
+PR: Azure/kars (branch `fix/cli-npm-audit-drop-blessed-contrib`)
+
+## Scope
+
+The capability-path change is in `cli/src/commands/operator.ts` plus a new
+helper `cli/src/lib/operator-tui.ts`. It removes the `blessed-contrib`
+dependency from `@kars-runtime/cli` and reimplements the only three widgets the
+operator dashboard used (`grid`, `table`, `log`) on top of plain `blessed`:
+
+- `makeGrid(screen, 12, 12)` reproduces `contrib.grid`'s percentage-based cell
+  geometry (and default line border).
+- `makeTable(opts)` reproduces `contrib.table` as a bordered `blessed.box`
+  containing a fixed header line + a scrollable `blessed.list` exposed as
+  `.rows` — the exact surface `operator.ts` consumes
+  (`setData({headers,data})`, `.rows.selected/.select/.focus`, `.show/.hide`,
+  `.style.border.fg`).
+- The activity log switches to `blessed.log` (`.log()` is identical).
+
+Motivation: `blessed-contrib` pulls vulnerable transitive dependencies with no
+consumer-applicable fix — `lodash` (GHSA-r5fr-rjxr-66jc code injection via
+`_.template`; GHSA-f23m-r3pf-42rh prototype pollution) and `xml2js` via
+`map-canvas` (GHSA-776f-qx25-q3cc prototype pollution). npm `overrides` in a
+published package are ignored when it is installed as a dependency, so the only
+durable remedy is to stop depending on `blessed-contrib`. `blessed` alone has
+zero advisories. Verified: a consumer `npm install` of the packed tarball now
+reports `found 0 vulnerabilities` (was 5: 3 high + 2 moderate).
+
+Non-capability changes in the same PR (noted, not the audit subject): CLI
+version bump 0.1.1 → 0.1.2; `tools/cleanup-ghcr-tags.sh` keeps clean-release
+per-arch tags; `docs/security/supply-chain-posture.md` records the npm-audit
+result and the reviewed-benign Socket.dev `execa` "obfuscated code" alert.
+
+## Threat model
+
+### T1: New TUI widget code — does it introduce a new attack surface? (NO)
+`operator-tui.ts` is pure local-terminal rendering. It performs no I/O, no
+process spawning, no network, and no filesystem access — it constructs
+`blessed` widgets and formats fixed-width text. It runs only inside
+`kars operator`, an interactive dashboard the user already invokes against
+clusters they are authenticated to. No new privilege, capability, or data path
+is introduced; the change is strictly a dependency-surface *reduction*.
+
+### T2: Table cell rendering — injection / escaping? (NO REGRESSION)
+The agent-table cells are plain operator-derived strings (sandbox name, status,
+runtime, model, age, cluster) — the same data `contrib.table` rendered before.
+`blessed` tag markup (`{...}`) is only enabled where it already was; cell
+values are not attacker-controlled (they come from the user's own cluster /
+CRDs) and are pad/truncated, not evaluated. Selection math preserves the prior
+`.rows.selected` semantics (data-row indexed, header excluded), verified by a
+headless render smoke-test exercising `setData`, `select`, and `style` mutation.
+
+### T3: Removing a dependency — supply-chain effect (STRICT IMPROVEMENT)
+Dropping `blessed-contrib` removes `lodash`, `map-canvas`, and `xml2js` from the
+installed tree, taking the published CLI from 5 advisories to 0 and shrinking
+the dependency count. No functionality the operator used is lost (grid/table/log
+are reimplemented; the unused `map`/chart widgets are gone with their deps).
+
+## What this audit does NOT cover
+
+- The broader operator command logic (sandbox listing, egress approve/deny,
+  model switch) — unchanged by this PR and covered by prior operator audits.
+- The `kars dev --release --target local-k8s` image-load path — tracked
+  separately.
+
+## Verdict
+
+Accept. The change reduces the published CLI's supply-chain surface to a clean
+`npm audit`, introduces no new runtime capability, network path, or
+attacker-reachable input, and preserves the dashboard's behaviour (verified by
+the full 801-test suite + a headless TUI smoke-test).
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/docs/security/supply-chain-posture.md
+++ b/docs/security/supply-chain-posture.md
@@ -12,6 +12,7 @@ finding. Tracking issue: **#410**.
 | **Pinned-Dependencies — GitHub Actions** | All GitHub-owned + third-party actions pinned by commit SHA. |
 | **Vulnerabilities — actionable** | `RUSTSEC-2026-0185` (quinn-proto) fixed by upgrade. |
 | **Signing (images)** | Every container image is cosign keyless-signed + carries an SPDX SBOM + a GitHub build-provenance (SLSA) attestation. |
+| **Vulnerabilities — npm CLI** | `@kars-runtime/cli` ships a **clean `npm audit`** (0 advisories). Removed `blessed-contrib`, whose transitive `lodash` (GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh) and `xml2js` via `map-canvas` (GHSA-776f-qx25-q3cc) had no consumer-applicable fix — its three used widgets (grid/table/log) are reimplemented on plain `blessed` in `cli/src/lib/operator-tui.ts`. |
 
 ## Accepted with rationale
 
@@ -43,6 +44,17 @@ reproducibility) — tracked in #410.
 Reproducibility for these is provided by lockfiles (`Cargo.lock`,
 `package-lock.json`) and the vendored wheels, which Scorecard's heuristic does
 not credit. Hash-pinning is tracked in #410.
+
+### Socket.dev "obfuscated code" — `execa@9.6.1`
+**False positive — reviewed & accepted.** Socket flags `lib/methods/create.js`
+in [`execa`](https://socket.dev/npm/package/@kars-runtime/cli/alerts/0.1.1)
+as "obfuscated code". `execa` (by sindresorhus) is a benign, ubiquitous
+process-execution wrapper; the flagged file is its argument-dispatch shim. The
+Socket reviewer note itself concludes there are "no signs of obfuscation,
+hard-coded secrets, or explicit malicious behavior." kars only ever invokes
+`execa` with **fixed argument arrays** (never the shell-template form) and never
+passes untrusted, unvalidated input as a command, so the heuristic's
+command-injection concern does not apply.
 
 ## Open / external
 

--- a/tools/cleanup-ghcr-tags.sh
+++ b/tools/cleanup-ghcr-tags.sh
@@ -31,6 +31,18 @@ if ! gh api "/orgs/${ORG}/packages/container/kars-controller/versions?per_page=1
   echo "ERR: cannot list package versions for org '${ORG}'."
   echo "     Token needs read:packages (+ delete:packages to delete):"
   echo "       gh auth refresh -h github.com -s read:packages,delete:packages"
+  # Common trap: a GH_TOKEN / GITHUB_TOKEN env var overrides the keyring
+  # token, and `gh auth refresh` only updates the keyring — so the refresh
+  # silently has no effect while the env token keeps its old scopes.
+  if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
+    echo
+    echo "  NOTE: GH_TOKEN/GITHUB_TOKEN is set in your environment. gh uses that"
+    echo "        token (not the keyring), and 'gh auth refresh' canNOT add scopes"
+    echo "        to an env-var token. Unset it first, then refresh:"
+    echo "          unset GH_TOKEN GITHUB_TOKEN"
+    echo "          gh auth refresh -h github.com -s read:packages,delete:packages"
+    echo "        (or export a token that already has read:packages,delete:packages)"
+  fi
   exit 1
 fi
 
@@ -45,7 +57,23 @@ PACKAGES=(
 is_cruft_tag() {
   case "$1" in
     sha-[0-9a-f]*|main|dev) return 0 ;;
-    *-amd64|*-arm64)        return 0 ;;
+    *-amd64|*-arm64)
+      # Per-arch tags are cruft EXCEPT when they back a clean published
+      # release (vMAJOR.MINOR.PATCH with no pre-release suffix). For the
+      # natively-built+merged images (sandbox-base, openclaw-sandbox,
+      # relay, registry) the multi-arch vX.Y.Z manifest list references
+      # these per-arch images — deleting v0.1.1-arm64 etc. risks breaking
+      # the very release `kars dev --release vX.Y.Z` pulls. Keep them.
+      local base="$1"
+      base="${base%-amd64}"; base="${base%-arm64}"
+      case "$base" in
+        v[0-9]*.[0-9]*.[0-9]*)
+          case "$base" in
+            *-*) return 0 ;;   # has a pre-release suffix (interim/rc/…) → cruft
+            *)   return 1 ;;   # clean release base → KEEP (load-bearing)
+          esac ;;
+        *) return 0 ;;          # non-release base (sha/branch) → cruft
+      esac ;;
   esac
   if [ "$DROP_OLD_INTERIMS" = 1 ]; then
     case "$1" in v*-interim.*|v*-interim) return 0 ;; esac


### PR DESCRIPTION
## Why
A fresh `npm i @kars-runtime/cli` reported **5 advisories (3 high, 2 moderate)** — all transitive via `blessed-contrib`:
- `lodash` GHSA-r5fr-rjxr-66jc (code injection), GHSA-f23m-r3pf-42rh (prototype pollution)
- `xml2js` via `map-canvas` GHSA-776f-qx25-q3cc (prototype pollution)

None have a consumer-applicable fix, and npm `overrides` in a published package are **ignored** when it's installed as a dependency — so the durable fix is to drop `blessed-contrib`.

## What
- The operator dashboard used only 3 blessed-contrib widgets (`grid`, `table`, `log`). Reimplemented on plain `blessed` in **`cli/src/lib/operator-tui.ts`** (`blessed` alone = 0 advisories) and swapped `operator.ts` over.
- **Bump 0.1.1 → 0.1.2** (0.1.1 is already published).
- **`tools/cleanup-ghcr-tags.sh`**: previously classified *every* `*-amd64`/`*-arm64` tag as cruft — which would have deleted the per-arch images backing the `v0.1.0`/`v0.1.1` multi-arch manifests and broken `kars dev --release`. Now keeps per-arch tags for clean releases; still prunes interim/sha. Also detects the `GH_TOKEN` env override that defeats `gh auth refresh`.
- Documented the npm-audit result + the reviewed-benign Socket.dev `execa` false positive in `supply-chain-posture.md`.

## Verify
- Consumer `npm i <packed tarball>` → **`found 0 vulnerabilities`** (was 5)
- `npm run typecheck` + `oxlint` clean; **801 tests pass**
- Headless TUI smoke-test exercises `setData`/`rows.selected`/`select`/`style.border.fg`/`show/hide` — OK
- Security-audit doc added (operator.ts is a capability path).