### PR TITLE
fix(router): hot-reload ConfigMap edits (follow symlinks) + kars connect wait-for-ready (v0.1.14)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {

--- a/cli/src/commands/connect.ts
+++ b/cli/src/commands/connect.ts
@@ -352,10 +352,103 @@ export function connectCommand(): Command {
         // Start port-forward — pipe stderr so we can surface kubectl errors
         // when the connection drops. Without this, all the user sees is
         // "Disconnected." with no diagnostic.
-        console.log(chalk.dim(`  Starting port-forward on localhost:${localPort}...`));
+
+        // Wait for the pod to actually be Running with the agent container
+        // Ready before forwarding. `kubectl port-forward` fails hard with
+        // "unable to forward port because pod is not running. Current
+        // status=Pending" if the pod is still scheduling/pulling — which is
+        // common right after `kars up` (the deploy finishes before the image
+        // is pulled on the node). Poll until ready, fail fast on image-pull
+        // errors, and print a clean message instead of a raw Node stack trace.
+        const podReady = await (async (): Promise<{ ok: boolean; detail: string }> => {
+          const deadlineMs = Date.now() + 180_000; // 3 min — first image pull on a fresh node can be slow
+          const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+          let lastPhase = "Unknown";
+          let printedWait = false;
+          while (Date.now() < deadlineMs) {
+            let pod: {
+              status?: {
+                phase?: string;
+                containerStatuses?: { name: string; ready?: boolean; state?: { waiting?: { reason?: string; message?: string } } }[];
+                initContainerStatuses?: { name: string; state?: { waiting?: { reason?: string; message?: string } } }[];
+              };
+            } | undefined;
+            try {
+              const { stdout } = await execa("kubectl", [
+                ...ctxArgs, "get", "pod", "-n", namespace,
+                "-l", `kars.azure.com/sandbox=${name}`,
+                "--sort-by=.metadata.creationTimestamp", "-o", "json",
+              ], { stdio: "pipe" });
+              const items = JSON.parse(stdout).items as typeof pod[];
+              pod = items[items.length - 1]; // newest pod (handles rollouts)
+            } catch {
+              await sleep(2500);
+              continue;
+            }
+            if (!pod) { await sleep(2500); continue; }
+            lastPhase = pod.status?.phase ?? "Unknown";
+            const cs = (pod.status?.containerStatuses ?? []).find(c => c.name === podContainer);
+            if (lastPhase === "Running" && cs?.ready === true) {
+              if (printedWait) process.stdout.write("\n");
+              return { ok: true, detail: "" };
+            }
+            // Fail fast on unrecoverable image / container errors (the agent
+            // container OR the egress-guard init / inference-router sidecar).
+            const waiters = [
+              ...(pod.status?.initContainerStatuses ?? []),
+              ...(pod.status?.containerStatuses ?? []),
+            ];
+            const fatal = waiters
+              .map(c => ({ name: c.name, w: c.state?.waiting }))
+              .find(x => x.w && /ImagePullBackOff|ErrImagePull|InvalidImageName|CreateContainerConfigError|CrashLoopBackOff/.test(x.w.reason ?? ""));
+            if (fatal) {
+              if (printedWait) process.stdout.write("\n");
+              return { ok: false, detail: `${fatal.name}: ${fatal.w?.reason}${fatal.w?.message ? ` — ${fatal.w.message}` : ""}` };
+            }
+            const secsLeft = Math.max(0, Math.round((deadlineMs - Date.now()) / 1000));
+            process.stdout.write(`\r  ${chalk.dim(`Waiting for ${name} to be ready (phase=${lastPhase}, ${secsLeft}s left)…   `)}`);
+            printedWait = true;
+            await sleep(3000);
+          }
+          if (printedWait) process.stdout.write("\n");
+          return { ok: false, detail: `timed out after 3m (last phase=${lastPhase})` };
+        })();
+
+        if (!podReady.ok) {
+          console.log();
+          console.log(chalk.red(`  Sandbox '${name}' pod is not ready — ${podReady.detail}`));
+          console.log(chalk.dim(`  Inspect it with:  kubectl describe pod -n ${namespace} -l kars.azure.com/sandbox=${name}`));
+          console.log(chalk.dim(`  Then retry:       kars connect ${name}\n`));
+          return;
+        }
+
+        // Pick a free local port. If the requested port is taken by something
+        // that ISN'T a reusable HTTP forward (handled above), bump to the next
+        // free port instead of crashing with EADDRINUSE — the original
+        // "address already in use" footgun when 18789 is held by a stale
+        // process or an unrelated listener.
+        const effectivePort = await (async (): Promise<number> => {
+          const net = await import("node:net");
+          const canBind = (p: number) => new Promise<boolean>((resolve) => {
+            const srv = net.createServer();
+            srv.once("error", () => resolve(false));
+            srv.once("listening", () => srv.close(() => resolve(true)));
+            srv.listen(p, "127.0.0.1");
+          });
+          const start = Number(localPort);
+          for (let p = start; p < start + 20; p++) {
+            if (await canBind(p)) return p;
+          }
+          return start; // give up — let kubectl surface the bind error
+        })();
+        if (effectivePort !== Number(localPort)) {
+          console.log(chalk.dim(`  Port ${localPort} is in use — using ${effectivePort} instead.`));
+        }
+
+        console.log(chalk.dim(`  Starting port-forward on localhost:${effectivePort}...`));
         const pf = execa("kubectl", [
           ...ctxArgs, "port-forward", "-n", namespace,
-          `deploy/${name}`, `${localPort}:18789`,
+          `deploy/${name}`, `${effectivePort}:18789`,
         ], { stdio: ["ignore", "pipe", "pipe"] });
 
         let pfStderr = "";
@@ -372,7 +465,7 @@ export function connectCommand(): Command {
         // Wait for port-forward to be ready
         await new Promise(r => setTimeout(r, 2000));
 
-        const url = `http://localhost:${localPort}/#token=${gatewayToken}`;
+        const url = `http://localhost:${effectivePort}/#token=${gatewayToken}`;
         console.log();
         console.log(`  ${chalk.green("→")} ${chalk.cyan.underline(url)}`);
         console.log();

--- a/docs/internal/security-audits/2026-06-25-router-configmap-hot-reload.md
+++ b/docs/internal/security-audits/2026-06-25-router-configmap-hot-reload.md
@@ -1,0 +1,87 @@
+# Security Audit — Router ConfigMap hot-reload fix + `kars connect` wait-for-ready (v0.1.14)
+
+Date: 2026-06-25
+Scope: `inference-router/src/config_mount.rs` (new), `inference-router/src/{inference_policy_loader,egress_allowlist_loader,memory_binding_loader}.rs`, `inference-router/src/governance/mod.rs`, `inference-router/src/lib.rs`, `cli/src/commands/connect.ts`.
+Gated path: `cli/src/commands/connect.ts` (capability surface).
+
+## Summary
+
+Two fixes:
+
+1. **Router ConfigMap hot-reload (the load-bearing fix).** All four router
+   change-detection watchers (`InferencePolicy`, `EgressAllowlist`,
+   `KarsMemory` binding, AGT governance policies) used a `dir_max_mtime` built
+   on `std::fs::DirEntry::metadata()` — an **`lstat`** that does **not** follow
+   symlinks. Kubernetes projects ConfigMap/Secret mounts as per-key **symlinks**
+   into an atomically-swapped `..data` directory; on update kubelet swaps
+   `..data` but never recreates the per-key symlink, so its `lstat` mtime is
+   frozen at pod start. Result: the 5s mtime poll **never detected a ConfigMap
+   update**, and the router silently kept enforcing the **boot-time** policy
+   until the pod was restarted. Live-confirmed in production: a patched
+   `InferencePolicy` reached the ConfigMap in 22s but the router never
+   reloaded in 120s; only a pod bump applied it.
+
+   Fix: a single shared `config_mount::dir_max_mtime(dir, exts)` that stats via
+   `std::fs::metadata(e.path())` (**follows** symlinks → sees the real file's
+   mtime, which advances on every `..data` swap). All four watchers delegate to
+   it, so the bug cannot reappear in one loader while fixed in another. A
+   regression test reproduces the exact kubelet atomic `..data` symlink swap
+   and is proven to FAIL on the old `lstat` code and PASS on the fix.
+
+2. **`kars connect` wait-for-ready + free-port.** `connect` started
+   `kubectl port-forward` without waiting for the pod, so a still-`Pending`
+   sandbox produced a raw Node stack trace; and a busy `:18789` produced
+   `EADDRINUSE`. Now it polls until the pod is `Running` + the agent container
+   `Ready` (fail-fast with a clean message on `ImagePullBackOff`/
+   `CrashLoopBackOff`), and auto-picks the next free local port.
+
+## T1: New capability / attack surface? (NO)
+
+- The hot-reload fix changes only **how a change is detected** (stat vs lstat)
+  on the same already-mounted, controller-published ConfigMaps. No new mount,
+  path, network listener, or privilege. Reading file content already followed
+  symlinks; only the mtime probe was wrong.
+- `connect` adds a read-only `kubectl get pod` poll and a localhost TCP
+  bind-probe for a free port. No new cluster permission; the operator already
+  holds `port-forward`.
+
+## T2: Security-control change? (STRICTER / NEUTRAL)
+
+- Hot-reload is a **fail-closed improvement for enforcement freshness**: prompt
+  shields, content-safety floors, token budgets, egress allowlists, and AGT
+  governance edits now take effect within the advertised window instead of
+  silently lagging until a pod restart. Tightening an `InferencePolicy`
+  (e.g. enabling Prompt Shields, lowering a severity floor, or shrinking the
+  egress allowlist) previously did **not** apply to a running router — a real
+  fail-**open** gap that this closes. The loaders’ digest-comparison and
+  content parsing are unchanged; only change-detection is corrected.
+- `connect` changes operator UX only; no enforcement, RBAC, admission, mesh, or
+  auth path is touched. The token is still read from the namespaced
+  `gateway-token` Secret.
+
+## T3: Availability / fail-open risk? (REDUCED)
+
+- `std::fs::metadata` follows symlinks with one extra `stat` per `*.json`/
+  `*.yaml` file every 5s — negligible. A dangling symlink mid-swap is skipped
+  (treated as "no change") rather than erroring, so a transient swap window
+  cannot crash or wedge the watcher.
+- `connect` fails fast with a clear message instead of a stack trace and no
+  longer crashes on a busy port. Pure availability/UX improvement.
+
+## Verification
+
+- New `config_mount` unit tests (5) incl. `detects_configmap_data_symlink_swap`,
+  which simulates kubelet's atomic `..data` rename. **Proven**: FAILS on the
+  old `e.metadata()` (lstat) implementation, PASSES on `std::fs::metadata`.
+- `cargo clippy -p kars-inference-router --lib` clean; **944** router lib tests
+  pass (939 prior + 5 new).
+- CLI: `tsc --noEmit` + oxlint clean; **821** vitest tests pass.
+
+## Verdict
+
+Accept. Fixes a silent fail-open in router policy-enforcement freshness with a
+single shared, regression-tested helper, and removes two first-run `kars connect`
+footguns. No security control is weakened; enforcement timeliness is improved.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/inference-router/src/config_mount.rs
+++ b/inference-router/src/config_mount.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Helpers for change-detection on Kubernetes ConfigMap / Secret mounts.
+//!
+//! # Why this module exists
+//!
+//! A projected ConfigMap/Secret mount does **not** lay the keys down as
+//! plain files. kubelet builds the directory like this:
+//!
+//! ```text
+//!   <mount>/inference-policy.json -> ..data/inference-policy.json   (symlink)
+//!   <mount>/..data                -> ..2026_06_25_00_00_00.123      (symlink)
+//!   <mount>/..2026_06_25_00_00_00.123/inference-policy.json         (real file)
+//! ```
+//!
+//! On every update kubelet writes a brand-new timestamped directory and
+//! then **atomically swaps the `..data` symlink** to point at it. Crucially,
+//! the per-key symlink (`inference-policy.json`) is created **once** and is
+//! never recreated on subsequent updates — only its target changes.
+//!
+//! This breaks the obvious mtime-poll. [`std::fs::DirEntry::metadata`] is an
+//! `lstat`: it returns the metadata of the **symlink itself**, whose mtime is
+//! frozen at pod start. So a poll built on `DirEntry::metadata().modified()`
+//! returns the same value forever and **never detects a ConfigMap update** —
+//! the router silently keeps enforcing the boot-time policy until the pod is
+//! restarted. (This was a real production bug: live `kars policy` / prompt-
+//! shields / egress / memory edits required a pod bump to take effect.)
+//!
+//! The fix is to **follow the symlink** with [`std::fs::metadata`] (a `stat`),
+//! which resolves through `..data` to the real file whose mtime advances on
+//! every kubelet swap. Every router watcher MUST use this helper instead of a
+//! hand-rolled `DirEntry::metadata()` loop so the bug cannot reappear in one
+//! loader while being fixed in another.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+/// Maximum mtime across files in `dir` whose extension is one of `exts`,
+/// **following symlinks** so Kubernetes ConfigMap/Secret `..data` swaps are
+/// detected.
+///
+/// Returns `None` when `dir` is not a directory or contains no matching,
+/// resolvable file. A dangling symlink (target temporarily absent mid-swap)
+/// is skipped rather than treated as a change.
+#[must_use]
+pub fn dir_max_mtime(dir: &str, exts: &[&str]) -> Option<SystemTime> {
+    let path = Path::new(dir);
+    if !path.is_dir() {
+        return None;
+    }
+    std::fs::read_dir(path)
+        .ok()?
+        .flatten()
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|x| exts.iter().any(|want| x == *want))
+        })
+        // `std::fs::metadata` (stat) FOLLOWS symlinks — unlike
+        // `DirEntry::metadata` (lstat). This is the whole point: a ConfigMap
+        // `..data` swap changes the symlink *target's* mtime, not the
+        // user-facing symlink's own mtime, so we must stat through it.
+        .filter_map(|e| std::fs::metadata(e.path()).ok()?.modified().ok())
+        .max()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    #[test]
+    fn none_for_missing_dir() {
+        assert!(dir_max_mtime("/nonexistent/definitely/not/here", &["json"]).is_none());
+    }
+
+    #[test]
+    fn respects_extension_filter() {
+        let d = tempdir().unwrap();
+        std::fs::write(d.path().join("note.txt"), b"x").unwrap();
+        assert!(
+            dir_max_mtime(d.path().to_str().unwrap(), &["json"]).is_none(),
+            "non-matching extension must be ignored"
+        );
+        std::fs::write(d.path().join("p.json"), b"{}").unwrap();
+        assert!(dir_max_mtime(d.path().to_str().unwrap(), &["json"]).is_some());
+    }
+
+    #[test]
+    fn matches_multiple_extensions() {
+        let d = tempdir().unwrap();
+        std::fs::write(d.path().join("agt-profile.yaml"), b"a: 1").unwrap();
+        assert!(dir_max_mtime(d.path().to_str().unwrap(), &["yaml", "yml"]).is_some());
+    }
+
+    #[test]
+    fn detects_plain_file_change() {
+        let d = tempdir().unwrap();
+        let f = d.path().join("p.json");
+        std::fs::write(&f, b"A").unwrap();
+        let before = dir_max_mtime(d.path().to_str().unwrap(), &["json"]).unwrap();
+        std::thread::sleep(Duration::from_millis(1100));
+        std::fs::write(&f, b"BB").unwrap();
+        let after = dir_max_mtime(d.path().to_str().unwrap(), &["json"]).unwrap();
+        assert!(after > before, "a plain file rewrite must bump max-mtime");
+    }
+
+    /// The regression test for the production bug. Replicates the kubelet
+    /// ConfigMap layout (per-key symlink -> `..data` -> timestamped dir) and
+    /// performs the **atomic `..data` symlink swap** kubelet does on update.
+    ///
+    /// The old `DirEntry::metadata()` (lstat) implementation returns the
+    /// frozen mtime of the unchanged per-key symlink, so `after == before`
+    /// and the assertion FAILS — exactly the silent "no hot-reload" bug.
+    /// Following the symlink (this helper) detects the swap and the
+    /// assertion PASSES.
+    #[cfg(unix)]
+    #[test]
+    fn detects_configmap_data_symlink_swap() {
+        use std::os::unix::fs::symlink;
+        let root = tempdir().unwrap();
+        let rp = root.path();
+
+        // Generation A: the dir + policy file kubelet first writes.
+        let gen_a = rp.join("gen_a");
+        std::fs::create_dir(&gen_a).unwrap();
+        std::fs::write(gen_a.join("policy.json"), b"A").unwrap();
+        // `..data` -> gen_a (the symlink kubelet atomically re-points).
+        symlink("gen_a", rp.join("..data")).unwrap();
+        // User-facing key -> ..data/policy.json. Created ONCE; never
+        // recreated on update — which is why lstat-on-it is frozen.
+        symlink("..data/policy.json", rp.join("policy.json")).unwrap();
+
+        let before = dir_max_mtime(rp.to_str().unwrap(), &["json"])
+            .expect("policy.json must resolve through the symlink chain");
+
+        // Guarantee a strictly-later mtime regardless of filesystem
+        // timestamp granularity (ext4/HFS+ can be 1s).
+        std::thread::sleep(Duration::from_millis(1100));
+
+        // kubelet update: write generation B, then atomically swap ..data.
+        let gen_b = rp.join("gen_b");
+        std::fs::create_dir(&gen_b).unwrap();
+        std::fs::write(gen_b.join("policy.json"), b"BB").unwrap();
+        let tmp = rp.join("..data_tmp");
+        symlink("gen_b", &tmp).unwrap();
+        std::fs::rename(&tmp, rp.join("..data")).unwrap(); // atomic swap
+
+        let after = dir_max_mtime(rp.to_str().unwrap(), &["json"])
+            .expect("policy.json must still resolve after the swap");
+
+        assert!(
+            after > before,
+            "dir_max_mtime must detect a ConfigMap `..data` symlink swap; \
+             this is the regression guard for the lstat-on-symlink hot-reload bug"
+        );
+    }
+}

--- a/inference-router/src/egress_allowlist_loader.rs
+++ b/inference-router/src/egress_allowlist_loader.rs
@@ -528,16 +528,7 @@ pub fn spawn_egress_allowlist_watcher_with_approvals(
 }
 
 fn dir_max_mtime(dir: &str) -> Option<std::time::SystemTime> {
-    let path = Path::new(dir);
-    if !path.is_dir() {
-        return None;
-    }
-    std::fs::read_dir(path)
-        .ok()?
-        .flatten()
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
-        .filter_map(|e| e.metadata().ok()?.modified().ok())
-        .max()
+    crate::config_mount::dir_max_mtime(dir, &["json"])
 }
 
 #[cfg(test)]

--- a/inference-router/src/governance/mod.rs
+++ b/inference-router/src/governance/mod.rs
@@ -808,21 +808,11 @@ impl Governance {
 }
 
 /// Get the maximum mtime of YAML files in a directory (for change detection).
+/// Delegates to [`crate::config_mount::dir_max_mtime`], which follows symlinks
+/// so a Kubernetes ConfigMap `..data` swap is detected (an `lstat` poll never
+/// reloads — see that module).
 fn dir_max_mtime(dir: &str) -> Option<std::time::SystemTime> {
-    let path = Path::new(dir);
-    if !path.is_dir() {
-        return None;
-    }
-    std::fs::read_dir(path)
-        .ok()?
-        .flatten()
-        .filter(|e| {
-            e.path()
-                .extension()
-                .is_some_and(|ext| ext == "yaml" || ext == "yml")
-        })
-        .filter_map(|e| e.metadata().ok()?.modified().ok())
-        .max()
+    crate::config_mount::dir_max_mtime(dir, &["yaml", "yml"])
 }
 
 /// Convert trust score to tier label (matches _score_to_tier convention).

--- a/inference-router/src/inference_policy_loader.rs
+++ b/inference-router/src/inference_policy_loader.rs
@@ -469,17 +469,12 @@ pub fn spawn_inference_policy_watcher(
 
 /// Get the max mtime across `*.json` files in `dir`. Filter mirrors
 /// the controller-side compile output (`inference-policy.json`).
+///
+/// Delegates to [`crate::config_mount::dir_max_mtime`], which FOLLOWS
+/// symlinks so a Kubernetes ConfigMap `..data` swap is detected (an
+/// `lstat`-based poll silently never reloads — see that module).
 fn dir_max_mtime(dir: &str) -> Option<std::time::SystemTime> {
-    let path = Path::new(dir);
-    if !path.is_dir() {
-        return None;
-    }
-    std::fs::read_dir(path)
-        .ok()?
-        .flatten()
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
-        .filter_map(|e| e.metadata().ok()?.modified().ok())
-        .max()
+    crate::config_mount::dir_max_mtime(dir, &["json"])
 }
 
 /// **Latency-optimised snapshot** of every enforcement axis the

--- a/inference-router/src/lib.rs
+++ b/inference-router/src/lib.rs
@@ -23,6 +23,7 @@ pub mod behavior_monitor;
 pub mod blocklist;
 pub mod budget;
 pub mod config;
+pub mod config_mount;
 pub mod copilot_auth;
 pub mod deployment_health;
 pub mod egress_allowlist_loader;

--- a/inference-router/src/memory_binding_loader.rs
+++ b/inference-router/src/memory_binding_loader.rs
@@ -340,18 +340,10 @@ pub fn spawn_memory_binding_watcher(
 /// Get the max mtime across `*.json` files in `dir` (mirrors
 /// `governance::dir_max_mtime` but scoped to JSON since the
 /// controller publishes the binding as a single
-/// `binding.json`).
+/// `binding.json`). Delegates to [`crate::config_mount::dir_max_mtime`]
+/// so the ConfigMap symlink-swap fix is shared.
 fn dir_max_mtime(dir: &str) -> Option<std::time::SystemTime> {
-    let path = Path::new(dir);
-    if !path.is_dir() {
-        return None;
-    }
-    std::fs::read_dir(path)
-        .ok()?
-        .flatten()
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
-        .filter_map(|e| e.metadata().ok()?.modified().ok())
-        .max()
+    crate::config_mount::dir_max_mtime(dir, &["json"])
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## The bug (live-confirmed in production)

Router policy edits silently did **not** take effect until a **pod restart**. Root cause: all four router change-detection watchers (`InferencePolicy`, `EgressAllowlist`, `KarsMemory`, AGT governance) used `dir_max_mtime` built on `DirEntry::metadata()` — an **`lstat`** that does not follow symlinks.

Kubernetes projects ConfigMap mounts as per-key **symlinks** into an atomically-swapped `..data` dir. On update kubelet swaps `..data` but never recreates the per-key symlink, so its `lstat` mtime is **frozen at pod start**. The 5s poll therefore never saw a change → the router kept enforcing the **boot-time** policy.

**Live proof:** patched an `InferencePolicy` → controller updated the ConfigMap in **22s** → router logged **no reload in 120s**. Only a pod bump applied it.

### Blast radius
Every router-enforced live edit until pod restart: prompt shields, content-safety floors, token budgets, model prefs, egress allowlists/approvals, memory bindings, AGT governance. This is a **fail-open** gap (tightening a policy didn't apply).

## The fix
One shared `config_mount::dir_max_mtime(dir, exts)` that stats via `std::fs::metadata(e.path())` (**follows** symlinks → real file mtime, which advances on every `..data` swap). All four watchers delegate to it so it can't diverge again.

### Why the existing tests missed it
`watcher_reloads_on_mtime_change` writes a **plain file** (mtime changes). The new `detects_configmap_data_symlink_swap` reproduces kubelet's **atomic `..data` symlink rename** — **proven to FAIL on the old `lstat` code and PASS on the fix**.

## Also: `kars connect` first-run footguns
Waits for the pod to be Running + agent Ready before port-forward (fail-fast on ImagePull/CrashLoop), and auto-picks a free local port — fixes `pod is not running. status=Pending` and `address already in use`.

## Verification
- 944 router lib tests pass (939 + 5 new); clippy clean.
- 821 CLI vitest pass; tsc + oxlint clean.
- Security audit: `docs/internal/security-audits/2026-06-25-router-configmap-hot-reload.md` (2 sign-offs).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>