### PR TITLE
fix(memory): consolidate Foundry Memory Store on the router; heal RBAC on upgrade

### DIFF
--- a/cli/src/commands/up/foundry_memory_rbac.test.ts
+++ b/cli/src/commands/up/foundry_memory_rbac.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+type Execa = typeof import("execa").execa;
+
+// A no-op stepper — the helper only calls update().
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fakeStepper = { update: () => {}, detail: () => {} } as any;
+
+const FOUNDRY_EP = "https://acct.services.ai.azure.com/api/projects/proj";
+
+// Controlled `setupFoundryForKars` result, swapped per test.
+let setupResult: unknown = null;
+
+vi.mock("./foundry_setup.js", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("./foundry_setup.js")>();
+  return {
+    ...orig, // keep the real parseFoundryEndpoint
+    setupFoundryForKars: vi.fn(async () => setupResult),
+  };
+});
+
+/** Fake execa for the helper's own `az` calls (group show + role create). */
+function makeFakeExeca(opts: {
+  rgId?: string;
+  roleCreate?: "ok" | "exists" | "denied";
+  calls: string[][];
+}): Execa {
+  const { rgId = "/subscriptions/s/resourceGroups/rg", roleCreate = "ok", calls } = opts;
+  return (async (_bin: string, args: readonly string[]) => {
+    calls.push([...args]);
+    const a = args.join(" ");
+    if (a.includes("group show")) return { stdout: rgId };
+    if (a.includes("role assignment create")) {
+      if (roleCreate === "ok") return { stdout: "" };
+      if (roleCreate === "exists") throw new Error("RoleAssignmentExists: already there");
+      throw new Error("AuthorizationFailed: caller lacks User Access Administrator");
+    }
+    return { stdout: "" };
+  }) as unknown as Execa;
+}
+
+beforeEach(() => {
+  setupResult = {
+    accountName: "acct",
+    accountResourceId: "/subscriptions/s/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/acct",
+    resourceGroup: "rg",
+    projectName: "proj",
+    embeddingModel: "text-embedding-3-large",
+    projectMiPrincipalId: "mi-principal-123",
+    miJustEnabled: false,
+    notes: ["Enabled the Foundry project's system-assigned managed identity."],
+  };
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("buildProjectMiRoleAssignmentArgs", () => {
+  it("grants the Azure AI User role at the given scope by object id", async () => {
+    const { buildProjectMiRoleAssignmentArgs, AZURE_AI_USER_ROLE_ID } = await import("./foundry_memory_rbac.js");
+    expect(buildProjectMiRoleAssignmentArgs("pid", "/rgid")).toEqual([
+      "role", "assignment", "create",
+      "--assignee-object-id", "pid",
+      "--assignee-principal-type", "ServicePrincipal",
+      "--role", AZURE_AI_USER_ROLE_ID,
+      "--scope", "/rgid",
+      "--output", "none",
+    ]);
+  });
+});
+
+describe("ensureFoundryMemoryRbac", () => {
+  it("skips a non-Foundry endpoint (plain Azure OpenAI)", async () => {
+    const { ensureFoundryMemoryRbac } = await import("./foundry_memory_rbac.js");
+    const execa = vi.fn() as unknown as Execa;
+    const res = await ensureFoundryMemoryRbac({
+      execa,
+      stepper: fakeStepper,
+      foundryEndpoint: "https://my-aoai.openai.azure.com",
+    });
+    expect(res.granted).toBe(false);
+    expect(execa as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(res.notes.join(" ")).toMatch(/not applicable/i);
+  });
+
+  it("grants the project MI Azure AI User on the RG (happy path)", async () => {
+    const { ensureFoundryMemoryRbac, buildProjectMiRoleAssignmentArgs } = await import("./foundry_memory_rbac.js");
+    const calls: string[][] = [];
+    const res = await ensureFoundryMemoryRbac({
+      execa: makeFakeExeca({ calls }),
+      stepper: fakeStepper,
+      foundryEndpoint: FOUNDRY_EP,
+    });
+    expect(res.granted).toBe(true);
+    expect(res.projectMiPrincipalId).toBe("mi-principal-123");
+    const roleCall = calls.find((c) => c.join(" ").includes("role assignment create"));
+    expect(roleCall).toEqual(
+      buildProjectMiRoleAssignmentArgs("mi-principal-123", "/subscriptions/s/resourceGroups/rg"),
+    );
+  });
+
+  it("treats RoleAssignmentExists as success (idempotent)", async () => {
+    const { ensureFoundryMemoryRbac } = await import("./foundry_memory_rbac.js");
+    const res = await ensureFoundryMemoryRbac({
+      execa: makeFakeExeca({ calls: [], roleCreate: "exists" }),
+      stepper: fakeStepper,
+      foundryEndpoint: FOUNDRY_EP,
+    });
+    expect(res.granted).toBe(true);
+  });
+
+  it("returns granted=false with a remediation note when the caller lacks rights", async () => {
+    const { ensureFoundryMemoryRbac } = await import("./foundry_memory_rbac.js");
+    const res = await ensureFoundryMemoryRbac({
+      execa: makeFakeExeca({ calls: [], roleCreate: "denied" }),
+      stepper: fakeStepper,
+      foundryEndpoint: FOUNDRY_EP,
+    });
+    expect(res.granted).toBe(false);
+    expect(res.notes.join(" ")).toMatch(/User Access Administrator|grant it once/i);
+  });
+
+  it("does not grant when the project MI principalId is unavailable", async () => {
+    const { ensureFoundryMemoryRbac } = await import("./foundry_memory_rbac.js");
+    setupResult = {
+      accountName: "acct", accountResourceId: "x", resourceGroup: "rg", projectName: "proj",
+      projectMiPrincipalId: "", miJustEnabled: false, notes: [],
+    };
+    const calls: string[][] = [];
+    const res = await ensureFoundryMemoryRbac({
+      execa: makeFakeExeca({ calls }),
+      stepper: fakeStepper,
+      foundryEndpoint: FOUNDRY_EP,
+    });
+    expect(res.granted).toBe(false);
+    expect(calls.find((c) => c.join(" ").includes("role assignment create"))).toBeUndefined();
+  });
+});

--- a/cli/src/commands/up/foundry_memory_rbac.ts
+++ b/cli/src/commands/up/foundry_memory_rbac.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// up/foundry_memory_rbac.ts — make the Foundry **Memory Store** actually
+// persist, idempotently.
+//
+// The Memory Store is the one Foundry capability whose `update`/`search`
+// operations call models INTERNALLY, authenticating as the Foundry
+// PROJECT's managed identity (not the caller). So the store CRUD can
+// succeed for the caller while every persist/recall 403s — the classic
+// "store creates but nothing sticks" symptom — unless the project MI:
+//   1. exists (system-assigned MI enabled on the project), and
+//   2. holds `Azure AI User` on the resource group hosting the account, and
+//   3. the project has an embedding model deployed.
+//
+// `setupFoundryForKars` already (1) enables the MI and (3) deploys an
+// embedding model. This module adds (2) — the resource-group role grant —
+// and bundles all three into a single idempotent call that both `kars up`
+// and `kars upgrade` run, so the fix rides along with any upgrade instead
+// of requiring a fresh `kars up`.
+
+import type { Stepper } from "../../stepper.js";
+import { parseFoundryEndpoint, setupFoundryForKars } from "./foundry_setup.js";
+
+type Execa = typeof import("execa").execa;
+
+/** Built-in role definition GUID for **Azure AI User** (a.k.a. "Foundry
+ *  User") — carries the `Microsoft.CognitiveServices/*` data actions the
+ *  Memory Store needs for its internal chat + embedding calls. */
+export const AZURE_AI_USER_ROLE_ID = "53ca6127-db72-4b80-b1b0-d745d6d5456d";
+
+export interface FoundryMemoryRbacResult {
+  /** True when the project MI holds the role afterwards (granted now or
+   *  already present). */
+  granted: boolean;
+  /** Project system-assigned MI principalId, or "" when unavailable. */
+  projectMiPrincipalId: string;
+  /** Embedding deployment name in use, or undefined. */
+  embeddingModel?: string;
+  /** Human-readable status notes for the report. */
+  notes: string[];
+}
+
+/** Build the `az role assignment create` argv granting `principalId` the
+ *  Azure AI User role at resource-group scope. `az` treats a duplicate
+ *  create as a success (no-op), so this is safe to re-run. Exported for
+ *  tests. */
+export function buildProjectMiRoleAssignmentArgs(
+  principalId: string,
+  resourceGroupId: string,
+): string[] {
+  return [
+    "role", "assignment", "create",
+    "--assignee-object-id", principalId,
+    "--assignee-principal-type", "ServicePrincipal",
+    "--role", AZURE_AI_USER_ROLE_ID,
+    "--scope", resourceGroupId,
+    "--output", "none",
+  ];
+}
+
+/** A 403/RoleAssignmentExists message from `az` means the assignment is
+ *  already there — that's success for our idempotent intent. */
+function isAlreadyExists(message: string): boolean {
+  return /RoleAssignmentExists|already exists/i.test(message);
+}
+
+/**
+ * Idempotently ensure the bound Foundry project can run Memory Store
+ * persistence: enable the project MI, ensure an embedding deployment, and
+ * grant the project MI `Azure AI User` on the resource group. Best-effort
+ * and non-fatal — every failure degrades to an actionable note. Returns a
+ * structured result so callers can surface a clear status.
+ *
+ * `foundryEndpoint` must be a Foundry PROJECT endpoint
+ * (`https://<acct>.services.ai.azure.com/api/projects/<proj>`); a plain
+ * Azure OpenAI endpoint has no Memory Store and is skipped.
+ */
+export async function ensureFoundryMemoryRbac(args: {
+  execa: Execa;
+  stepper: Stepper;
+  foundryEndpoint: string;
+}): Promise<FoundryMemoryRbacResult> {
+  const { execa, stepper, foundryEndpoint } = args;
+  const notes: string[] = [];
+
+  if (!parseFoundryEndpoint(foundryEndpoint)) {
+    return {
+      granted: false,
+      projectMiPrincipalId: "",
+      notes: ["No Foundry project endpoint bound — Memory Store RBAC not applicable."],
+    };
+  }
+
+  const setup = await setupFoundryForKars({ execa, stepper, foundryEndpoint }).catch(() => null);
+  if (!setup) {
+    return {
+      granted: false,
+      projectMiPrincipalId: "",
+      notes: ["Foundry project auto-setup did not run — Memory Store RBAC skipped."],
+    };
+  }
+  notes.push(...setup.notes);
+
+  const principalId = setup.projectMiPrincipalId;
+  if (!principalId) {
+    notes.push(
+      "Foundry project MI principalId is not available yet — Memory Store RBAC " +
+        "not granted. Re-run after the identity propagates (a minute or two).",
+    );
+    return { granted: false, projectMiPrincipalId: "", embeddingModel: setup.embeddingModel, notes };
+  }
+  if (!setup.resourceGroup) {
+    notes.push("Could not resolve the Foundry resource group — Memory Store RBAC not granted.");
+    return { granted: false, projectMiPrincipalId: principalId, embeddingModel: setup.embeddingModel, notes };
+  }
+
+  // Resolve the resource-group ARM id (the role scope).
+  const { stdout: rgIdRaw } = await execa("az", [
+    "group", "show", "--name", setup.resourceGroup, "--query", "id", "--output", "tsv",
+  ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
+  const resourceGroupId = (rgIdRaw || "").trim().split("\n").pop()?.trim() || "";
+  if (!resourceGroupId) {
+    notes.push(
+      `Could not resolve the ARM id for resource group '${setup.resourceGroup}' — ` +
+        "Memory Store RBAC not granted.",
+    );
+    return { granted: false, projectMiPrincipalId: principalId, embeddingModel: setup.embeddingModel, notes };
+  }
+
+  stepper.update("Granting Foundry project MI 'Azure AI User' on the resource group...");
+  const granted = await execa(
+    "az",
+    buildProjectMiRoleAssignmentArgs(principalId, resourceGroupId),
+    { stdio: "pipe" },
+  )
+    .then(() => true)
+    .catch((e: unknown) => isAlreadyExists(e instanceof Error ? e.message : String(e)));
+
+  if (granted) {
+    notes.push(
+      "Foundry project MI holds 'Azure AI User' on the resource group " +
+        "(Memory Store internal model calls). RBAC can take a few minutes to propagate.",
+    );
+  } else {
+    notes.push(
+      "Could not grant the Foundry project MI 'Azure AI User' on the resource group " +
+        "(needs Owner or User Access Administrator). Grant it once, then Memory Store " +
+        "persistence will work: az role assignment create --assignee-object-id " +
+        `${principalId} --role "${AZURE_AI_USER_ROLE_ID}" --scope ${resourceGroupId}`,
+    );
+  }
+
+  return { granted, projectMiPrincipalId: principalId, embeddingModel: setup.embeddingModel, notes };
+}

--- a/cli/src/commands/upgrade.test.ts
+++ b/cli/src/commands/upgrade.test.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "vitest";
+import { isFoundryProjectHost } from "./upgrade.js";
+
+describe("isFoundryProjectHost", () => {
+  it("accepts a real Foundry project endpoint", () => {
+    expect(isFoundryProjectHost("https://acct.services.ai.azure.com/api/projects/p")).toBe(true);
+    expect(isFoundryProjectHost("https://services.ai.azure.com")).toBe(true);
+  });
+
+  it("rejects look-alike hosts that a substring match would accept", () => {
+    // The classic incomplete-sanitization bypass.
+    expect(isFoundryProjectHost("https://services.ai.azure.com.evil.com/api/projects/p")).toBe(false);
+    expect(isFoundryProjectHost("https://evilservices.ai.azure.com/x")).toBe(false);
+    expect(isFoundryProjectHost("https://attacker.com/?q=services.ai.azure.com")).toBe(false);
+  });
+
+  it("rejects plain Azure OpenAI and empty/garbage input", () => {
+    expect(isFoundryProjectHost("https://my-aoai.openai.azure.com")).toBe(false);
+    expect(isFoundryProjectHost("")).toBe(false);
+    expect(isFoundryProjectHost("not a url")).toBe(false);
+  });
+});

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -28,6 +28,20 @@ import {
 
 const NS = "kars-system";
 
+/** True only when `ep` is a Foundry project endpoint whose host is exactly
+ *  `services.ai.azure.com` or a subdomain of it. A proper hostname check —
+ *  NOT a substring match, which `https://services.ai.azure.com.evil.com`
+ *  would defeat. */
+export function isFoundryProjectHost(ep: string): boolean {
+  if (!ep) return false;
+  try {
+    const host = new URL(ep).hostname.toLowerCase();
+    return host === "services.ai.azure.com" || host.endsWith(".services.ai.azure.com");
+  } catch {
+    return false;
+  }
+}
+
 interface UpgradeContext {
   acrLoginServer: string;
   aksCluster: string;
@@ -35,6 +49,7 @@ interface UpgradeContext {
   wiClientId?: string;
   keyVaultName?: string;
   foundryEndpoint?: string;
+  foundryProjectEndpoint?: string;
 }
 
 /** Build the `helm upgrade` args. `--atomic` makes a failed upgrade auto-roll
@@ -112,12 +127,13 @@ Examples:
         wiClientId: ctxRaw.wiClientId,
         keyVaultName: ctxRaw.keyVaultName,
         foundryEndpoint: ctxRaw.foundryEndpoint,
+        foundryProjectEndpoint: ctxRaw.foundryProjectEndpoint,
       };
       const acrName = ctx.acrLoginServer.replace(/\.azurecr\.io$/, "");
 
       banner("kars · Upgrade", "Move an existing cluster to a published release");
 
-      const stepper = new Stepper({ totalSteps: options.rollback ? 4 : 7 });
+      const stepper = new Stepper({ totalSteps: options.rollback ? 4 : 8 });
 
       try {
         // ── Step 1: Connect to the cluster ────────────────────────────
@@ -246,7 +262,30 @@ Examples:
         if (healthy) stepper.done("Cluster healthy on the new release");
         else stepper.warn("Upgrade applied but some workloads aren't Ready yet — check `kars status` / `kubectl get pods -A`");
 
-        // ── Step 7: Report ────────────────────────────────────────────
+        // ── Step 7: Reconcile Foundry Memory Store access ─────────────
+        // Memory persistence depends on the Foundry PROJECT managed
+        // identity holding `Azure AI User` on the resource group plus an
+        // embedding deployment — provisioning that historically only ran
+        // on a fresh `kars up`. Re-reconcile it idempotently here so an
+        // existing cluster's memory starts working on upgrade. Best-effort:
+        // memory is one capability and never fails the upgrade itself.
+        stepper.step("Reconciling Foundry Memory Store access...");
+        const foundryProjectEp = ctx.foundryProjectEndpoint || ctx.foundryEndpoint || "";
+        if (isFoundryProjectHost(foundryProjectEp)) {
+          try {
+            const { ensureFoundryMemoryRbac } = await import("./up/foundry_memory_rbac.js");
+            const mem = await ensureFoundryMemoryRbac({ execa, stepper, foundryEndpoint: foundryProjectEp });
+            for (const n of mem.notes) stepper.detail("info", n);
+            if (mem.granted) stepper.done("Foundry Memory Store access reconciled");
+            else stepper.warn("Foundry Memory Store needs manual RBAC — see the notes above");
+          } catch {
+            stepper.warn("Could not reconcile Foundry Memory Store access (non-fatal) — run `kars up` to retry");
+          }
+        } else {
+          stepper.done("No Foundry project bound — Memory Store reconcile skipped");
+        }
+
+        // ── Step 8: Report ────────────────────────────────────────────
         stepper.step("Done");
         stepper.done(`Upgraded ${current || "cluster"} → ${target}`);
         stepper.summary();

--- a/controller/src/crd_validations.rs
+++ b/controller/src/crd_validations.rs
@@ -350,9 +350,14 @@ pub fn inference_policy_crd() -> CustomResourceDefinition {
 ///   verbatim in URLs and ConfigMap labels.
 /// - `sandboxRef.name` non-empty (1-253 chars; same length cap as
 ///   K8s object names).
-/// - `scope` non-empty (1-256 chars). Foundry uses scope as a
-///   partition key — empty scope would cross-contaminate every
-///   sandbox bound to the same store.
+/// - `scope` non-empty (1-256 chars) and restricted to the Foundry
+///   Memory Store partition-key charset (letters, digits, and
+///   `_ - . % + @ /`). Foundry uses scope as a partition key — an empty
+///   scope would cross-contaminate every sandbox bound to the same
+///   store, and an out-of-charset value (most commonly a colon, e.g.
+///   `agent:foo`) is rejected by the data plane with HTTP 400. The
+///   router sanitizes defensively at call time, but rejecting at
+///   admission gives the operator an immediate, legible error.
 /// - `retentionDays > 0` when present. Zero would request immediate
 ///   deletion, which is what `delete_scope` is for.
 #[must_use]
@@ -373,8 +378,8 @@ pub fn kars_memory_validations() -> Vec<ValidationRule> {
             ..ValidationRule::default()
         },
         ValidationRule {
-            rule: "has(self.bundleRef) || (has(self.scope) && size(self.scope) > 0 && size(self.scope) <= 256)".into(),
-            message: Some("spec.scope must be 1-256 characters when spec.bundleRef is not set".into()),
+            rule: "has(self.bundleRef) || (has(self.scope) && size(self.scope) > 0 && size(self.scope) <= 256 && self.scope.matches('^[A-Za-z0-9_./%+@-]+$'))".into(),
+            message: Some("spec.scope must be 1-256 characters using only letters, digits, and _ - . % + @ / (colons are rejected by the Foundry Memory Store) when spec.bundleRef is not set".into()),
             reason: Some("FieldValueInvalid".into()),
             ..ValidationRule::default()
         },

--- a/controller/src/kars_memory.rs
+++ b/controller/src/kars_memory.rs
@@ -108,9 +108,10 @@ pub struct KarsMemorySpec {
     pub sandbox_ref: SandboxRef,
 
     /// Scope key under which this sandbox writes/reads memories.
-    /// Foundry Memory Store partitions data per scope. CEL:
-    /// non-empty. Default convention (set by the runtime path if
-    /// absent here): `agent:{sandboxName}`.
+    /// Foundry Memory Store partitions data per scope and validates the
+    /// value to letters, digits, and `_ - . % + @ /` — colons are
+    /// rejected. CEL: non-empty + charset. Default convention (set by
+    /// the runtime path if absent here): `agent_{sandboxName}`.
     ///
     /// Required when [`Self::bundle_ref`] is absent (the inline
     /// path); MUST be absent when [`Self::bundle_ref`] is set.

--- a/controller/src/kars_memory_compile.rs
+++ b/controller/src/kars_memory_compile.rs
@@ -125,7 +125,7 @@ mod tests {
             sandbox_ref: SandboxRef {
                 name: "agent-x".into(),
             },
-            scope: Some("agent:agent-x".into()),
+            scope: Some("agent_agent-x".into()),
             retention_days: Some(30),
             delete_on_sandbox_delete: Some(true),
             display_name: Some("Agent X memory".into()),
@@ -140,13 +140,13 @@ mod tests {
             sandbox_ref: SandboxRef {
                 name: "agent".into(),
             },
-            scope: Some("agent:agent".into()),
+            scope: Some("agent_agent".into()),
             ..KarsMemorySpec::default()
         };
         let binding = compile_to_binding(&spec);
         assert_eq!(binding["storeName"], "minimal");
         assert_eq!(binding["sandboxRef"]["name"], "agent");
-        assert_eq!(binding["scope"], "agent:agent");
+        assert_eq!(binding["scope"], "agent_agent");
         assert!(binding["retentionDays"].is_null());
         // delete_on_sandbox_delete defaults to true at compile time
         // (preserving the prior bool-default semantics).
@@ -159,7 +159,7 @@ mod tests {
         let binding = compile_to_binding(&spec);
         assert_eq!(binding["storeName"], "agent-x-mem");
         assert_eq!(binding["sandboxRef"]["name"], "agent-x");
-        assert_eq!(binding["scope"], "agent:agent-x");
+        assert_eq!(binding["scope"], "agent_agent-x");
         assert_eq!(binding["retentionDays"], 30);
         assert_eq!(binding["deleteOnSandboxDelete"], true);
         assert_eq!(binding["displayName"], "Agent X memory");

--- a/controller/src/policy_canonical/memory.rs
+++ b/controller/src/policy_canonical/memory.rs
@@ -273,14 +273,14 @@ mod tests {
     fn parse_full_bundle_ok() {
         let body = br#"{
             "storeName": "agent-x-mem",
-            "scope": "agent:agent-x",
+            "scope": "agent_agent-x",
             "retentionDays": 30,
             "deleteOnSandboxDelete": true,
             "displayName": "Agent X memory"
         }"#;
         let v = parse(body).unwrap();
         assert_eq!(v.store_name.as_deref(), Some("agent-x-mem"));
-        assert_eq!(v.scope.as_deref(), Some("agent:agent-x"));
+        assert_eq!(v.scope.as_deref(), Some("agent_agent-x"));
         assert_eq!(v.retention_days, Some(30));
         assert_eq!(v.delete_on_sandbox_delete, Some(true));
         assert_eq!(v.display_name.as_deref(), Some("Agent X memory"));

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -2453,18 +2453,24 @@ async fn reconcile(sandbox: Arc<KarsSandbox>, ctx: Arc<Context>) -> Result<Actio
 
         // KarsMemory (optional, Slice 3a): if the sandbox references
         // one via `spec.memoryRef`, mirror its compiled binding
-        // ConfigMap and mount it into the inference-router. The
-        // router's `memory_binding_loader` reads the file, registers
-        // the digest under `PolicyKind::Memory`, and echoes it via
-        // `/internal/policy-status` so the `kars_memory_reconciler`
-        // can close the §3 Ready ⇔ router-echo loop.
+        // ConfigMap and mount it into the inference-router. The router's
+        // `memory_binding_loader` reads the file, registers the digest
+        // under `PolicyKind::Memory`, and echoes it via
+        // `/internal/policy-status` so the `kars_memory_reconciler` can
+        // close the §3 Ready ⇔ router-echo loop.
+        //
+        // The agent container does NOT need this mount: memory is a
+        // router-owned capability. Both runtime plugins (OpenClaw and
+        // Hermes) are thin clients — they forward `foundry.memory`
+        // intent to the router's platform MCP server and the router
+        // resolves the store name + scope from this binding, applies the
+        // Memory Store REST contract, auto-provisions, and retries. The
+        // agent process therefore carries no Foundry contract knowledge
+        // and never reads `binding.json` directly.
         //
         // Failure mode: source missing → mount omitted, router boots
         // without a binding loaded (digest absent in
         // `/internal/policy-status`, KarsMemory stays `Compiled`).
-        // Memory consumption today still runs through the existing
-        // env-driven `FOUNDRY_MEMORY_STORE_ID` path (Slice 3b will
-        // rewire to the binding).
         if let Some(memory_ref) = spec.memory_ref.as_ref() {
             let memory_name = memory_ref.name.trim();
             if !memory_name.is_empty() {

--- a/deploy/helm/kars/templates/crd-karsmemory.yaml
+++ b/deploy/helm/kars/templates/crd-karsmemory.yaml
@@ -135,9 +135,10 @@ spec:
               scope:
                 description: |-
                   Scope key under which this sandbox writes/reads memories.
-                  Foundry Memory Store partitions data per scope. CEL:
-                  non-empty. Default convention (set by the runtime path if
-                  absent here): `agent:{sandboxName}`.
+                  Foundry Memory Store partitions data per scope and validates the
+                  value to letters, digits, and `_ - . % + @ /` — colons are
+                  rejected. CEL: non-empty + charset. Default convention (set by
+                  the runtime path if absent here): `agent_{sandboxName}`.
 
                   Required when [`Self::bundle_ref`] is absent (the inline
                   path); MUST be absent when [`Self::bundle_ref`] is set.
@@ -166,9 +167,9 @@ spec:
             - message: spec.sandboxRef.name must be 1-253 characters
               reason: FieldValueInvalid
               rule: size(self.sandboxRef.name) > 0 && size(self.sandboxRef.name) <= 253
-            - message: spec.scope must be 1-256 characters when spec.bundleRef is not set
+            - message: spec.scope must be 1-256 characters using only letters, digits, and _ - . % + @ / (colons are rejected by the Foundry Memory Store) when spec.bundleRef is not set
               reason: FieldValueInvalid
-              rule: has(self.bundleRef) || (has(self.scope) && size(self.scope) > 0 && size(self.scope) <= 256)
+              rule: has(self.bundleRef) || (has(self.scope) && size(self.scope) > 0 && size(self.scope) <= 256 && self.scope.matches('^[A-Za-z0-9_./%+@-]+$'))
             - message: spec.retentionDays must be > 0 when set (use delete_scope for immediate deletion)
               reason: FieldValueInvalid
               rule: '!has(self.retentionDays) || self.retentionDays > 0'

--- a/docs/internal/security-audits/2026-06-26-foundry-memory-router-consolidation.md
+++ b/docs/internal/security-audits/2026-06-26-foundry-memory-router-consolidation.md
@@ -1,0 +1,109 @@
+# Security Audit — Foundry Memory Store consolidated on the router; RBAC heal on `kars upgrade` (v0.1.19)
+
+Date: 2026-06-26
+Scope: `inference-router/src/mcp/platform.rs`, `runtimes/openclaw/src/core/agt-tools/foundry.ts`, `runtimes/openclaw/src/core/router-client.ts`, `runtimes/hermes/src/kars_runtime_hermes/plugin/foundry.py`, `controller/src/crd_validations.rs` (+ synced `controller/src/kars_memory.rs`, `deploy/helm/kars/templates/crd-karsmemory.yaml`), `controller/src/reconciler/mod.rs` (comment only), `cli/src/commands/up/foundry_memory_rbac.ts` (new), `cli/src/commands/upgrade.ts`.
+Gated paths: `inference-router/src/mcp`, `controller/src/crd_validations.rs`, `cli/src/commands/up/foundry_memory_rbac.ts`, `cli/src/commands/upgrade.ts`, `runtimes/openclaw/src/core`.
+
+## Summary
+
+Persistent agent memory failed from both OpenClaw and Hermes ("the store
+creates but nothing persists / recall 403s"). Root causes spanned every layer.
+The fix makes the **inference-router the single owner of the Foundry Memory
+Store contract** and turns the two runtime plugins into thin clients.
+
+1. **One contract, in the router.** `foundry.memory`
+   (`mcp/platform.rs`) now emits the real Memory Store REST shape (`items[]`
+   of message items + `scope` + `options.max_memories` / `update_delay`),
+   adds `delete_scope` + `top_k`, pins the data-plane `api-version` on every
+   memory path (the proxy does not inject one — a latent bug), defaults the
+   store to the per-sandbox convention `memory-<sandbox>`, and resolves the
+   scope via `effective_scope()` (agent arg → KarsMemory binding → convention),
+   always run through `sanitize_scope()`.
+
+2. **Thin runtime clients.** OpenClaw (`foundry.ts` + new
+   `callPlatformTool` in `router-client.ts`) and Hermes (`foundry.py`) now send
+   a single JSON-RPC `tools/call` to the loopback-only `/platform/mcp`. They
+   carry **no** Foundry contract logic and **no** store-name override — the
+   bound KarsMemory CRD is the single source of truth. This makes TS/Python
+   wire drift structurally impossible.
+
+3. **Admission guard + RBAC heal.** `KarsMemory.spec.scope` now has a CEL
+   charset rule (rejects colons, which the data plane 400s). `kars upgrade`
+   gains an idempotent `ensureFoundryMemoryRbac()` step that enables the
+   Foundry **project** managed identity, ensures an embedding deployment, and
+   grants the project MI `Azure AI User` on the resource group — the identity
+   that Memory Store's internal model calls authenticate as. This heals an
+   existing cluster's memory on upgrade instead of requiring a fresh `kars up`.
+
+## T1: New capability / attack surface? (NEUTRAL — net reduction)
+- The agent-facing surface **shrinks**: the per-call `store_name` override was
+  removed from both plugins, so an agent can no longer redirect memory ops to
+  an arbitrary store id. Store selection is now infra-controlled (binding /
+  `FOUNDRY_MEMORY_STORE_ID` / `memory-<sandbox>`), never agent-controlled.
+- `delete_scope` is now reachable by agents, but each sandbox resolves to its
+  own store and agent control of `scope` (per-user/session namespacing) already
+  existed by design. No new cross-store / cross-tenant boundary is crossed.
+- `/platform/mcp` is a pre-existing, loopback-only, no-OAuth endpoint (only the
+  in-pod runtime can reach it; the egress-guard init container blocks everything
+  else). The thin clients only forward `operation/text/query/scope/top_k`.
+
+## T2: Security-control change? (NEUTRAL / hardening)
+- **`sanitize_scope` (`platform.rs`)** coerces the agent-supplied `scope` to the
+  Foundry charset `[A-Za-z0-9_-.%+@/]`. `/` is allowed but `scope` is only ever
+  placed in the JSON request **body** (`:search_memories` / `:update_memories` /
+  `:delete_scope`), never interpolated into a URL path or shell — confirmed by
+  grep. No path traversal / SSRF / injection.
+- **`store_id` into the URL path** (`/memory_stores/{store_id}…`) resolves only
+  from router-only infra inputs (binding / env / `memory-<sandbox>`); not
+  attacker-controllable.
+- **CEL scope rule (`crd_validations.rs`)** `^[A-Za-z0-9_./%+@-]+$` is fully
+  anchored; `+` does not match newlines → no admission bypass. Synced to the
+  helm CRD (drift test passes).
+- **RBAC helper (`foundry_memory_rbac.ts`)** issues `az` via `execa` with an
+  **argv array** (no shell), a hardcoded role-definition GUID, and
+  principal/scope values sourced from `az` output. No command injection. The
+  grant runs under the **operator's** existing credentials during `kars upgrade`,
+  not via any agent-triggerable path — not a privilege-escalation primitive. The
+  role granted (`Azure AI User`, `53ca6127-…`) and its RG scope are exactly what
+  Memory Store's internal model calls require and match the existing
+  `kars up` BYO-Foundry grant; no widening.
+- JSON-RPC bodies are built with structured `json!` / object literals, not
+  string concatenation. No secrets, weak crypto, or HTTP-downgrade in the diff.
+
+## T3: Availability / fail-open risk? (REDUCED)
+- The `kars upgrade` RBAC step is **best-effort and non-fatal**: any failure
+  degrades to an actionable note and never fails the upgrade. The role create is
+  idempotent (`RoleAssignmentExists` treated as success).
+- The router keeps ensure-on-404 + retry, and surfaces upstream 401/403 as a
+  CRD `Degraded=AuthMisconfigured` with the exact RBAC remediation — so a
+  misconfigured project MI is now legible instead of silent.
+- **Reviewer-found bug, fixed before release:** `delete_scope` against a
+  non-existent store skips ensure-on-404 (by design — we don't auto-create a
+  store just to wipe it), but the later `MemoryStoreMissing` recorder was not
+  similarly guarded, so a benign agent-initiated delete could flip the
+  KarsMemory CRD to `Degraded`. Added `&& op != "delete_scope"` to the recorder
+  and a regression test (`memory_delete_scope_404_does_not_record_memory_store_missing`).
+
+## Verification
+- Independent security review (no vulnerabilities found) and code review (the
+  `delete_scope`/Degraded bug above, since fixed) on the full diff.
+- Router: 51 `mcp::platform` + 948 lib + integration tests pass; `cargo clippy
+  --all-targets -- -D warnings` + `cargo fmt --check` clean.
+- Controller: 849 tests pass incl. `helm_drift` (Rust ↔ helm CRD in sync) and
+  `crd_validations`.
+- CLI: 850 vitest (incl. 6 new `foundry_memory_rbac` tests); `tsc --noEmit` +
+  oxlint clean.
+- OpenClaw: 102 vitest + `tsc` + oxlint clean. Hermes: 27 Foundry tests +
+  `ruff check` clean (the JSON-RPC envelope parsed by both thin clients matches
+  the router's `result.content[].text` / `isError` / `error.data.reason`).
+
+## Verdict
+Accept. Consolidating the Memory Store contract in the router removes the
+cross-runtime drift that caused the failures, **reduces** the agent-facing
+attack surface (no store override; infra-owned store/scope), adds an admission
+charset guard, and heals the project-MI RBAC idempotently on upgrade under
+operator credentials. No security control is weakened; the one reviewer-found
+correctness bug was fixed and covered by a test.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/inference-router/src/mcp/platform.rs
+++ b/inference-router/src/mcp/platform.rs
@@ -79,11 +79,48 @@ use crate::policy_status::{PolicyKind, PolicyStatusRegistry};
 /// `wiremock`/axum fake on a free port.
 const DEFAULT_ROUTER_PORT: u16 = 8443;
 
-/// Default Memory Store id when callers don't pin one explicitly via
-/// `FOUNDRY_MEMORY_STORE_ID`. Foundry projects ship with a
-/// project-default store named `default`; production deployments that
-/// pin a per-tenant store override the env var.
-const DEFAULT_MEMORY_STORE: &str = "default";
+/// Per-sandbox Memory Store name prefix. When neither
+/// `FOUNDRY_MEMORY_STORE_ID` nor a KarsMemory binding pins a store, the
+/// dispatcher falls back to `<prefix><sandbox>` — the same convention
+/// the runtime plugins use (`memory-<sandbox>`).
+const DEFAULT_MEMORY_STORE_PREFIX: &str = "memory-";
+
+/// Foundry Memory Store data-plane API version. The router self-calls
+/// its own `/memory_stores` proxy, which forwards the query string
+/// verbatim, so the version must be pinned here (the proxy does NOT
+/// inject a default). Mirrors the value the runtime plugins use.
+const MEMORY_API_VERSION: &str = "2025-11-15-preview";
+
+/// A single conversation item in the Foundry Memory Store contract
+/// shape. Both `:update_memories` and `:search_memories` take an
+/// `items` array of Responses-API message items — NOT a `messages`
+/// array or a bare `query`/`top_k` pair. Contract:
+/// <https://learn.microsoft.com/azure/ai-foundry/agents/how-to/memory-usage>
+fn memory_item(text: &str) -> Value {
+    json!({
+        "type": "message",
+        "role": "user",
+        "content": [{ "type": "input_text", "text": text }],
+    })
+}
+
+/// Coerce an arbitrary scope string to the Foundry Memory Store charset.
+/// Foundry partitions memories by `scope` and accepts only letters,
+/// digits, and `_ - . % + @ /`. Anything else (most commonly a colon
+/// from a legacy `agent:foo` convention) is rejected with HTTP 400, so
+/// we map every out-of-charset byte to `_`. A no-op for already-valid
+/// scopes.
+fn sanitize_scope(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '%' | '+' | '@' | '/') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
 
 /// Sync-path return for any `foundry.*` tool. The async path
 /// ([`PlatformDispatcher`] as `AsyncToolDispatcher`) does the real
@@ -157,22 +194,35 @@ pub fn foundry_tool_catalog() -> ToolCatalog {
         ToolDefinition {
             name: "foundry.memory".into(),
             description: "Persistent agent memory via Azure AI Foundry Memory Store. Use \
-                'search' to recall, 'update' to store new knowledge."
+                'search' to recall, 'update' to store new knowledge, 'delete_scope' to \
+                wipe a partition. Store name and scope come from the bound KarsMemory CRD."
                 .into(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "operation": {
                         "type": "string",
-                        "enum": ["search", "update"],
-                        "description": "Operation: 'search' or 'update'."
+                        "enum": ["search", "update", "delete_scope"],
+                        "description": "Operation: 'search', 'update', or 'delete_scope'."
                     },
                     "text": {
                         "type": "string",
-                        "description": "For 'update': the fact to remember. For 'search': the query."
+                        "description": "For 'update': the fact to remember. For 'search': the query (alias: 'query')."
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Alias for 'text' on 'search' (empty = list all in scope)."
+                    },
+                    "scope": {
+                        "type": "string",
+                        "description": "Memory partition. Defaults to the CRD/convention scope. Use '_' as the separator (e.g. 'session_<id>', 'user_<id>') — colons are rejected by the API."
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "For 'search': max memories to return (default 10)."
                     }
                 },
-                "required": ["operation", "text"]
+                "required": ["operation"]
             }),
         },
         ToolDefinition {
@@ -326,7 +376,7 @@ impl PlatformDispatcher {
     /// Default dispatcher: catalog of 9 tools, base URL derived from
     /// `ROUTER_INTERNAL_PORT` (default `8443`), sandbox identifier from
     /// `SANDBOX_NAME` (default `unknown`), memory store id from
-    /// `FOUNDRY_MEMORY_STORE_ID` (default `default`).
+    /// `FOUNDRY_MEMORY_STORE_ID` (default `memory-<sandbox>`).
     pub fn standard() -> Self {
         let port = std::env::var("ROUTER_INTERNAL_PORT")
             .ok()
@@ -334,8 +384,19 @@ impl PlatformDispatcher {
             .unwrap_or(DEFAULT_ROUTER_PORT);
         let base_url = format!("http://127.0.0.1:{port}");
         let sandbox_name = std::env::var("SANDBOX_NAME").unwrap_or_else(|_| "unknown".into());
+        // Store-id precedence: explicit `FOUNDRY_MEMORY_STORE_ID` env →
+        // the per-sandbox convention `memory-<sandbox>`. The KarsMemory
+        // binding (when present) overrides both at call time via
+        // `effective_memory_store_id`. The convention default keeps the
+        // router as a faithful single source of truth: a sandbox with no
+        // CRD and no env still lands on the same store the runtime
+        // plugins historically used (`memory-<sandbox>`), not the
+        // project-wide `default` store.
         let memory_store_id = std::env::var("FOUNDRY_MEMORY_STORE_ID")
-            .unwrap_or_else(|_| DEFAULT_MEMORY_STORE.into());
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| format!("{DEFAULT_MEMORY_STORE_PREFIX}{sandbox_name}"));
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()
@@ -414,6 +475,40 @@ impl PlatformDispatcher {
             }
         }
         self.memory_store_id.clone()
+    }
+
+    /// Resolve the effective memory `scope` (partition key) for a
+    /// `foundry.memory` call. Precedence: an explicit `scope` arg from
+    /// the agent → the KarsMemory binding's `scope` → the convention
+    /// `agent_<cluster>_<sandbox>` (or `agent_<sandbox>` when no cluster
+    /// is set). Every branch is run through [`sanitize_scope`] so an
+    /// out-of-charset value (e.g. a legacy colon scope baked into a CRD)
+    /// can never reach the upstream and 400 the whole call.
+    async fn effective_scope(&self, args: &Value) -> String {
+        if let Some(s) = args.get("scope").and_then(|v| v.as_str()) {
+            let s = s.trim();
+            if !s.is_empty() {
+                return sanitize_scope(s);
+            }
+        }
+        if let Some(handle) = self.memory_binding.as_ref() {
+            let guard = handle.read().await;
+            if let Some(binding) = guard.as_ref() {
+                let s = binding.scope.trim();
+                if !s.is_empty() {
+                    return sanitize_scope(s);
+                }
+            }
+        }
+        let sandbox = sanitize_scope(self.sandbox_name.trim());
+        match std::env::var("CLUSTER_NAME")
+            .ok()
+            .map(|c| c.trim().to_string())
+            .filter(|c| !c.is_empty())
+        {
+            Some(cluster) => format!("agent_{}_{}", sanitize_scope(&cluster), sandbox),
+            None => format!("agent_{sandbox}"),
+        }
     }
 
     pub fn with_catalog(mut self, catalog: ToolCatalog) -> Self {
@@ -509,22 +604,60 @@ impl PlatformDispatcher {
 
     async fn memory(&self, args: &Value) -> Result<ToolCallOutput, DispatchError> {
         let op = self.require_str(args, "operation", "foundry.memory")?;
-        let text = self.require_str(args, "text", "foundry.memory")?;
+        let scope = self.effective_scope(args).await;
+        // `text` is the memory/query content; accept the `query` alias
+        // for search. Update requires non-empty text; search and
+        // delete_scope do not (empty search = list everything in scope).
+        let text = args
+            .get("text")
+            .or_else(|| args.get("query"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let max_memories = args
+            .get("top_k")
+            .and_then(|v| v.as_u64())
+            .filter(|n| *n >= 1)
+            .unwrap_or(10);
+
         let (suffix, body) = match op {
-            "search" => (":search_memories", json!({"query": text, "top_k": 10})),
-            "update" => (
-                ":update_memories",
-                json!({"messages": [{"role": "user", "content": text}]}),
+            "search" => (
+                ":search_memories",
+                json!({
+                    "scope": scope,
+                    "items": [memory_item(&text)],
+                    "options": { "max_memories": max_memories },
+                }),
             ),
+            "update" => {
+                if text.is_empty() {
+                    return Err(DispatchError::InvalidArguments {
+                        tool: "foundry.memory".into(),
+                        reason: "operation=update requires a non-empty 'text'".into(),
+                    });
+                }
+                (
+                    ":update_memories",
+                    json!({
+                        "scope": scope,
+                        "items": [memory_item(&text)],
+                        "update_delay": 0,
+                    }),
+                )
+            }
+            "delete_scope" => (":delete_scope", json!({ "scope": scope })),
             other => {
                 return Err(DispatchError::InvalidArguments {
                     tool: "foundry.memory".into(),
-                    reason: format!("operation must be 'search' or 'update', got '{other}'"),
+                    reason: format!(
+                        "operation must be 'search', 'update', or 'delete_scope', got '{other}'"
+                    ),
                 });
             }
         };
         let store_id = self.effective_memory_store_id().await;
-        let path = format!("/memory_stores/{store_id}{suffix}");
+        let path = format!("/memory_stores/{store_id}{suffix}?api-version={MEMORY_API_VERSION}");
         let (status, output) = self
             .post_json_with_status("foundry.memory", &path, &body)
             .await;
@@ -545,7 +678,7 @@ impl PlatformDispatcher {
         // fails for any other reason → fall through to the existing
         // `MemoryStoreMissing:` record path so the operator still
         // gets a signal.
-        if status == Some(404) {
+        if status == Some(404) && op != "delete_scope" {
             match self.ensure_memory_store(&store_id).await {
                 EnsureOutcome::Ready => {
                     let (retry_status, retry_output) = self
@@ -619,10 +752,16 @@ impl PlatformDispatcher {
         // ensure-on-404 path either failed for a non-auth reason or
         // claimed success but the store still 404s (defensive).
         // Otherwise the retry above already returned 2xx and we
-        // never get here. The wire prefix is pinned controller-side
-        // as `conditions::MEMORY_STORE_MISSING_PREFIX`; replicated
-        // here as a literal because no cross-binary dep is allowed.
+        // never get here. `delete_scope` is excluded: it deliberately
+        // skips the ensure path (we don't auto-create a store just to
+        // wipe it), so a 404 there is a benign idempotent no-op, not a
+        // misconfiguration — recording MemoryStoreMissing would flip the
+        // CRD to Degraded on an ordinary agent-initiated delete. The
+        // wire prefix is pinned controller-side as
+        // `conditions::MEMORY_STORE_MISSING_PREFIX`; replicated here as a
+        // literal because no cross-binary dep is allowed.
         if status == Some(404)
+            && op != "delete_scope"
             && let Some(registry) = self.policy_status.as_ref()
         {
             let source_path = registry
@@ -674,7 +813,11 @@ impl PlatformDispatcher {
             },
         });
         let (status, _envelope) = self
-            .post_json_with_status("foundry.memory.ensure", "/memory_stores", &body)
+            .post_json_with_status(
+                "foundry.memory.ensure",
+                &format!("/memory_stores?api-version={MEMORY_API_VERSION}"),
+                &body,
+            )
             .await;
         match status {
             Some(s) if (200..300).contains(&s) || s == 409 => {
@@ -1245,10 +1388,118 @@ mod tests {
         .unwrap();
         let req = &server.received_requests().await.unwrap()[0];
         let body: Value = serde_json::from_slice(&req.body).unwrap();
-        assert_eq!(
-            body["messages"][0]["content"],
-            json!("user prefers concise replies")
+        // Foundry Memory Store contract: items[] of message items, NOT a
+        // legacy {messages:[{role,content}]} shape.
+        assert!(
+            body.get("messages").is_none(),
+            "legacy messages shape must be gone"
         );
+        assert_eq!(body["update_delay"], json!(0));
+        assert_eq!(
+            body["items"][0],
+            json!({
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": "user prefers concise replies" }],
+            })
+        );
+        // Scope must be present and colon-free.
+        let scope = body["scope"].as_str().unwrap();
+        assert!(
+            !scope.is_empty() && !scope.contains(':'),
+            "scope `{scope}` must be a valid partition key"
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_search_sends_items_and_options_not_query_top_k() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/memstore-test:search_memories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"memories": []})))
+            .mount(&server)
+            .await;
+        let d = dispatcher_for(&server);
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "search", "query": "what did I say", "top_k": 3}),
+        )
+        .await
+        .unwrap();
+        let req = &server.received_requests().await.unwrap()[0];
+        let body: Value = serde_json::from_slice(&req.body).unwrap();
+        assert!(body.get("query").is_none() && body.get("top_k").is_none());
+        assert_eq!(body["options"]["max_memories"], json!(3));
+        assert_eq!(
+            body["items"][0]["content"][0]["text"],
+            json!("what did I say")
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_delete_scope_sends_scope_only_and_skips_ensure() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/memstore-test:delete_scope"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"deleted": 4})))
+            .mount(&server)
+            .await;
+        let d = dispatcher_for(&server);
+        let out = AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "delete_scope", "scope": "session_abc"}),
+        )
+        .await
+        .unwrap();
+        assert!(!out.is_error);
+        let req = &server.received_requests().await.unwrap()[0];
+        let body: Value = serde_json::from_slice(&req.body).unwrap();
+        assert_eq!(body, json!({"scope": "session_abc"}));
+    }
+
+    #[tokio::test]
+    async fn memory_binding_scope_overrides_and_colon_is_sanitized() {
+        use crate::memory_binding_loader::{LoadedMemoryBinding, empty_handle};
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/memstore-test:search_memories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"memories": []})))
+            .mount(&server)
+            .await;
+        let handle = empty_handle();
+        {
+            let mut g = handle.write().await;
+            *g = Some(LoadedMemoryBinding {
+                digest: "sha256:deadbeef".into(),
+                source_path: "/etc/kars/memory/binding.json".into(),
+                store_name: "memstore-test".into(),
+                // legacy colon scope from a CRD — must be coerced to a
+                // valid partition key before it reaches the upstream.
+                scope: "agent:legacy".into(),
+                raw: json!({}),
+            });
+        }
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("memstore-test")
+            .with_memory_binding(handle);
+        AsyncToolDispatcher::invoke(&d, "foundry.memory", &json!({"operation": "search"}))
+            .await
+            .unwrap();
+        let req = &server.received_requests().await.unwrap()[0];
+        let body: Value = serde_json::from_slice(&req.body).unwrap();
+        assert_eq!(body["scope"], json!("agent_legacy"));
+    }
+
+    #[test]
+    fn sanitize_scope_maps_out_of_charset_to_underscore() {
+        assert_eq!(sanitize_scope("agent:foo"), "agent_foo");
+        assert_eq!(
+            sanitize_scope("session_1-a.b@c/d+e%f"),
+            "session_1-a.b@c/d+e%f"
+        );
+        assert_eq!(sanitize_scope("a b:c"), "a_b_c");
     }
 
     #[tokio::test]
@@ -1851,6 +2102,53 @@ mod tests {
         // Digest preserved through the error record (matches the
         // 3b.4 design — record_error never wipes the digest).
         assert_eq!(entry.digest, Some(prior_digest));
+    }
+
+    #[tokio::test]
+    async fn memory_delete_scope_404_does_not_record_memory_store_missing() {
+        // A delete_scope against a store that doesn't exist is a benign
+        // idempotent no-op — it must NOT flip the KarsMemory CRD to
+        // Degraded (delete skips ensure-on-404 AND the missing-store
+        // record).
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/memory_stores/store-xyz:delete_scope"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        let registry = Arc::new(PolicyStatusRegistry::new());
+        registry.record_success(
+            PolicyKind::Memory,
+            "/etc/kars/memory/binding.json",
+            b"binding",
+        );
+
+        let d = PlatformDispatcher::with_base_url(server.uri())
+            .with_memory_store_id("store-xyz")
+            .with_policy_status(registry.clone());
+        AsyncToolDispatcher::invoke(
+            &d,
+            "foundry.memory",
+            &json!({"operation": "delete_scope", "scope": "session_x"}),
+        )
+        .await
+        .unwrap();
+
+        // No ensure attempt + no MemoryStoreMissing record → status stays clean.
+        let entry = registry.get(PolicyKind::Memory).expect("entry present");
+        assert!(
+            entry.last_error.is_none(),
+            "delete_scope 404 must not record an error, got {:?}",
+            entry.last_error
+        );
+        // Only the delete_scope call should have hit the upstream (no
+        // ensure POST /memory_stores).
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(
+            reqs.len(),
+            1,
+            "delete_scope must not trigger an ensure call"
+        );
     }
 
     /// 404 must NOT trip the AuthMisconfigured surface — the

--- a/runtimes/hermes/src/kars_runtime_hermes/plugin/foundry.py
+++ b/runtimes/hermes/src/kars_runtime_hermes/plugin/foundry.py
@@ -37,99 +37,84 @@ logger = logging.getLogger("kars.hermes.foundry")
 
 _FOUNDRY_API_VERSION = "2025-11-15-preview"
 
+# The Foundry Memory Store contract — store + scope resolution from the
+# KarsMemory binding, the request body shapes, auto-provision on 404,
+# retry, and 401/403 RBAC surfacing — is owned by the inference router's
+# platform MCP ``foundry.memory`` tool. This wrapper is a thin client: it
+# forwards intent to ``POST /platform/mcp`` and returns the router's text
+# result. A single contract implementation (in the router) means the
+# OpenClaw and Hermes runtimes can never drift apart on the wire shape,
+# and a custom storeName/scope on the KarsMemory CR is honoured centrally
+# without the agent process needing any Foundry knowledge.
 
-def _store_name() -> str:
-    """Resolve the Foundry Memory Store this sandbox is bound to.
 
-    Convention (matches OpenClaw plugin + KarsMemory CR ``storeName``):
-    ``memory-${SANDBOX_NAME}``. Operators bind via
-    ``KarsMemory.spec.storeName: memory-<sandbox>``; the router
-    auto-provisions on first 404.
+def _call_platform_tool(name: str, arguments: dict[str, Any]) -> str:
+    """Invoke a router platform-MCP tool via one JSON-RPC ``tools/call``.
+
+    Returns the flattened text content. A JSON-RPC error (unknown tool,
+    invalid arguments) or a tool-level ``isError`` is surfaced as the
+    returned text so the LLM sees the real reason.
     """
-    sandbox = os.environ.get("SANDBOX_NAME", "unknown")
-    # Defensive truncation: K8s DNS-label limit is 63 chars; we use 7
-    # chars for the "memory-" prefix, leaving 56 for the sandbox name.
-    return f"memory-{sandbox[:56]}"
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+    try:
+        resp = router_client.call("POST", "/platform/mcp", json=rpc)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"{name} request failed: {exc}"})
+    if resp.status_code >= 400:
+        return json.dumps(
+            {"error": f"{name} HTTP {resp.status_code}", "body": resp.text[:500]}
+        )
+    try:
+        payload = resp.json()
+    except Exception:  # noqa: BLE001
+        return resp.text[:2000]
+    if isinstance(payload, dict) and payload.get("error"):
+        err = payload["error"] or {}
+        reason = (
+            (err.get("data") or {}).get("reason")
+            or err.get("message")
+            or "unknown error"
+        )
+        return json.dumps({"error": f"{name}: {reason}"})
+    result = payload.get("result") if isinstance(payload, dict) else None
+    content = result.get("content") if isinstance(result, dict) else None
+    if isinstance(content, list):
+        texts = [
+            c["text"]
+            for c in content
+            if isinstance(c, dict)
+            and c.get("type") == "text"
+            and isinstance(c.get("text"), str)
+        ]
+        if texts:
+            return "\n\n".join(texts)
+    return json.dumps(result if result is not None else payload)
 
 
 def _foundry_memory(args: dict[str, Any], **_kwargs: Any) -> str:
-    """Memory CRUD against the Foundry Memory Store bound to this sandbox."""
-    op = str(args.get("operation", "")).lower().strip()
-    store = str(args.get("store_name") or _store_name()).strip()
-    scope = str(args.get("scope") or f"agent:{os.environ.get('SANDBOX_NAME', 'unknown')}").strip()
-
-    if op not in ("search", "update", "delete_scope"):
-        return json.dumps(
-            {
-                "error": "operation must be 'search', 'update', or 'delete_scope'",
-                "got": op,
-            }
-        )
-
-    api_ver = f"api-version={_FOUNDRY_API_VERSION}"
-    base = f"/memory_stores/{store}"
-
-    try:
-        if op == "search":
-            query = args.get("query", "")
-            body = {
-                "query_text": str(query) if query else "",
-                "scope": scope,
-                "top_k": int(args.get("top_k", 10)),
-            }
-            resp = router_client.call(
-                "POST", f"{base}:search_memories?{api_ver}", json=body
-            )
-        elif op == "update":
-            text = args.get("text", "")
-            if not text:
-                return json.dumps({"error": "operation=update requires 'text'"})
-            body = {
-                "messages": [{"role": "user", "content": str(text)}],
-                "scope": scope,
-            }
-            resp = router_client.call(
-                "POST", f"{base}:update_memories?{api_ver}", json=body
-            )
-        else:  # delete_scope
-            resp = router_client.call(
-                "POST", f"{base}:delete_scope?{api_ver}", json={"scope": scope}
-            )
-    except Exception as exc:  # noqa: BLE001
-        return json.dumps({"error": f"foundry_memory request failed: {exc}"})
-
-    if resp.status_code == 404 and op != "delete_scope":
-        # First-time use: router auto-creates the store on next call.
-        # Retry once.
-        try:
-            router_client.call(
-                "POST",
-                f"/memory_stores?{api_ver}",
-                json={
-                    "name": store,
-                    "description": f"kars memory binding for sandbox {os.environ.get('SANDBOX_NAME', '')}",
-                },
-            )
-        except Exception:  # noqa: BLE001
-            pass  # the next call below will surface the real error
-
-    if resp.status_code >= 400:
-        return json.dumps(
-            {
-                "error": f"foundry_memory HTTP {resp.status_code}",
-                "body": resp.text[:500],
-                "operation": op,
-                "store": store,
-                "scope": scope,
-            }
-        )
-
-    try:
-        return json.dumps(resp.json())
-    except Exception:  # noqa: BLE001
-        return json.dumps(
-            {"operation": op, "store": store, "scope": scope, "raw": resp.text[:500]}
-        )
+    """Persistent agent memory — thin client over the router's
+    ``foundry.memory`` platform-MCP tool. The router owns the Memory
+    Store contract, store/scope resolution from the KarsMemory binding,
+    auto-provision, retry, and CRD status."""
+    forwarded: dict[str, Any] = {"operation": str(args.get("operation", "")).strip()}
+    text = args.get("text")
+    if isinstance(text, str) and text:
+        forwarded["text"] = text
+    query = args.get("query")
+    if isinstance(query, str) and query:
+        forwarded["query"] = query
+    scope = args.get("scope")
+    if isinstance(scope, str) and scope:
+        forwarded["scope"] = scope
+    top_k = args.get("top_k")
+    if isinstance(top_k, int):
+        forwarded["top_k"] = top_k
+    return _call_platform_tool("foundry.memory", forwarded)
 
 
 _FOUNDRY_MEMORY_SCHEMA = {
@@ -140,7 +125,7 @@ _FOUNDRY_MEMORY_SCHEMA = {
         "scope), 'update' (write a new memory), 'delete_scope' (wipe all "
         "memories under a scope). The store name follows the kars convention "
         "memory-${SANDBOX_NAME} and is auto-provisioned on first use. The "
-        "scope defaults to agent:${SANDBOX_NAME}; pass scope to namespace "
+        "scope defaults to agent_${SANDBOX_NAME}; pass scope to namespace "
         "memories per-session or per-user."
     ),
     "parameters": {
@@ -166,16 +151,10 @@ _FOUNDRY_MEMORY_SCHEMA = {
             "scope": {
                 "type": "string",
                 "description": (
-                    "Memory namespace (default: agent:${SANDBOX_NAME}). "
-                    "Use 'session:<id>' for per-conversation memory, "
-                    "'user:<id>' for per-user memory across sessions."
-                ),
-            },
-            "store_name": {
-                "type": "string",
-                "description": (
-                    "Override the kars store name convention "
-                    "(default: memory-${SANDBOX_NAME}). Usually leave unset."
+                    "Memory namespace (default: agent_${SANDBOX_NAME}). "
+                    "Use 'session_<id>' for per-conversation memory, "
+                    "'user_<id>' for per-user memory across sessions. "
+                    "Use '_' as the separator — colons are rejected by the API."
                 ),
             },
         },

--- a/runtimes/hermes/tests/test_foundry_http_fetch.py
+++ b/runtimes/hermes/tests/test_foundry_http_fetch.py
@@ -34,118 +34,106 @@ class _FakeCtx:
         self.tools[kwargs["name"]] = kwargs
 
 
-# ── foundry_memory — store name convention ─────────────────────────
+# ── foundry_memory — thin client over the router platform MCP ──────
+#
+# The router owns the Memory Store contract; the Hermes tool only
+# forwards intent to `POST /platform/mcp` as a JSON-RPC `tools/call`.
+# These tests pin THAT seam — the on-the-wire contract is exercised by
+# the router's own platform tests (inference-router/src/mcp/platform.rs).
 
 
-def test_store_name_follows_kars_convention(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "auditor")
-    assert foundry._store_name() == "memory-auditor"
+def _rpc_ok(text: str, *, is_error: bool = False) -> dict[str, Any]:
+    """A JSON-RPC `tools/call` success envelope as the router returns it."""
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"content": [{"type": "text", "text": text}], "isError": is_error},
+    }
 
 
-def test_store_name_truncates_long_sandbox_names(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "a" * 100)
-    name = foundry._store_name()
-    assert len(name) <= 63
-    assert name.startswith("memory-")
-
-
-def test_store_name_falls_back_when_sandbox_name_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("SANDBOX_NAME", raising=False)
-    assert foundry._store_name() == "memory-unknown"
-
-
-# ── foundry_memory — operation dispatch ─────────────────────────────
-
-
-def test_foundry_memory_rejects_unknown_operation(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "x")
-    result = foundry._foundry_memory({"operation": "purge"})
-    parsed = json.loads(result)
-    assert "must be" in parsed["error"]
-
-
-def test_foundry_memory_search_uses_correct_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "auditor")
+def _capture_platform_call(response: httpx.Response) -> tuple[dict[str, Any], Any]:
+    """Build a `router_client.call` fake that records the JSON-RPC body."""
     captured: dict[str, Any] = {}
 
     def fake_call(method: str, path: str, **kwargs: Any) -> httpx.Response:
         captured["method"] = method
         captured["path"] = path
         captured["body"] = kwargs.get("json")
-        return _mock_response(200, {"memories": [{"text": "hello"}]})
+        return response
 
-    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
-        result = foundry._foundry_memory({"operation": "search", "query": "test"})
-
-    assert captured["method"] == "POST"
-    assert ":search_memories" in captured["path"]
-    assert "memory-auditor" in captured["path"]
-    assert captured["body"]["query_text"] == "test"
-    assert captured["body"]["scope"] == "agent:auditor"
-    parsed = json.loads(result)
-    assert "memories" in parsed
+    return captured, fake_call
 
 
-def test_foundry_memory_update_requires_text(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "x")
-    result = foundry._foundry_memory({"operation": "update"})
-    parsed = json.loads(result)
-    assert "requires 'text'" in parsed["error"]
-
-
-def test_foundry_memory_update_wraps_text_in_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "x")
-    captured: dict[str, Any] = {}
-
-    def fake_call(method: str, path: str, **kwargs: Any) -> httpx.Response:
-        captured["body"] = kwargs.get("json")
-        return _mock_response(200, {"id": "mem-1"})
-
-    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
-        foundry._foundry_memory({"operation": "update", "text": "remember this"})
-
-    body = captured["body"]
-    assert body["messages"][0]["content"] == "remember this"
-    assert body["scope"] == "agent:x"
-
-
-def test_foundry_memory_custom_scope_overrides_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "x")
-    captured: dict[str, Any] = {}
-
-    def fake_call(method: str, path: str, **kwargs: Any) -> httpx.Response:
-        captured["body"] = kwargs.get("json")
-        return _mock_response(200, {"results": []})
-
-    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
-        foundry._foundry_memory(
-            {"operation": "search", "query": "x", "scope": "session:abc123"}
-        )
-
-    assert captured["body"]["scope"] == "session:abc123"
-
-
-def test_foundry_memory_delete_scope() -> None:
-    captured: dict[str, Any] = {}
-
-    def fake_call(method: str, path: str, **kwargs: Any) -> httpx.Response:
-        captured["path"] = path
-        captured["body"] = kwargs.get("json")
-        return _mock_response(200, {"deleted_count": 5})
-
+def test_foundry_memory_forwards_search_to_platform_mcp() -> None:
+    captured, fake_call = _capture_platform_call(_mock_response(200, _rpc_ok('{"memories": []}')))
     with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
         result = foundry._foundry_memory(
-            {"operation": "delete_scope", "scope": "session:xyz"}
+            {"operation": "search", "query": "coffee?", "top_k": 5}
         )
 
-    assert ":delete_scope" in captured["path"]
-    assert captured["body"]["scope"] == "session:xyz"
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/platform/mcp"
+    body = captured["body"]
+    assert body["method"] == "tools/call"
+    assert body["params"]["name"] == "foundry.memory"
+    # Only intent is forwarded — no store name, no scope unless given,
+    # no REST contract shape.
+    assert body["params"]["arguments"] == {
+        "operation": "search",
+        "query": "coffee?",
+        "top_k": 5,
+    }
+    # The router's text result is flattened back to the caller.
+    assert json.loads(result) == {"memories": []}
+
+
+def test_foundry_memory_forwards_update_text() -> None:
+    captured, fake_call = _capture_platform_call(_mock_response(200, _rpc_ok("queued")))
+    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
+        result = foundry._foundry_memory(
+            {"operation": "update", "text": "likes dark roast"}
+        )
+    assert captured["body"]["params"]["arguments"] == {
+        "operation": "update",
+        "text": "likes dark roast",
+    }
+    assert result == "queued"
+
+
+def test_foundry_memory_forwards_scope_and_delete_scope() -> None:
+    captured, fake_call = _capture_platform_call(_mock_response(200, _rpc_ok('{"deleted": 3}')))
+    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
+        foundry._foundry_memory({"operation": "delete_scope", "scope": "session_xyz"})
+    assert captured["body"]["params"]["arguments"] == {
+        "operation": "delete_scope",
+        "scope": "session_xyz",
+    }
+
+
+def test_foundry_memory_surfaces_jsonrpc_error() -> None:
+    err_env = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32602, "message": "bad", "data": {"reason": "operation must be search"}},
+    }
+    _, fake_call = _capture_platform_call(_mock_response(200, err_env))
+    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
+        result = foundry._foundry_memory({"operation": "purge"})
     parsed = json.loads(result)
-    assert parsed["deleted_count"] == 5
+    assert "operation must be search" in parsed["error"]
 
 
-def test_foundry_memory_http_error_surfaces_status(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SANDBOX_NAME", "x")
+def test_foundry_memory_surfaces_tool_is_error_text() -> None:
+    # A tool-level failure (e.g. upstream 403) comes back as result.content
+    # text with isError=true; the text is what the LLM should see.
+    hint = "foundry.memory:search returned HTTP 403 (verify the project managed identity...)"
+    _, fake_call = _capture_platform_call(_mock_response(200, _rpc_ok(hint, is_error=True)))
+    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
+        result = foundry._foundry_memory({"operation": "search", "query": "x"})
+    assert "HTTP 403" in result
+
+
+def test_foundry_memory_surfaces_http_error() -> None:
     with mock.patch.object(
         foundry.router_client,
         "call",

--- a/runtimes/openclaw/src/core/agt-tools/foundry.ts
+++ b/runtimes/openclaw/src/core/agt-tools/foundry.ts
@@ -14,9 +14,8 @@
 //   foundry_evaluations      foundry_deployments
 //   foundry_agents
 
-import { routerCall, routerCallStrict, routerCallBinary } from "../router-client.js";
+import { routerCall, routerCallBinary, callPlatformTool } from "../router-client.js";
 import { safeJson } from "../safe-json.js";
-import { resolveMemoryStoreName, resolveMemoryScope } from "../memory-binding.js";
 import type { FoundryProjectInfo } from "../foundry-discovery.js";
 
 // _routerCall is the historical alias used inside these blocks; keep it for
@@ -622,6 +621,10 @@ export function registerFoundryTools(api: AnyApi, deps: FoundryToolsDeps): void 
   });
 
   // ── Foundry Memory: persistent semantic memory store ────────────────
+  // Thin client. The router's platform MCP `foundry.memory` tool owns the
+  // Memory Store REST contract, store/scope resolution from the KarsMemory
+  // binding, auto-provision, retry, and CRD status reporting. This handler
+  // only forwards intent — no Foundry contract logic lives in the agent.
   api.registerTool({
     name: "foundry_memory",
     label: "Foundry Memory Store",
@@ -641,168 +644,28 @@ export function registerFoundryTools(api: AnyApi, deps: FoundryToolsDeps): void 
           type: "string",
           description: "For 'update': the fact or preference to remember (e.g. 'User prefers dark roast coffee'). For 'search': the query to find relevant memories (e.g. 'coffee preferences').",
         },
-        scope: { type: "string", description: "Memory scope (default: sandbox name). Use to partition memories by user." },
-        store_name: { type: "string", description: "Memory store name (default: 'memory-{agent}')." },
+        scope: {
+          type: "string",
+          description: "Memory scope/partition (default: the bound KarsMemory scope, else 'agent_<sandbox>'). Use '_' as the separator (e.g. 'session_<id>', 'user_<id>') — colons are rejected by the API.",
+        },
+        top_k: {
+          type: "integer",
+          description: "For 'search': max memories to return (default 10).",
+        },
       },
-      required: ["operation", "text"],
+      required: ["operation"],
     },
     async execute(_id: string, params: Record<string, unknown>) {
+      const op = String(params.operation ?? "");
+      const args: Record<string, unknown> = { operation: op };
+      if (typeof params.text === "string" && params.text.length > 0) args.text = params.text;
+      if (typeof params.scope === "string" && params.scope.length > 0) args.scope = params.scope;
+      if (typeof params.top_k === "number") args.top_k = params.top_k;
       try {
-        const agentName = process.env.SANDBOX_NAME || process.env.HOSTNAME || "default";
-        const store = (params.store_name as string) || resolveMemoryStoreName(agentName);
-        const scope = (params.scope as string) || resolveMemoryScope(agentName);
-        const op = params.operation as string;
-        const text = (params.text as string) || "";
-        const apiVer = "api-version=2025-11-15-preview";
-
-        // Build Foundry-format conversation item (same for both update and search)
-        const makeItem = (content: string) => ({
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: content }],
-        });
-
-        // Poll an update operation until complete (LRO)
-        const pollUpdate = async (updateId: string, maxWaitMs = 60000) => {
-          const start = Date.now();
-          while (Date.now() - start < maxWaitMs) {
-            await new Promise(r => setTimeout(r, 2000));
-            try {
-              const status = await routerCall("GET", `/memory_stores/${store}/updates/${updateId}?${apiVer}`);
-              const state = status?.status || status?.state;
-              if (state === "completed" || state === "succeeded") return status;
-              if (state === "failed" || state === "error") throw new Error(`Memory update failed: ${safeJson(status)}`);
-            } catch (e: any) {
-              if (!e.message?.includes("404")) throw e;
-            }
-          }
-          return { status: "timeout", message: "Memory update still processing. It will complete in the background." };
-        };
-
-        const isNotFound = (r: any): boolean => {
-          if (!r || typeof r !== "object") return false;
-          const code = r?.error?.code || r?.code;
-          const msg = r?.error?.message || r?.message;
-          return code === "not_found" || code === 404 ||
-            (typeof msg === "string" && (msg.includes("not found") || msg.includes("not_found")));
-        };
-
-        const ensureStore = async () => {
-          try {
-            const probe = await routerCall("GET", `/memory_stores/${store}?${apiVer}`);
-            if (!isNotFound(probe)) return;
-          } catch (e: any) {
-            if (!(e.message?.includes("404") || e.message?.includes("not_found") || e.message?.includes("not found"))) {
-              return;
-            }
-          }
-          const chatModel = process.env.OPENCLAW_MODEL || "gpt-4.1";
-          const embeddingModel = getFoundryProject()?.deployments?.find(
-            (d: any) => d.id?.includes("embedding") || d.model?.includes("embedding")
-          )?.id || "text-embedding-3-small";
-          log.info(`Creating memory store '${store}' (chat=${chatModel}, embedding=${embeddingModel})`);
-          // Use the STRICT call so an upstream 4xx (e.g. 403 because the Foundry
-          // project's managed identity isn't enabled / lacks Azure AI User on
-          // the resource group, or 400 because no embedding model is deployed)
-          // surfaces the REAL reason instead of being swallowed and collapsing
-          // into a generic "could not be created".
-          await routerCallStrict("POST", `/memory_stores?${apiVer}`, {
-            name: store,
-            description: "kars agent persistent memory",
-            definition: {
-              kind: "default",
-              chat_model: chatModel,
-              embedding_model: embeddingModel,
-              options: {
-                user_profile_enabled: true,
-                user_profile_details: "Store user preferences, decisions, and project context",
-                chat_summary_enabled: true,
-              },
-            },
-          });
-          log.info(`Memory store '${store}' created successfully`);
-        };
-
-        if (op === "search") {
-          const body = {
-            scope,
-            items: [makeItem(text)],
-            options: { max_memories: 10 },
-          };
-          try {
-            let result = await routerCall("POST", `/memory_stores/${store}:search_memories?${apiVer}`, body);
-            if (isNotFound(result)) {
-              await ensureStore();
-              result = await routerCall("POST", `/memory_stores/${store}:search_memories?${apiVer}`, body);
-              if (isNotFound(result)) {
-                return { content: [{ type: "text", text: "Memory store just created — no memories stored yet. Try saving something first." }] };
-              }
-            }
-            return { content: [{ type: "text", text: safeJson(result) }] };
-          } catch (e: any) {
-            if (e.message?.includes("not found") || e.message?.includes("not_found")) {
-              try {
-                await ensureStore();
-                const result = await routerCall("POST", `/memory_stores/${store}:search_memories?${apiVer}`, body);
-                return { content: [{ type: "text", text: safeJson(result) }] };
-              } catch {
-                return { content: [{ type: "text", text: "Memory store just created — no memories stored yet. Try saving something first." }] };
-              }
-            }
-            log.warn(`Memory search failed: ${e.message}`);
-            return { content: [{ type: "text", text: `Memory search failed: ${e.message}. The memory service may still be initializing.` }] };
-          }
-        } else if (op === "update") {
-          const body = {
-            scope,
-            items: [makeItem(text)],
-            update_delay: 0,
-          };
-          const doUpdate = async () => {
-            const result = await routerCall("POST", `/memory_stores/${store}:update_memories?${apiVer}`, body);
-            // update_memories is a LRO — log completion in background, don't block chat
-            const updateId = result?.update_id || result?.id;
-            if (updateId && (result?.status === "queued" || result?.status === "running")) {
-              pollUpdate(updateId).then(
-                (r) => log.info(`Memory update ${updateId} completed: ${JSON.stringify(r?.memory_operations?.length ?? 0)} ops`),
-                (e) => log.warn(`Memory update ${updateId} failed: ${e.message}`),
-              );
-            }
-            return result;
-          };
-          try {
-            let result = await doUpdate();
-            if (isNotFound(result)) {
-              await ensureStore();
-              result = await doUpdate();
-            }
-            if (isNotFound(result)) {
-              return { content: [{ type: "text", text: `Memory update failed: store '${store}' could not be created — the Foundry Memory Store service returned not-found after a create attempt. Common causes: the Foundry project's system-assigned managed identity isn't enabled or lacks 'Azure AI User' on the resource group (RBAC can take a few minutes to propagate), or no embedding model is deployed in the project.` }] };
-            }
-            const status = result?.status || "submitted";
-            return { content: [{ type: "text", text: `Memory update ${status}. The memory will be available shortly.` }] };
-          } catch (e: any) {
-            if (e.message?.includes("not found") || e.message?.includes("not_found")) {
-              try {
-                await ensureStore();
-                const result = await doUpdate();
-                const status = result?.status || "submitted";
-                return { content: [{ type: "text", text: `Memory update ${status}. The memory will be available shortly.` }] };
-              } catch (retryErr: any) {
-                log.warn(`Memory update failed after store creation: ${retryErr.message}`);
-                return { content: [{ type: "text", text: `Memory update failed: ${retryErr.message}` }] };
-              }
-            }
-            log.warn(`Memory update failed: ${e.message}`);
-            return { content: [{ type: "text", text: `Memory update failed: ${e.message}. The memory service may still be initializing.` }] };
-          }
-        } else if (op === "delete_scope") {
-          await routerCall("POST", `/memory_stores/${store}:delete_scope?${apiVer}`, { scope });
-          return { content: [{ type: "text", text: `Scope '${scope}' deleted from memory store '${store}'.` }] };
-        }
-        return { content: [{ type: "text", text: `Unknown operation: ${op}` }] };
+        const { text, isError } = await callPlatformTool("foundry.memory", args);
+        return { content: [{ type: "text", text }], isError };
       } catch (e: any) {
-        return { content: [{ type: "text", text: `Foundry memory failed: ${e.message}` }] };
+        return { content: [{ type: "text", text: `Foundry memory failed: ${e.message}` }], isError: true };
       }
     },
   });

--- a/runtimes/openclaw/src/core/router-client.ts
+++ b/runtimes/openclaw/src/core/router-client.ts
@@ -264,3 +264,48 @@ export async function pushSigningCounter(action: "signed" | "verified" | "reject
     });
   } catch { /* best effort */ }
 }
+
+/**
+ * Invoke a tool on the router's **platform MCP server** (`POST
+ * /platform/mcp`) via a single JSON-RPC `tools/call`. This is the
+ * canonical seam for capabilities the router owns end-to-end (e.g.
+ * `foundry.memory`): the runtime expresses intent + arguments, the
+ * router owns the upstream REST contract, store/scope resolution from
+ * the KarsMemory binding, auto-provision, retry, and CRD status. The
+ * agent process therefore carries no Foundry contract knowledge.
+ *
+ * Returns the flattened text content plus the tool's `isError` flag.
+ * A JSON-RPC error (unknown tool, invalid arguments) is surfaced as
+ * `{ isError: true }` with the server-provided reason.
+ */
+export async function callPlatformTool(
+  name: string,
+  args: Record<string, unknown>,
+  timeoutMs = 60000,
+): Promise<{ text: string; isError: boolean }> {
+  const rpc = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const resp: any = await routerCall("POST", "/platform/mcp", rpc, timeoutMs);
+  if (resp && typeof resp === "object" && resp.error) {
+    const reason =
+      resp.error?.data?.reason || resp.error?.message || "unknown error";
+    return { text: `${name}: ${reason}`, isError: true };
+  }
+  const result = resp?.result;
+  const content = Array.isArray(result?.content) ? result.content : [];
+  const text = content
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((c: any) => c?.type === "text" && typeof c.text === "string")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((c: any) => c.text)
+    .join("\n\n");
+  return {
+    text: text || JSON.stringify(result ?? resp ?? {}),
+    isError: Boolean(result?.isError),
+  };
+}

--- a/runtimes/openclaw/src/index.test.ts
+++ b/runtimes/openclaw/src/index.test.ts
@@ -734,6 +734,18 @@ describe("Foundry tool registration", () => {
     expect(tools.has("foundry_memory")).toBe(true);
   });
 
+  it("foundry_memory is a thin client (operation-only required, no store_name)", () => {
+    const tool = tools.get("foundry_memory")!;
+    const props = tool.parameters?.properties ?? {};
+    // Router owns the contract; the agent only forwards intent.
+    expect(tool.parameters.required).toEqual(["operation"]);
+    expect(props.operation.enum).toEqual(["search", "update", "delete_scope"]);
+    expect(props.top_k).toBeDefined();
+    // store_name override is gone — the bound KarsMemory CRD is the
+    // single source of truth for the store name.
+    expect(props.store_name).toBeUndefined();
+  });
+
   it("registers http_fetch tool", () => {
     expect(tools.has("http_fetch")).toBe(true);
   });


### PR DESCRIPTION
## Why

Persistent agent memory failed from **both** OpenClaw and Hermes — the Foundry Memory Store would be created, but `update`/`search` never persisted/recalled (403s and silent drops). Root causes spanned every layer (divergent TS/Python contracts, wrong request shapes, a missing `api-version`, and an un-granted project managed identity).

## What

Make the **inference-router the single owner** of the Foundry Memory Store contract; the runtime plugins become thin clients.

**Router (`inference-router/src/mcp/platform.rs`)**
- `foundry.memory` now sends the real contract (`items[]` message items + `scope` + `options.max_memories`/`update_delay`), adds `delete_scope` + `top_k`.
- `effective_scope()`: agent arg → KarsMemory binding → `agent_<cluster>_<sandbox>`, always run through `sanitize_scope()` (colons → `_`, which the data plane rejects).
- Pins `api-version` on every memory path incl. ensure-create (the proxy doesn't inject one — a latent bug).
- Default store is the per-sandbox convention `memory-<sandbox>` (not the project-wide `default`). Keeps ensure-on-404 + 401/403 → CRD `AuthMisconfigured`.

**Thin runtime clients** (one JSON-RPC `tools/call` → loopback `/platform/mcp`)
- OpenClaw `foundry.ts` + new `callPlatformTool()` in `router-client.ts`; **dropped the `store_name` override** (the bound CRD is the source of truth).
- Hermes `foundry.py` `_foundry_memory` delegates; removed all dead REST helpers. TS/Python drift is now structurally impossible.

**Controller**
- KarsMemory `spec.scope` CEL now enforces the Foundry charset (rejects colon scopes at admission); Rust doc + helm CRD synced (drift tests pass).
- Binding mount stays router-only (agents no longer read `binding.json`).

**RBAC heal rides along with `kars upgrade`** (`cli/src/commands/up/foundry_memory_rbac.ts`)
- Memory Store `update`/`search` run internally as the Foundry **project** MI, which needs `Azure AI User` on the resource group + an embedding deploy. `ensureFoundryMemoryRbac()` enables the project MI, ensures an embedding model, and grants the RG role **idempotently**. `kars upgrade` now runs it, so an existing broken cluster heals on upgrade instead of needing a fresh `kars up`.

## Tests / CI
- Router: 51 `mcp::platform` + 948 lib + integration; `clippy -D warnings` + `fmt` clean.
- Controller: 849 (incl. `helm_drift` Rust↔helm CRD sync).
- CLI: 850 vitest (+6 new RBAC); `tsc` + oxlint clean.
- OpenClaw: 102; Hermes: 27 Foundry tests; `ruff` clean.
- Security review: no vulnerabilities. Code review: one `delete_scope`/Degraded bug found → **fixed + regression test added**. Audit: `docs/internal/security-audits/2026-06-26-foundry-memory-router-consolidation.md`.

Part of the **v0.1.19** launch release.
