### PR TITLE
chore(release): bump CLI to 0.1.7 (kind mesh image load fix)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Ships #430 — `kars dev --release --target local-k8s` loads the multi-arch AgentMesh images into kind correctly.