### PR TITLE
chore(release): bump CLI to 0.1.3

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Aligns the npm package version with the **v0.1.3** release that exercises the new **signed release-asset** pipeline (SHA256SUMS + cosign keyless + SLSA provenance, merged in #421). No CLI code change.