### PR TITLE
fix(up): don't run Entra Graph preflight for anonymous trust; never hang on device-code

### DIFF
--- a/cli/src/commands/mesh/agent_id_setup.test.ts
+++ b/cli/src/commands/mesh/agent_id_setup.test.ts
@@ -234,6 +234,23 @@ describe("checkAgentIdRole", () => {
     expect(r.message).toContain("az login --scope https://graph.microsoft.com//.default");
   });
 
+  it("does NOT attempt device-code re-login on AADSTS530084 when interactive=false (preflight)", async () => {
+    // Single Graph call returns the CA block. With interactive=false the
+    // helper must NOT shell out to `az login --use-device-code` (which would
+    // hang `up` on tenants whose CA also blocks the device-code device).
+    mockedExeca.mockRejectedValueOnce(
+      new Error(
+        "ERROR: AADSTS530084: Access has been blocked by conditional access token protection policy configured by this organization.",
+      ),
+    );
+    const r = await checkAgentIdRole({ interactive: false });
+    expect(r.hasRole).toBe(false);
+    expect(r.inconclusive).toBe(true);
+    expect(r.message).toContain("AADSTS530084");
+    // Exactly one az call — the Graph GET. No device-code re-login.
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
+  });
+
   it("emits the az-login workaround when AADSTS65001/65002 (missing consent) is detected", async () => {
     mockedExeca.mockRejectedValueOnce(
       new Error("ERROR: AADSTS65001: The user or administrator has not consented..."),

--- a/cli/src/commands/mesh/agent_id_setup.ts
+++ b/cli/src/commands/mesh/agent_id_setup.ts
@@ -136,17 +136,24 @@ async function azGraphRest<T>(
   method: "GET" | "POST" | "PATCH" | "DELETE",
   graphPath: string,
   body?: unknown,
+  interactive = true,
 ): Promise<T | null> {
-  return azGraphRestWithRetry<T>(method, graphPath, body, false);
+  return azGraphRestWithRetry<T>(method, graphPath, body, false, interactive);
 }
 
 /// Internal: shared implementation. `alreadyRetried` prevents an
 /// infinite loop if device-code re-login also returns AADSTS530084.
+/// `interactive` gates the device-code re-login: preflight/read-only
+/// callers pass `false` so a Conditional-Access Graph block (AADSTS530084)
+/// propagates as a normal error (→ soft warning) instead of launching a
+/// blocking `az login --use-device-code` prompt that hangs `up` on tenants
+/// whose CA also blocks the device-code device.
 async function azGraphRestWithRetry<T>(
   method: "GET" | "POST" | "PATCH" | "DELETE",
   graphPath: string,
   body: unknown,
   alreadyRetried: boolean,
+  interactive = true,
 ): Promise<T | null> {
   // Microsoft Graph requires the OData-Version header for derived
   // types like agentIdentityBlueprint. `az rest` does not let us set
@@ -184,10 +191,10 @@ async function azGraphRestWithRetry<T>(
     // differently (the device-code app may not be subject to the
     // same token-binding rule). One-shot: if it fails again, give
     // up and propagate so the caller can fall back to Bicep.
-    if (!alreadyRetried && msg.includes("AADSTS530084")) {
+    if (!alreadyRetried && interactive && msg.includes("AADSTS530084")) {
       const tenantArgs = await deviceCodeReloginForGraph();
       if (tenantArgs) {
-        return azGraphRestWithRetry<T>(method, graphPath, body, true);
+        return azGraphRestWithRetry<T>(method, graphPath, body, true, interactive);
       }
     }
 
@@ -290,6 +297,7 @@ interface BlueprintGraphResponse {
 /// operator error.
 async function findExistingBlueprint(
   displayName: string,
+  interactive = true,
 ): Promise<BlueprintGraphResponse | null> {
   const filter = encodeURIComponent(`displayName eq '${displayName}'`);
   interface ListResp {
@@ -298,6 +306,8 @@ async function findExistingBlueprint(
   const resp = await azGraphRest<ListResp>(
     "GET",
     `/beta/applications?$filter=${filter}&$top=2`,
+    undefined,
+    interactive,
   );
   if (!resp || !resp.value || resp.value.length === 0) return null;
   if (resp.value.length > 1) {
@@ -922,12 +932,15 @@ const AGENT_ID_ROLE_TEMPLATE_IDS: Record<string, string> = {
 /// `/me/transitiveMemberOf`. Soft-fails on permission errors —
 /// returning `inconclusive: true` so preflight surfaces a warning,
 /// not a block.
-export async function checkAgentIdRole(): Promise<AgentIdRoleCheckResult> {
+export async function checkAgentIdRole(opts?: { interactive?: boolean }): Promise<AgentIdRoleCheckResult> {
+  const interactive = opts?.interactive ?? true;
   let resp: MeMemberOfResp | null;
   try {
     resp = await azGraphRest<MeMemberOfResp>(
       "GET",
       "/beta/me/transitiveMemberOf/microsoft.graph.directoryRole?$select=id,displayName,roleTemplateId&$top=100",
+      undefined,
+      interactive,
     );
   } catch (e) {
     const msg = (e as Error).message;
@@ -1008,9 +1021,10 @@ export async function checkAgentIdRole(): Promise<AgentIdRoleCheckResult> {
 /// kubeconfig that may not be ready yet during preflight).
 export async function detectExistingBlueprint(
   displayName: string,
+  opts?: { interactive?: boolean },
 ): Promise<{ present: boolean; appId?: string; message: string }> {
   try {
-    const blueprint = await findExistingBlueprint(displayName);
+    const blueprint = await findExistingBlueprint(displayName, opts?.interactive ?? true);
     if (blueprint) {
       return {
         present: true,

--- a/cli/src/commands/up/preflight.ts
+++ b/cli/src/commands/up/preflight.ts
@@ -337,6 +337,7 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
       isolation: options.isolation,
       foundryEndpoint: options.foundryEndpoint,
       skipPreflight: options.skipPreflight,
+      meshTrust: (options as { meshTrust?: string }).meshTrust,
     });
     if (!pf.ok) {
       process.exit(1);

--- a/cli/src/preflight.ts
+++ b/cli/src/preflight.ts
@@ -38,6 +38,9 @@ export interface PreflightOptions {
   foundryEndpoint?: string;
   /** If set, skip all preflight checks (escape hatch). */
   skipPreflight?: boolean;
+  /** Mesh trust mode. The Entra Agent ID (Microsoft Graph) preflight only
+   * runs for 'entra'; the default 'anonymous' needs no Graph access. */
+  meshTrust?: string;
 }
 
 export interface PreflightResult {
@@ -323,48 +326,54 @@ export async function runPreflightChecks(opts: PreflightOptions): Promise<Prefli
     );
   }
 
-  // 5. Entra Agent ID prerequisites
-  //    Check that the signed-in user has a role permitting blueprint
-  //    creation. Soft-fail (warning, not blocking) when Graph lookup
-  //    is inconclusive, since the existing legacy auth fallback keeps
-  //    the cluster functional in anonymous tier.
-  spin = ora({ text: "Checking Entra Agent ID directory role...", color: "cyan" }).start();
-  try {
-    const { checkAgentIdRole, detectExistingBlueprint } = await import(
-      "./commands/mesh/agent_id_setup.js"
-    );
-    const roleCheck = await checkAgentIdRole();
-    if (roleCheck.hasRole) {
-      spin.succeed(`Entra Agent ID — role present (${roleCheck.detectedRoles.map((r) => r.displayName).join(", ")})`);
-    } else if (roleCheck.inconclusive) {
-      spin.warn(`Entra Agent ID — ${roleCheck.message}`);
-      result.warnings.push(
-        `Could not verify Entra Agent ID role. If \`kars up\` aborts during the Entra setup phase, grant 'Agent ID Developer' to the signed-in user.`,
+  // 5. Entra Agent ID prerequisites (ONLY for --mesh-trust=entra)
+  //    The default 'anonymous' trust mode needs NO Microsoft Graph access,
+  //    so we must NOT make any Graph call (or its interactive device-code
+  //    re-login) in that case — doing so hangs `up` on tenants whose
+  //    Conditional Access blocks the az CLI Graph token (AADSTS530084).
+  //    Even for 'entra', run the check NON-INTERACTIVELY: a Graph CA-block
+  //    becomes a soft warning here, not a blocking device-code prompt. The
+  //    real Entra setup phase (later in `up`) is where an interactive
+  //    re-login, if any, belongs.
+  if (opts.meshTrust === "entra") {
+    spin = ora({ text: "Checking Entra Agent ID directory role...", color: "cyan" }).start();
+    try {
+      const { checkAgentIdRole, detectExistingBlueprint } = await import(
+        "./commands/mesh/agent_id_setup.js"
       );
-    } else {
-      spin.warn("Entra Agent ID — directory role missing");
-      result.warnings.push(
-        `Per-sandbox Entra Agent IDs require the signed-in user to hold ` +
-          chalk.cyan("Agent ID Developer") +
-          ` (or stronger). Without it, ` +
-          `\`kars up\` will skip the Entra setup step and the cluster will ` +
-          `run in AGT anonymous tier. Activate the role via PIM at ` +
-          chalk.cyan("https://entra.microsoft.com") +
-          ` > Identity > Roles & admins, then re-run \`kars up\`.`,
-      );
-    }
+      const roleCheck = await checkAgentIdRole({ interactive: false });
+      if (roleCheck.hasRole) {
+        spin.succeed(`Entra Agent ID — role present (${roleCheck.detectedRoles.map((r) => r.displayName).join(", ")})`);
+      } else if (roleCheck.inconclusive) {
+        spin.warn(`Entra Agent ID — ${roleCheck.message}`);
+        result.warnings.push(
+          `Could not verify Entra Agent ID role. If \`kars up\` aborts during the Entra setup phase, grant 'Agent ID Developer' to the signed-in user.`,
+        );
+      } else {
+        spin.warn("Entra Agent ID — directory role missing");
+        result.warnings.push(
+          `Per-sandbox Entra Agent IDs require the signed-in user to hold ` +
+            chalk.cyan("Agent ID Developer") +
+            ` (or stronger). Without it, ` +
+            `\`kars up\` will skip the Entra setup step and the cluster will ` +
+            `run in AGT anonymous tier. Activate the role via PIM at ` +
+            chalk.cyan("https://entra.microsoft.com") +
+            ` > Identity > Roles & admins, then re-run \`kars up\`.`,
+        );
+      }
 
-    // Best-effort blueprint detection — purely informational.
-    const blueprintCheck = await detectExistingBlueprint("kars-blueprint");
-    if (blueprintCheck.present) {
-      console.log(chalk.dim(`      · ${blueprintCheck.message}`));
+      // Best-effort blueprint detection — purely informational.
+      const blueprintCheck = await detectExistingBlueprint("kars-blueprint", { interactive: false });
+      if (blueprintCheck.present) {
+        console.log(chalk.dim(`      · ${blueprintCheck.message}`));
+      }
+    } catch (e) {
+      // Preflight should never crash if our Graph helper throws unexpectedly.
+      spin.warn(`Entra Agent ID check skipped — ${(e as Error).message.split("\n")[0].slice(0, 100)}`);
+      result.warnings.push(
+        "Entra Agent ID preflight skipped due to an internal error. Cluster will run in anonymous tier unless `kars mesh setup-trust` succeeds later.",
+      );
     }
-  } catch (e) {
-    // Preflight should never crash if our Graph helper throws unexpectedly.
-    spin.warn(`Entra Agent ID check skipped — ${(e as Error).message.split("\n")[0].slice(0, 100)}`);
-    result.warnings.push(
-      "Entra Agent ID preflight skipped due to an internal error. Cluster will run in anonymous tier unless `kars mesh setup-trust` succeeds later.",
-    );
   }
 
   // Summary

--- a/docs/internal/security-audits/2026-06-23-preflight-entra-graph-gating.md
+++ b/docs/internal/security-audits/2026-06-23-preflight-entra-graph-gating.md
@@ -1,0 +1,68 @@
+# Security Audit — gate Entra Agent ID Graph preflight on `--mesh-trust=entra`, non-interactively
+
+PR: Azure/kars (branch `fix/preflight-entra-graph-gating`)
+
+## Scope
+
+Capability-path changes in `cli/src/commands/mesh/agent_id_setup.ts` and
+`cli/src/commands/up/preflight.ts` (plus the non-capability `cli/src/preflight.ts`):
+
+The `kars up` preflight ran the **Microsoft Graph** "Entra Agent ID directory
+role" check **unconditionally**, and on a Conditional-Access Graph block
+(`AADSTS530084`) the shared Graph helper launched an **interactive
+`az login --use-device-code`** re-login. On tenants whose CA also requires a
+managed device for the device-code flow, that prompt can never complete, so
+`kars up` **hung in preflight — even with the default `--mesh-trust=anonymous`,
+which needs no Graph access at all.**
+
+Two fixes:
+
+1. **Gate the check on trust mode.** Thread `meshTrust` into `PreflightOptions`
+   and only run the Entra Agent ID Graph check when `meshTrust === "entra"`.
+   The default `anonymous` mode now makes **zero** Graph calls.
+2. **Non-interactive in preflight.** Thread an `interactive` flag through
+   `azGraphRest`/`azGraphRestWithRetry` and `checkAgentIdRole` /
+   `detectExistingBlueprint`. The preflight passes `interactive: false`, so a
+   `AADSTS530084` (or `65001/65002`) block propagates to the existing graceful
+   handler → a **soft warning**, never a blocking device-code prompt. Default
+   callers (the real Entra *setup* phase) keep `interactive: true`, so the
+   device-code re-login still happens there, where interactivity is expected.
+
+## Threat model
+
+### T1: Does skipping the Graph check for `anonymous` weaken trust? (NO)
+`anonymous` mesh trust never used Entra Agent IDs — the preflight Graph call was
+purely advisory and, by design, only relevant to `entra`. Skipping it removes an
+unnecessary, hang-prone auth round-trip; it changes **no** runtime trust control.
+The actual `entra` setup phase (unchanged) still enforces Agent-ID issuance.
+
+### T2: Does non-interactive preflight hide a real misconfiguration? (NO)
+A CA block / missing role still surfaces — as a clearly-worded **warning** with
+remediation (`az login --scope https://graph.microsoft.com//.default`, or grant
+`Agent ID Developer`). The preflight was already declared "soft-fail (warning,
+not blocking)"; this makes it actually behave that way instead of blocking on an
+interactive login. The authoritative enforcement remains the setup phase.
+
+### T3: Does the new `interactive` flag change the setup-phase auth path? (NO)
+`interactive` defaults to `true`; every existing caller (the `ensureAgentId*`
+setup path) is unchanged and still attempts the one-shot device-code re-login on
+`AADSTS530084`. Only the two read-only preflight callers opt into
+`interactive: false`. A regression test asserts that with `interactive: false`
+exactly one `az` call is made (no device-code re-login).
+
+## What this audit does NOT cover
+
+- The Entra Agent ID **issuance / federation** logic (`ensureAgentIdTrust*`) —
+  unchanged here; covered by prior Agent-ID audits.
+- Tenant Conditional-Access policy itself (operator/tenant responsibility).
+
+## Verdict
+
+Accept. The change removes a preflight hang, makes no Graph calls in the default
+`anonymous` mode, and downgrades an `entra` CA-block from a blocking interactive
+prompt to a documented warning — without altering the authoritative Entra setup
+path. Verified by the full 804-test suite incl. a new non-interactive regression
+test; typecheck + lint clean.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem
A colleague's `kars up` **hangs in preflight** at *"Evaluating RBAC… → To sign in, use a web browser … device login"*, and the device-code login fails with *"your admin requires the device to be managed."*

Root cause: the preflight ran the **Microsoft Graph** "Entra Agent ID directory role" check **unconditionally**, and on a Conditional-Access Graph block (`AADSTS530084`) the Graph helper launched an **interactive `az login --use-device-code`**. On tenants whose CA also blocks the device-code device, that prompt can never complete — so `up` hangs. **This fired even with the default `--mesh-trust=anonymous`, which needs no Graph at all** — so dropping/changing the flag didn't help.

## Fix
1. **Gate on trust mode** — thread `meshTrust` into `PreflightOptions`; only run the Entra Graph check when `meshTrust === "entra"`. Default `anonymous` makes **zero** Graph calls.
2. **Non-interactive preflight** — thread an `interactive` flag through `azGraphRest`/`checkAgentIdRole`/`detectExistingBlueprint`; preflight passes `interactive:false` so a CA block → **soft warning** (with remediation), never a device-code hang. The real Entra *setup* phase keeps `interactive:true`.

## Result
- `kars up ... --mesh-trust=anonymous` (default): no Graph call, no hang.
- `kars up ... --mesh-trust=entra` on a CA-blocked tenant: warns + continues (anonymous tier) instead of hanging.

## Verify
- 804 tests pass incl. a new regression test (interactive:false → exactly one `az` call, no device-code).
- typecheck + lint clean. Security-audit doc added (touches `cli/src/commands/**`).