### PR TITLE
fix(entra): don't hang on CA-blocked Graph; reach Bicep fallback OOTB (v0.1.11)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {

--- a/cli/src/commands/mesh/agent_id_setup.ts
+++ b/cli/src/commands/mesh/agent_id_setup.ts
@@ -185,66 +185,27 @@ async function azGraphRestWithRetry<T>(
     const msg = (err.stderr ?? err.message ?? "").toString();
 
     // AADSTS530084 = Conditional Access token-binding policy block on
-    // the az CLI's first-party app token for Microsoft Graph. Trying
-    // a device-code re-login refreshes the Graph token via a
-    // different OAuth flow that some tenant CA policies treat
-    // differently (the device-code app may not be subject to the
-    // same token-binding rule). One-shot: if it fails again, give
-    // up and propagate so the caller can fall back to Bicep.
+    // the az CLI's first-party app token for Microsoft Graph. We do NOT
+    // attempt a device-code re-login here: on tenants whose CA also
+    // requires a compliant/managed device, `az login --use-device-code`
+    // hangs for ~15 min polling a device code the CA will never authorize
+    // (then fails AADSTS530033), freezing `kars up` at the Entra step.
+    // Instead, surface a clear notice and propagate immediately so the
+    // caller (`ensureAgentIdTrustAutoFallback`) falls back to the Bicep
+    // ARM path, which reaches Graph through ARM's deployment engine and is
+    // NOT subject to this CA policy (verified: the Graph request goes
+    // through server-side).
     if (!alreadyRetried && interactive && msg.includes("AADSTS530084")) {
-      const tenantArgs = await deviceCodeReloginForGraph();
-      if (tenantArgs) {
-        return azGraphRestWithRetry<T>(method, graphPath, body, true, interactive);
-      }
+      console.log();
+      console.log(
+        "  ↻ Microsoft Graph is blocked by tenant Conditional Access (AADSTS530084).",
+      );
+      console.log(
+        "    Falling back to Bicep ARM deployment — bypasses the Graph CA policy.",
+      );
     }
 
     throw new Error(msg.trim() || `az rest ${graphPath} failed`);
-  }
-}
-
-/// Attempt a one-shot `az login --use-device-code --scope graph`
-/// refresh of the Graph token cache. Returns true on success so the
-/// caller can retry the failing Graph call.
-///
-/// Device code flow uses a different OAuth path than the default
-/// interactive flow — the user authenticates on a SECOND device by
-/// visiting microsoft.com/devicelogin and entering the code. Some
-/// Conditional Access policies that block token-binding on the
-/// primary device's az CLI session do not apply to this flow.
-async function deviceCodeReloginForGraph(): Promise<boolean> {
-  console.log();
-  console.log(
-    "  ↻ AADSTS530084: az CLI token is CA-blocked for Microsoft Graph.",
-  );
-  console.log(
-    "    Attempting device-code re-login for the Graph scope...",
-  );
-  console.log(
-    "    You will be prompted to visit https://microsoft.com/devicelogin in a browser.",
-  );
-
-  try {
-    await execa(
-      "az",
-      [
-        "login",
-        "--use-device-code",
-        "--scope",
-        "https://graph.microsoft.com//.default",
-        "--allow-no-subscriptions",
-      ],
-      // Use inherit so the device-code prompt is visible to the user.
-      { stdio: ["inherit", "inherit", "inherit"] },
-    );
-    console.log("  ✓ Graph token cache refreshed via device-code flow.");
-    return true;
-  } catch (e) {
-    const msg = (e as { stderr?: string; message?: string }).stderr ?? (e as Error).message ?? "";
-    console.log(
-      `  ✘ Device-code re-login also failed (${msg.split("\n")[0].slice(0, 120)}).`,
-    );
-    console.log("    Will fall back to Bicep ARM deployment.");
-    return false;
   }
 }
 

--- a/cli/src/commands/mesh/agent_id_setup_bicep.ts
+++ b/cli/src/commands/mesh/agent_id_setup_bicep.ts
@@ -20,6 +20,7 @@ import { execa } from "execa";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { kvLine, section } from "../../stepper.js";
+import { requireBundledAsset } from "../../lib/repo-assets.js";
 
 export interface BicepSetupOptions {
   clusterName?: string;
@@ -88,28 +89,20 @@ interface DeploymentResult {
 /// `deploy/bicep/agent-id-trust.bicep` anchor. Falls back to the
 /// repo-relative path during local dev.
 function resolveBicepTemplate(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  // From cli/src/commands/mesh/ → ../../../../deploy/bicep/...
-  // Also handle dist/commands/mesh/ → ../../../../deploy/bicep/...
-  const candidates = [
-    path.resolve(here, "../../../../deploy/bicep/agent-id-trust.bicep"),
-    path.resolve(here, "../../../deploy/bicep/agent-id-trust.bicep"),
-    path.resolve(process.cwd(), "deploy/bicep/agent-id-trust.bicep"),
-  ];
-  for (const c of candidates) {
-    // We cannot import 'fs' lazily inside the helper without changing
-    // the surrounding test mock surface; use a small sync existsSync
-    // ESM import here to keep mocked `execa` calls clean.
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { existsSync } = require("fs");
-      if (existsSync(c)) return c;
-    } catch {
-      /* env without sync require — fall through */
-    }
+  // Resolve via the shared repo-or-bundled resolver: in a repo checkout
+  // this finds `deploy/bicep/agent-id-trust.bicep`; in an npm-installed
+  // CLI it finds the copy bundled into `dist/deploy/bicep/` by
+  // scripts/bundle-deploy-assets.mjs. The previous repo-relative walk
+  // missed the bundled location entirely, so the Bicep fallback failed
+  // with "template not found" for OOTB (no-checkout) users.
+  try {
+    return requireBundledAsset("deploy/bicep/agent-id-trust.bicep");
+  } catch {
+    // Last-resort fallback (e.g. exotic packaging) — let `az deployment`
+    // surface a clear "template not found" rather than throwing here.
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    return path.resolve(here, "../../deploy/bicep/agent-id-trust.bicep");
   }
-  // Best-effort default — `az deployment` will error clearly if missing.
-  return candidates[0];
 }
 
 async function getTenantInfo(): Promise<{ tenantId: string; subscriptionId: string; user: string }> {
@@ -246,6 +239,18 @@ export async function ensureAgentIdTrustViaBicep(
       .join("\n")
       .trim();
     const summary = cleaned.split("\n")[0] || raw.split("\n")[0] || "deployment failed";
+
+    // Corp-tenant app registrations require a valid ServiceTree GUID. The
+    // raw Graph error ("ServiceManagementReference must be a valid GUID")
+    // is opaque — surface an actionable hint pointing at --service-tree.
+    if (/ServiceTree|ServiceManagementReference/i.test(raw)) {
+      throw new Error(
+        "Bicep deployment failed: your tenant requires a valid ServiceTree GUID for app " +
+          "registration. Re-run with `--service-tree <GUID>` (or set KARS_SERVICE_TREE). " +
+          `Underlying error: ${summary.slice(0, 200)}`,
+      );
+    }
+
     throw new Error(`Bicep deployment failed: ${summary.slice(0, 400)}`);
   }
 

--- a/docs/internal/security-audits/2026-06-24-entra-graph-ca-bicep-fallback.md
+++ b/docs/internal/security-audits/2026-06-24-entra-graph-ca-bicep-fallback.md
@@ -1,0 +1,72 @@
+# Security Audit — Entra Agent ID: don't hang on CA-blocked Graph; reach the Bicep fallback OOTB
+
+PR: Azure/kars (branch `fix/entra-graph-ca-bicep-fallback`)
+
+## Scope
+
+Capability-path changes in `cli/src/commands/mesh/agent_id_setup.ts` and
+`cli/src/commands/mesh/agent_id_setup_bicep.ts`.
+
+`kars up --mesh-trust=entra` froze at step 7/9 on a Microsoft-corp tenant. Field
+trace + a direct `az deployment sub create` test established the exact behaviour:
+
+1. The Graph REST call hits `AADSTS530084` (Conditional Access token-binding
+   block on the az CLI's Graph token).
+2. The CLI then ran `az login --use-device-code` to "refresh" the Graph token.
+   On tenants whose CA *also* requires a compliant/managed device, the device
+   code is never authorised (browser completion returns `AADSTS530033`), so
+   `az login --use-device-code` **polls for ~15 min** before failing — a hang.
+3. The intended fallback — provisioning the Entra objects via a Bicep
+   `Microsoft.Graph`-extension deployment, which reaches Graph through ARM's
+   deployment engine and is **not** subject to the CA token-binding policy — was
+   only reached after that hang, and then failed to even locate its template in
+   an npm-installed CLI because `resolveBicepTemplate()` only checked
+   repo-relative paths, never the bundled `dist/deploy/bicep/` copy.
+
+A direct test confirmed the Bicep path bypasses the CA block: the deployment
+reached Graph server-side (real Graph request-id, no 530084) and failed only on
+the corp-tenant `ServiceManagementReference must be a valid GUID` requirement.
+
+## Changes
+
+- **`agent_id_setup.ts`:** on `AADSTS530084`, **do not** attempt a device-code
+  re-login (removed `deviceCodeReloginForGraph`). Print a one-line notice and
+  propagate immediately so `ensureAgentIdTrustAutoFallback` falls back to Bicep
+  without the ~15-min hang.
+- **`agent_id_setup_bicep.ts`:** resolve the Bicep template via the shared
+  repo-or-bundled resolver (`requireBundledAsset("deploy/bicep/agent-id-trust.bicep")`)
+  so the fallback works from an npm-installed CLI (the template is already
+  bundled by `scripts/bundle-deploy-assets.mjs`). Detect the
+  `ServiceTree`/`ServiceManagementReference` Graph error and surface an
+  actionable hint to pass `--service-tree <GUID>`.
+
+## Threat model
+
+### T1: New asset source / attacker-reachable input? (NO)
+No new input or network path. The template is the same in-repo/bundled artifact,
+now resolved through the existing audited resolver. The Bicep deployment is the
+same `az deployment sub create` already shipped.
+
+### T2: Security-control change? (NO — strictly safer)
+Removing the device-code re-login only deletes an interactive auth attempt that
+could not succeed on these tenants; it does not weaken auth. Provisioning still
+goes through ARM + the `Microsoft.Graph` extension with the operator's own
+credentials and requires the same `Agent ID Developer` role. On failure the
+caller still degrades to the anonymous mesh tier (unchanged), so the cluster is
+never left in a more-trusting state than before.
+
+### T3: Fail-open / hang risk? (REDUCED)
+The change removes a denial-of-service-shaped hang (15-min poll) and makes the
+CA-blocked path fail fast into the declarative Bicep fallback, which is the
+tenant-CA-safe provisioning path. No new fail-open behaviour.
+
+## Verdict
+
+Accept. Fixes a hang and an OOTB template-resolution gap in the
+`--mesh-trust=entra` provisioning path; no runtime security control is weakened.
+Verified: CLI typecheck + lint (0 errors) + 818 tests (48 mesh tests incl. the
+CA-block fast-fall path) pass; the Bicep path's CA-bypass and the ServiceTree
+requirement were confirmed against the live tenant via `az deployment sub create`.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Summary
`kars up --mesh-trust=entra` froze at **7/9** on a Microsoft-corp tenant. Root-caused live (incl. a direct `az deployment sub create` test).

### What happened
1. Graph REST → `AADSTS530084` (CA token-binding block on the az CLI Graph token).
2. CLI ran `az login --use-device-code` to refresh Graph — but on **device-compliance-CA** tenants the device code is never authorized (browser → `AADSTS530033`), so it **polls ~15 min** then fails. **That's the hang.**
3. The intended **Bicep fallback** (Microsoft.Graph extension via ARM — bypasses the Graph CA) was only reached after the hang, and then couldn't find its template in an npm-installed CLI (`resolveBicepTemplate` only checked repo-relative paths, never bundled `dist/deploy/bicep/`).

A direct test proved the Bicep path **bypasses the CA block** — it reached Graph server-side (real request-id, no 530084) and failed only on the corp `ServiceManagementReference must be a valid GUID` requirement.

### Fixes
- **`agent_id_setup.ts`**: on `AADSTS530084`, **skip** the device-code re-login (removed) and propagate immediately → `ensureAgentIdTrustAutoFallback` runs Bicep. No hang.
- **`agent_id_setup_bicep.ts`**: resolve the template via `requireBundledAsset` (repo-or-bundled) so the fallback works OOTB; detect the ServiceTree error and hint to pass `--service-tree <GUID>`.

### Verification
- CLI typecheck + lint (0 errors) + **818 tests** (48 mesh, incl. the CA-block fast-fall path)
- Live: controller 2/2 + full deploy completion confirmed on the user's cluster; Bicep CA-bypass + ServiceTree requirement confirmed via `az deployment sub create`

### Security
Gated path (`cli/src/commands/mesh/*`) → audit `docs/internal/security-audits/2026-06-24-entra-graph-ca-bicep-fallback.md` (2 sign-offs). Strictly safer: removes an unauthenticatable hang; no security control weakened; still degrades to anonymous on failure.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>