### PR TITLE
fix(up): idempotent AKS RBAC role assignments + Docker not required for --release (v0.1.15)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {

--- a/cli/src/commands/up/preflight.ts
+++ b/cli/src/commands/up/preflight.ts
@@ -46,6 +46,10 @@ export interface UpOptionsForPreflight {
   foundryEndpoint?: string;
   openaiEndpoint?: string;
   build: boolean;
+  /** `--release [version]`: import published GHCR images instead of building.
+   * `true` for bare `--release`, or the pinned tag string. When set, the
+   * local Docker build path (and its Docker preflight requirement) is skipped. */
+  release?: string | boolean;
   sourceAcr: string;
   dryRun: boolean;
   skipInfra: boolean;
@@ -71,8 +75,13 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
   const { default: inquirer } = await import("inquirer");
   const { execa } = await import("execa");
 
-  // Auto-detect developer mode: if running from the repo (Dockerfile exists), default to --build
-  if (!options.build && !process.argv.includes("--source-acr")) {
+  // Auto-detect developer mode: if running from the repo (Dockerfile exists),
+  // default to --build. BUT not when --release is set: `kars up --release`
+  // imports the published GHCR images via `az acr import` (server-side) and
+  // never builds locally, so Docker must NOT be required — otherwise a clone
+  // without Docker fails preflight even though it never needs Docker.
+  const releaseMode = Boolean(options.release) || process.argv.includes("--release");
+  if (!options.build && !releaseMode && !process.argv.includes("--source-acr")) {
     const repoRoot = new URL("../../../..", import.meta.url).pathname;
     if (existsSync(`${repoRoot}/inference-router/Dockerfile`) || existsSync("inference-router/Dockerfile")) {
       options.build = true;

--- a/deploy/bicep/main.json
+++ b/deploy/bicep/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "17988187282288113771"
+      "version": "0.44.1.10279",
+      "templateHash": "940580305345174806"
     }
   },
   "parameters": {
@@ -127,8 +127,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "14451878920477996846"
+              "version": "0.44.1.10279",
+              "templateHash": "2707625082998162876"
             }
           },
           "parameters": {
@@ -229,8 +229,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "6253323614075829972"
+              "version": "0.44.1.10279",
+              "templateHash": "7925585065634029621"
             }
           },
           "parameters": {
@@ -327,8 +327,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "14420824941714154587"
+              "version": "0.44.1.10279",
+              "templateHash": "18367271307769626034"
             }
           },
           "parameters": {
@@ -456,8 +456,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "12722266352135439899"
+              "version": "0.44.1.10279",
+              "templateHash": "12523284796891620699"
             }
           },
           "parameters": {
@@ -566,8 +566,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "10277985618594722511"
+              "version": "0.44.1.10279",
+              "templateHash": "5350835899888631225"
             }
           },
           "parameters": {
@@ -738,72 +738,150 @@
               ]
             },
             {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "scope": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name')))]",
-              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), 'mi-contributor')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-sandbox-rbac', parameters('name'))]",
               "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e40ec5ca-96e0-45a2-b4ff-59039f2c2b59')]",
-                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), '2023-01-31').principalId]",
-                "principalType": "ServicePrincipal"
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "sandboxIdentityId": {
+                    "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name')))]"
+                  },
+                  "sandboxPrincipalId": {
+                    "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), '2023-01-31').principalId]"
+                  },
+                  "kubeletPrincipalId": {
+                    "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('name')), '2024-09-01').identityProfile.kubeletidentity.objectId]"
+                  },
+                  "acrName": {
+                    "value": "[last(split(parameters('acrId'), '/'))]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "openAiAccountId": {
+                    "value": "[parameters('openAiAccountId')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.44.1.10279",
+                      "templateHash": "9340508370433890200"
+                    }
+                  },
+                  "parameters": {
+                    "sandboxIdentityId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Resource ID of the sandbox user-assigned identity (scope for the MI-Contributor grant)."
+                      }
+                    },
+                    "sandboxPrincipalId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "principalId (objectId) of the sandbox user-assigned identity."
+                      }
+                    },
+                    "kubeletPrincipalId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "principalId (objectId) of the AKS kubelet identity."
+                      }
+                    },
+                    "acrName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "ACR name (the sandbox UAMI gets AcrPull on it; kubelet gets AcrPull at RG scope)."
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Key Vault name (the sandbox UAMI gets Key Vault Secrets User on it)."
+                      }
+                    },
+                    "openAiAccountId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Full resource ID of the Azure OpenAI / AI Services account, or empty when using an external endpoint."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "acrPullRole": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+                    "miContributorRole": "e40ec5ca-96e0-45a2-b4ff-59039f2c2b59",
+                    "openAiUserRole": "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
+                    "kvSecretsUserRole": "4633458b-17de-408a-b874-0445c86b69e6"
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', last(split(parameters('sandboxIdentityId'), '/')))]",
+                      "name": "[guid(parameters('sandboxIdentityId'), parameters('sandboxPrincipalId'), variables('miContributorRole'))]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('miContributorRole'))]",
+                        "principalId": "[parameters('sandboxPrincipalId')]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "name": "[guid(resourceGroup().id, parameters('kubeletPrincipalId'), variables('acrPullRole'))]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRole'))]",
+                        "principalId": "[parameters('kubeletPrincipalId')]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+                      "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), parameters('sandboxPrincipalId'), variables('acrPullRole'))]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRole'))]",
+                        "principalId": "[parameters('sandboxPrincipalId')]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    },
+                    {
+                      "condition": "[not(empty(parameters('openAiAccountId')))]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', last(split(parameters('openAiAccountId'), '/')))]",
+                      "name": "[guid(parameters('openAiAccountId'), parameters('sandboxPrincipalId'), variables('openAiUserRole'))]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('openAiUserRole'))]",
+                        "principalId": "[parameters('sandboxPrincipalId')]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+                      "name": "[guid(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), parameters('sandboxPrincipalId'), variables('kvSecretsUserRole'))]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('kvSecretsUserRole'))]",
+                        "principalId": "[parameters('sandboxPrincipalId')]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    }
+                  ]
+                }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name')))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "name": "[guid(resourceId('Microsoft.ContainerService/managedClusters', parameters('name')), parameters('acrId'), 'acrpull')]",
-              "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
-                "principalId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('name')), '2024-09-01').identityProfile.kubeletidentity.objectId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.ContainerService/managedClusters', parameters('name'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('acrId'), '/')))]",
-              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), parameters('acrId'), 'acrpull')]",
-              "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
-                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), '2023-01-31').principalId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name')))]"
-              ]
-            },
-            {
-              "condition": "[not(empty(parameters('openAiAccountId')))]",
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', last(split(parameters('openAiAccountId'), '/')))]",
-              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), parameters('openAiAccountId'), 'openai-user')]",
-              "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')]",
-                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), '2023-01-31').principalId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name')))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
-              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), 'kv-secrets-user')]",
-              "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
-                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name'))), '2023-01-31').principalId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', parameters('name'))]",
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-sandbox-wi', parameters('name')))]"
               ]
             }

--- a/deploy/bicep/modules/aks.bicep
+++ b/deploy/bicep/modules/aks.bicep
@@ -168,76 +168,23 @@ resource controllerFederatedCredential 'Microsoft.ManagedIdentity/userAssignedId
 }
 
 // Grant sandbox MI "Managed Identity Contributor" on itself — controller can create/delete fedcreds
-resource miContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(sandboxIdentity.id, sandboxIdentity.id, 'mi-contributor')
-  scope: sandboxIdentity
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e40ec5ca-96e0-45a2-b4ff-59039f2c2b59')  // Managed Identity Contributor
-    principalId: sandboxIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// ─── RBAC Role Assignments ──────────────────────────────────────────────────
-
-// Grant AKS kubelet pull access to ACR
-resource acrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(aks.id, acrId, 'acrpull')
-  scope: resourceGroup()
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')  // AcrPull
-    principalId: aks.properties.identityProfile.kubeletidentity.objectId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// Grant the sandbox/controller workload identity AcrPull on the ACR.
-// The controller uses this UAMI (federated via OIDC) to fetch signed
-// egress allowlist artifacts (and any other policy artifacts) from
-// the registry as part of `AllowlistVerified` verification. Without
-// this assignment the controller falls back to anonymous, which 401s
-// when anonymous pull is disabled (the secure default).
-resource acrRef 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
-  name: last(split(acrId, '/'))
-}
-
-resource sandboxAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(sandboxIdentity.id, acrId, 'acrpull')
-  scope: acrRef
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')  // AcrPull
-    principalId: sandboxIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// Grant sandbox identity "Cognitive Services OpenAI User" on the AOAI resource (only when AOAI is deployed)
-resource openAiAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = if (!empty(openAiAccountId)) {
-  name: last(split(openAiAccountId, '/'))
-}
-
-resource openAiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(openAiAccountId)) {
-  name: guid(sandboxIdentity.id, openAiAccountId, 'openai-user')
-  scope: openAiAccount
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')  // Cognitive Services OpenAI User
-    principalId: sandboxIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// Grant sandbox identity "Key Vault Secrets User" on Key Vault
-resource keyVaultRef 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
-}
-
-resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(sandboxIdentity.id, keyVaultRef.id, 'kv-secrets-user')
-  scope: keyVaultRef
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')  // Key Vault Secrets User
-    principalId: sandboxIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
+// ─── RBAC Role Assignments (idempotent — see modules/sandbox-rbac.bicep) ────
+//
+// Delegated to a sub-module so every role-assignment `name` GUID can include the
+// assignee principalId (BCP120 forbids a runtime `reference()` in a roleAssignment
+// name, but a module string param is allowed). Without this, a rotated identity
+// (recreated AKS kubelet identity, or a re-created sandbox UAMI of the same name)
+// keeps the old GUID with a new principalId and ARM fails the whole deploy with
+// `RoleAssignmentUpdateNotPermitted`.
+module sandboxRbac 'sandbox-rbac.bicep' = {
+  name: '${name}-sandbox-rbac'
+  params: {
+    sandboxIdentityId: sandboxIdentity.id
+    sandboxPrincipalId: sandboxIdentity.properties.principalId
+    kubeletPrincipalId: aks.properties.identityProfile.kubeletidentity.objectId
+    acrName: last(split(acrId, '/'))
+    keyVaultName: keyVaultName
+    openAiAccountId: openAiAccountId
   }
 }
 

--- a/deploy/bicep/modules/sandbox-rbac.bicep
+++ b/deploy/bicep/modules/sandbox-rbac.bicep
@@ -1,0 +1,122 @@
+// Sandbox + kubelet RBAC for the AKS cluster, with **idempotent** role-
+// assignment names.
+//
+// Why this is a separate module
+// ─────────────────────────────
+// A `Microsoft.Authorization/roleAssignments` `name` must be a GUID that is
+// calculable at the START of the deployment (Bicep BCP120). The Azure-
+// recommended idempotent pattern is `guid(scope, principalId, roleDefId)` so
+// that:
+//   • re-deploying with the SAME principal reuses the same name (no-op), and
+//   • a ROTATED identity (new principalId) yields a NEW name → a CREATE, not a
+//     conflicting UPDATE that fails with `RoleAssignmentUpdateNotPermitted`
+//     ("principal ID ... not allowed to be updated").
+// But `principalId` read off a live resource (`x.properties.principalId`,
+// `aks...kubeletidentity.objectId`) is a runtime `reference()` — NOT allowed in
+// a role-assignment `name` (BCP120). A **module parameter**, however, IS a
+// deploy-start value inside the module, so the parent passes the runtime
+// principalIds in as string params here and the GUIDs become legal.
+//
+// The AKS kubelet identity rotates whenever the cluster is recreated (e.g.
+// `kars up --from-scratch` after a teardown); the sandbox UAMI's principalId
+// rotates if its resource group is deleted and re-created with the same name.
+// Both used to wedge re-deploys with `RoleAssignmentUpdateNotPermitted`; with
+// principalId in the GUID they now create fresh assignments cleanly. Orphaned
+// old assignments (principal deleted) are harmless.
+
+@description('Resource ID of the sandbox user-assigned identity (scope for the MI-Contributor grant).')
+param sandboxIdentityId string
+
+@description('principalId (objectId) of the sandbox user-assigned identity.')
+param sandboxPrincipalId string
+
+@description('principalId (objectId) of the AKS kubelet identity.')
+param kubeletPrincipalId string
+
+@description('ACR name (the sandbox UAMI gets AcrPull on it; kubelet gets AcrPull at RG scope).')
+param acrName string
+
+@description('Key Vault name (the sandbox UAMI gets Key Vault Secrets User on it).')
+param keyVaultName string
+
+@description('Full resource ID of the Azure OpenAI / AI Services account, or empty when using an external endpoint.')
+param openAiAccountId string = ''
+
+// Built-in role definition GUIDs.
+var acrPullRole = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+var miContributorRole = 'e40ec5ca-96e0-45a2-b4ff-59039f2c2b59'
+var openAiUserRole = '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
+var kvSecretsUserRole = '4633458b-17de-408a-b874-0445c86b69e6'
+
+resource sandboxIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: last(split(sandboxIdentityId, '/'))
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
+  name: acrName
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource openAiAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = if (!empty(openAiAccountId)) {
+  name: last(split(openAiAccountId, '/'))
+}
+
+// Sandbox MI "Managed Identity Contributor" on itself — controller can
+// create/delete federated credentials on the UAMI.
+resource miContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(sandboxIdentityId, sandboxPrincipalId, miContributorRole)
+  scope: sandboxIdentity
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', miContributorRole)
+    principalId: sandboxPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// AKS kubelet AcrPull (RG scope — pull node/system images).
+resource kubeletAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, kubeletPrincipalId, acrPullRole)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRole)
+    principalId: kubeletPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Sandbox/controller workload identity AcrPull on the ACR (fetch signed
+// egress-allowlist / policy artifacts; anonymous pull is disabled by default).
+resource sandboxAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, sandboxPrincipalId, acrPullRole)
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRole)
+    principalId: sandboxPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Sandbox identity "Cognitive Services OpenAI User" on the AOAI resource
+// (only when AOAI is deployed in-RG).
+resource openAiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(openAiAccountId)) {
+  name: guid(openAiAccountId, sandboxPrincipalId, openAiUserRole)
+  scope: openAiAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', openAiUserRole)
+    principalId: sandboxPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Sandbox identity "Key Vault Secrets User" on Key Vault.
+resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, sandboxPrincipalId, kvSecretsUserRole)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', kvSecretsUserRole)
+    principalId: sandboxPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/docs/internal/security-audits/2026-06-25-rbac-idempotency-docker-preflight.md
+++ b/docs/internal/security-audits/2026-06-25-rbac-idempotency-docker-preflight.md
@@ -1,0 +1,72 @@
+# Security Audit — Idempotent AKS RBAC role assignments + Docker preflight for `--release` (v0.1.15)
+
+Date: 2026-06-25
+Scope: `deploy/bicep/modules/sandbox-rbac.bicep` (new), `deploy/bicep/modules/aks.bicep`, `deploy/bicep/main.json` (recompiled), `cli/src/commands/up/preflight.ts`.
+Gated path: `cli/src/commands/up/preflight.ts`.
+
+## Summary
+
+1. **Idempotent role-assignment names (the `kars up` blocker).** The AKS module's
+   five role assignments named themselves `guid(<resource>.id, ...)` — stable
+   across an identity rotation. When the AKS **kubelet identity** rotates (it gets
+   a fresh objectId whenever the cluster is recreated, e.g. `kars up
+   --from-scratch` after a teardown) or the sandbox UAMI is re-created with the
+   same name, the GUID stayed constant but the `principalId` changed, so ARM tried
+   to **update** an existing assignment's principal and failed the whole deploy
+   with `RoleAssignmentUpdateNotPermitted` ("principal ID … not allowed to be
+   updated").
+
+   Fix: a new `modules/sandbox-rbac.bicep` receives the principalIds as **string
+   parameters** (legal in a roleAssignment `name`, unlike a runtime
+   `reference()` — Bicep BCP120) and names each assignment
+   `guid(scope, principalId, roleDefId)`. A rotated identity now yields a new name
+   → a clean CREATE instead of a conflicting UPDATE. Every **role, principal, and
+   scope is preserved exactly** (kubelet AcrPull @ RG; sandbox AcrPull @ ACR;
+   OpenAI User @ AOAI account; KV Secrets User @ Key Vault; MI Contributor @ the
+   UAMI). Orphaned old assignments (principal deleted) are harmless.
+
+2. **Docker no longer required for `kars up --release`.** Preflight auto-enabled
+   `build=true` whenever a repo Dockerfile was present (developer-mode detection),
+   without excluding `--release`. So running `kars up --release` from a clone
+   demanded Docker even though release mode only `az acr import`s published images
+   (server-side, no local build). Fix: skip the auto-build (and its Docker
+   requirement) when `--release` is set.
+
+## T1: New capability / attack surface? (NO)
+- No new role, principal, or scope is granted. The set of effective RBAC after a
+  successful deploy is identical; only the assignment **resource names** (GUIDs)
+  change to be idempotent. The grants remain least-privilege and resource-scoped
+  exactly as before.
+- The preflight change only *relaxes a tooling requirement* for a mode that never
+  used Docker; it touches no deployed resource, credential, or policy.
+
+## T2: Security-control change? (NEUTRAL)
+- Roles unchanged: AcrPull (`7f951dda…`), Managed Identity Contributor
+  (`e40ec5ca…`), Cognitive Services OpenAI User (`5e0bd9bd…`), Key Vault Secrets
+  User (`4633458b…`). Scopes unchanged. `principalType` unchanged. No widening
+  (e.g. no move from resource scope to RG/subscription scope).
+- `--release` Docker skip does not alter any enforcement; image provenance is
+  still the signed GHCR images imported via `az acr import`.
+
+## T3: Availability / fail-open risk? (REDUCED)
+- Removes a hard deploy failure (`RoleAssignmentUpdateNotPermitted`) on re-deploys
+  over a rotated identity — a pure reliability win. Idempotent CREATE semantics
+  mean re-runs converge instead of wedging.
+- Removes a false-blocking preflight failure for valid `--release` runs without
+  Docker.
+
+## Verification
+- `az bicep build --file deploy/bicep/main.bicep` compiles clean (validates the
+  new module's `existing`/scope wiring and the BCP120-safe names);
+  `deploy/bicep/main.json` recompiled in sync.
+- CLI `tsc --noEmit` + oxlint clean; 821 vitest tests pass.
+- Module file is bundled into the npm package (`dist/deploy/bicep/modules/sandbox-rbac.bicep`)
+  so `az deployment … --template-file main.bicep` resolves it for a clean install.
+
+## Verdict
+Accept. Makes AKS RBAC re-deploys idempotent (fixes a hard `kars up` failure) with
+zero change to the effective permission set, and stops `--release` from demanding
+Docker it never uses. No security control is weakened.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Blocker: `RoleAssignmentUpdateNotPermitted` on `kars up`

`aks.bicep` named its role assignments `guid(<resource>.id, …)` — stable across an identity rotation. When the AKS **kubelet identity** rotates (fresh objectId on cluster recreate, e.g. `--from-scratch` after a teardown) or the sandbox UAMI is recreated with the same name, the GUID stayed constant but the `principalId` changed, so ARM tried to **update** an existing assignment's principal → `RoleAssignmentUpdateNotPermitted` ("principal ID … not allowed to be updated"), failing the whole deploy.

### Fix
New `modules/sandbox-rbac.bicep` receives the principalIds as **string params** — legal in a roleAssignment `name`, unlike a runtime `reference()` (Bicep **BCP120**, which is why the obvious inline fix doesn't compile) — and names each assignment `guid(scope, principalId, roleDefId)`. A rotated identity now yields a new name → a clean **CREATE** instead of a conflicting **UPDATE**.

**Every role, principal, and scope is preserved exactly** (kubelet AcrPull @ RG; sandbox AcrPull @ ACR; OpenAI User @ AOAI; KV Secrets User @ KV; MI Contributor @ UAMI). `main.json` recompiled in sync.

## Also: `kars up --release` wrongly required Docker
Preflight auto-set `build=true` whenever a repo Dockerfile existed (dev-mode detection) **without excluding `--release`** — so running from a clone demanded Docker even though release mode only `az acr import`s published images (no local build). Fixed to skip the auto-build + Docker requirement under `--release`.

## Verification
- `az bicep build --file deploy/bicep/main.bicep` compiles clean (validates the module's `existing`/scope wiring + BCP120-safe names); `main.json` regenerated.
- CLI `tsc` + oxlint clean; 821 vitest pass.
- Module bundled into the npm package (`dist/deploy/bicep/modules/`).
- Security audit: `docs/internal/security-audits/2026-06-25-rbac-idempotency-docker-preflight.md` (2 sign-offs).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>