### PR TITLE
fix(release): kars up --upgrade works out-of-the-box

### DIFF
--- a/cli/src/commands/up/fast_upgrade.ts
+++ b/cli/src/commands/up/fast_upgrade.ts
@@ -6,12 +6,11 @@
 // cached context. Caller invokes when `options.upgrade` is set and
 // returns immediately afterwards.
 
-import * as path from "node:path";
-import * as fs from "node:fs";
 import chalk from "chalk";
 import ora from "ora";
 import { execa } from "execa";
 import { loadContext } from "../../config.js";
+import { requireBundledAsset } from "../../lib/repo-assets.js";
 
 export interface UpOptionsForUpgrade {
   upgrade?: boolean;
@@ -36,26 +35,9 @@ export async function runFastUpgrade(options: UpOptionsForUpgrade): Promise<void
         await execa("az", ["aks", "get-credentials", "--name", ctx.aksCluster, "--resource-group", ctx.resourceGroup, "--overwrite-existing"], { stdio: "pipe" });
         spin.succeed("AKS connected");
 
-        // Find Helm chart — try cwd, then walk up, then try relative to CLI source
-        let repoRoot = process.cwd();
-        for (let i = 0; i < 5; i++) {
-          if (fs.existsSync(path.join(repoRoot, "deploy", "helm"))) break;
-          repoRoot = path.dirname(repoRoot);
-        }
-        if (!fs.existsSync(path.join(repoRoot, "deploy", "helm"))) {
-          // Try relative to the CLI package itself
-          const cliDir = new URL("../../..", import.meta.url).pathname;
-          repoRoot = cliDir;
-          for (let i = 0; i < 3; i++) {
-            if (fs.existsSync(path.join(repoRoot, "deploy", "helm"))) break;
-            repoRoot = path.dirname(repoRoot);
-          }
-        }
-        if (!fs.existsSync(path.join(repoRoot, "deploy", "helm"))) {
-          console.error(chalk.red("\n  Helm chart not found. Run from the kars repo directory.\n"));
-          process.exit(1);
-        }
-        const helmPath = path.join(repoRoot, "deploy", "helm", "kars");
+        // Resolve the Helm chart from a repo checkout OR the bundled package
+        // copy (so `kars up --upgrade` works with no source tree).
+        const helmPath = requireBundledAsset("deploy/helm/kars");
 
         // Build Helm args from cached context
         const openAiEndpoint = ctx.foundryEndpoint || "";

--- a/docs/internal/security-audits/2026-06-24-fast-upgrade-ootb.md
+++ b/docs/internal/security-audits/2026-06-24-fast-upgrade-ootb.md
@@ -1,0 +1,37 @@
+# Security Audit — `kars up --upgrade` resolves the chart from the bundled package
+
+PR: Azure/kars (branch `fix/fast-upgrade-ootb`)
+
+## Scope
+
+Capability-path change in `cli/src/commands/up/fast_upgrade.ts`.
+
+Final follow-up to the `--release` OOTB work (#428, #432). `kars up --upgrade`
+(fast Helm upgrade of an existing AKS deployment) located the kars Helm chart via
+a cwd/CLI-relative walk and errored "Helm chart not found. Run from the kars repo
+directory." when run from an npm-installed CLI with no checkout.
+
+Fix: resolve the chart with `requireBundledAsset("deploy/helm/kars")` (repo-or-
+bundled), removing the bespoke chart-finding walk. The chart is already bundled
+into the package by `scripts/bundle-deploy-assets.mjs`.
+
+## Threat model
+
+### T1: New asset source / input? (NO)
+Same chart already bundled + audited in #428; this only routes one more command
+through the existing resolver, called with a fixed string constant
+("deploy/helm/kars") — no user input, no new registry/credential.
+
+### T2: Behaviour change? (NO, EQUIVALENT)
+`helm upgrade` runs against the same chart with the same cached-context args; only
+the chart's source path changes (repo walk → bundled package).
+
+## Verdict
+
+Accept. `kars up --upgrade` now works from an npm install with no repo checkout,
+resolving the same bundled, provenance-attested chart through the existing
+resolver. No new attacker-reachable input, no runtime security-control change.
+Verified by typecheck + lint (0 warnings) + the OOTB resolver checks.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
Final user-facing repo-checkout dependency — `kars up --upgrade` now resolves the Helm chart from the bundled package via `requireBundledAsset('deploy/helm/kars')`. Completes the OOTB sweep (a full grep confirms no remaining user-facing `repoRoot`+deploy asset access; only `kars push` / `kars dev --build` still need a checkout, which is correct — they compile from source).