### PR TITLE
fix(dev): load local-dev image names (`:dev`) into kind, not ACR `:latest`

### DIFF
--- a/cli/src/commands/dev/local-k8s.ts
+++ b/cli/src/commands/dev/local-k8s.ts
@@ -1407,36 +1407,45 @@ export async function runLocalK8s(opts: LocalK8sOptions): Promise<void> {
     // for re-tagging. `loadImageIfPresent` re-tags the matched local
     // image AS the target before kind-loading, so the kind containerd
     // ends up with the canonical name in `crictl images` and the
-    // controller's IfNotPresent pull succeeds without ever touching
-    // the network.
+    // workload's `imagePullPolicy: Never` pull succeeds without ever
+    // touching the network.
     //
-    // Why we DON'T list `kars.azurecr.io/...`: that ACR doesn't exist.
-    // The legacy typo crept in from the 2026-05-27 rename
-    // (azureclaw→kars) before anyone noticed the real ACR is
-    // `karsjpdyyv.azurecr.io` (azd-suffixed) — the `karsacr` alias
-    // here is the canonical name the operator's deploy script
-    // re-publishes to. Keep only `karsacr.azurecr.io/...` so the
-    // controller env stays correct on AKS too.
+    // The target MUST be the exact image name the local-dev workloads
+    // reference, because `imagePullPolicy: Never` does a literal name match:
+    //   - controller pod    → `controller.image` (values-local-dev.yaml)
+    //   - sandbox container  → controller's `SANDBOX_IMAGE` env
+    //                          (= `sandbox.image`, values-local-dev.yaml)
+    //   - router sidecar     → controller's `INFERENCE_ROUTER_IMAGE` env
+    //                          (= `inferenceRouter.image`, values-local-dev.yaml)
+    // values-local-dev.yaml pins all three to local `:dev` tags, so the
+    // targets here are those `:dev` names — NOT the `karsacr.azurecr.io/...`
+    // ACR names (those are the AKS/`kars up` image strings the controller
+    // falls back to only when the `*_IMAGE` env is unset; on local-dev the
+    // env is always set to `:dev`). Loading the ACR name into the node while
+    // the workload requests `:dev` is an ErrImageNeverPull — the controller
+    // never starts and `kars dev` times out at "Waiting for sandbox pod".
+    // The ACR `:latest` names are kept as *aliases* (fallback retag sources).
     const images: { target: string; aliases: string[] }[] = [
       {
-        target: "karsacr.azurecr.io/openclaw-sandbox:latest",
+        target: "kars-sandbox:dev", // matches sandbox.image (values-local-dev)
         aliases: [
-          opts.image,                       // e.g. "kars-sandbox:dev" (the local build)
+          opts.image, // the local build / --release retag (usually kars-sandbox:dev)
+          "karsacr.azurecr.io/openclaw-sandbox:latest",
           "openclaw-sandbox:latest",
           "openclaw-sandbox:dev",
         ],
       },
       {
-        target: "karsacr.azurecr.io/kars-controller:latest",
+        target: "kars-controller:dev", // matches controller.image
         aliases: [
-          "kars-controller:dev",
+          "karsacr.azurecr.io/kars-controller:latest",
           "kars-controller:latest",
         ],
       },
       {
-        target: "karsacr.azurecr.io/kars-inference-router:latest",
+        target: "kars-inference-router:dev", // matches inferenceRouter.image
         aliases: [
-          "kars-inference-router:dev",
+          "karsacr.azurecr.io/kars-inference-router:latest",
           "kars-inference-router:latest",
         ],
       },

--- a/docs/internal/security-audits/2026-06-26-dev-kind-image-names.md
+++ b/docs/internal/security-audits/2026-06-26-dev-kind-image-names.md
@@ -1,0 +1,42 @@
+# Security Audit — `kars dev` loads local `:dev` image names into kind (not ACR `:latest`)
+
+Date: 2026-06-26
+Scope: `cli/src/commands/dev/local-k8s.ts` (`runLocalK8s` image target table).
+Gated path: `cli/src/commands/dev/local-k8s.ts`.
+
+## Summary
+
+On `kars dev --target local-k8s`, the workloads run with `imagePullPolicy:
+Never`, which does a literal image-name match. `values-local-dev.yaml` pins the
+controller, sandbox, and inference-router to local `:dev` tags, but the kind
+image-load table targeted `karsacr.azurecr.io/...:latest` names instead. The
+node ended up with the ACR names while pods requested `:dev` →
+`ErrImageNeverPull`, the controller never started, and `kars dev` timed out at
+"Waiting for sandbox pod". Fix: target the exact `:dev` names the workloads
+reference, keeping the ACR `:latest` names as retag **aliases** (fallback
+sources).
+
+## T1: New capability / attack surface? (NO)
+- Local developer-loop only (kind). Renames which local image tags are loaded /
+  retagged into the kind node. No deployed resource, credential, registry
+  auth, or network path changes. `imagePullPolicy: Never` means nothing is
+  pulled from any registry.
+
+## T2: Security-control change? (NO)
+- No auth, crypto, provenance, or isolation change. Images are the operator's
+  locally-built artifacts; the AKS/`kars up` ACR image strings are untouched
+  (they remain the controller's fallback when `*_IMAGE` env is unset).
+
+## T3: Availability / fail-open risk? (REDUCED)
+- Fixes a hard `kars dev` bring-up failure (ErrImageNeverPull). No fail-open:
+  a missing local image still surfaces as a normal load error.
+
+## Verification
+- CLI `tsc --noEmit` + oxlint clean; vitest green. Manual: `kars dev --target
+  local-k8s` brings the controller + sandbox Ready without ErrImageNeverPull.
+
+## Verdict
+Accept. Local-dev correctness fix; no security-relevant surface.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem

`kars dev` (and `kars dev --release`) times out at "Waiting for sandbox pod to be ready", because the controller never starts:

```
local-k8s dev failed: controller did not create deployment '<name>' in
namespace 'kars-<name>' within 120s.

# kubectl get pods -n kars-system
kars-controller-…   0/1   ErrImageNeverPull
```

## Root cause

A name mismatch between what the loader puts into the kind node and what the local-dev workloads request — and since `values-local-dev.yaml` uses `imagePullPolicy: Never`, the match is **literal by image name**.

- `values-local-dev.yaml` pins the controller / inferenceRouter / sandbox images to local **`:dev`** tags, and `controller-deployment.yaml` wires the latter two into the controller's `SANDBOX_IMAGE` / `INFERENCE_ROUTER_IMAGE` env. So the workloads request:
  - controller pod → `kars-controller:dev`
  - sandbox container → `kars-sandbox:dev`
  - router sidecar → `kars-inference-router:dev`
- `loadImageIfPresent` instead loaded the **`karsacr.azurecr.io/*:latest`** target names into the node.

Result: the node has the ACR `:latest` names but every local-dev workload references the `:dev` names → `ErrImageNeverPull`. The controller (the only Helm-deployed workload) fails first and masks the identical sandbox + router mismatches that would surface on the first spawn.

Confirmed empirically: with `--release`, `kars-controller:dev` is created on the host but the node ends up with `karsacr.azurecr.io/kars-controller:latest`, while the running Deployment requests `kars-controller:dev`.

## Fix

Make the three load `target`s the `:dev` names the local-dev chart actually references (controller / sandbox / inference-router), keeping the `karsacr.azurecr.io/*:latest` names as retag-source aliases. The code comment already stated the intent ("Desired tag inside kind (matches values-local-dev.yaml)") — the targets had drifted from it.

Runtime adapter images (Hermes, …) are unchanged — those use the controller's compiled-in ACR defaults, which `values-local-dev.yaml` does not override.

## Scope / safety

This loader runs only in the `kars dev` local-k8s path; the AKS / `kars up` path (real registry pulls) is unaffected.

## Related

Stacks logically with #464 (the `docker save` maxBuffer fix) — both are `kars dev --release` blockers in the same file, at different lines (no conflict). Together they make `kars dev --release` work end-to-end again.