### PR TITLE
fix(release): kars sre install + kars headlamp --install work out-of-the-box

### DIFF
--- a/cli/src/commands/headlamp.ts
+++ b/cli/src/commands/headlamp.ts
@@ -62,8 +62,10 @@ export function headlampCommand(): Command {
         if (options.install) {
           const { installHeadlamp: stackInstallHeadlamp, installKarsPlugin, installPrometheus } =
             await import("./up/headlamp_stack.js");
-          const { findRepoRoot } = await import("./up/helpers.js");
-          const repoRoot = findRepoRoot(process.cwd());
+          const { findRepoRootOrNull } = await import("../lib/repo-assets.js");
+          // repoRoot is OPTIONAL now — the stack resolves the bundled plugin +
+          // monitoring when not in a checkout (npm-installed `kars`).
+          const repoRoot = findRepoRootOrNull(process.cwd()) ?? undefined;
           console.log(chalk.bold(`  Installing Headlamp + kars plugin + Prometheus into ${chalk.cyan(ctx!)}…\n`));
           await stackInstallHeadlamp({ context: ctx!, repoRoot });
           console.log();

--- a/cli/src/commands/sre.ts
+++ b/cli/src/commands/sre.ts
@@ -4,45 +4,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { execa } from "execa";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
+import { requireBundledAsset } from "../lib/repo-assets.js";
 
 /**
- * Resolve the kars repo root.
- *
- * Strategy mirrors `cli/src/commands/up.ts`: first try the
- * three-levels-up-from-the-installed-CLI-file path (works for
- * `npm link` installs), then fall back to walking up from CWD
- * looking for `deploy/helm`.
+ * `kars sre` — autonomous incident triage controller.
  */
-function resolveRepoRoot(): string {
-  // Strategy 1: from the file's own location (works for npm link
-  // since the link points back into the repo's cli/dist/ tree)
-  try {
-    const thisFile = fileURLToPath(import.meta.url);
-    const cliDir = path.dirname(path.dirname(thisFile)); // .../cli/dist
-    const candidate = path.resolve(cliDir, "..", "..");  // .../<repo>
-    if (fs.existsSync(path.join(candidate, "deploy", "helm", "kars"))) {
-      return candidate;
-    }
-  } catch {
-    // import.meta.url may not be a file URL in some test contexts
-  }
-  // Strategy 2: walk up from CWD looking for deploy/helm
-  let cur = process.cwd();
-  for (let i = 0; i < 8; i++) {
-    if (fs.existsSync(path.join(cur, "deploy", "helm", "kars"))) return cur;
-    const parent = path.dirname(cur);
-    if (parent === cur) break;
-    cur = parent;
-  }
-  throw new Error(
-    "Could not resolve the kars repo root (looked for deploy/helm/kars). " +
-    "Run `kars sre install` from inside an kars checkout, or set the working " +
-    "directory to the repo root first.",
-  );
-}
 
 /**
  * `kars sre` — manage the built-in kars-sre agent.
@@ -93,7 +59,7 @@ export function sreCommand(): Command {
     }) => {
       let chartPath: string;
       try {
-        chartPath = path.join(resolveRepoRoot(), "deploy", "helm", "kars");
+        chartPath = requireBundledAsset("deploy/helm/kars");
       } catch (err: any) {
         console.error(chalk.red(`✗ ${err.message}`));
         process.exit(1);
@@ -291,7 +257,7 @@ export function sreCommand(): Command {
     .action(async (options: { release: string; namespace: string; context?: string }) => {
       let chartPath: string;
       try {
-        chartPath = path.join(resolveRepoRoot(), "deploy", "helm", "kars");
+        chartPath = requireBundledAsset("deploy/helm/kars");
       } catch (err: any) {
         console.error(chalk.red(`✗ ${err.message}`));
         process.exit(1);

--- a/cli/src/commands/up/headlamp_stack.ts
+++ b/cli/src/commands/up/headlamp_stack.ts
@@ -27,6 +27,7 @@ import chalk from "chalk";
 import * as path from "node:path";
 import { existsSync, mkdtempSync, rmSync, readFileSync, writeFileSync, statSync, readdirSync } from "node:fs";
 import * as os from "node:os";
+import { resolveBundledAsset, findRepoRootOrNull } from "../../lib/repo-assets.js";
 
 /** Pin the same chart version as local-k8s so the kars plugin's
  * pluginLib API stays compatible. Bumping requires re-testing the
@@ -37,8 +38,13 @@ const KPS_CHART_VERSION = "85.3.3";
 export interface HeadlampStackOptions {
   /** kubectl context name. e.g. `kars-aks` or `kind-kars`. */
   context: string;
-  /** Absolute path to the repo root, used to locate the plugin source. */
-  repoRoot: string;
+  /**
+   * Optional repo root, used only to locate the Headlamp plugin SOURCE for
+   * an on-demand rebuild in a dev checkout. When omitted (npm-installed CLI),
+   * the prebuilt plugin + monitoring manifests are resolved from the bundled
+   * package instead.
+   */
+  repoRoot?: string;
 }
 
 /** Build a kubectl arg list scoped to the target context. */
@@ -103,59 +109,72 @@ export async function installHeadlamp(opts: HeadlampStackOptions): Promise<void>
  * the dashboard still works for built-in resources.
  */
 export async function installKarsPlugin(opts: HeadlampStackOptions): Promise<void> {
-  const { context, repoRoot } = opts;
-  const pluginDir = path.join(repoRoot, "tools", "headlamp-plugin");
-  const distDir = path.join(pluginDir, "dist");
-  const mainJs = path.join(distDir, "main.js");
-  const pkgJson = path.join(pluginDir, "package.json");
+  const { context } = opts;
 
-  // Always rebuild when ANY source file is newer than dist/main.js.
-  // Stale dist was the source of "no agents visible / wrong CRD group"
-  // bugs on AKS — the plugin was renamed from the pre-v0.1.0 brand to
-  // kars but the cached dist predated the rename. Walk src/ +
-  // package.json and rebuild if needed.
-  let needsBuild = !existsSync(mainJs);
-  if (!needsBuild) {
-    try {
-      const distMtime = statSync(mainJs).mtimeMs;
-      const srcDir = path.join(pluginDir, "src");
-      const candidates = [pkgJson];
-      if (existsSync(srcDir)) {
-        for (const f of readdirSync(srcDir)) {
-          candidates.push(path.join(srcDir, f));
-        }
-      }
-      for (const f of candidates) {
-        if (existsSync(f) && statSync(f).mtimeMs > distMtime) {
-          needsBuild = true;
-          break;
-        }
-      }
-    } catch {
-      needsBuild = true;
+  // Prefer the prebuilt plugin bundled with the CLI (so this works with no
+  // repo checkout — npm-installed `kars`). Fall back to a repo checkout,
+  // rebuilding on demand if the source is newer than the built dist.
+  let mainJs = resolveBundledAsset("tools/headlamp-plugin/dist/main.js");
+  let pkgJson = resolveBundledAsset("tools/headlamp-plugin/package.json");
+
+  if (!mainJs || !pkgJson) {
+    const repoRoot = opts.repoRoot ?? findRepoRootOrNull(process.cwd());
+    if (!repoRoot) {
+      console.warn(chalk.yellow(
+        "    ⚠ Headlamp plugin not bundled and no repo checkout found — skipping " +
+          "(dashboard still works for built-in resources; kars CRD views won't load).",
+      ));
+      return;
     }
-  }
+    const pluginDir = path.join(repoRoot, "tools", "headlamp-plugin");
+    const distDir = path.join(pluginDir, "dist");
+    const distMain = path.join(distDir, "main.js");
+    pkgJson = path.join(pluginDir, "package.json");
 
-  if (needsBuild) {
-    const reason = !existsSync(mainJs) ? "no dist yet" : "src newer than dist";
-    console.log(chalk.dim(`    rebuilding plugin (${reason}) — npm run build in tools/headlamp-plugin…`));
-    if (!existsSync(path.join(pluginDir, "node_modules"))) {
+    // Rebuild when ANY source file is newer than dist/main.js (stale dist was
+    // the source of "no agents visible / wrong CRD group" bugs).
+    let needsBuild = !existsSync(distMain);
+    if (!needsBuild) {
       try {
-        await execa("npm", ["install", "--no-audit", "--no-fund"], { cwd: pluginDir, stdio: "inherit" });
+        const distMtime = statSync(distMain).mtimeMs;
+        const srcDir = path.join(pluginDir, "src");
+        const candidates = [pkgJson];
+        if (existsSync(srcDir)) {
+          for (const f of readdirSync(srcDir)) candidates.push(path.join(srcDir, f));
+        }
+        for (const f of candidates) {
+          if (existsSync(f) && statSync(f).mtimeMs > distMtime) {
+            needsBuild = true;
+            break;
+          }
+        }
+      } catch {
+        needsBuild = true;
+      }
+    }
+
+    if (needsBuild) {
+      const reason = !existsSync(distMain) ? "no dist yet" : "src newer than dist";
+      console.log(chalk.dim(`    rebuilding plugin (${reason}) — npm run build in tools/headlamp-plugin…`));
+      if (!existsSync(path.join(pluginDir, "node_modules"))) {
+        try {
+          await execa("npm", ["install", "--no-audit", "--no-fund"], { cwd: pluginDir, stdio: "inherit" });
+        } catch (err) {
+          console.warn(chalk.yellow(
+            `    ⚠ npm install failed (${(err as Error).message}); skipping plugin install. ` +
+              "Run 'cd tools/headlamp-plugin && npm install && npm run build' manually then re-run.",
+          ));
+          return;
+        }
+      }
+      try {
+        await execa("npm", ["run", "build"], { cwd: pluginDir, stdio: "inherit" });
       } catch (err) {
-        console.warn(chalk.yellow(
-          `    ⚠ npm install failed (${(err as Error).message}); skipping plugin install. ` +
-            "Run 'cd tools/headlamp-plugin && npm install && npm run build' manually then re-run.",
-        ));
+        console.warn(chalk.yellow(`    ⚠ plugin build failed (${(err as Error).message}); skipping plugin install.`));
         return;
       }
     }
-    try {
-      await execa("npm", ["run", "build"], { cwd: pluginDir, stdio: "inherit" });
-    } catch (err) {
-      console.warn(chalk.yellow(`    ⚠ plugin build failed (${(err as Error).message}); skipping plugin install.`));
-      return;
-    }
+    mainJs = distMain;
   }
 
   const mainContent = readFileSync(mainJs, "utf8");
@@ -231,7 +250,8 @@ ${indent(pkgContent, 4)}
  * sandbox router's `:8443` metrics endpoint stays unreachable.
  */
 export async function installPrometheus(opts: HeadlampStackOptions): Promise<void> {
-  const { context, repoRoot } = opts;
+  const { context } = opts;
+  void opts.repoRoot;
 
   try {
     await execa("kubectl", kctl(context, ["create", "namespace", "monitoring"]), { stdio: "pipe" });
@@ -391,7 +411,12 @@ kubeProxy:
     ));
   }
 
-  const monitoringDir = path.join(repoRoot, "deploy", "monitoring");
+  // Resolve monitoring manifests from a repo checkout OR the bundled copy.
+  const monitoringDir = resolveBundledAsset("deploy/monitoring");
+  if (!monitoringDir) {
+    console.warn(chalk.yellow("  ⚠ monitoring manifests not bundled — skipping dashboards"));
+    return;
+  }
   for (const f of [
     "podmonitor-sandbox-router.yaml",
     "agentmesh-json-exporter.yaml",

--- a/docs/internal/security-audits/2026-06-24-sre-headlamp-ootb.md
+++ b/docs/internal/security-audits/2026-06-24-sre-headlamp-ootb.md
@@ -1,0 +1,62 @@
+# Security Audit — `kars sre install` + `kars headlamp --install` work out-of-the-box
+
+PR: Azure/kars (branch `fix/sre-headlamp-ootb`)
+
+## Scope
+
+Capability-path changes in `cli/src/commands/sre.ts`, `cli/src/commands/headlamp.ts`,
+and `cli/src/commands/up/headlamp_stack.ts`.
+
+A follow-up to the `--release` OOTB work (PR #428). After
+`kars dev --release --target local-k8s` ran cleanly end-to-end from an
+npm-installed CLI, two more user-facing commands still hard-required a repo
+checkout:
+
+- `kars sre install` → "Could not resolve the kars repo root (looked for
+  deploy/helm/kars)". It resolved the kars Helm chart via a repo-root walk.
+- `kars headlamp --install` → `findRepoRoot()` threw, and the shared
+  `up/headlamp_stack.ts` (also used by the AKS observability path) located the
+  Headlamp plugin + monitoring manifests under `repoRoot`.
+
+Fix — resolve those assets via the bundled-asset resolver
+(`lib/repo-assets.ts`, added in #428):
+
+- `sre.ts`: the chart is now `requireBundledAsset("deploy/helm/kars")`; the
+  repo-only `resolveRepoRoot()` is deleted.
+- `headlamp_stack.ts`: `installKarsPlugin` prefers the prebuilt **bundled**
+  plugin and only falls back to a repo source build; `installPrometheus`
+  resolves `deploy/monitoring` via the resolver. `repoRoot` is now optional.
+- `headlamp.ts`: `repoRoot` is resolved best-effort (`findRepoRootOrNull`) and
+  passed through as optional.
+
+All of these assets are already bundled into the package by
+`scripts/bundle-deploy-assets.mjs`.
+
+## Threat model
+
+### T1: New asset source / trust surface? (NO)
+The Helm chart, monitoring manifests, and Headlamp plugin are the project's own
+templates, already bundled (and audited) in #428 — this PR only routes two more
+commands through the same resolver. No new registry, credential, or input.
+
+### T2: Path resolution — traversal? (NO)
+`requireBundledAsset` / `resolveBundledAsset` are called with fixed string
+constants ("deploy/helm/kars", "deploy/monitoring",
+"tools/headlamp-plugin/dist/main.js") — never user input.
+
+### T3: Behaviour change to `kars sre install` / observability? (NO, EQUIVALENT)
+Same chart / same manifests applied to the same cluster; only the **source path**
+of the static files changes (repo → bundled package). The SRE controller, RBAC,
+and the Headlamp/Grafana stack are byte-identical to before. The plugin install
+remains best-effort (skips with a warning if unavailable), so it can never block.
+
+## Verdict
+
+Accept. Two more user-facing commands now run from an npm install with no repo
+checkout, resolving the same bundled, provenance-attested assets through the
+existing resolver. No new attacker-reachable input, no runtime security-control
+change. Verified by 810 tests, typecheck, lint, and a build that re-bundles the
+assets.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem
After `kars dev --release --target local-k8s` ran fully OOTB (#428/#430), the colleague's next command failed the same way:
```
$ kars sre install
✗ Could not resolve the kars repo root (looked for deploy/helm/kars). Run from inside an kars checkout…
```
Same class of bug. Audited the remaining user-facing commands and found **two**: `kars sre install` and `kars headlamp --install` (the latter shares `up/headlamp_stack.ts` with the AKS observability path).

## Fix — route both through the bundled-asset resolver (#428's `lib/repo-assets.ts`)
- **sre.ts**: chart → `requireBundledAsset('deploy/helm/kars')`; delete repo-only `resolveRepoRoot()`.
- **headlamp_stack.ts**: `installKarsPlugin` prefers the **bundled prebuilt** plugin (falls back to repo source build); `installPrometheus` resolves `deploy/monitoring` via the resolver; `repoRoot` now optional.
- **headlamp.ts**: `repoRoot` resolved best-effort, passed as optional.

(`kars push` / `kars dev --build` legitimately still need a checkout — they compile from source — so left as-is.)

## Verify
- 810 tests pass; typecheck + lint clean.
- Assets already bundled (#428); the resolver finds `deploy/helm/kars` + `deploy/monitoring` + the plugin from a non-repo dir (verified earlier).
- Security-audit doc added.