### PR TITLE
fix(release): make --release work out-of-the-box (bundle deploy assets, no repo checkout)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,7 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "tsc && chmod +x dist/index.js && cp -r profiles dist/profiles",
+    "build": "tsc && chmod +x dist/index.js && cp -r profiles dist/profiles && node scripts/bundle-deploy-assets.mjs",
     "dev": "tsx watch src/index.ts",
     "lint": "oxlint .",
     "format": "oxfmt .",

--- a/cli/scripts/bundle-deploy-assets.mjs
+++ b/cli/scripts/bundle-deploy-assets.mjs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// bundle-deploy-assets.mjs — copy the repo's static K8s deploy assets into
+// the CLI's dist/ so they ship inside the npm package. This is what lets
+// `kars dev --release` / `kars up --release` run with NO repo checkout
+// (the resolver in src/lib/repo-assets.ts looks here when not in a repo).
+//
+// Run as part of `npm run build` (after tsc). Idempotent.
+
+import { existsSync, mkdirSync, cpSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cliRoot = path.resolve(here, "..");
+const repoRoot = path.resolve(cliRoot, "..");
+const distDeploy = path.join(cliRoot, "dist", "deploy");
+
+// Repo-relative asset → bundled under dist/deploy preserving the layout the
+// resolver expects (it looks up "deploy/<...>").
+const assets = [
+  "deploy/helm/kars",            // Helm chart + values-local-dev.yaml + templates + CRDs
+  "deploy/bicep",                // AKS/Foundry infra templates for `kars up --release`
+  "deploy/agentmesh-agt.yaml",   // AgentMesh relay+registry manifest
+  "deploy/agentmesh-ingress.yaml",
+  "deploy/monitoring",           // PodMonitor + Grafana dashboards (best-effort)
+  "tools/headlamp-plugin/dist/main.js",   // prebuilt Headlamp CRD-view plugin
+  "tools/headlamp-plugin/package.json",
+];
+
+let copied = 0;
+const missing = [];
+for (const rel of assets) {
+  const src = path.join(repoRoot, rel);
+  if (!existsSync(src)) {
+    missing.push(rel);
+    continue;
+  }
+  // rel always starts with "deploy/"; place under dist/deploy/<rest>.
+  const dest = path.join(cliRoot, "dist", rel);
+  mkdirSync(path.dirname(dest), { recursive: true });
+  cpSync(src, dest, { recursive: true });
+  copied++;
+}
+
+mkdirSync(distDeploy, { recursive: true });
+console.log(`[bundle-deploy-assets] copied ${copied} asset(s) into dist/deploy`);
+if (missing.length) {
+  // The chart + agentmesh manifest are REQUIRED for the release K8s path —
+  // fail the build if either load-bearing asset is missing so we never
+  // publish a broken package.
+  const required = ["deploy/helm/kars", "deploy/agentmesh-agt.yaml"];
+  const missingRequired = missing.filter((m) => required.includes(m));
+  if (missingRequired.length) {
+    console.error(
+      `[bundle-deploy-assets] ERROR: required asset(s) not found at repo root: ${missingRequired.join(", ")}`,
+    );
+    process.exit(1);
+  }
+  console.warn(`[bundle-deploy-assets] (optional, skipped): ${missing.join(", ")}`);
+}

--- a/cli/src/commands/dev/local-k8s.ts
+++ b/cli/src/commands/dev/local-k8s.ts
@@ -28,6 +28,7 @@ import { loadAgtProfile } from "../../refs.js";
 import { stageRustBinaries, type RustArch } from "../../lib/stage-rust-bin.js";
 import { stageMeshPlugin } from "../../lib/stage-mesh-plugin.js";
 import { ensureAgtRepo, ensureAgtWheels } from "../../lib/agt-bootstrap.js";
+import { resolveBundledAsset, requireBundledAsset, findRepoRootOrNull } from "../../lib/repo-assets.js";
 import { buildCopilotFallbackChain } from "../../github-copilot.js";
 
 export interface LocalK8sOptions {
@@ -1039,7 +1040,6 @@ async function provisionDevCreds(
 async function deployAgentMesh(
   tools: Tooling,
   clusterName: string,
-  repoRoot: string,
   meshProvider: "agt",
   agtRepo: string | undefined,
   archToken: string,
@@ -1119,10 +1119,7 @@ async function deployAgentMesh(
   }
 
   // ── Rewrite manifest: swap ACR image refs → local tags, set Never ──
-  const manifestPath = path.join(repoRoot, "deploy", "agentmesh-agt.yaml");
-  if (!existsSync(manifestPath)) {
-    throw new Error(`Mesh manifest not found at ${manifestPath}`);
-  }
+  const manifestPath = requireBundledAsset("deploy/agentmesh-agt.yaml");
   let manifest = readFileSync(manifestPath, "utf8");
   // Plain-string replacements (no regex) — the manifest contains fixed ACR
   // image references that we swap for the local kind-loaded tags. Using
@@ -1191,26 +1188,25 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
   const releaseRef = (name: string): string =>
     `${RELEASE_REGISTRY}/${name}:${opts.releaseVersion}`;
 
-  // Fail fast if the user is running outside the kars checkout.
-  // `--target local-k8s` needs the repo root for the Helm chart
-  // (deploy/helm/kars) and the agentmesh manifest (deploy/agentmesh-agt.yaml),
-  // and — unless --release pulls published images — it also builds the
-  // controller, router, and sandbox images from local source.
-  // Without this check the failure surfaces only AFTER kind cluster
-  // creation (10+ seconds wasted, orphaned cluster left behind).
-  if (!opts.noBuild) {
+  // Fail fast if the user is running outside the kars checkout — but ONLY
+  // when we actually need to build from source. `--release` pulls published
+  // images and uses the BUNDLED Helm chart + agentmesh manifest (shipped in
+  // the npm package), so it must work with no repo checkout at all. Without
+  // this guard release mode would later throw a confusing repo-root error.
+  if (!opts.noBuild && !releaseMode) {
     try {
       findRepoRoot(process.cwd());
     } catch {
       throw new Error(
-        "`kars dev --target local-k8s` must be run from inside the kars " +
-          "repo checkout — the dev flow rebuilds the controller, inference-router, " +
-          "and sandbox images from local source.\n\n" +
+        "`kars dev --target local-k8s` (build mode) must be run from inside the " +
+          "kars repo checkout — it rebuilds the controller, inference-router, and " +
+          "sandbox images from local source.\n\n" +
           "Either:\n" +
+          "  • run `kars dev --release --target local-k8s` to use published images " +
+          "(no checkout, no compile), or\n" +
           "  • `cd` into your kars checkout and re-run, or\n" +
           "  • pass `--no-build` to use already-loaded images, or\n" +
-          "  • use `--target docker` (no cluster, no rebuild — fastest dev loop), or\n" +
-          "  • use `kars up` to deploy to an existing AKS cluster (ACR images).",
+          "  • use `--target docker` (no cluster, no rebuild — fastest dev loop).",
       );
     }
   }
@@ -1256,7 +1252,11 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
   // and cli/src/commands/up.ts (line ~617) — keep the three call sites
   // consistent or fresh-machine OOTB breaks on whichever entry point
   // is missing.
-  if (opts.noMesh !== true && !opts.globalRegistry) {
+  // The AGT toolkit + Python wheels are only needed to BUILD images from
+  // source. In --release mode we pull published relay/registry images, so
+  // skip the bootstrap entirely (it also requires a repo checkout, which a
+  // released/npm-installed run won't have).
+  if (opts.noMesh !== true && !opts.globalRegistry && !releaseMode) {
     stepper.step("Bootstrapping AGT toolkit + Python wheels…");
     try {
       const repoRootForAgt = findRepoRoot(process.cwd());
@@ -1516,15 +1516,13 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
   }
 
   stepper.step("Helm-installing the kars chart (with local-dev overlay)…");
-  const repoRoot = findRepoRoot(process.cwd());
-  const chartDir = path.join(repoRoot, "deploy", "helm", "kars");
-  if (!existsSync(chartDir)) {
-    throw new Error(`kars helm chart not found at ${chartDir}`);
-  }
+  // Resolve the Helm chart from a repo checkout OR the bundled copy shipped
+  // in the npm package — so `kars dev --release` works with no source tree.
+  const chartDir = requireBundledAsset("deploy/helm/kars");
   const valuesOverlay = path.join(chartDir, "values-local-dev.yaml");
   if (!existsSync(valuesOverlay)) {
     throw new Error(
-      `Expected local-dev overlay at ${valuesOverlay} — your checkout is incomplete.`,
+      `Expected local-dev overlay at ${valuesOverlay} — the kars chart bundle is incomplete.`,
     );
   }
   // Ensure the namespace exists before applying namespaced resources.
@@ -1590,7 +1588,6 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
     await deployAgentMesh(
       tools,
       opts.clusterName,
-      repoRoot,
       meshProvider,
       opts.agtRepo,
       archToken,
@@ -1641,26 +1638,31 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
   }
   stepper.done("controller rollout check finished");
 
-  // Phase 4: Headlamp dashboard for local-k8s observability.
-  // We treat Headlamp as a hard dependency of the local-k8s target — the
-  // whole point is to give devs a UI without spinning up AKS / Portal.
-  stepper.step("Installing Headlamp dashboard…");
-  await installHeadlamp(tools, opts.clusterName);
-  stepper.done("Headlamp installed");
+  // Phase 4–5b: Headlamp dashboard + kars plugin + Prometheus/Grafana.
+  // These are observability extras — make them BEST-EFFORT so a hiccup
+  // (missing asset, slow image pull, kindnet timing) never blocks an
+  // otherwise-working sandbox. The core agent is already up by here.
+  try {
+    stepper.step("Installing Headlamp dashboard…");
+    await installHeadlamp(tools, opts.clusterName);
+    stepper.done("Headlamp installed");
 
-  // Phase 5: side-load the kars Headlamp plugin (CRD views).
-  // Built into a ConfigMap and volume-mounted at /headlamp/plugins/kars
-  // so it survives pod restarts.
-  stepper.step("Installing kars Headlamp plugin…");
-  await installAzureclawPlugin(tools, opts.clusterName);
-  stepper.done("kars plugin installed");
+    stepper.step("Installing kars Headlamp plugin…");
+    await installAzureclawPlugin(tools, opts.clusterName);
+    stepper.done("kars plugin installed");
 
-  // Phase 5b: Prometheus + Grafana stack so the Headlamp plugin's
-  // metric panels (mesh topology msg counts, token budgets, AGT decisions,
-  // policy bundle health) have data on first run — no manual helm dance.
-  stepper.step("Installing Prometheus + Grafana stack…");
-  await installPrometheus(tools, opts.clusterName);
-  stepper.done("Prometheus + Grafana installed");
+    stepper.step("Installing Prometheus + Grafana stack…");
+    await installPrometheus(tools, opts.clusterName);
+    stepper.done("Prometheus + Grafana installed");
+  } catch (e) {
+    stepper.stop();
+    console.warn(
+      chalk.yellow(
+        `  ⚠ Observability stack (Headlamp/Grafana) didn't fully install — ${(e as Error).message.split("\n")[0].slice(0, 100)}.\n` +
+          "    Your sandbox + mesh are running regardless; re-run later or inspect with kubectl.",
+      ),
+    );
+  }
 
   // Open Headlamp in the user's browser. Port-forward runs detached so
   // it survives the CLI command exiting; user kills it via `kars dev down`
@@ -2092,8 +2094,12 @@ kubeProxy:
   // Apply our kars-specific monitoring manifests: PodMonitor for
   // every sandbox router, prometheus-json-exporter for the AGT relay
   // /health endpoint, and the two Grafana dashboards (fleet + ops).
-  const repoRoot = findRepoRoot(process.cwd());
-  const monitoringDir = path.join(repoRoot, "deploy", "monitoring");
+  // Resolve from a repo checkout OR the bundled copy (so --release works).
+  const monitoringDir = resolveBundledAsset("deploy/monitoring");
+  if (!monitoringDir) {
+    console.log(chalk.dim("    monitoring manifests not bundled — skipping dashboards"));
+    return;
+  }
   for (const f of [
     "podmonitor-sandbox-router.yaml",
     "agentmesh-json-exporter.yaml",
@@ -2192,42 +2198,58 @@ async function installAzureclawPlugin(
   tools: Tooling,
   clusterName: string,
 ): Promise<void> {
-  const repoRoot = findRepoRoot(process.cwd());
-  const pluginDir = path.join(repoRoot, "tools", "headlamp-plugin");
-  const distDir = path.join(pluginDir, "dist");
-  const mainJs = path.join(distDir, "main.js");
-  const pkgJson = path.join(pluginDir, "package.json");
+  // Prefer the prebuilt plugin bundled with the CLI (so `kars dev --release`
+  // works with no repo checkout); fall back to a repo checkout, building it
+  // on demand if a source tree is present.
+  let mainJs = resolveBundledAsset("tools/headlamp-plugin/dist/main.js");
+  let pkgJson = resolveBundledAsset("tools/headlamp-plugin/package.json");
 
-  if (!existsSync(mainJs)) {
-    console.log(
-      chalk.dim("    plugin not built yet — running 'npm run build' in tools/headlamp-plugin…"),
-    );
-    if (!existsSync(path.join(pluginDir, "node_modules"))) {
+  if (!mainJs || !pkgJson) {
+    const repoRoot = findRepoRootOrNull(process.cwd());
+    if (!repoRoot) {
+      console.warn(
+        chalk.yellow(
+          "    ⚠ Headlamp plugin not bundled and no repo checkout found — skipping " +
+            "(the dashboard still works for built-in resources; kars CRD views won't load).",
+        ),
+      );
+      return;
+    }
+    const pluginDir = path.join(repoRoot, "tools", "headlamp-plugin");
+    const distMain = path.join(pluginDir, "dist", "main.js");
+    pkgJson = path.join(pluginDir, "package.json");
+    if (!existsSync(distMain)) {
+      console.log(
+        chalk.dim("    plugin not built yet — running 'npm run build' in tools/headlamp-plugin…"),
+      );
+      if (!existsSync(path.join(pluginDir, "node_modules"))) {
+        try {
+          await execa("npm", ["install", "--no-audit", "--no-fund"], {
+            cwd: pluginDir,
+            stdio: "inherit",
+          });
+        } catch (err) {
+          console.warn(
+            chalk.yellow(
+              `    ⚠ npm install failed (${(err as Error).message}); skipping plugin install. ` +
+                "Run 'cd tools/headlamp-plugin && npm install && npm run build' manually then re-run this command.",
+            ),
+          );
+          return;
+        }
+      }
       try {
-        await execa("npm", ["install", "--no-audit", "--no-fund"], {
-          cwd: pluginDir,
-          stdio: "inherit",
-        });
+        await execa("npm", ["run", "build"], { cwd: pluginDir, stdio: "inherit" });
       } catch (err) {
         console.warn(
           chalk.yellow(
-            `    ⚠ npm install failed (${(err as Error).message}); skipping plugin install. ` +
-              "Run 'cd tools/headlamp-plugin && npm install && npm run build' manually then re-run this command.",
+            `    ⚠ plugin build failed (${(err as Error).message}); skipping plugin install.`,
           ),
         );
         return;
       }
     }
-    try {
-      await execa("npm", ["run", "build"], { cwd: pluginDir, stdio: "inherit" });
-    } catch (err) {
-      console.warn(
-        chalk.yellow(
-          `    ⚠ plugin build failed (${(err as Error).message}); skipping plugin install.`,
-        ),
-      );
-      return;
-    }
+    mainJs = distMain;
   }
 
   // Build the ConfigMap. Headlamp expects each plugin to be a sub-dir

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -5,9 +5,11 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync } from "fs";
 import * as path from "path";
+import * as os from "node:os";
 import { Stepper, banner } from "../stepper.js";
 import { isValidAzureHost } from "./up/preflight.js";
 import { acquireImages } from "./up/images.js";
+import { requireBundledAsset } from "../lib/repo-assets.js";
 
 export function upCommand(): Command {
   const cmd = new Command("up");
@@ -219,15 +221,11 @@ Auto-resume:
           }
         }
 
-        const bicepPath = path.join(repoRoot, "deploy/bicep/main.bicep");
-        const helmPath = path.join(repoRoot, "deploy/helm/kars");
-
-        if (!existsSync(bicepPath)) {
-          stepper.fail("Bicep template not found");
-          console.log(chalk.yellow(`  Expected at: ${bicepPath}`));
-          console.log(chalk.yellow(`  Run from the kars repo root.\n`));
-          process.exit(1);
-        }
+        // Resolve the infra templates + chart from a repo checkout OR the
+        // copies bundled in the npm package — so `kars up --release` works
+        // with no source tree.
+        const bicepPath = requireBundledAsset("deploy/bicep/main.bicep");
+        const helmPath = requireBundledAsset("deploy/helm/kars");
 
         // ── Step 1: Create resource group ────────────────────────────
         stepper.step(`Setting up resource group '${rg}'...`);
@@ -656,7 +654,7 @@ Auto-resume:
                 "}",
               ].join("\n");
               const fs = await import("fs");
-              const tmpBicep = path.join(repoRoot, ".tmp-role.bicep");
+              const tmpBicep = path.join(os.tmpdir(), `kars-role-${Date.now()}.bicep`);
               fs.writeFileSync(tmpBicep, bicepRole);
               await execa("az", [
                 "deployment", "sub", "create",

--- a/cli/src/commands/up/agentmesh_deploy.ts
+++ b/cli/src/commands/up/agentmesh_deploy.ts
@@ -12,7 +12,9 @@
 // Returns the registry-mode triple consumed by the KarsSandbox CR
 // creation step (d.4) and the saveContext() call at end-of-deploy.
 import path from "node:path";
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import * as os from "node:os";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { resolveBundledAsset } from "../../lib/repo-assets.js";
 import type { Stepper } from "../../stepper.js";
 import { kvLine } from "../../stepper.js";
 
@@ -67,7 +69,8 @@ export async function deployAgentMesh(
   options: AgentMeshDeployOptions,
 ): Promise<AgentMeshDeployResult> {
   const { execa } = await import("execa");
-  const { repoRoot, acr: _acr, acrLoginServer, baseName, rg, stepper, entraVerify } = ctx;
+  const { acr: _acr, acrLoginServer, baseName, rg, stepper, entraVerify } = ctx;
+  void ctx.repoRoot;
 
   // Inspektor Gadget (eBPF observability) — non-fatal
   await execa("kubectl", ["gadget", "deploy"], { stdio: "pipe" }).catch(() => {});
@@ -91,8 +94,10 @@ export async function deployAgentMesh(
   } else {
     // Local registry mode — deploy AGT relay + registry in-cluster.
     const manifestName = "agentmesh-agt.yaml";
-    const agentmeshManifest = path.join(repoRoot, "deploy", manifestName);
-    if (existsSync(agentmeshManifest)) {
+    // Resolve from a repo checkout OR the bundled package copy (so
+    // `kars up --release` works without a source tree).
+    const agentmeshManifest = resolveBundledAsset(`deploy/${manifestName}`);
+    if (agentmeshManifest) {
       // Ensure the agentmesh namespace exists
       await execa("kubectl", ["create", "namespace", "agentmesh"], { stdio: "pipe" }).catch(() => {});
 
@@ -102,7 +107,7 @@ export async function deployAgentMesh(
         "karsacr.azurecr.io",
         acrLoginServer,
       );
-      const tmpManifest = path.join(repoRoot, `.tmp-${manifestName}`);
+      const tmpManifest = path.join(os.tmpdir(), `kars-${manifestName}-${Date.now()}`);
       try {
         writeFileSync(tmpManifest, patchedManifest);
         await execa("kubectl", ["apply", "-f", tmpManifest], { stdio: "pipe" });
@@ -165,8 +170,8 @@ export async function deployAgentMesh(
     // Deploy AGIC Ingress if --expose-registry is set
     if (options.exposeRegistry) {
       stepper.step("Deploying AgentMesh Ingress (public endpoints)...");
-      const ingressManifest = path.join(repoRoot, "deploy", "agentmesh-ingress.yaml");
-      if (existsSync(ingressManifest)) {
+      const ingressManifest = resolveBundledAsset("deploy/agentmesh-ingress.yaml");
+      if (ingressManifest) {
         const ingressYaml = readFileSync(ingressManifest, "utf-8");
         const domain = `${baseName}.kars.dev`;
         const { stdout: currentSubId } = await execa("az", [
@@ -177,7 +182,7 @@ export async function deployAgentMesh(
           .replace(/SUBSCRIPTION_ID/g, currentSubId.trim())
           .replace(/RESOURCE_GROUP/g, rg)
           .replace(/karsacr\.azurecr\.io/g, acrLoginServer);
-        const tmpIngress = path.join(repoRoot, ".tmp-agentmesh-ingress.yaml");
+        const tmpIngress = path.join(os.tmpdir(), `kars-agentmesh-ingress-${Date.now()}.yaml`);
         try {
           writeFileSync(tmpIngress, patchedIngress);
           await execa("kubectl", ["apply", "-f", tmpIngress], { stdio: "pipe" });

--- a/cli/src/lib/repo-assets.test.ts
+++ b/cli/src/lib/repo-assets.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, mkdtempSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findRepoRootOrNull,
+  resolveBundledAsset,
+  requireBundledAsset,
+} from "./repo-assets.js";
+
+// Repo root, derived from this test file's location (cli/src/lib/ → ../../..).
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..", "..");
+
+/**
+ * The deploy/build assets each `--release` use case needs to run with NO
+ * repo checkout (npm-installed CLI). These MUST be:
+ *   1. present at the repo root (so the build can bundle them), and
+ *   2. listed in cli/scripts/bundle-deploy-assets.mjs (so they ARE bundled).
+ *
+ * This list is the regression guard for the class of bug where a `--release`
+ * path silently assumes a repo checkout — exactly what broke
+ * `kars dev --release --target local-k8s` out of the box.
+ */
+const REQUIRED_RELEASE_ASSETS = [
+  // local-k8s (kars dev --release --target local-k8s)
+  "deploy/helm/kars",
+  "deploy/helm/kars/values-local-dev.yaml",
+  "deploy/agentmesh-agt.yaml",
+  // aks (kars up --release)
+  "deploy/bicep/main.bicep",
+  // shared / observability (best-effort)
+  "deploy/agentmesh-ingress.yaml",
+  "deploy/monitoring",
+  "tools/headlamp-plugin/dist/main.js",
+  "tools/headlamp-plugin/package.json",
+];
+
+describe("findRepoRootOrNull", () => {
+  it("finds the kars repo root from inside the checkout", () => {
+    const root = findRepoRootOrNull(here);
+    expect(root).toBe(repoRoot);
+  });
+
+  it("returns null when run from outside any repo (e.g. an npm global dir)", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "kars-norepo-"));
+    expect(findRepoRootOrNull(tmp)).toBeNull();
+  });
+});
+
+describe("resolveBundledAsset", () => {
+  it("resolves every required release asset from a repo checkout", () => {
+    for (const rel of REQUIRED_RELEASE_ASSETS) {
+      const resolved = resolveBundledAsset(rel, here);
+      expect(resolved, `asset '${rel}' must resolve`).not.toBeNull();
+      expect(existsSync(resolved!), `'${rel}' resolved to a real path`).toBe(true);
+    }
+  });
+
+  it("returns null for an asset that exists nowhere", () => {
+    expect(resolveBundledAsset("deploy/does-not-exist.yaml", here)).toBeNull();
+  });
+});
+
+describe("requireBundledAsset", () => {
+  it("throws an actionable error for a missing asset", () => {
+    expect(() => requireBundledAsset("deploy/nope.yaml", here)).toThrow(
+      /Could not locate 'deploy\/nope\.yaml'/,
+    );
+  });
+});
+
+/**
+ * Guards the bundle manifest itself: every required release asset must be
+ * declared in the build's bundling script, or a future asset addition would
+ * silently not ship and break `--release` OOTB again.
+ */
+describe("bundle-deploy-assets manifest", () => {
+  it("declares (a prefix of) every required release asset", async () => {
+    const { readFileSync } = await import("node:fs");
+    const script = readFileSync(
+      path.join(repoRoot, "cli", "scripts", "bundle-deploy-assets.mjs"),
+      "utf8",
+    );
+    // Extract the quoted asset paths the script declares in its `assets` list.
+    const declared = [...script.matchAll(/"((?:deploy|tools)\/[^"]+)"/g)].map((m) => m[1]);
+    expect(declared.length).toBeGreaterThan(0);
+    for (const rel of REQUIRED_RELEASE_ASSETS) {
+      // Covered if the asset is declared directly, or lives under a declared
+      // directory entry (the script copies directories recursively).
+      const covered = declared.some((d) => rel === d || rel.startsWith(d + "/"));
+      expect(covered, `bundle script must cover '${rel}'`).toBe(true);
+    }
+  });
+});

--- a/cli/src/lib/repo-assets.ts
+++ b/cli/src/lib/repo-assets.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * repo-assets — resolve repo-relative deploy/build assets so the CLI works
+ * BOTH from a kars repo checkout AND from an npm-installed package.
+ *
+ * `kars dev --release` / `kars up --release` are the no-compile, no-checkout
+ * paths: a user runs `npm i -g @kars-runtime/cli` and expects everything to
+ * work out of the box. But the K8s flows need static assets that live in the
+ * repo — the Helm chart (`deploy/helm/kars`), the AgentMesh manifest
+ * (`deploy/agentmesh-agt.yaml`), monitoring manifests, etc. Those are
+ * **bundled into the published package** (copied into `dist/deploy/…` at build
+ * time; see cli/package.json `build`), so this resolver checks, in order:
+ *
+ *   1. A kars repo checkout, by walking up from `process.cwd()`.
+ *   2. The assets bundled alongside the compiled CLI (`<dist>/<relPath>`).
+ *
+ * Returns an absolute path, or null when the asset is found in neither place.
+ */
+
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Marker files that identify a kars repo checkout root. */
+const REPO_MARKERS = ["Cargo.toml", "deploy/helm/kars"];
+
+/** Directory containing the compiled CLI bundle (`dist/`). */
+function bundleRoot(): string {
+  // This module compiles to `dist/lib/repo-assets.js`, so `dist/` is one up.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..");
+}
+
+/** Find the nearest kars repo checkout root above `start`, or null. */
+export function findRepoRootOrNull(start: string = process.cwd()): string | null {
+  let dir = path.resolve(start);
+  for (let i = 0; i < 24; i++) {
+    if (REPO_MARKERS.some((m) => existsSync(path.join(dir, m)))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Resolve a repo-relative asset path (e.g. "deploy/helm/kars",
+ * "deploy/agentmesh-agt.yaml") to an absolute path that exists, checking a
+ * repo checkout first, then the bundled copy shipped with the package.
+ * Returns null if found in neither location.
+ */
+export function resolveBundledAsset(relPath: string, cwd: string = process.cwd()): string | null {
+  const repoRoot = findRepoRootOrNull(cwd);
+  if (repoRoot) {
+    const inRepo = path.join(repoRoot, relPath);
+    if (existsSync(inRepo)) return inRepo;
+  }
+  const bundled = path.join(bundleRoot(), relPath);
+  if (existsSync(bundled)) return bundled;
+  return null;
+}
+
+/**
+ * Like {@link resolveBundledAsset} but throws a clear, actionable error when
+ * the asset cannot be found in a repo checkout or the bundled package.
+ */
+export function requireBundledAsset(relPath: string, cwd: string = process.cwd()): string {
+  const resolved = resolveBundledAsset(relPath, cwd);
+  if (resolved) return resolved;
+  throw new Error(
+    `Could not locate '${relPath}'.\n` +
+      `  It should be bundled with the kars CLI (npm package) or present in a kars\n` +
+      `  repo checkout. Try reinstalling the CLI:\n` +
+      `      npm i -g @kars-runtime/cli\n` +
+      `  or run the command from inside a kars repo checkout.`,
+  );
+}

--- a/docs/internal/security-audits/2026-06-24-release-ootb-bundle-assets.md
+++ b/docs/internal/security-audits/2026-06-24-release-ootb-bundle-assets.md
@@ -1,0 +1,85 @@
+# Security Audit — `--release` works out-of-the-box (bundle deploy assets; no repo checkout)
+
+PR: Azure/kars (branch `fix/release-ootb-bundle-assets`)
+
+## Scope
+
+Capability-path changes in `cli/src/commands/dev/local-k8s.ts`,
+`cli/src/commands/up.ts`, and `cli/src/commands/up/agentmesh_deploy.ts`, plus a
+new helper `cli/src/lib/repo-assets.ts`, a build-time bundler
+`cli/scripts/bundle-deploy-assets.mjs`, and tests.
+
+`kars dev --release --target local-k8s` (and `kars up --release`) **failed out
+of the box** when the CLI was installed from npm with no repo checkout: the K8s
+flows resolved the Helm chart, AgentMesh manifest, bicep templates, monitoring
+manifests, and the Headlamp plugin from a repo-relative `repoRoot`, and a hard
+"must be run from inside the kars repo checkout" guard fired even in `--release`
+mode (which pulls published images and needs no source).
+
+Fix — make all three `--release` use cases (docker / local-k8s / aks) run with
+**no source tree**:
+
+1. **Bundle** the static deploy assets into the published package: the build
+   copies `deploy/helm/kars`, `deploy/bicep`, `deploy/agentmesh-agt.yaml`,
+   `deploy/agentmesh-ingress.yaml`, `deploy/monitoring`, and the prebuilt
+   `tools/headlamp-plugin/dist/main.js` (+ its `package.json`) into `dist/`.
+2. **Resolve** those assets via `resolveBundledAsset()` / `requireBundledAsset()`
+   — repo checkout first, then the bundled copy — instead of `repoRoot` joins.
+3. **Gate** the repo-only build guard and the AGT-toolkit/Python-wheel bootstrap
+   on `!releaseMode` in local-k8s (release pulls published images).
+4. **Relocate temp writes** (`up.ts` role bicep, `agentmesh_deploy.ts`
+   manifest/ingress) from `repoRoot/.tmp-*` to `os.tmpdir()` so they don't
+   require a writable source tree (an npm global dir is typically read-only).
+5. Make the local-k8s observability extras (Headlamp / plugin / Prometheus)
+   **best-effort** so they can never block an otherwise-running agent.
+
+docker `--release` was already OOTB-clean (build is `!releaseMode`-gated; the
+seccomp profile loads from the bundled `dist/profiles`; the plugin is baked into
+the published sandbox image) — verified, no change needed.
+
+## Threat model
+
+### T1: Do bundled deploy assets add a trust/tamper surface? (NO)
+The bundled chart/bicep/manifests/plugin are the project's **own** templates,
+copied verbatim from the repo at build time and versioned with the CLI. They are
+declarative K8s/bicep YAML + a prebuilt Headlamp UI plugin — no secrets, no
+credentials. The published npm package is provenance-attested (SLSA) and
+`npm audit`-clean, so the bundle's integrity rides on the same signing as the
+CLI itself. AKS/kind still pull container images from the user's own ACR / public
+GHCR exactly as before.
+
+### T2: Path resolution — any traversal risk? (NO)
+`resolveBundledAsset(relPath)` is only ever called with **fixed string
+constants** ("deploy/helm/kars", etc.) — never user input. It checks a repo root
+(walked up via marker files) then a path under the compiled bundle dir; both are
+derived from the process, not from attacker-controlled data.
+
+### T3: Temp-file relocation to os.tmpdir() — safe? (IMPROVEMENT)
+Writing patched manifests/role-bicep to `os.tmpdir()` with a unique
+`Date.now()`-suffixed name (then unlinking) avoids writing into the install dir
+and matches the existing pattern used elsewhere. Contents are the same
+non-secret, ACR-substituted templates as before.
+
+### T4: Best-effort observability — does skipping reduce security? (NO)
+Headlamp/Grafana are operator-convenience dashboards, not a security control.
+Wrapping their install in try/catch only prevents a non-security add-on from
+aborting a correctly-sandboxed, NetworkPolicy-isolated agent. The controller,
+router, mesh, seccomp, and NetworkPolicy posture are unchanged.
+
+## What this audit does NOT cover
+- Image contents (covered by the build/sign audits).
+- The full live AKS `kars up --release` deploy (to be smoke-tested on a real
+  subscription — mechanically identical to the existing source-ACR import path).
+
+## Verdict
+
+Accept. The change ships the project's own deploy templates inside the
+provenance-attested package and resolves them deterministically, removes a
+hard repo-checkout requirement from the no-build `--release` paths, and moves
+temp writes out of the install tree — with no new attacker-reachable input and
+no change to the runtime security posture. Verified by 810 tests (incl. new
+resolver + bundle-completeness regression tests), an out-of-repo resolver check,
+typecheck, lint, and a tarball-contents check.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem (reported)
```
$ kars dev --release --target local-k8s     # from ~, npm-installed, no repo
  local-k8s dev failed: `kars dev --target local-k8s` must be run from inside
  the kars repo checkout — the dev flow rebuilds … from local source.
```
The no-build `--release` path still demanded a repo checkout. Same class of bug as `kars up --build`. Audited **all three** use cases.

## Fix — docker / local-k8s / aks all run with NO source tree
- **Bundle** static deploy assets into the package at build time (`scripts/bundle-deploy-assets.mjs` → `dist/deploy/*`, `dist/tools/headlamp-plugin/*`): Helm chart + `values-local-dev.yaml`, `deploy/bicep`, agentmesh manifest + ingress, monitoring, prebuilt Headlamp plugin.
- **Resolver** `lib/repo-assets.ts` (`resolveBundledAsset`/`requireBundledAsset`): repo checkout first, then bundled copy.
- **Gate** the repo-only build guard + AGT toolkit/wheel bootstrap on `!releaseMode` in local-k8s.
- **Relocate temp writes** (role-bicep, agentmesh manifest/ingress) to `os.tmpdir()` (npm global dir is read-only).
- **Best-effort** local-k8s observability (Headlamp/plugin/Prometheus) so it never blocks a running agent.
- **docker `--release`** was already OOTB-clean (build `!releaseMode`-gated; seccomp from bundled `dist/profiles`; plugin baked into the image) — verified.

## Why tests didn't catch it → now they do
New `lib/repo-assets.test.ts`: resolver behaviour + a **bundle-completeness regression guard** asserting every required release asset is declared in the bundler and present. 

## Verify
- 810 tests pass; typecheck + lint clean; LOC gate green.
- Out-of-repo resolver check (from `/tmp`): all 6 assets resolve to bundled `dist/` paths; `findRepoRootOrNull` → null.
- `npm pack`: 65 bundled deploy/plugin files ship in the tarball.
- Plugin publishing tracked separately in #427.
- Security-audit doc added.
- ⚠️ Live AKS `kars up --release` deploy to be smoke-tested on a real subscription.