### PR TITLE
fix(ootb): onboarding hardening + keyless web search (v0.1.16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: az bicep build --file deploy/bicep/main.bicep
+      # Regression gate: every role assignment must be idempotent (principalId in
+      # the name GUID) so identity rotation can't trigger RoleAssignmentUpdateNotPermitted.
+      - name: RBAC idempotency gate
+        run: python3 ci/bicep-rbac-idempotency.py
 
   helm-lint:
     name: Helm Lint

--- a/ci/bicep-rbac-idempotency.py
+++ b/ci/bicep-rbac-idempotency.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# CI gate: every `Microsoft.Authorization/roleAssignments` in deploy/bicep must
+# name itself with a GUID that incorporates the assignee **principalId**, so an
+# identity rotation (e.g. the AKS kubelet identity on cluster recreate, or a
+# UAMI re-created with the same name) produces a NEW assignment name — a clean
+# CREATE — instead of an UPDATE that ARM rejects with
+# `RoleAssignmentUpdateNotPermitted`.
+#
+# This is the static regression guard for the v0.1.15 idempotency fix. A role
+# assignment whose name GUID is derived only from resource `.id`s (stable across
+# rotation) is the exact bug that broke `kars up` on existing/recreated RGs.
+#
+# A name is considered idempotent if its GUID expression references a token
+# matching principalId / objectId / spObjectId (case-insensitive) — i.e. the
+# assignee principal, not just scope/resource ids.
+
+import glob
+import re
+import sys
+
+PRINCIPAL_TOKEN = re.compile(r"principal[_]?id|object[_]?id|spobjectid", re.IGNORECASE)
+GUID_INLINE = re.compile(r"^\s*name:\s*(guid\(.+)$")
+NAME_LINE = re.compile(r"^\s*name:\s*(.+?)\s*$")
+VAR_GUID = re.compile(r"^\s*var\s+(\w+)\s*=\s*(guid\(.+)$", re.MULTILINE)
+RA_TYPE = "Microsoft.Authorization/roleAssignments@"
+
+
+def check_file(path: str) -> list[str]:
+    errs: list[str] = []
+    src = open(path, encoding="utf-8").read()
+    lines = src.splitlines()
+
+    # Map: var name -> its `guid(...)` definition (single-line vars).
+    var_guid: dict[str, str] = {}
+    for m in VAR_GUID.finditer(src):
+        var_guid[m.group(1)] = m.group(2)
+
+    for i, line in enumerate(lines):
+        if RA_TYPE not in line:
+            continue
+        # Find the resource's `name:` within the next few lines.
+        name_expr = None
+        for j in range(i, min(i + 8, len(lines))):
+            nm = NAME_LINE.match(lines[j])
+            if nm:
+                name_expr = nm.group(1)
+                break
+        loc = f"{path}:{i + 1}"
+        if name_expr is None:
+            errs.append(f"{loc}: roleAssignment has no resolvable `name:` (cannot verify idempotency)")
+            continue
+        # Resolve the name to a guid() expression: inline, or via a var.
+        if name_expr.startswith("guid("):
+            expr = name_expr
+        elif name_expr in var_guid:
+            expr = var_guid[name_expr]
+        else:
+            errs.append(
+                f"{loc}: roleAssignment name `{name_expr}` is not a guid()/known var — "
+                f"cannot verify it includes the principalId"
+            )
+            continue
+        if not PRINCIPAL_TOKEN.search(expr):
+            errs.append(
+                f"{loc}: roleAssignment name does NOT include a principalId/objectId — "
+                f"not idempotent on identity rotation (would risk RoleAssignmentUpdateNotPermitted): "
+                f"{expr[:90]}"
+            )
+    return errs
+
+
+def main() -> int:
+    files = sorted(glob.glob("deploy/bicep/**/*.bicep", recursive=True))
+    if not files:
+        print("bicep-rbac-idempotency: no .bicep files found under deploy/bicep", file=sys.stderr)
+        return 1
+    all_errs: list[str] = []
+    ra_count = 0
+    for f in files:
+        ra_count += open(f, encoding="utf-8").read().count(RA_TYPE)
+        all_errs.extend(check_file(f))
+    if all_errs:
+        print("❌ Bicep RBAC idempotency gate FAILED:\n")
+        for e in all_errs:
+            print(f"  - {e}")
+        print(
+            "\nFix: name role assignments `guid(<scope>, <principalId>, <roleDefId>)`. "
+            "If the principalId is a runtime reference(), pass it as a string param via a "
+            "module (BCP120) — see deploy/bicep/modules/sandbox-rbac.bicep."
+        )
+        return 1
+    print(f"✅ Bicep RBAC idempotency gate OK — {ra_count} role assignment(s) across {len(files)} file(s), all include a principalId.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -1425,6 +1425,28 @@ Notes:
         stepper.step("Starting sandbox container...");
         const containerName = `kars-${options.name}`;
 
+        // Pick a free host port for the WebUI (container always listens on
+        // 18789 internally). Binding host 18789 unconditionally crashes
+        // `docker run` with "port is already allocated" when another sandbox,
+        // a `kars up` port-forward, or a second `kars dev --name` already holds
+        // it — an ugly, unhandled failure on the default onboarding path.
+        const webUiHostPort = await (async (): Promise<number> => {
+          const net = await import("node:net");
+          const canBind = (p: number) => new Promise<boolean>((resolve) => {
+            const srv = net.createServer();
+            srv.once("error", () => resolve(false));
+            srv.once("listening", () => srv.close(() => resolve(true)));
+            srv.listen(p, "127.0.0.1");
+          });
+          for (let p = 18789; p < 18789 + 20; p++) {
+            if (await canBind(p)) return p;
+          }
+          return 18789; // give up — let docker surface the bind error
+        })();
+        if (webUiHostPort !== 18789) {
+          stepper.detail("info", `Port 18789 in use — exposing WebUI on ${webUiHostPort} instead`);
+        }
+
         // Clean up any previous instance
         try {
           await execa("docker", ["rm", "-f", containerName], { stdio: "pipe" });
@@ -1553,7 +1575,7 @@ Notes:
           "--tmpfs", "/mnt:ro,size=0",
           "--tmpfs", "/srv:ro,size=0",
           "--tmpfs", "/root:ro,size=0",
-          "-p", "18789:18789",
+          "-p", `${webUiHostPort}:18789`,
           "-e", `OPENCLAW_MODEL=${model}`,
           "-e", `DEFAULT_MODEL=${model}`,
           "-e", `AZURE_OPENAI_ENDPOINT=${creds.endpoint}`,
@@ -1717,7 +1739,7 @@ Notes:
         console.log(`  Status:   ${chalk.cyan(`kars status ${options.name}`)}`);
         console.log(`  Stop:     ${chalk.cyan(`kars destroy ${options.name}`)}`);
         if (gatewayToken) {
-          const url = `http://localhost:18789/#token=${gatewayToken}`;
+          const url = `http://localhost:${webUiHostPort}/#token=${gatewayToken}`;
           // Print URL without chalk formatting — terminals auto-detect http:// links.
           // Chalk ANSI codes break terminal URL detection in most emulators.
           console.log(`  Web UI:   ${url}`);

--- a/cli/src/commands/mesh/agent_id_setup_bicep.ts
+++ b/cli/src/commands/mesh/agent_id_setup_bicep.ts
@@ -238,16 +238,36 @@ export async function ensureAgentIdTrustViaBicep(
       .filter((line) => !line.trimStart().startsWith("WARNING:"))
       .join("\n")
       .trim();
-    const summary = cleaned.split("\n")[0] || raw.split("\n")[0] || "deployment failed";
+    // Prefer the line carrying the actual Graph/ARM rejection over the generic
+    // first line ("Deployment failed. Correlation id: ...") so the surfaced
+    // hint is the real cause, not boilerplate.
+    const lines = cleaned.split("\n").map((l) => l.trim()).filter(Boolean);
+    const meaningful =
+      lines.find((l) =>
+        /ServiceManagementReference|Authorization_RequestDenied|InvalidFederatedIdentity|insufficient privileges|forbidden|does not have permission/i.test(
+          l,
+        ),
+      ) ?? lines[0] ?? raw.split("\n")[0] ?? "deployment failed";
+    const summary = meaningful;
 
-    // Corp-tenant app registrations require a valid ServiceTree GUID. The
-    // raw Graph error ("ServiceManagementReference must be a valid GUID")
-    // is opaque — surface an actionable hint pointing at --service-tree.
+    // App registration in a Microsoft-corporate tenant needs a valid
+    // ServiceTree GUID. Only steer the user to `--service-tree` when they did
+    // NOT already pass one — otherwise the GUID they supplied is being
+    // rejected (wrong value, or their account isn't linked to that service),
+    // and telling them to "re-run with --service-tree" is misleading.
     if (/ServiceTree|ServiceManagementReference/i.test(raw)) {
+      if (!serviceTree) {
+        throw new Error(
+          "Bicep deployment failed: your tenant requires a valid ServiceTree GUID for app " +
+            "registration. Re-run with `--service-tree <GUID>` (or set KARS_SERVICE_TREE). " +
+            `Underlying error: ${summary.slice(0, 240)}`,
+        );
+      }
       throw new Error(
-        "Bicep deployment failed: your tenant requires a valid ServiceTree GUID for app " +
-          "registration. Re-run with `--service-tree <GUID>` (or set KARS_SERVICE_TREE). " +
-          `Underlying error: ${summary.slice(0, 200)}`,
+        `Bicep deployment failed: the ServiceTree GUID you supplied (${serviceTree}) was rejected ` +
+          "by the tenant. Confirm it's a valid ServiceTree *service* GUID and that your account is " +
+          "associated with it (the value must match a real service, not just be a well-formed GUID). " +
+          `Underlying error: ${summary.slice(0, 240)}`,
       );
     }
 

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -43,6 +43,8 @@ export function upCommand(): Command {
     .option("--skip-infra", "Skip infrastructure provisioning (reuse existing cluster)", false)
     .option("--force-infra", "Force Bicep deployment even if AKS cluster exists", false)
     .option("--skip-preflight", "Skip upfront RBAC & provider checks (advanced; you know what you're doing)", false)
+    .option("--skip-validate", "Skip the pre-deploy ARM what-if/validate gate (advanced; only if it false-positives)", false)
+    .option("--yes", "Non-interactive: never prompt — use provided flags + defaults (for CI/automation). Also auto-engaged when stdin is not a TTY.", false)
     // ── Images ─────────────────────────────────────────────────────────
     .option("--source-acr <server>", "Source ACR for pre-built images (customers)", "karsacr.azurecr.io")
     .option("--release [version]", "Import the PUBLIC, signed GHCR release images (ghcr.io/azure/*) into your ACR instead of building from source. Bare --release uses the latest release; pass a tag (e.g. v0.1.4) to pin. No Rust/Docker build needed.")
@@ -193,19 +195,29 @@ Auto-resume:
         console.log(chalk.dim(`  --from-scratch: any cached partial state will be ignored.\n`));
       }
       const resumeFromPhase = resumeState?.resumeFromPhase ?? null;
-      // Stepper counts the 9 runtime phases below (10 with --expose-registry).
-      // Preflight runs before the stepper (see runPreflightChecks above).
+      // Stepper total = the runtime phases below. Each phase that calls
+      // `stepper.step()` increments the counter, so the total MUST include
+      // every conditional phase or the final step overflows (e.g. the old
+      // `10/9`). Phases:
       //   1. Resource group + preview features
       //   2. Bicep deploy (or verify existing)
       //   3. Network/firewalls/ACR attach
       //   4. Get AKS credentials
       //   5. Build OR import images
       //   6. Helm install (CRD + controller + seccomp DS)
-      //   7. AgentMesh infrastructure (relay + registry)
-      //   8. (optional) AgentMesh Ingress — only with --expose-registry
-      //   9. Create KarsSandbox CR
-      //  10. Wait for sandbox Running
-      const totalSteps = 9 + (options.exposeRegistry ? 1 : 0);
+      //   7. (optional) Entra Agent ID trust anchor — only with --mesh-trust=entra
+      //   8. AgentMesh infrastructure (relay + registry)
+      //   9. (optional) AgentMesh Ingress — only with --expose-registry
+      //  10. Create KarsSandbox CR
+      //  11. Wait for sandbox Running
+      // Base (without the two optionals) = 9 phases. We over-count rather than
+      // under-count for the rare resume path that skips the Entra provisioning
+      // step: a graceful `9/10` is fine; a broken `10/9` is not.
+      const meshTrustForCount = (options as { meshTrust?: string }).meshTrust ?? "anonymous";
+      const totalSteps =
+        9 +
+        (options.exposeRegistry ? 1 : 0) +
+        (meshTrustForCount === "entra" ? 1 : 0);
       const stepper = new Stepper({ totalSteps });
 
       try {
@@ -358,6 +370,47 @@ Auto-resume:
           }
           if (options.foundryEndpoint) {
             bicepParams.push("deployAoai=false");
+          }
+
+          // ── Pre-deploy gate: ARM preflight validation (no resources created) ──
+          // `az deployment group validate` runs Azure's two-phase server-side
+          // preflight — static (template/params) AND resource-provider preflight
+          // (RBAC, permissions, scope, name uniqueness, API/SKU). It fails in
+          // seconds INSTEAD of after minutes of partial provisioning, for both
+          // fresh and existing RGs, and surfaces CLI↔template version skew with a
+          // clear fix. `--skip-validate` opts out for the rare false positive.
+          if (!options.skipValidate) {
+            stepper.update("Validating deployment (Azure ARM preflight — no resources created yet)...");
+            try {
+              await execa("az", [
+                "deployment", "group", "validate",
+                "--resource-group", rg,
+                "--template-file", bicepPath,
+                "--parameters", ...bicepParams,
+                "--output", "none",
+              ], { stdio: "pipe" });
+            } catch (vErr: unknown) {
+              const e = vErr as { stderr?: string; message?: string };
+              const msg = String(e.stderr || e.message || vErr).trim();
+              const head = msg.split("\n").slice(0, 12).map((l) => "      " + l).join("\n");
+              // CLI passed a parameter the bundled template doesn't declare (or
+              // vice-versa) — almost always a stale local build.
+              if (/unrecognized template parameter|is not valid|No parameter named|not a valid parameter|InvalidTemplate.*[Pp]arameter/i.test(msg)) {
+                throw new Error(
+                  "Pre-deploy validation failed: the CLI and its bundled Bicep template are out of sync " +
+                  "(a parameter the template doesn't recognize).\n\n" +
+                  "  This is almost always a stale local build. Fix:\n" +
+                  "    npm i -g @kars-runtime/cli@latest        (published)\n" +
+                  "    # or, in a repo checkout:  cd cli && npm run build\n\n" +
+                  "  Azure said:\n" + head,
+                );
+              }
+              throw new Error(
+                "Pre-deploy validation failed (Azure ARM preflight) — no resources were created. " +
+                "Fix this, then re-run:\n\n" + head + "\n\n" +
+                "  If you're certain this is a false positive, re-run with --skip-validate.",
+              );
+            }
           }
 
           // Run Bicep deployment with a progress ticker

--- a/cli/src/commands/up/agentmesh_deploy.ts
+++ b/cli/src/commands/up/agentmesh_deploy.ts
@@ -114,20 +114,32 @@ export async function deployAgentMesh(
 
         // Wait for AgentMesh pods to be ready
         stepper.update("Waiting for AgentMesh pods to be ready...");
-        await execa("kubectl", [
+        const relayReady = await execa("kubectl", [
           "wait", "--for=condition=Ready", "pod",
           "-l", "app=agentmesh-relay",
           "-n", "agentmesh",
           "--timeout=180s",
-        ], { stdio: "pipe" }).catch(() => {});
-        await execa("kubectl", [
+        ], { stdio: "pipe" }).then(() => true).catch(() => false);
+        const registryReady = await execa("kubectl", [
           "wait", "--for=condition=Ready", "pod",
           "-l", "app=agentmesh-registry",
           "-n", "agentmesh",
           "--timeout=180s",
-        ], { stdio: "pipe" }).catch(() => {});
+        ], { stdio: "pipe" }).then(() => true).catch(() => false);
 
-        stepper.done(`AgentMesh infrastructure deployed (agt)`);
+        if (!relayReady || !registryReady) {
+          // Don't claim a clean success when the mesh never came up — that's
+          // the silent "broken mesh, green checkmark" trap. Sub-agent handoff
+          // will fail until these are Running; point the user at the fix.
+          const which = [!relayReady ? "relay" : "", !registryReady ? "registry" : ""]
+            .filter(Boolean).join(" + ");
+          stepper.warn(
+            `AgentMesh ${which} not Ready after 180s — sub-agent handoff won't work yet. ` +
+              `Check: kubectl get pods -n agentmesh (likely ImagePullBackOff or slow pull).`,
+          );
+        } else {
+          stepper.done(`AgentMesh infrastructure deployed (agt)`);
+        }
 
         // Phase 6.c — enable JWT verification on the relay + registry
         // when the operator has provisioned an Entra Agent Identity

--- a/cli/src/commands/up/images.ts
+++ b/cli/src/commands/up/images.ts
@@ -255,36 +255,58 @@ export async function acquireImages(ctx: AcquireImagesContext): Promise<void> {
     // Customer mode: import pre-built images from source ACR
     stepper.step("Importing images from source ACR...");
     const sourceAcr = options.sourceAcr;
-    const images = [
-      { source: `${sourceAcr}/kars-controller:latest`, target: "kars-controller:latest" },
-      { source: `${sourceAcr}/kars-inference-router:latest`, target: "kars-inference-router:latest" },
-      { source: `${sourceAcr}/openclaw-sandbox:latest`, target: "openclaw-sandbox:latest" },
-      { source: `${sourceAcr}/agentmesh-relay:latest`, target: "agentmesh-relay:latest" },
-      { source: `${sourceAcr}/agentmesh-registry:latest`, target: "agentmesh-registry:latest" },
+    // `required` images must land or the cluster can't run; runtime adapters
+    // are optional (a given source ACR may not host every runtime). Mesh
+    // images MUST use the `-agt` suffix — that's the tag the
+    // deploy/agentmesh-agt.yaml manifest references; importing them without it
+    // (the old bug) left the relay/registry in ImagePullBackOff while the
+    // deploy still reported success.
+    const images: Array<{ source: string; target: string; required: boolean }> = [
+      { source: `${sourceAcr}/kars-controller:latest`, target: "kars-controller:latest", required: true },
+      { source: `${sourceAcr}/kars-inference-router:latest`, target: "kars-inference-router:latest", required: true },
+      { source: `${sourceAcr}/openclaw-sandbox:latest`, target: "openclaw-sandbox:latest", required: true },
+      { source: `${sourceAcr}/agentmesh-relay-agt:latest`, target: "agentmesh-relay-agt:latest", required: true },
+      { source: `${sourceAcr}/agentmesh-registry-agt:latest`, target: "agentmesh-registry-agt:latest", required: true },
       // Multi-runtime adapter images. Failures here are non-fatal —
       // some source ACRs may not host every runtime.
-      { source: `${sourceAcr}/kars-runtime-openai-agents:latest`, target: "kars-runtime-openai-agents:latest" },
-      { source: `${sourceAcr}/kars-runtime-maf-python:latest`, target: "kars-runtime-maf-python:latest" },
-      { source: `${sourceAcr}/kars-runtime-anthropic:latest`, target: "kars-runtime-anthropic:latest" },
-      { source: `${sourceAcr}/kars-runtime-langgraph:latest`, target: "kars-runtime-langgraph:latest" },
-      { source: `${sourceAcr}/kars-runtime-langgraph-ts:latest`, target: "kars-runtime-langgraph-ts:latest" },
-      { source: `${sourceAcr}/kars-runtime-pydantic-ai:latest`, target: "kars-runtime-pydantic-ai:latest" },
-      { source: `${sourceAcr}/kars-runtime-hermes:latest`, target: "kars-runtime-hermes:latest" },
+      { source: `${sourceAcr}/kars-runtime-openai-agents:latest`, target: "kars-runtime-openai-agents:latest", required: false },
+      { source: `${sourceAcr}/kars-runtime-maf-python:latest`, target: "kars-runtime-maf-python:latest", required: false },
+      { source: `${sourceAcr}/kars-runtime-anthropic:latest`, target: "kars-runtime-anthropic:latest", required: false },
+      { source: `${sourceAcr}/kars-runtime-langgraph:latest`, target: "kars-runtime-langgraph:latest", required: false },
+      { source: `${sourceAcr}/kars-runtime-langgraph-ts:latest`, target: "kars-runtime-langgraph-ts:latest", required: false },
+      { source: `${sourceAcr}/kars-runtime-pydantic-ai:latest`, target: "kars-runtime-pydantic-ai:latest", required: false },
+      { source: `${sourceAcr}/kars-runtime-hermes:latest`, target: "kars-runtime-hermes:latest", required: false },
     ];
 
+    let customerFailures = 0;
     for (const img of images) {
       stepper.update(`Importing ${img.target}...`);
-      await execa("az", [
-        "acr", "import",
-        "--name", acr,
-        "--source", img.source,
-        "--image", img.target,
-        "--force",
-      ], { stdio: "pipe" }).then(() => {
+      try {
+        await execa("az", [
+          "acr", "import",
+          "--name", acr,
+          "--source", img.source,
+          "--image", img.target,
+          "--force",
+        ], { stdio: "pipe" });
         stepper.detail("ok", img.target);
-      }).catch(() => {
-        stepper.detail("skip", `${img.target} — import failed (may already exist)`);
-      });
+      } catch (e) {
+        const msg = ((e as { message?: string }).message ?? "").split("\n")[0].slice(0, 90);
+        if (img.required) {
+          customerFailures++;
+          stepper.detail("skip", `${img.target} — import FAILED (${msg})`);
+        } else {
+          stepper.detail("skip", `${img.target} — import failed (optional: ${msg})`);
+        }
+      }
+    }
+    if (customerFailures > 0) {
+      throw new Error(
+        `Failed to import ${customerFailures} required image(s) from ${sourceAcr}. ` +
+          `Verify you can 'az acr import' from it (network + auth) and that it hosts the ` +
+          `controller, inference-router, openclaw-sandbox, and agentmesh-*-agt images. ` +
+          `Tip: 'kars up --release' imports the public GHCR images instead — no source-ACR access needed.`,
+      );
     }
 
     stepper.done("Images available in ACR");

--- a/cli/src/commands/up/preflight.ts
+++ b/cli/src/commands/up/preflight.ts
@@ -75,6 +75,12 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
   const { default: inquirer } = await import("inquirer");
   const { execa } = await import("execa");
 
+  // Non-interactive when explicitly requested (--yes) or when there's no TTY to
+  // read prompts from (CI / piped stdin). In that mode we NEVER call inquirer;
+  // every value comes from flags + defaults, so `kars up` is fully scriptable.
+  // The interactive TTY path is unchanged.
+  const interactive = !(options as { yes?: boolean }).yes && process.stdin.isTTY === true;
+
   // Auto-detect developer mode: if running from the repo (Dockerfile exists),
   // default to --build. BUT not when --release is set: `kars up --release`
   // imports the published GHCR images via `az acr import` (server-side) and
@@ -125,11 +131,22 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
   }
 
   // ── 1. Check required CLI tools ────────────────────────────────
+  // Docker is only needed for `--build`. When it isn't required (the common
+  // `--release` / customer path) probe the *binary* with `docker --version`
+  // rather than `docker info`: `docker info` needs a running daemon, so a
+  // machine that HAS Docker installed but with the daemon stopped would print
+  // a misleading "not found". `--build` still uses `docker info` because a live
+  // daemon is genuinely required to build.
   const tools: { cmd: string; args: string[]; label: string; required: boolean }[] = [
     { cmd: "az", args: ["--version"], label: "Azure CLI", required: true },
     { cmd: "kubectl", args: ["version", "--client"], label: "kubectl", required: true },
     { cmd: "helm", args: ["version", "--short"], label: "Helm", required: true },
-    { cmd: "docker", args: ["info", "--format", "{{.ServerVersion}}"], label: "Docker", required: options.build },
+    {
+      cmd: "docker",
+      args: options.build ? ["info", "--format", "{{.ServerVersion}}"] : ["--version"],
+      label: "Docker",
+      required: options.build,
+    },
   ];
 
   {
@@ -187,7 +204,7 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
         ], { stdio: "pipe" });
         const subs = JSON.parse(subsJson) as { id: string; name: string; isDefault: boolean }[];
 
-        if (subs.length > 1) {
+        if (subs.length > 1 && interactive) {
           // Multiple subscriptions — let user confirm or pick
           const subChoices = subs.map((s) => ({
             name: `${s.name} (${s.id.slice(0, 8)}...)${s.isDefault ? chalk.dim(" ← default") : ""}`,
@@ -223,7 +240,7 @@ export async function runPreflight(options: UpOptionsForPreflight): Promise<Pref
   const userProvidedName = process.argv.includes("--name");
   const userProvidedIsolation = process.argv.includes("--isolation");
 
-  if (!options.dryRun && (!userProvidedRegion || !userProvidedName || !userProvidedIsolation)) {
+  if (!options.dryRun && interactive && (!userProvidedRegion || !userProvidedName || !userProvidedIsolation)) {
     console.log();
 
     if (!userProvidedRegion) {

--- a/cli/src/commands/up/sandbox_bringup.ts
+++ b/cli/src/commands/up/sandbox_bringup.ts
@@ -427,6 +427,25 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
           try { unlinkSync(tmpBicep); } catch {}
         }
       }
+
+      // ── Bing / web_search self-heal: remove DANGLING Grounding-with-Bing
+      // connections ────────────────────────────────────────────────────────
+      // kars uses the KEYLESS, Microsoft-managed `web_search` tool (Entra/IMDS
+      // auth, no API key). But if the project has a `GroundingWithBingSearch`
+      // connection — especially an `isDefault` one — pointing at a Bing
+      // resource that no longer exists (e.g. it lived in a since-deleted
+      // `kars-<region>` RG), Foundry routes web_search through that dead
+      // connection and returns a misleading 401 "audience is incorrect
+      // (https://bing.azure.com)". We detect connections whose backing
+      // `metadata.ResourceId` no longer resolves and remove them so the
+      // managed keyless path works. Purely advisory — never aborts the deploy,
+      // and never touches a connection whose Bing resource is still alive.
+      await removeDanglingBingConnections({
+        execa,
+        stepper,
+        foundryResourceId,
+        foundryProjectName,
+      }).catch(() => { /* advisory only — never block the deploy */ });
     }
   }
 
@@ -506,37 +525,61 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
   let gatewayToken = "";
   let webUiUrl = "";
   try {
-    // Wait for gateway to be ready inside the pod
-    await new Promise(r => setTimeout(r, 5000));
+    // Extract the gateway token from the sandbox. The gateway is started in
+    // the background by entrypoint.sh, so on a fresh deploy `.bashrc` may not
+    // be written yet — retry with backoff instead of failing the whole WebUI
+    // step on a first-run race (the symptom behind "port-forward failed" even
+    // though `kars connect` worked moments later).
+    for (let attempt = 0; attempt < 6 && !gatewayToken; attempt++) {
+      await new Promise(r => setTimeout(r, attempt === 0 ? 5000 : 3000));
+      const { stdout: bashrc } = await execa("kubectl", [
+        "exec", "-n", sandboxNs, `deploy/${options.name}`,
+        "-c", "openclaw", "--",
+        "cat", "/sandbox/.bashrc",
+      ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
+      const tokenMatch = bashrc.match(/OPENCLAW_GATEWAY_TOKEN="([^"]+)"/);
+      if (tokenMatch) gatewayToken = tokenMatch[1];
+    }
 
-    // Extract gateway token from the sandbox
-    const { stdout: bashrc } = await execa("kubectl", [
-      "exec", "-n", sandboxNs, `deploy/${options.name}`,
-      "-c", "openclaw", "--",
-      "cat", "/sandbox/.bashrc",
-    ], { stdio: "pipe" });
-    const tokenMatch = bashrc.match(/OPENCLAW_GATEWAY_TOKEN="([^"]+)"/);
-    if (tokenMatch) {
-      gatewayToken = tokenMatch[1];
+    // Pick a free local port starting at 18789. Binding 18789 unconditionally
+    // is the original footgun — a stale forward, another sandbox, or `kars dev`
+    // commonly holds it, so the forward fails. Mirror `kars connect` and bump
+    // to the next free port instead.
+    const net = await import("node:net");
+    const canBind = (p: number) => new Promise<boolean>((resolve) => {
+      const srv = net.createServer();
+      srv.once("error", () => resolve(false));
+      srv.once("listening", () => srv.close(() => resolve(true)));
+      srv.listen(p, "127.0.0.1");
+    });
+    let localPort = 18789;
+    for (let p = 18789; p < 18789 + 20; p++) {
+      if (await canBind(p)) { localPort = p; break; }
+    }
+    if (localPort !== 18789) {
+      stepper.detail("info", `Port 18789 in use — using ${localPort} for the WebUI forward`);
     }
 
     // Start port-forward in background (fully detached so CLI can exit)
     const { spawn } = await import("child_process");
     const portForward = spawn("kubectl", [
       "port-forward", "-n", sandboxNs,
-      `deploy/${options.name}`, "18789:18789",
+      `deploy/${options.name}`, `${localPort}:18789`,
     ], { stdio: "ignore", detached: true });
     portForward.unref();
     // Give it a moment to bind
     await new Promise(r => setTimeout(r, 2000));
 
     if (gatewayToken) {
-      webUiUrl = `http://localhost:18789/#token=${gatewayToken}`;
+      webUiUrl = `http://localhost:${localPort}/#token=${gatewayToken}`;
+      stepper.done("Sandbox running");
+    } else {
+      // The sandbox is up; only the token read raced. Don't claim failure —
+      // `kars connect` re-derives the token and works.
+      stepper.warn(`Sandbox running — WebUI token not ready yet; run 'kars connect ${options.name}'`);
     }
-
-    stepper.done("Sandbox running");
   } catch {
-    stepper.warn("Sandbox running but WebUI port-forward failed");
+    stepper.warn(`Sandbox running but WebUI setup failed — run 'kars connect ${options.name}'`);
   }
 
   stepper.summary();
@@ -607,4 +650,88 @@ export async function bringUpSandbox(ctx: SandboxBringUpContext): Promise<void> 
   } catch { /* non-critical */ }
 
   console.log();
+}
+
+/**
+ * Detect and remove DANGLING `GroundingWithBingSearch` connections on a Foundry
+ * project — connections whose backing `Microsoft.Bing/accounts` resource no
+ * longer exists. Such a connection (especially when `isDefault`) makes the
+ * keyless, Microsoft-managed `web_search` tool fail with a misleading
+ * `401 "audience is incorrect (https://bing.azure.com)"`, because Foundry tries
+ * to route web_search through the dead connection instead of the managed Bing
+ * resource.
+ *
+ * kars never provisions or stores a Bing API key (its `web_search` is keyless),
+ * so the correct remediation is to delete the stale connection and let the
+ * managed path take over. Strictly advisory: any error is swallowed by the
+ * caller, and a connection whose Bing resource is still alive is left untouched.
+ */
+async function removeDanglingBingConnections(ctx: {
+  execa: typeof import("execa").execa;
+  stepper: Stepper;
+  /** Full ARM id of the Foundry (CognitiveServices) account. */
+  foundryResourceId: string;
+  /** Project name (the `…/api/projects/<name>` segment). */
+  foundryProjectName: string;
+}): Promise<void> {
+  const { execa, stepper, foundryResourceId, foundryProjectName } = ctx;
+  if (!foundryResourceId || !foundryProjectName) return;
+
+  const connectionsUrl =
+    `${foundryResourceId}/projects/${foundryProjectName}/connections?api-version=2025-06-01`;
+  const { stdout: connsJson } = await execa("az", [
+    "rest", "--method", "get", "--url", connectionsUrl,
+  ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
+  if (!connsJson.trim()) return;
+
+  let connections: Array<{
+    name?: string;
+    properties?: {
+      category?: string;
+      isDefault?: boolean;
+      metadata?: { ResourceId?: string };
+    };
+  }> = [];
+  try {
+    connections = (JSON.parse(connsJson).value ?? []) as typeof connections;
+  } catch {
+    return;
+  }
+
+  for (const conn of connections) {
+    if (conn.properties?.category !== "GroundingWithBingSearch") continue;
+    const bingResourceId = conn.properties?.metadata?.ResourceId;
+    const connName = conn.name;
+    if (!bingResourceId || !connName) continue;
+
+    // Does the backing Bing resource still resolve? A 404 / ResourceGroupNotFound
+    // (e.g. the RG was deleted) marks the connection as dangling.
+    const probe = await execa("az", [
+      "rest", "--method", "get",
+      "--url", `${bingResourceId}?api-version=2020-06-10`,
+    ], { stdio: "pipe" }).then(() => ({ ok: true, err: "" }))
+      .catch((e: { stderr?: string; message?: string }) => ({
+        ok: false,
+        err: String(e.stderr || e.message || ""),
+      }));
+
+    const dangling = !probe.ok &&
+      /ResourceGroupNotFound|ResourceNotFound|NotFound|could not be found|status code 404/i.test(probe.err);
+    if (!dangling) continue;
+
+    // Remove the dead connection at both project and account scope (it can
+    // exist at either). Deletions are idempotent — a missing one is fine.
+    const projConnUrl =
+      `${foundryResourceId}/projects/${foundryProjectName}/connections/${connName}?api-version=2025-06-01`;
+    const acctConnUrl =
+      `${foundryResourceId}/connections/${connName}?api-version=2025-06-01`;
+    await execa("az", ["rest", "--method", "delete", "--url", projConnUrl], { stdio: "pipe" }).catch(() => {});
+    await execa("az", ["rest", "--method", "delete", "--url", acctConnUrl], { stdio: "pipe" }).catch(() => {});
+
+    stepper.detail(
+      "info",
+      `Removed dangling Bing connection '${connName}' (backing resource deleted) — ` +
+        `keyless managed web_search will be used instead`,
+    );
+  }
 }

--- a/cli/src/stepper.ts
+++ b/cli/src/stepper.ts
@@ -49,7 +49,11 @@ export class Stepper {
   }
 
   private prefix(): string {
-    return chalk.dim(`  ${this.current}/${this.total}`);
+    // Clamp the numerator so a miscounted total can never render an overflow
+    // like `10/9` (the displayed step is at most the total). The flow is
+    // responsible for an accurate `totalSteps`; this is a last-resort guard.
+    const shown = Math.min(this.current, this.total);
+    return chalk.dim(`  ${shown}/${this.total}`);
   }
 
   /** Start a new step — automatically completes the previous one */

--- a/deploy/bicep/modules/acr-pull-assignment.bicep
+++ b/deploy/bicep/modules/acr-pull-assignment.bicep
@@ -1,0 +1,31 @@
+// Reusable, **idempotent** AcrPull role assignment scoped to an ACR.
+//
+// `principalId` is a STRING parameter (legal in a roleAssignment `name`, unlike
+// a runtime `reference()` — Bicep BCP120), so the assignment is named
+// `guid(acr.id, principalId, roleId)`. A re-deploy with the same principal is a
+// no-op; a rotated identity (same UAMI name re-created, etc.) yields a NEW name
+// → a clean CREATE instead of failing with `RoleAssignmentUpdateNotPermitted`.
+
+@description('ACR (registry) name in this resource group.')
+param acrName string
+
+@description('Object ID (principalId) of the identity to grant AcrPull.')
+param principalId string
+
+var acrPullRoleId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
+  name: acrName
+}
+
+resource assignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, principalId, acrPullRoleId)
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output roleAssignmentId string = assignment.id

--- a/deploy/bicep/standalone/controller-acrpull.bicep
+++ b/deploy/bicep/standalone/controller-acrpull.bicep
@@ -23,29 +23,21 @@ param acrName string = 'karsacr'
 @description('User-assigned managed identity used by the AKS sandbox / controller workload identity.')
 param controllerIdentityName string = 'kars-aks-sandbox-wi'
 
-resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
-  name: acrName
-}
-
 resource controllerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: controllerIdentityName
 }
 
-// AcrPull built-in role
-var acrPullRoleId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions',
-  '7f951dda-4ed3-4680-a7ca-43fe172d538d'
-)
-
-resource controllerAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(controllerIdentity.id, acr.id, 'acrpull')
-  scope: acr
-  properties: {
-    roleDefinitionId: acrPullRoleId
+// Idempotent assignment via the shared module: the name GUID includes the
+// controller identity's principalId (passed as a string param — BCP120-safe),
+// so re-applying after the UAMI is recreated CREATEs a fresh assignment instead
+// of failing with RoleAssignmentUpdateNotPermitted.
+module controllerAcrPull '../modules/acr-pull-assignment.bicep' = {
+  name: 'controller-acrpull'
+  params: {
+    acrName: acrName
     principalId: controllerIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
   }
 }
 
-output roleAssignmentId string = controllerAcrPull.id
+output roleAssignmentId string = controllerAcrPull.outputs.roleAssignmentId
 output principalId string = controllerIdentity.properties.principalId

--- a/deploy/bicep/standalone/controller-acrpull.json
+++ b/deploy/bicep/standalone/controller-acrpull.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "14104848645051047431"
+      "version": "0.44.1.10279",
+      "templateHash": "10162397949945554113"
     }
   },
   "parameters": {
@@ -24,26 +24,78 @@
       }
     }
   },
-  "variables": {
-    "acrPullRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]"
-  },
   "resources": [
     {
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2022-04-01",
-      "scope": "[format('Microsoft.ContainerRegistry/registries/{0}', parameters('acrName'))]",
-      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('controllerIdentityName')), resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'acrpull')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "controller-acrpull",
       "properties": {
-        "roleDefinitionId": "[variables('acrPullRoleId')]",
-        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('controllerIdentityName')), '2023-01-31').principalId]",
-        "principalType": "ServicePrincipal"
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "acrName": {
+            "value": "[parameters('acrName')]"
+          },
+          "principalId": {
+            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('controllerIdentityName')), '2023-01-31').principalId]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.44.1.10279",
+              "templateHash": "2251908231826129564"
+            }
+          },
+          "parameters": {
+            "acrName": {
+              "type": "string",
+              "metadata": {
+                "description": "ACR (registry) name in this resource group."
+              }
+            },
+            "principalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Object ID (principalId) of the identity to grant AcrPull."
+              }
+            }
+          },
+          "variables": {
+            "acrPullRoleId": "7f951dda-4ed3-4680-a7ca-43fe172d538d"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+              "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), parameters('principalId'), variables('acrPullRoleId'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRoleId'))]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ],
+          "outputs": {
+            "roleAssignmentId": {
+              "type": "string",
+              "value": "[extensionResourceId(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), parameters('principalId'), variables('acrPullRoleId')))]"
+            }
+          }
+        }
       }
     }
   ],
   "outputs": {
     "roleAssignmentId": {
       "type": "string",
-      "value": "[extensionResourceId(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('controllerIdentityName')), resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'acrpull'))]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'controller-acrpull'), '2025-04-01').outputs.roleAssignmentId.value]"
     },
     "principalId": {
       "type": "string",

--- a/docs/internal/security-audits/2026-06-25-onboarding-hardening-websearch.md
+++ b/docs/internal/security-audits/2026-06-25-onboarding-hardening-websearch.md
@@ -1,0 +1,115 @@
+# Security Audit — OOTB onboarding hardening + keyless web search (v0.1.16)
+
+Date: 2026-06-25
+Scope:
+- `cli/src/commands/up.ts` (pre-deploy ARM validate gate, `--skip-validate`, `--yes`, stepper count)
+- `cli/src/commands/up/preflight.ts` (non-interactive mode; Docker preflight false-negative)
+- `cli/src/commands/up/images.ts` (customer-mode mesh `-agt` tag + required-failure gate)
+- `cli/src/commands/up/agentmesh_deploy.ts` (surface mesh-readiness timeout instead of swallowing)
+- `cli/src/commands/up/sandbox_bringup.ts` (free-port WebUI forward, token-read retry, dangling-Bing-connection self-heal)
+- `cli/src/commands/dev.ts` (free host port for the dev container WebUI)
+- `cli/src/commands/mesh/agent_id_setup_bicep.ts` (service-tree error classifier)
+- `cli/src/stepper.ts` (numerator clamp)
+- `runtimes/openclaw/src/core/agt-tools/foundry.ts`, `runtimes/openclaw/src/core/agt-task-loop.ts`
+  (`foundry_web_search`: classic key-based `bing_grounding` → keyless managed `web_search`)
+- `ci/bicep-rbac-idempotency.py` (new), `.github/workflows/ci.yml` (static RBAC gate)
+- `deploy/bicep/modules/acr-pull-assignment.bicep` (new), `deploy/bicep/standalone/controller-acrpull.bicep` (+recompiled `.json`)
+
+Gated paths (per CI `security-audit-required`): `cli/src/commands/*`, `runtimes/openclaw/src/core/*`.
+
+## Summary
+
+A batch of first-run ("out-of-the-box") reliability fixes plus a credentials-posture
+improvement for web search. None grants a new role, scope, or principal; the only
+identity/credential change **removes** an API-key code path in favour of the keyless,
+Entra/IMDS-authenticated managed tool.
+
+1. **Pre-deploy ARM validate gate.** `kars up` runs `az deployment group validate`
+   before creating resources. Read-only; fails fast on template/param/RBAC issues
+   with no side effects. `--skip-validate` opts out.
+
+2. **Non-interactive `--yes` / no-TTY.** Preflight skips `inquirer` prompts when
+   `--yes` or no TTY. Only affects prompting; all values still come from flags +
+   defaults. No control is bypassed.
+
+3. **Docker preflight false-negative.** `--release` (Docker not required) now probes
+   `docker --version` (binary) instead of `docker info` (needs a running daemon).
+   `--build` still uses `docker info`. No security impact — Docker is a local
+   tooling check, not a deployed control.
+
+4. **Customer-mode image import correctness + fail-closed.** Mesh images now import
+   with the `-agt` suffix the manifest references (was silently wrong → ImagePullBackOff),
+   and a **required**-image import failure now aborts instead of being swallowed.
+   This *strengthens* integrity (no partial/mismatched deploy reported as success).
+   Image provenance is unchanged (`az acr import` of the same sources).
+
+5. **Mesh-readiness timeout surfaced.** `agentmesh_deploy` previously swallowed a
+   180s readiness timeout and reported success; now it warns. Pure observability;
+   no control change.
+
+6. **WebUI port-forward free-port + token retry (`kars up`/`kars dev`).** Auto-pick a
+   free localhost/host port instead of hard-binding 18789; retry the gateway-token
+   read with backoff. Loopback/localhost only; no new exposure (same per-pod gateway,
+   same token gate).
+
+7. **Dangling Grounding-with-Bing connection self-heal.** When `--foundry-endpoint`
+   is set, `kars up` removes project `GroundingWithBingSearch` connections whose
+   backing `Microsoft.Bing/accounts` resource no longer resolves (e.g. its RG was
+   deleted). Advisory, idempotent, never aborts the deploy, and never touches a
+   connection whose Bing resource is still alive. Removing a connection only deletes
+   a stale pointer (and its now-orphaned stored key reference) — it grants nothing.
+
+8. **service-tree error classifier.** Only improves the Entra Bicep-fallback error
+   message (no longer tells the user to pass `--service-tree` when they already did).
+   No behavioural change to provisioning.
+
+9. **Keyless web search (credentials posture — the notable change).**
+   `foundry_web_search` previously sent `tools=[{type:"bing_grounding",
+   bing_grounding:{search_configurations:[{project_connection_id}]}}]` and
+   auto-discovered a `GroundingWithBingSearch` connection — a path that depends on an
+   **API key** stored in a Foundry connection. It now sends `tools=[{type:"web_search"}]`,
+   the Microsoft-**managed** Bing tool that authenticates with the router's existing
+   Entra/IMDS token (`ai.azure.com` audience) and needs **no Bing API key, no
+   user-created Bing resource, and no project connection**. This *reduces* the
+   credential surface and aligns with kars's no-API-keys principle.
+
+## T1: New capability / attack surface? (NO / REDUCED)
+- No new RBAC role, principal, or scope. The effective permission set after a deploy
+  is unchanged (RBAC items here are the already-audited v0.1.15 set; only the
+  `controller-acrpull` standalone helper is re-expressed via the idempotent module).
+- The web-search change **removes** a key-based code path; nothing new is reachable.
+- The Bing self-heal only **deletes** a dead connection; it cannot create resources,
+  roles, or connections.
+
+## T2: Security-control change? (NEUTRAL / IMPROVED)
+- Content Safety, Prompt Shields, egress allowlist, NetworkPolicy, seccomp, token
+  budget, AGT governance — all unchanged. `web_search` still flows through the same
+  router inference path and governance gates as before (the router posts to the same
+  Foundry endpoint with the same Entra/IMDS auth).
+- Required-image fail-closed and managed-Bing keyless auth are net integrity/credential
+  improvements.
+
+## T3: Availability / fail-open risk? (REDUCED)
+- Validate gate, free-port forwards, token retry, mesh-readiness warning, customer-mode
+  fail-closed, and the Bing self-heal all remove confusing OOTB failure modes or make
+  them explicit. The validate gate and self-heal are read-mostly and never block on
+  their own optional failures (`.catch` advisory).
+- `--yes`/no-TTY makes `kars up` scriptable without weakening any check.
+
+## Verification
+- `python3 ci/bicep-rbac-idempotency.py` → OK (8 role assignments / 12 files, all
+  include a principalId). `az bicep build` of `main.bicep`, the standalone helper,
+  and the new module all compile; `controller-acrpull.json` recompiled in sync.
+- CLI: `tsc --noEmit` clean, oxlint 0 errors, **821 vitest tests pass**.
+- Runtime (`runtimes/openclaw`): `tsc --noEmit` clean, oxlint 0 errors, **244 tests pass**.
+- Keyless `web_search` proven against a live Foundry project (`/openai/v1/responses`
+  and `/openai/responses?api-version=2025-11-15-preview`): HTTP 200 with real,
+  cited results and a `web_search_call` step — with no Bing connection present.
+
+## Verdict
+Accept. A batch of OOTB reliability fixes with no expansion of roles, scopes, or
+network exposure; the one credential-relevant change **removes** an API-key path in
+favour of keyless Entra/IMDS-authenticated managed web search. Net posture: neutral-to-improved.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/runtimes/openclaw/src/core/agt-task-loop.ts
+++ b/runtimes/openclaw/src/core/agt-task-loop.ts
@@ -436,25 +436,15 @@ export async function processTaskWithTools(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             let reqBody: any;
             if (fnName === "foundry_web_search") {
-              let connId: string | undefined;
-              try {
-                const connsRaw = await new Promise<string>((resolve, reject) => {
-                  const r = http.get(routerUrl("/connections?api-version=2025-05-15-preview"), { timeout: 10000 }, (res) => {
-                    let body = ""; res.on("data", (c: Buffer) => { body += c.toString(); }); res.on("end", () => resolve(body));
-                  });
-                  r.on("error", reject); r.on("timeout", () => { r.destroy(); reject(new Error("timeout")); });
-                });
-                const conns = JSON.parse(connsRaw);
-                const bingConn = (conns.value || conns || []).find(
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  (c: any) => c.type === "GroundingWithBingSearch" || c.properties?.category === "GroundingWithBingSearch"
-                );
-                if (bingConn) connId = bingConn.id;
-              } catch { /* fall through */ }
+              // Keyless, Microsoft-managed web search — no Bing key, no
+              // user-created Bing resource, no GroundingWithBingSearch
+              // connection. Authenticated by the router's Entra/IMDS token.
+              // (The classic `bing_grounding` tool requires a key-based
+              // connection's project_connection_id and 400s without one.)
               reqBody = {
                 model: model,
                 input: args.query,
-                tools: [{ type: "bing_grounding", bing_grounding: { search_configurations: [{ project_connection_id: connId }] } }],
+                tools: [{ type: "web_search" }],
                 store: false,
               };
             } else if (fnName === "foundry_code_execute") {

--- a/runtimes/openclaw/src/core/agt-tools/foundry.ts
+++ b/runtimes/openclaw/src/core/agt-tools/foundry.ts
@@ -476,29 +476,19 @@ export function registerFoundryTools(api: AnyApi, deps: FoundryToolsDeps): void 
     },
     async execute(_id: string, params: Record<string, unknown>) {
       try {
-        // Connection ID: env var override → auto-discover first GroundingWithBingSearch connection.
-        // The Responses API requires the FULL resource ID, not short /connections/name.
-        let connId = process.env.BING_CONNECTION_ID;
-        if (!connId) {
-          try {
-            const conns = await routerCall("GET", "/connections?api-version=2025-05-15-preview");
-            const bingConn = (conns.value || conns || []).find(
-              (c: any) => c.type === "GroundingWithBingSearch" ||
-                c.properties?.category === "GroundingWithBingSearch"
-            );
-            if (bingConn) connId = bingConn.id; // full resource ID
-          } catch { /* fall through to default */ }
-        }
-
+        // Keyless, Microsoft-managed web search. The `web_search` tool uses a
+        // Microsoft-managed Bing resource and authenticates via the router's
+        // Entra/IMDS token (ai.azure.com) — NO Bing API key, NO user-created
+        // `Microsoft.Bing/accounts` resource, and NO `GroundingWithBingSearch`
+        // connection on the project. This is the right fit for kars's
+        // no-API-keys principle. (The classic `bing_grounding` tool, by
+        // contrast, REQUIRES a key-based connection's `project_connection_id`
+        // and 400s without one — which is what previously broke this tool when
+        // no/stale Bing connection existed.)
         const result = await routerCall("POST", "/openai/responses?api-version=2025-11-15-preview", {
           model: (params.model as string) || "gpt-4.1",
           input: params.query,
-          tools: [{
-            type: "bing_grounding",
-            bing_grounding: {
-              search_configurations: [{ project_connection_id: connId }],
-            },
-          }],
+          tools: [{ type: "web_search" }],
           store: false,
         });
         const output = result.output || result;


### PR DESCRIPTION
## Summary

Out-of-the-box reliability fixes for `kars up` / `kars dev`, plus a credentials-posture improvement for Foundry web search. Bumps CLI to **v0.1.16**.

All changes were surfaced from a real clean-room `kars up --release --mesh-trust=entra` run and verified end-to-end.

### `kars up`
- **Pre-deploy ARM validate gate** — `az deployment group validate` runs before any resource is created (fail-before-mutate); `--skip-validate` to opt out.
- **`--yes` / no-TTY non-interactive mode** — fully scriptable; never prompts when there's no TTY.
- **Docker preflight false-negative** — probe `docker --version` (binary) instead of `docker info` (needs a running daemon) when Docker isn't required (`--release`).
- **Customer-mode image import** — use the `-agt` mesh tags the manifest references (was silently wrong → ImagePullBackOff), and **fail closed** on a required-image import error (previously swallowed and reported as success).
- **AgentMesh readiness** — surface the 180s timeout as a warning instead of swallowing it.
- **WebUI port-forward** — auto-pick a free local port + retry the gateway-token read (no more "port-forward failed" on a first-run race / busy 18789).
- **Dangling Grounding-with-Bing self-heal** — remove project Bing connections whose backing `Microsoft.Bing/accounts` resource was deleted (advisory; never aborts the deploy).
- **service-tree error classifier** — don't tell the user to pass `--service-tree` when they already did; surface the real Graph error.
- **Stepper** — clamp the numerator (`10/9` can't render) and count the `--mesh-trust=entra` phase.

### `kars dev`
- Auto-pick a free host port for the container WebUI (no "port already allocated" crash on a busy 18789).

### Web search (sandbox runtime) — credentials posture
- `foundry_web_search` now uses the **keyless, Microsoft-managed `web_search`** tool (Entra/IMDS auth) instead of the classic key-based `bing_grounding` tool that required a `project_connection_id`. **No Bing API key, no user-created Bing resource, no project connection** — aligns with the no-API-keys principle and fixes the `401` / `project_connection_id required` failures. Proven `HTTP 200` with cited results against a live Foundry project.

### CI / infra
- New static **RBAC idempotency gate** (`ci/bicep-rbac-idempotency.py`) wired into CI.
- Idempotent AcrPull module for the standalone controller helper (`deploy/bicep/modules/acr-pull-assignment.bicep`).

## Security audit
`docs/internal/security-audits/2026-06-25-onboarding-hardening-websearch.md` (2 sign-offs). No new role/scope/principal; the one credential-relevant change **removes** an API-key path. `security-audit-required` + `copyright-headers` gates pass locally.

## Verification
- CLI: `tsc --noEmit` clean, oxlint 0 errors, **821 tests pass**.
- Runtime (`runtimes/openclaw`): `tsc --noEmit` clean, oxlint 0 errors, **244 tests pass**.
- `az bicep build` (main + standalone + module) compiles; `controller-acrpull.json` recompiled in sync; RBAC idempotency gate OK (8 assignments / 12 files).

## Note
The `web_search` fix lives in the **sandbox image**, so a running pod needs the rebuilt image (`kars push --only sandbox --apply`, or the tagged release build) before the live agent picks it up.