### PR TITLE
fix(dev): load multi-arch AgentMesh images into kind via loadImageIntoKind

### DIFF
--- a/cli/src/commands/dev/local-k8s.ts
+++ b/cli/src/commands/dev/local-k8s.ts
@@ -451,7 +451,11 @@ async function loadImageIntoKind(
     await execa(
       kind,
       ["load", "docker-image", image, "--name", clusterName],
-      { stdio: "inherit", env },
+      // Quiet (pipe, not inherit): on the containerd image store this prints
+      // a scary "ctr: content digest … not found" ERROR for multi-arch images
+      // even though the save|ctr-import fallback below recovers cleanly.
+      // Swallow it; the verify step decides success.
+      { stdio: "pipe", env },
     );
   } catch {
     // fall through to the ctr import path
@@ -1110,12 +1114,17 @@ async function deployAgentMesh(
   }
 
   // ── Load images into kind ─────────────────────────────────────────
+  // Route through loadImageIntoKind (NOT a bare `kind load docker-image`):
+  // released relay/registry images are multi-arch, and `kind load
+  // docker-image` runs `ctr import --all-platforms`, which fails on the
+  // containerd image store because only the host-platform blobs are present
+  // locally ("content digest … not found"). loadImageIntoKind falls back to
+  // `<runtime> save | ctr import -` (host platform only), which loads the
+  // multi-arch-origin image cleanly — same path the controller/router/sandbox
+  // images already use.
   for (const component of ["relay", "registry"] as const) {
     const tag = localTag(component);
-    await execa(tools.kind, ["load", "docker-image", tag, "--name", clusterName], {
-      env: tools.env,
-      stdio: "inherit",
-    });
+    await loadImageIntoKind(tools.kind, tools.runtime, clusterName, tag, tools.env);
   }
 
   // ── Rewrite manifest: swap ACR image refs → local tags, set Never ──

--- a/docs/internal/security-audits/2026-06-24-kind-mesh-multiarch-load.md
+++ b/docs/internal/security-audits/2026-06-24-kind-mesh-multiarch-load.md
@@ -1,0 +1,67 @@
+# Security Audit — fix multi-arch AgentMesh image load into kind (`kars dev --release --target local-k8s`)
+
+PR: Azure/kars (branch `fix/kind-mesh-multiarch-load`)
+
+## Scope
+
+Capability-path change in `cli/src/commands/dev/local-k8s.ts` (the kind/local-k8s
+dev flow only).
+
+`kars dev --release --target local-k8s` failed at step 7/14 ("Deploying
+agentmesh-agt") with:
+
+```
+ERROR: failed to load image: ctr ... images import --all-platforms ... content
+digest <...> not found
+local-k8s dev failed: kind load docker-image 'agentmesh-relay-agt:dev' --name kars-dev
+```
+
+Root cause: the AgentMesh relay/registry images are **multi-arch**, and
+`deployAgentMesh()` loaded them with a **bare `kind load docker-image`**, which
+runs `ctr import --all-platforms` against the containerd image store — that fails
+because only the host-platform blobs are present locally. The controller / router
+/ sandbox images already loaded fine because they go through `loadImageIntoKind()`,
+which falls back to `<runtime> save | ctr import -` (host platform only). The mesh
+load was the last code path still using the bare loader.
+
+Fix:
+1. Route the relay/registry load through the existing `loadImageIntoKind()` helper
+   (same robust path the other images use).
+2. Quiet the primary `kind load docker-image` attempt inside `loadImageIntoKind`
+   (`stdio: "pipe"`), since it prints a scary-but-recovered "content digest not
+   found" ERROR for multi-arch images before the fallback succeeds.
+
+Only `--target local-k8s` (kind) is affected: `kars dev --release` (docker) runs
+the pulled image directly and `kars up` (AKS) pulls multi-arch images from ACR —
+neither uses `kind load`.
+
+## Threat model
+
+### T1: Does the alternate load path change WHAT runs? (NO)
+`loadImageIntoKind()` loads the **same** local image tag into the kind node's
+containerd, just via `docker save | ctr import -` instead of `kind load
+docker-image` when the latter can't satisfy `--all-platforms`. The image bytes,
+digests, and the host-arch variant selected are identical; only the transport
+into the node changes. The image was already pulled from the signed public GHCR
+release in the prior step.
+
+### T2: Does quieting the primary attempt hide a real failure? (NO)
+`loadImageIntoKind()` always **verifies** the image is present on the node after
+the primary attempt and runs the `ctr import` fallback if not; success is decided
+by that verification, not by the (now-piped) output of the best-effort first try.
+A genuine load failure still surfaces (the fallback throws).
+
+### T3: Blast radius (LOCAL DEV ONLY)
+The change is confined to the kind-based local dev loop. No production / AKS path,
+no controller, router, mesh-crypto, NetworkPolicy, or seccomp behaviour changes.
+
+## Verdict
+
+Accept. The fix makes the kind mesh-image load use the same verified, fallback-
+backed loader as every other image, with no change to image contents or any
+runtime security control. Confined to `kars dev --target local-k8s`. Verified by
+build + dev tests + lint; the failing real-world `kars dev --release --target
+local-k8s` step is the reproduction.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem
After the OOTB fix (#428) got `kars dev --release --target local-k8s` running, your colleague hit the **next** wall at step 7/14:
```
ERROR: failed to load image: ctr ... images import --all-platforms ... content digest <...> not found
local-k8s dev failed: kind load docker-image 'agentmesh-relay-agt:dev' --name kars-dev
```
The relay/registry images are **multi-arch**; a bare `kind load docker-image` runs `ctr import --all-platforms` against the containerd store and fails (only host-platform blobs present). The controller/router/sandbox loads survived because they use the robust `loadImageIntoKind` (which falls back to `docker save | ctr import -`). The **mesh** load was the last bare one.

## Fix
- Route the relay/registry load through `loadImageIntoKind`.
- Quiet the recovered-but-scary primary `kind load` ERROR (`stdio: pipe`).

## Scope
Only `--target local-k8s` (kind). **docker `--release`** runs the pulled image directly; **`kars up`** (AKS) pulls multi-arch from ACR — neither uses `kind load`. (Confirmed: 0 `kind load` refs in up.ts/images.ts.)

## Verify
- build + dev tests + lint clean.
- This was the live reproduction on a fresh npm install.