### PR TITLE
chore(release): bump CLI to 0.1.10 (AKS controller readiness + VM SKU OOTB)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for the AKS OOTB fixes merged in #436:
- Subscription-aware VM SKU selection (auto-pick available sizes; `--node-vm-size`/`--system-vm-size`)
- Controller readiness fix (serve `/healthz` before the leader-election barrier so both replicas pass probes)
- Helm controller `--wait` 5m→10m

Tagging `v0.1.10` after merge triggers `release-public-interim.yml` → rebuilds the fixed controller image to GHCR + publishes npm.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>