### PR TITLE
fix(dev): stream `docker save` without buffering in kind image load

### DIFF
--- a/cli/src/commands/dev/local-k8s.ts
+++ b/cli/src/commands/dev/local-k8s.ts
@@ -496,7 +496,14 @@ async function loadImageIntoKind(
 
   if (upToDate) return;
 
-  const save = execa(runtime, ["save", image]);
+  // `buffer: false` is essential: execa otherwise accumulates the
+  // subprocess stdout into its result (capped at `maxBuffer`, default
+  // 100 MB) *even when the stream is also piped*. `docker save` of a
+  // multi-hundred-MB image (e.g. openclaw-sandbox) overflows that cap and
+  // fails the whole `kars dev` bring-up at "Loading kars images". We never
+  // need the tarball in memory — it streams straight to `ctr import` — so
+  // disable buffering entirely.
+  const save = execa(runtime, ["save", image], { buffer: false });
   const importProc = execa(
     runtime,
     ["exec", "-i", node, "ctr", "-n=k8s.io", "images", "import", "-"],

--- a/docs/internal/security-audits/2026-06-26-dev-docker-save-stream.md
+++ b/docs/internal/security-audits/2026-06-26-dev-docker-save-stream.md
@@ -1,0 +1,37 @@
+# Security Audit — `kars dev` kind image load streams `docker save` (no maxBuffer overflow)
+
+Date: 2026-06-26
+Scope: `cli/src/commands/dev/local-k8s.ts` (`loadImageIntoKind`).
+Gated path: `cli/src/commands/dev/local-k8s.ts`.
+
+## Summary
+
+`loadImageIntoKind` piped `execa(runtime, ["save", image])` into `ctr images
+import`, but execa buffers child stdout into its result (capped at `maxBuffer`,
+default 100 MB) **even when the stream is also piped**. A multi-hundred-MB image
+(`openclaw-sandbox`) overflowed the cap and failed `kars dev` at "Loading kars
+images". Fix: pass `{ buffer: false }` so the tarball streams straight to `ctr
+import` and is never held in memory.
+
+## T1: New capability / attack surface? (NO)
+- Local developer-loop only (`kars dev --target local-k8s`, kind). No deployed
+  resource, credential, network path, or policy is touched. Same two processes,
+  same pipe; only execa's in-memory buffering is disabled.
+
+## T2: Security-control change? (NO)
+- No auth, crypto, image-provenance, or isolation change. The image bytes are
+  the operator's own locally-built/loaded image, unchanged.
+
+## T3: Availability / fail-open risk? (REDUCED)
+- Removes a hard, size-dependent failure of `kars dev`. Pure reliability win;
+  no fail-open (a genuine `docker save`/`ctr import` error still propagates).
+
+## Verification
+- CLI `tsc --noEmit` + oxlint clean; vitest green. Manual: `kars dev --target
+  local-k8s` loads the large sandbox image without the maxBuffer error.
+
+## Verdict
+Accept. Local-dev reliability fix with no security-relevant surface.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem

`kars dev` (and `kars dev --release`) fails at step "Loading kars images into the kind cluster" with:

```
local-k8s dev failed: Command's stdout was larger than 100000000 characters:
/opt/homebrew/bin/docker save 'karsacr.azurecr.io/openclaw-sandbox:latest'
maxBuffer exceeded
```

## Root cause

`loadImageIntoKind()` in `cli/src/commands/dev/local-k8s.ts` pipes `docker save <image>` straight into the kind node's `ctr import`:

```ts
const save = execa(runtime, ["save", image]);
const importProc = execa(runtime, ["exec", "-i", node, "ctr", "-n=k8s.io", "images", "import", "-"], …);
save.stdout.pipe(importProc.stdin);
```

Even though the stream is piped, **execa still accumulates the subprocess stdout into its result**, capped at `maxBuffer` (default 100 MB). The `openclaw-sandbox` image exceeds 100 MB, so execa throws `maxBuffer exceeded` and aborts the entire bring-up.

## Fix

Pass `{ buffer: false }` to the `docker save` subprocess. The tarball is never needed in memory — it streams directly to `ctr import` — so buffering is pure overhead and the source of the failure. One-line change plus an explanatory comment.

## Testing

- Reproduced: `kars dev --release` aborts at "Loading kars images" on a host where the sandbox image is > 100 MB.
- With the fix, `docker save | ctr import` streams to completion and the kind load proceeds.

## Scope

Isolated, standalone CLI bugfix; no behavioral change beyond no longer aborting on large images.