### PR TITLE
fix(aks): controller readiness + subscription-aware VM SKU selection (OOTB)

### DIFF
--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -10,6 +10,7 @@ import { Stepper, banner } from "../stepper.js";
 import { isValidAzureHost } from "./up/preflight.js";
 import { acquireImages } from "./up/images.js";
 import { requireBundledAsset } from "../lib/repo-assets.js";
+import { resolveVmSizes } from "../lib/vm-size.js";
 
 export function upCommand(): Command {
   const cmd = new Command("up");
@@ -35,6 +36,8 @@ export function upCommand(): Command {
       "enhanced"
     )
     .option("-g, --resource-group <name>", "Resource group name")
+    .option("--node-vm-size <sku>", "VM size for the sandbox (user) node pool. Default: auto-pick a size available to your subscription (D4s/D4as family).")
+    .option("--system-vm-size <sku>", "VM size for the system node pool. Default: auto-pick a size available to your subscription (D2as/D2s family).")
     // ── Infrastructure ────────────────────────────────────────────────
     .option("--skip-infra", "Skip infrastructure provisioning (reuse existing cluster)", false)
     .option("--force-infra", "Force Bicep deployment even if AKS cluster exists", false)
@@ -327,9 +330,24 @@ Auto-resume:
             stepper.detail("info", `Resources: AKS + ACR + Key Vault + Azure OpenAI + Monitor`);
           }
           stepper.detail("info", `This takes 5–10 minutes. Deploying now...`);
+
+          // Resolve VM sizes that are actually available to this subscription in
+          // this region (subscriptions commonly gate specific SKUs). Auto-picks a
+          // working size or honours --node-vm-size / --system-vm-size.
+          const vmSizes = await resolveVmSizes(
+            options.region,
+            options.nodeVmSize,
+            options.systemVmSize,
+          );
+          if (vmSizes.checked) {
+            stepper.detail("info", `Node SKUs: system=${vmSizes.system}, sandbox=${vmSizes.node}`);
+          }
+
           const bicepParams = [
             `location=${options.region}`,
             `baseName=${baseName}`,
+            `vmSize=${vmSizes.node}`,
+            `systemVmSize=${vmSizes.system}`,
           ];
           if (options.isolation === "confidential") {
             bicepParams.push("enableKata=true");
@@ -694,7 +712,13 @@ Auto-resume:
           "--set", `azure.keyVaultCsi.keyVaultName=${kvName}`,
           "--set", `mesh.provider=${(options.meshProvider as string | undefined) ?? "agt"}`,
           "--wait",
-          "--timeout", "5m",
+          // Cold-cluster first install: the controller + inference-router pull
+          // their (Rust) images with pullPolicy=Always and the controller
+          // fetches the Sigstore TUF trust root over the network at startup, so
+          // 2 replicas can take several minutes to all become Ready on fresh
+          // small system nodes. 10m avoids a spurious "context deadline
+          // exceeded" while k8s is still legitimately rolling out.
+          "--timeout", "10m",
           // Take ownership of fields previously written by `kubectl apply`
           // or `kubectl patch` (e.g. CRDs / ClusterRoles touched out-of-band
           // during prior debugging). Without this, Helm's server-side apply

--- a/cli/src/commands/up/preflight.ts
+++ b/cli/src/commands/up/preflight.ts
@@ -26,6 +26,7 @@ import { existsSync } from "fs";
 import { banner, checkLine } from "../../stepper.js";
 import { loadContext } from "../../config.js";
 import { runPreflightChecks } from "../../preflight.js";
+import { resolveVmSizes } from "../../lib/vm-size.js";
 
 export function isValidAzureHost(url: string, expectedSuffix: string): boolean {
   try {
@@ -349,47 +350,38 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
     console.log();
     console.log(chalk.dim(`  Checking VM SKU availability in ${options.region}...\n`));
 
-    // System pool is always D4s_v5. Agent pool depends on isolation level:
-    // - standard/enhanced: D4s_v5 (general purpose, works with runc)
-    // - confidential: Standard_DC4as_v5 (AMD SEV-SNP, required for Kata CC)
-    const agentSku = options.isolation === "confidential" ? "Standard_DC4as_v5" : "Standard_D4s_v5";
-    const agentLabel = options.isolation === "confidential"
-      ? `AKS Kata pool (DC4as_v5 — confidential compute)`
-      : `AKS agent pool (D4s_v5)`;
-
-    const skuChecks = [
-      { sku: "Standard_D4s_v5", label: "AKS system pool (D4s_v5)" },
-      { sku: agentSku, label: agentLabel },
-    ];
-    const checkOne = async (check: { sku: string; label: string }): Promise<{ ok: boolean; line: string; available: boolean }> => {
-      try {
-        const { stdout: skuJson } = await execa("az", [
-          "vm", "list-skus",
-          "--location", options.region,
-          "--size", check.sku,
-          "--query", "[0].restrictions",
-          "--output", "json",
-        ], { stdio: "pipe", timeout: 10000 });
-        const restrictions = JSON.parse(skuJson || "[]");
-        const blocked = restrictions.some((r: { type: string }) => r.type === "Location");
-        return blocked
-          ? { ok: false, available: false, line: `${check.label} — ${chalk.red("not available")} in ${options.region}` }
-          : { ok: true, available: true, line: `${check.label} — available` };
-      } catch {
-        // Network/CLI failure is non-fatal — surface as "could not verify" but don't fail preflight
-        return { ok: true, available: true, line: `${check.label} — ${chalk.yellow("could not verify")} (continuing)` };
-      }
-    };
-    const results = await Promise.all(skuChecks.map(checkOne));
-    let skuOk = true;
-    for (const r of results) {
-      checkLine(r.ok, r.line);
-      if (!r.available) skuOk = false;
-    }
-    if (!skuOk) {
-      console.log(chalk.yellow(`\n  Some VM SKUs are not available in ${options.region}.`));
-      console.log(chalk.yellow(`  Try a different region: ${chalk.cyan("kars up --region westus3")}\n`));
+    // Resolve the SKUs that the deploy will actually use — auto-picked from
+    // what this subscription allows in the region (or --node-vm-size /
+    // --system-vm-size overrides). This is the same resolution used by the
+    // Bicep deploy, so preflight reflects reality instead of a hardcoded guess.
+    let vmSizes;
+    try {
+      vmSizes = await resolveVmSizes(
+        options.region,
+        options.nodeVmSize as string | undefined,
+        options.systemVmSize as string | undefined,
+      );
+    } catch (err) {
+      checkLine(false, `VM SKU — ${(err as Error).message}`);
+      console.log(chalk.yellow(`\n  Try a different region: ${chalk.cyan("kars up --region westus3")}\n`));
       process.exit(1);
+    }
+
+    // For confidential isolation the sandbox pool is pinned to a CC SKU.
+    const confidential = options.isolation === "confidential";
+    const agentSku = confidential ? "Standard_DC4as_v5" : vmSizes.node;
+    const agentLabel = confidential
+      ? `AKS Kata pool (${agentSku} — confidential compute)`
+      : `AKS sandbox pool (${agentSku})`;
+
+    if (vmSizes.checked) {
+      checkLine(true, `AKS system pool (${vmSizes.system}) — available`);
+      checkLine(true, confidential ? agentLabel : `${agentLabel} — available`);
+    } else {
+      // Could not query az vm list-skus — non-fatal; the Bicep preflight will
+      // still surface a hard error if a size is truly unavailable.
+      checkLine(true, `AKS system pool (${vmSizes.system}) — ${chalk.yellow("could not verify")} (continuing)`);
+      checkLine(true, `${agentLabel} — ${chalk.yellow("could not verify")} (continuing)`);
     }
 
     // Quick check: can we create resources in this sub+region?

--- a/cli/src/lib/vm-size.test.ts
+++ b/cli/src/lib/vm-size.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "vitest";
+import {
+  usableSkuSet,
+  pickUsableVmSize,
+  SYSTEM_POOL_VM_PREFERENCES,
+  USER_POOL_VM_PREFERENCES,
+  type VmSku,
+} from "./vm-size.js";
+
+describe("usableSkuSet", () => {
+  it("includes SKUs with no restrictions", () => {
+    const skus: VmSku[] = [
+      { name: "Standard_D4s_v6" },
+      { name: "Standard_D2s_v6", restrictions: [] },
+    ];
+    const usable = usableSkuSet(skus);
+    expect(usable.has("standard_d4s_v6")).toBe(true);
+    expect(usable.has("standard_d2s_v6")).toBe(true);
+  });
+
+  it("excludes SKUs with a Location restriction", () => {
+    const skus: VmSku[] = [
+      {
+        name: "Standard_D4s_v5",
+        restrictions: [
+          {
+            type: "Location",
+            reasonCode: "NotAvailableForSubscription",
+            restrictionInfo: { locations: ["eastus2"] },
+          },
+        ],
+      },
+    ];
+    const usable = usableSkuSet(skus);
+    expect(usable.has("standard_d4s_v5")).toBe(false);
+  });
+
+  it("keeps SKUs that only have a Zone restriction", () => {
+    const skus: VmSku[] = [
+      { name: "Standard_D4s_v6", restrictions: [{ type: "Zone" }] },
+    ];
+    expect(usableSkuSet(skus).has("standard_d4s_v6")).toBe(true);
+  });
+
+  it("is case-insensitive on names", () => {
+    const usable = usableSkuSet([{ name: "STANDARD_D4S_V6" }]);
+    expect(usable.has("standard_d4s_v6")).toBe(true);
+  });
+});
+
+describe("pickUsableVmSize", () => {
+  // Models the real restricted subscription from the field report: _v5 blocked,
+  // _v6/_v4 of the same families allowed.
+  const usable = usableSkuSet([
+    { name: "Standard_D2s_v6" },
+    { name: "Standard_D2as_v4" },
+    { name: "Standard_D4s_v6" },
+    { name: "Standard_D4as_v4" },
+    {
+      name: "Standard_D2as_v5",
+      restrictions: [{ type: "Location", reasonCode: "NotAvailableForSubscription" }],
+    },
+    {
+      name: "Standard_D4s_v5",
+      restrictions: [{ type: "Location", reasonCode: "NotAvailableForSubscription" }],
+    },
+  ]);
+
+  it("picks the first available preference for the system pool", () => {
+    const sku = pickUsableVmSize({
+      usable,
+      preferences: SYSTEM_POOL_VM_PREFERENCES,
+      poolLabel: "system",
+      flagName: "--system-vm-size",
+    });
+    // D2as_v5 (blocked) and D2s_v5 (absent) are skipped → first available is D2s_v6.
+    expect(sku).toBe("Standard_D2s_v6");
+  });
+
+  it("picks the first available preference for the user pool", () => {
+    const sku = pickUsableVmSize({
+      usable,
+      preferences: USER_POOL_VM_PREFERENCES,
+      poolLabel: "sandbox",
+      flagName: "--node-vm-size",
+    });
+    expect(sku).toBe("Standard_D4s_v6");
+  });
+
+  it("honours an available explicit request", () => {
+    const sku = pickUsableVmSize({
+      usable,
+      preferences: USER_POOL_VM_PREFERENCES,
+      poolLabel: "sandbox",
+      flagName: "--node-vm-size",
+      requested: "Standard_D4as_v4",
+    });
+    expect(sku).toBe("Standard_D4as_v4");
+  });
+
+  it("rejects a restricted explicit request and lists alternatives", () => {
+    expect(() =>
+      pickUsableVmSize({
+        usable,
+        preferences: USER_POOL_VM_PREFERENCES,
+        poolLabel: "sandbox",
+        flagName: "--node-vm-size",
+        requested: "Standard_D4s_v5",
+      }),
+    ).toThrowError(/not available .* Available alternatives: .*Standard_D4s_v6/s);
+  });
+
+  it("throws when no preference is available", () => {
+    expect(() =>
+      pickUsableVmSize({
+        usable: new Set<string>(),
+        preferences: SYSTEM_POOL_VM_PREFERENCES,
+        poolLabel: "system",
+        flagName: "--system-vm-size",
+      }),
+    ).toThrowError(/None of the preferred system VM sizes/);
+  });
+
+  it("keeps the historical default first when it is available", () => {
+    const allUsable = usableSkuSet([
+      { name: "Standard_D2as_v5" },
+      { name: "Standard_D2s_v6" },
+    ]);
+    const sku = pickUsableVmSize({
+      usable: allUsable,
+      preferences: SYSTEM_POOL_VM_PREFERENCES,
+      poolLabel: "system",
+      flagName: "--system-vm-size",
+    });
+    expect(sku).toBe("Standard_D2as_v5");
+  });
+});

--- a/cli/src/lib/vm-size.ts
+++ b/cli/src/lib/vm-size.ts
@@ -1,0 +1,172 @@
+// VM-size (SKU) resolution for `kars up`.
+//
+// Azure subscriptions frequently restrict specific VM SKUs per region (trial,
+// MSDN, sponsored, and many enterprise subscriptions individually gate sizes —
+// e.g. the `_v5` D-series may be blocked while `_v4`/`_v6` of the same family are
+// allowed). A single hardcoded default therefore cannot work out-of-the-box for
+// every subscription, and the AKS system pool in particular previously pinned a
+// size the caller could not override.
+//
+// This module queries the SKUs actually available to the caller's subscription
+// in the target region and picks the first usable size from an ordered
+// preference list (keeping the historical defaults first so behaviour is
+// unchanged where they are available), or honours an explicit override.
+
+import { execa } from "execa";
+
+export interface SkuRestriction {
+  type?: string;
+  reasonCode?: string;
+  restrictionInfo?: { locations?: string[]; zones?: string[] };
+}
+
+export interface VmSku {
+  name?: string;
+  resourceType?: string;
+  restrictions?: SkuRestriction[];
+}
+
+// Ordered most-preferred → least. Historical defaults kept first so existing
+// subscriptions get identical SKUs; the rest are same-class fallbacks (2 vCPU
+// for the system pool, 4 vCPU for the sandbox/user pool).
+export const SYSTEM_POOL_VM_PREFERENCES = [
+  "Standard_D2as_v5",
+  "Standard_D2s_v5",
+  "Standard_D2as_v6",
+  "Standard_D2s_v6",
+  "Standard_D2as_v4",
+  "Standard_D2s_v4",
+  "Standard_D2as_v7",
+  "Standard_D2s_v7",
+  "Standard_D2as_v3",
+  "Standard_D2s_v3",
+];
+
+export const USER_POOL_VM_PREFERENCES = [
+  "Standard_D4s_v5",
+  "Standard_D4as_v5",
+  "Standard_D4s_v6",
+  "Standard_D4as_v6",
+  "Standard_D4s_v4",
+  "Standard_D4as_v4",
+  "Standard_D4s_v7",
+  "Standard_D4as_v7",
+  "Standard_D4s_v3",
+  "Standard_D4as_v3",
+];
+
+/**
+ * Build the set of SKU names (lower-cased) usable by the subscription in the
+ * queried region. A SKU is unusable if it carries a `Location`-type restriction
+ * (NotAvailableForSubscription in that region). Zone-only restrictions are
+ * ignored — the kars pools are not zone-pinned.
+ */
+export function usableSkuSet(skus: VmSku[]): Set<string> {
+  const usable = new Set<string>();
+  for (const s of skus) {
+    if (!s.name) continue;
+    const blockedInRegion = (s.restrictions ?? []).some(
+      (r) => (r.type ?? "").toLowerCase() === "location",
+    );
+    if (!blockedInRegion) usable.add(s.name.toLowerCase());
+  }
+  return usable;
+}
+
+/**
+ * Pick a usable VM size. If `requested` is given it must be usable, otherwise we
+ * throw with the usable subset of the preference list. With no request we return
+ * the first usable preference.
+ */
+export function pickUsableVmSize(opts: {
+  usable: Set<string>;
+  preferences: string[];
+  poolLabel: string;
+  flagName: string;
+  requested?: string;
+}): string {
+  const { usable, preferences, poolLabel, flagName, requested } = opts;
+
+  if (requested) {
+    if (usable.has(requested.toLowerCase())) return requested;
+    const alts = preferences.filter((p) => usable.has(p.toLowerCase()));
+    throw new Error(
+      `Requested ${poolLabel} VM size '${requested}' is not available to your subscription in this region.` +
+        (alts.length
+          ? ` Available alternatives: ${alts.join(", ")}.`
+          : ` Run \`az vm list-skus -l <region> --resource-type virtualMachines -o table\` to see what is available.`),
+    );
+  }
+
+  for (const p of preferences) {
+    if (usable.has(p.toLowerCase())) return p;
+  }
+
+  throw new Error(
+    `None of the preferred ${poolLabel} VM sizes are available to your subscription in this region ` +
+      `(${preferences.join(", ")}). Pass an explicit size with ${flagName}, or inspect ` +
+      `\`az vm list-skus -l <region> --resource-type virtualMachines -o table\`.`,
+  );
+}
+
+export interface ResolvedVmSizes {
+  node: string;
+  system: string;
+  /** false when the SKU list could not be queried (fell back to defaults/overrides). */
+  checked: boolean;
+}
+
+/**
+ * Resolve usable node (sandbox/user) and system pool SKUs for a region by
+ * querying `az vm list-skus`. If the query fails (no az, offline, permissions),
+ * fall back to the caller's overrides or the historical defaults rather than
+ * blocking the deploy — the bicep preflight will still surface a clear error.
+ */
+export async function resolveVmSizes(
+  region: string,
+  requestedNode?: string,
+  requestedSystem?: string,
+): Promise<ResolvedVmSizes> {
+  let skus: VmSku[];
+  try {
+    const { stdout } = await execa(
+      "az",
+      [
+        "vm",
+        "list-skus",
+        "--location",
+        region,
+        "--resource-type",
+        "virtualMachines",
+        "--output",
+        "json",
+      ],
+      { stdio: "pipe" },
+    );
+    skus = JSON.parse(stdout) as VmSku[];
+  } catch {
+    return {
+      node: requestedNode ?? USER_POOL_VM_PREFERENCES[0],
+      system: requestedSystem ?? SYSTEM_POOL_VM_PREFERENCES[0],
+      checked: false,
+    };
+  }
+
+  const usable = usableSkuSet(skus);
+  const system = pickUsableVmSize({
+    usable,
+    preferences: SYSTEM_POOL_VM_PREFERENCES,
+    poolLabel: "system",
+    flagName: "--system-vm-size",
+    requested: requestedSystem,
+  });
+  const node = pickUsableVmSize({
+    usable,
+    preferences: USER_POOL_VM_PREFERENCES,
+    poolLabel: "sandbox",
+    flagName: "--node-vm-size",
+    requested: requestedNode,
+  });
+
+  return { node, system, checked: true };
+}

--- a/cli/src/lib/vm-size.ts
+++ b/cli/src/lib/vm-size.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // VM-size (SKU) resolution for `kars up`.
 //
 // Azure subscriptions frequently restrict specific VM SKUs per region (trial,

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -108,6 +108,34 @@ async fn main() -> Result<()> {
 
     let client = Client::try_default().await?;
 
+    // S7.E: Prometheus + health server. Default ON; opt out via
+    // `CONTROLLER_METRICS_ADDR=disabled` (or empty). Failures here are
+    // non-fatal — the reconcile loops are the primary product.
+    //
+    // IMPORTANT: this MUST start *before* the leader-election barrier below.
+    // `/healthz` (served here) backs the pod readiness probe, and with
+    // `replicas: 2` only one pod wins the lease. If health came up only after
+    // acquiring leadership, the standby replica would block forever at
+    // `ready_rx.await` and never serve `/healthz` → it stays NotReady → the
+    // Deployment is stuck at 1/2 → `helm --wait` times out on every install.
+    // Readiness means "process is alive and ready to take over", not "is
+    // leader", so health must be live on both replicas immediately.
+    let metrics_handle = {
+        match metrics_server::bind_addr_from_env() {
+            Some(addr) => Some(tokio::spawn(async move {
+                if let Err(e) = metrics_server::run(addr).await {
+                    tracing::error!(error = %e, "controller metrics server exited");
+                }
+            })),
+            None => {
+                tracing::info!(
+                    "controller metrics server disabled (CONTROLLER_METRICS_ADDR=disabled)"
+                );
+                None
+            }
+        }
+    };
+
     // S7.C: controller-wide leader election. With `replicas: 2` shipped
     // in the Helm chart, both pods would otherwise reconcile in
     // parallel and double-emit Foundry agent creates / status patches /
@@ -307,25 +335,9 @@ async fn main() -> Result<()> {
         })
     };
 
-    // S7.E: optional Prometheus metrics server. Default ON; opt out
-    // via `CONTROLLER_METRICS_ADDR=disabled` (or empty). Failures
-    // here are non-fatal — the controller's reconcile loops are the
-    // primary product; metrics are observability sugar on top.
-    let metrics_handle = {
-        match metrics_server::bind_addr_from_env() {
-            Some(addr) => Some(tokio::spawn(async move {
-                if let Err(e) = metrics_server::run(addr).await {
-                    tracing::error!(error = %e, "controller metrics server exited");
-                }
-            })),
-            None => {
-                tracing::info!(
-                    "controller metrics server disabled (CONTROLLER_METRICS_ADDR=disabled)"
-                );
-                None
-            }
-        }
-    };
+    // S7.E: the Prometheus + health server is started earlier (before the
+    // leader-election barrier) so both replicas pass their readiness probe —
+    // see the `metrics_handle` block above `let leader_election_enabled`.
 
     // Convert Option<JoinHandle> to a future that pends forever when
     // leader election is disabled. This keeps the `tokio::select!`

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -17,6 +17,9 @@ param nodeCount int = 3
 @description('VM size for sandbox nodes')
 param vmSize string = 'Standard_D4s_v5'
 
+@description('VM size for the system node pool')
+param systemVmSize string = 'Standard_D2as_v5'
+
 @description('Enable Kata VM isolation for confidential sandbox level')
 param enableConfidential bool = false
 
@@ -99,6 +102,7 @@ module aks 'modules/aks.bicep' = {
     location: location
     nodeCount: nodeCount
     vmSize: enableConfidential ? 'Standard_DC4as_v5' : vmSize
+    systemVmSize: systemVmSize
     enableFips: enableFips
     logAnalyticsWorkspaceId: monitor.outputs.logAnalyticsWorkspaceId
     acrId: acr.outputs.acrId

--- a/deploy/bicep/main.json
+++ b/deploy/bicep/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "15572180885470160344"
+      "version": "0.43.8.12551",
+      "templateHash": "17988187282288113771"
     }
   },
   "parameters": {
@@ -37,6 +37,13 @@
       "defaultValue": "Standard_D4s_v5",
       "metadata": {
         "description": "VM size for sandbox nodes"
+      }
+    },
+    "systemVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2as_v5",
+      "metadata": {
+        "description": "VM size for the system node pool"
       }
     },
     "enableConfidential": {
@@ -120,8 +127,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "8843431098822094405"
+              "version": "0.43.8.12551",
+              "templateHash": "14451878920477996846"
             }
           },
           "parameters": {
@@ -222,8 +229,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "8262240890248690713"
+              "version": "0.43.8.12551",
+              "templateHash": "6253323614075829972"
             }
           },
           "parameters": {
@@ -320,8 +327,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "1248769661329074457"
+              "version": "0.43.8.12551",
+              "templateHash": "14420824941714154587"
             }
           },
           "parameters": {
@@ -449,8 +456,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "16540663700234282735"
+              "version": "0.43.8.12551",
+              "templateHash": "12722266352135439899"
             }
           },
           "parameters": {
@@ -528,6 +535,9 @@
             "value": "[parameters('nodeCount')]"
           },
           "vmSize": "[if(parameters('enableConfidential'), createObject('value', 'Standard_DC4as_v5'), createObject('value', parameters('vmSize')))]",
+          "systemVmSize": {
+            "value": "[parameters('systemVmSize')]"
+          },
           "enableFips": {
             "value": "[parameters('enableFips')]"
           },
@@ -556,8 +566,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "12432265393954369648"
+              "version": "0.43.8.12551",
+              "templateHash": "10277985618594722511"
             }
           },
           "parameters": {
@@ -582,7 +592,14 @@
             "vmSize": {
               "type": "string",
               "metadata": {
-                "description": "VM size for nodes"
+                "description": "VM size for sandbox (user) nodes"
+              }
+            },
+            "systemVmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D2as_v5",
+              "metadata": {
+                "description": "VM size for the system node pool"
               }
             },
             "enableFips": {
@@ -648,7 +665,7 @@
                   "networkPolicy": "cilium",
                   "networkDataplane": "cilium"
                 },
-                "agentPoolProfiles": "[concat(createArray(createObject('name', 'system', 'count', 2, 'vmSize', 'Standard_D2as_v5', 'osType', 'Linux', 'osSKU', 'AzureLinux', 'mode', 'System', 'enableFIPS', parameters('enableFips')), createObject('name', 'clawpool', 'count', parameters('nodeCount'), 'vmSize', parameters('vmSize'), 'osType', 'Linux', 'osSKU', 'AzureLinux', 'mode', 'User', 'enableFIPS', parameters('enableFips'), 'enableEncryptionAtHost', true(), 'nodeTaints', createArray('kars.azure.com/sandbox=true:NoSchedule'), 'nodeLabels', createObject('kars.azure.com/pool', 'sandbox'))), if(parameters('enableKata'), createArray(createObject('name', 'katapool', 'count', parameters('nodeCount'), 'vmSize', 'Standard_D4as_v6', 'osType', 'Linux', 'osSKU', 'AzureLinux', 'mode', 'User', 'enableFIPS', parameters('enableFips'), 'enableEncryptionAtHost', true(), 'workloadRuntime', 'KataMshvVmIsolation', 'nodeTaints', createArray('kars.azure.com/sandbox=true:NoSchedule'), 'nodeLabels', createObject('kars.azure.com/pool', 'sandbox-kata'))), createArray()))]",
+                "agentPoolProfiles": "[concat(createArray(createObject('name', 'system', 'count', 2, 'vmSize', parameters('systemVmSize'), 'osType', 'Linux', 'osSKU', 'AzureLinux', 'mode', 'System', 'enableFIPS', parameters('enableFips')), createObject('name', 'clawpool', 'count', parameters('nodeCount'), 'vmSize', parameters('vmSize'), 'osType', 'Linux', 'osSKU', 'AzureLinux', 'mode', 'User', 'enableFIPS', parameters('enableFips'), 'enableEncryptionAtHost', true(), 'nodeTaints', createArray('kars.azure.com/sandbox=true:NoSchedule'), 'nodeLabels', createObject('kars.azure.com/pool', 'sandbox'))), if(parameters('enableKata'), createArray(createObject('name', 'katapool', 'count', parameters('nodeCount'), 'vmSize', 'Standard_D4as_v6', 'osType', 'Linux', 'osSKU', 'AzureLinux', 'mode', 'User', 'enableFIPS', parameters('enableFips'), 'enableEncryptionAtHost', true(), 'workloadRuntime', 'KataMshvVmIsolation', 'nodeTaints', createArray('kars.azure.com/sandbox=true:NoSchedule'), 'nodeLabels', createObject('kars.azure.com/pool', 'sandbox-kata'))), createArray()))]",
                 "addonProfiles": {
                   "omsagent": {
                     "enabled": true,
@@ -723,7 +740,7 @@
             {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.ManagedIdentity/userAssignedIdentities/{0}', format('{0}-sandbox-wi', parameters('name')))]",
+              "scope": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name')))]",
               "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), 'mi-contributor')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e40ec5ca-96e0-45a2-b4ff-59039f2c2b59')]",
@@ -750,7 +767,7 @@
             {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.ContainerRegistry/registries/{0}', last(split(parameters('acrId'), '/')))]",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('acrId'), '/')))]",
               "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), parameters('acrId'), 'acrpull')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
@@ -765,7 +782,7 @@
               "condition": "[not(empty(parameters('openAiAccountId')))]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', last(split(parameters('openAiAccountId'), '/')))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', last(split(parameters('openAiAccountId'), '/')))]",
               "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), parameters('openAiAccountId'), 'openai-user')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')]",
@@ -779,7 +796,7 @@
             {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.KeyVault/vaults/{0}', parameters('keyVaultName'))]",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
               "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), 'kv-secrets-user')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",

--- a/deploy/bicep/modules/aks.bicep
+++ b/deploy/bicep/modules/aks.bicep
@@ -11,8 +11,11 @@ param location string
 @description('Node count for sandbox pool')
 param nodeCount int
 
-@description('VM size for nodes')
+@description('VM size for sandbox (user) nodes')
 param vmSize string
+
+@description('VM size for the system node pool')
+param systemVmSize string = 'Standard_D2as_v5'
 
 @description('Enable FIPS')
 param enableFips bool
@@ -56,7 +59,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
       {
         name: 'system'
         count: 2
-        vmSize: 'Standard_D2as_v5'
+        vmSize: systemVmSize
         osType: 'Linux'
         osSKU: 'AzureLinux'
         mode: 'System'

--- a/docs/internal/security-audits/2026-06-24-aks-controller-readiness-and-sku.md
+++ b/docs/internal/security-audits/2026-06-24-aks-controller-readiness-and-sku.md
@@ -1,0 +1,87 @@
+# Security Audit — AKS OOTB: controller readiness ordering + subscription-aware VM SKU selection
+
+PR: Azure/kars (branch `fix/aks-controller-readiness-and-sku`)
+
+## Scope
+
+Capability-path changes in `cli/src/commands/up.ts` and
+`cli/src/commands/up/preflight.ts`. Non-gated supporting changes:
+`controller/src/main.rs` (startup ordering), `cli/src/lib/vm-size.ts` (+ test),
+`deploy/bicep/{main.bicep,main.json,modules/aks.bicep}` (parameterize the system
+pool VM size).
+
+Two field-reproduced OOTB failures of `kars up --release` against a fresh AKS
+cluster, both upstream issues unrelated to any security control:
+
+1. **Bicep preflight rejected the deploy** because the chart pinned `_v5`
+   D-series SKUs (`Standard_D4s_v5` sandbox pool, hardcoded `Standard_D2as_v5`
+   system pool) that the operator's subscription gates in `eastus2` (while
+   `_v4`/`_v6`/`_v7` of the same families are allowed). No single hardcoded
+   default works across subscriptions, and the system pool size was not even
+   overridable.
+2. **Helm `--wait` timed out** because the `kars-controller` Deployment
+   (`replicas: 2`) was stuck at 1/2: the leader replica was healthy, but the
+   standby crashlooped. Root cause: `controller/src/main.rs` spawned the
+   `/healthz` server *after* the leader-election barrier (`ready_rx.await`), and
+   `leader_election::acquire_and_hold` signals readiness only on the *acquire*
+   branch — so the standby blocks forever, never serves `/healthz`, fails its
+   readiness probe, and is killed by its liveness probe (CrashLoopBackOff).
+   Latent since leader election (#223) but only fatal after `a7dddcb5`
+   (2026-06-01) switched the controller probes from a PID-1 exec check to
+   `httpGet /healthz`. Invisible in kind/dev because `values-local-dev.yaml`
+   sets `replicas: 1` + `LEADER_ELECTION_ENABLED=false`.
+
+## Changes
+
+- **VM SKU selection (`cli/src/lib/vm-size.ts`, `up.ts`, `up/preflight.ts`):**
+  before deploy, query `az vm list-skus --location <region>` for sizes actually
+  available to the subscription and auto-pick the first usable from an ordered
+  preference list (historical defaults first, so existing subs are unchanged), or
+  honour `--node-vm-size` / `--system-vm-size`. Graceful fallback to defaults if
+  the query can't run. Preflight now displays/validates the real resolved SKUs
+  instead of a hardcoded `D4s_v5`.
+- **Bicep:** parameterize the previously-hardcoded system-pool SKU
+  (`systemVmSize`); regenerate `main.json`.
+- **Controller (`main.rs`):** move the `/healthz`/metrics server to start
+  *before* the leader-election barrier so both leader and hot-standby pass their
+  readiness/liveness probes (a standby is healthy — ready to take over).
+- **Helm timeout (`up.ts`):** raise the controller `--wait` from 5m → 10m as
+  defense-in-depth for cold-cluster image pulls + Sigstore TUF fetch.
+
+## Threat model
+
+### T1: New asset source / attacker-reachable input? (NO)
+`az vm list-skus` is a read-only ARM query scoped to the operator's own
+subscription; its output only selects from a fixed, code-defined SKU preference
+allow-list. `--node-vm-size` / `--system-vm-size` are operator-supplied strings
+validated against that subscription's available set before use; an
+unavailable/typo'd value is rejected with the available alternatives. No new
+registry, credential, or network egress path.
+
+### T2: Behaviour / security-control change? (NO)
+No change to sandbox isolation, egress, RBAC, admission policies, mesh, or
+credentials. The controller change only reorders when the (already-present)
+health server starts; it does **not** change leader election — exactly one
+replica still holds the Lease and reconciles, so there is no double-write. The
+standby now reports Ready (correct: it is a viable hot standby) but still does
+not reconcile until it wins the Lease. VM size is a capacity/availability
+property, not a security boundary (confidential isolation still pins its CC SKU).
+
+### T3: Fail-open risk? (NO)
+If `az vm list-skus` cannot be queried, the CLI falls back to the historical
+defaults and the Bicep preflight still hard-fails on a truly unavailable SKU —
+no silent weakening. The controller readiness change can only make a
+genuinely-healthy standby report Ready; a crashed/hung process still fails
+`/healthz` and is restarted.
+
+## Verdict
+
+Accept. Both fixes address upstream availability/liveness bugs in the AKS deploy
+path with no change to any runtime security control. Verified: `cargo build`
++ 846 controller tests pass; CLI typecheck + lint (0 errors) + 818 tests
+(incl. 10 new `vm-size` tests) pass; `az bicep build` compiles; root cause
+confirmed against live cluster logs (standby stuck at lease wait, `/healthz`
+connection refused, CrashLoopBackOff from liveness).
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Summary
Fixes two field-reproduced failures of `kars up --release` against a **fresh AKS cluster** (both are upstream AKS-path bugs, not security-control changes).

### 1. Bicep preflight rejected the deploy — VM SKU not allowed
The chart pinned `_v5` D-series SKUs (`Standard_D4s_v5` sandbox, **hardcoded** `Standard_D2as_v5` system pool) that the operator's subscription gates in the region (while `_v4`/`_v6`/`_v7` of the same families are allowed). No single hardcoded default works across subscriptions, and the system-pool size wasn't overridable.

**Fix:** subscription-aware SKU selection — query `az vm list-skus` and auto-pick the first usable size from an ordered preference list (historical defaults first, so existing subs are unchanged), or honour new `--node-vm-size` / `--system-vm-size` flags. Parameterize the system-pool SKU in Bicep (`systemVmSize`). Preflight now shows/validates the **real** resolved SKUs instead of a hardcoded `D4s_v5`.

### 2. Helm `--wait` timed out — controller stuck at 1/2
`replicas: 2`; the leader was healthy but the **standby crashlooped**. Root cause: `main.rs` spawned the `/healthz` server **after** the leader-election barrier, and `acquire_and_hold` signals ready only on the *acquire* branch — so the standby blocks forever, never serves `/healthz`, fails readiness, and is killed by liveness (CrashLoopBackOff). Latent since #223; **fatal since `a7dddcb5`** (2026-06-01) which switched the probes from a PID-1 exec check to `httpGet /healthz`. Invisible in kind/dev (`replicas:1` + leader election off).

**Fix:** start the `/healthz`/metrics server **before** the leader-election barrier so both leader and hot-standby report Ready (a standby is healthy — ready to take over; it still doesn't reconcile until it wins the Lease). Also raise the controller `--wait` 5m→10m for cold-cluster pulls.

## Verification
- `cargo build` + **846 controller tests** pass
- CLI typecheck + lint (0 errors) + **818 tests** (incl. 10 new `vm-size` tests)
- `az bicep build` compiles; `main.json` regenerated
- Root cause **confirmed against live cluster logs** (standby stuck at lease wait, `/healthz` connection refused, CrashLoopBackOff from liveness)

## Security
Capability-path change (`cli/src/commands/up*`) → audit: `docs/internal/security-audits/2026-06-24-aks-controller-readiness-and-sku.md` (2 sign-offs). No change to isolation, egress, RBAC, admission, mesh, or credentials; leader election semantics unchanged (still exactly one reconciling replica).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>