### PR TITLE
fix(memory): use underscore scope convention everywhere (fix v0.1.19 CEL regression)

### DIFF
--- a/cli/src/commands/dev/local-k8s.ts
+++ b/cli/src/commands/dev/local-k8s.ts
@@ -2793,7 +2793,7 @@ async function autoCreateSandbox(
           "  sandboxRef:",
           `    name: ${opts.name}`,
           `  storeName: ${memoryStoreName}`,
-          `  scope: "agent:${opts.name}"`,
+          `  scope: "agent_${opts.name}"`,
           "  retentionDays: 30",
           "  deleteOnSandboxDelete: true",
           `  displayName: "Default memory for ${opts.name}"`,

--- a/cli/src/commands/memory.test.ts
+++ b/cli/src/commands/memory.test.ts
@@ -29,11 +29,11 @@ describe("memoryCommand — registration", () => {
 
 describe("memoryCommand — buildMemorySpecFromFlags", () => {
   it("emits sandboxRef.name + storeName + scope from flags", () => {
-    const spec = buildMemorySpecFromFlags({ sandbox: "my-agent", store: "episodic", scope: "agent:my-agent" });
+    const spec = buildMemorySpecFromFlags({ sandbox: "my-agent", store: "episodic", scope: "agent_my-agent" });
     expect(spec).toEqual({
       sandboxRef: { name: "my-agent" },
       storeName: "episodic",
-      scope: "agent:my-agent",
+      scope: "agent_my-agent",
     });
   });
 
@@ -54,7 +54,7 @@ describe("memoryCommand — buildMemorySpecFromFlags", () => {
 });
 
 describe("memoryCommand — validateMemorySpec", () => {
-  const ok = { sandboxRef: { name: "a" }, storeName: "s", scope: "agent:a" };
+  const ok = { sandboxRef: { name: "a" }, storeName: "s", scope: "agent_a" };
 
   it("accepts a minimal valid spec", () => {
     expect(validateMemorySpec(ok)).toEqual([]);
@@ -73,6 +73,15 @@ describe("memoryCommand — validateMemorySpec", () => {
   it("rejects empty scope", () => {
     const errs = validateMemorySpec({ ...ok, scope: "" });
     expect(errs.join(" ")).toMatch(/spec\.scope/);
+  });
+
+  it("rejects a scope with a colon (Foundry charset)", () => {
+    const errs = validateMemorySpec({ ...ok, scope: "agent:a" });
+    expect(errs.join(" ")).toMatch(/colons are rejected|may only contain/);
+  });
+
+  it("accepts a scope using the valid charset separators", () => {
+    expect(validateMemorySpec({ ...ok, scope: "session_1-a.b@c/d" })).toEqual([]);
   });
 
   it("rejects non-positive retentionDays", () => {
@@ -99,12 +108,12 @@ describe("memoryCommand — summarizeMemoryRow", () => {
     const row = summarizeMemoryRow(
       {
         metadata: { name: "mem1", creationTimestamp: "2024-12-25T00:00:00Z" },
-        spec: { sandboxRef: { name: "a" }, storeName: "episodic", scope: "agent:a", retentionDays: 30 },
+        spec: { sandboxRef: { name: "a" }, storeName: "episodic", scope: "agent_a", retentionDays: 30 },
         status: { phase: "Bound" },
       },
       NOW,
     );
-    expect(row).toEqual(["mem1", "a", "episodic", "agent:a", "30d", "7d", "Bound"]);
+    expect(row).toEqual(["mem1", "a", "episodic", "agent_a", "30d", "7d", "Bound"]);
   });
 
   it("renders '-' for missing retentionDays", () => {

--- a/cli/src/commands/memory.ts
+++ b/cli/src/commands/memory.ts
@@ -74,6 +74,11 @@ export function validateMemorySpec(spec: Record<string, unknown>): string[] {
     errs.push("missing required spec.scope — pass --scope");
   } else if (scope.length > 256) {
     errs.push("spec.scope must be 1–256 characters");
+  } else if (!/^[A-Za-z0-9_./%+@-]+$/.test(scope)) {
+    errs.push(
+      "spec.scope may only contain letters, digits, and _ - . % + @ / " +
+        "(colons are rejected by the Foundry Memory Store) — e.g. agent_my-agent",
+    );
   }
 
   const ret = spec.retentionDays;
@@ -118,7 +123,7 @@ export function memoryCommand(): Command {
     .option("--from-file <path>", "Read spec from a YAML/JSON file")
     .option("--sandbox <name>", "Sandbox to bind (spec.sandboxRef.name)")
     .option("--store <name>", "Foundry Memory Store name (DNS-label)")
-    .option("--scope <key>", "Scope key under which this sandbox reads/writes (e.g. agent:my-agent)")
+    .option("--scope <key>", "Scope key under which this sandbox reads/writes (e.g. agent_my-agent). Charset: letters, digits, _ - . % + @ / — no colons")
     .option("--retention-days <n>", "Retention floor in days (delete_scope sweep, >0)", (v) => parseInt(v, 10))
     .option("--display-name <s>", "Human-readable display label")
     .option("--no-delete-on-sandbox-delete", "Keep store contents when the sandbox is deleted (default: cleanup)")

--- a/cli/src/refs.ts
+++ b/cli/src/refs.ts
@@ -59,7 +59,7 @@ export function buildKarsMemory(opts: KarsMemoryOpts): Record<string, unknown> {
     spec: {
       sandboxRef: { name: opts.sandboxName },
       storeName: store,
-      scope: `agent:${opts.sandboxName}`,
+      scope: `agent_${opts.sandboxName}`,
       retentionDays: opts.retentionDays ?? 30,
       deleteOnSandboxDelete: true,
       displayName: `Default memory for ${opts.sandboxName}`,

--- a/docs/api/crd-reference.md
+++ b/docs/api/crd-reference.md
@@ -505,7 +505,7 @@ spec:
   sandboxRef:
     name: my-agent                                        # required: sibling KarsSandbox
   storeName: episodic                                     # required (unless bundleRef)
-  scope: "agent:my-agent"                                 # optional; default `agent:<sandboxName>`
+  scope: "agent_my-agent"                                 # optional; default `agent_<sandboxName>`; charset: letters/digits/_-.%+@/ (no colons)
   retentionDays: 30                                       # optional; > 0 when set
   deleteOnSandboxDelete: true                             # default true
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1688,7 +1688,7 @@ sandbox-delete sweep). Mirrors `kubectl get/apply/delete` patterns.
 | `--from-file <path>` | Read full spec from a YAML/JSON file (mutually exclusive with the flags below). |
 | `--sandbox <name>` | Sandbox to bind (`spec.sandboxRef.name`). |
 | `--store <name>` | Foundry Memory Store name (DNS-label). |
-| `--scope <key>` | Scope key under which this sandbox reads/writes (e.g. `agent:my-agent`). |
+| `--scope <key>` | Scope key under which this sandbox reads/writes (e.g. `agent_my-agent`). Charset: letters, digits, `_ - . % + @ /` — no colons. |
 | `--retention-days <n>` | Retention floor for the `delete_scope` sweep (must be > 0). |
 | `--display-name <s>` | Human-readable display label. |
 | `--no-delete-on-sandbox-delete` | Keep store contents when the sandbox is deleted (default: cleanup on delete). |
@@ -1700,7 +1700,7 @@ kars memory apply my-agent-mem \
   -n kars-my-agent \
   --sandbox my-agent \
   --store prod-shared-memory \
-  --scope agent:my-agent \
+  --scope agent_my-agent \
   --retention-days 30
 
 # List bindings in a namespace

--- a/docs/internal/security-audits/2026-06-26-memory-scope-underscore-convention.md
+++ b/docs/internal/security-audits/2026-06-26-memory-scope-underscore-convention.md
@@ -1,0 +1,50 @@
+# Security Audit — KarsMemory scope underscore convention (fix v0.1.19 CEL regression)
+
+Date: 2026-06-26
+Scope: `cli/src/refs.ts`, `cli/src/commands/dev/local-k8s.ts`, `cli/src/commands/memory.ts` (+ test), `tests/e2e/run.sh`, `tests/e2e-manual/scenarios/crd_admission.sh`, `examples/full-stack-demo/*`, `docs/api/crd-reference.md`, `docs/cli-reference.md`.
+Gated path: `cli/src/commands/memory.ts`, `cli/src/commands/dev/local-k8s.ts`.
+
+## Summary
+
+v0.1.19 added a CEL charset rule to `KarsMemory.spec.scope` (rejects colons,
+which the Foundry Memory Store 400s) but left colon-form scopes
+(`agent:<name>`) in CLI defaults, the example demo, docs, and the E2E fixture.
+Result: the E2E "KarsMemory apply rejected" failure, and — more importantly —
+`kars dev --target local-k8s` and `cli/src/refs.ts` would generate a KarsMemory
+CR that admission now rejects. This fix moves every generated/default/example
+scope to the underscore convention (`agent_<name>`), matching the router
+(`effective_scope` / `sanitize_scope`) and both runtime plugins, and adds
+client-side charset validation in `kars memory` for a clear pre-apply error.
+
+## T1: New capability / attack surface? (NO)
+- No new role, endpoint, or privilege. Pure convention/string change: the
+  generated `scope` value flips `:` → `_`. The Memory Store partition key
+  semantics are unchanged (scope still isolates each sandbox's memories).
+
+## T2: Security-control change? (HARDENING / NEUTRAL)
+- Adds a client-side `^[A-Za-z0-9_./%+@-]+$` check in `validateMemorySpec`
+  mirroring the CRD CEL rule — a clearer failure mode, no relaxation. The
+  authoritative guard remains admission CEL + the router's `sanitize_scope`.
+- Generated scopes were never security-relevant; the change keeps each sandbox
+  scoped to its own `agent_<name>` partition exactly as before.
+
+## T3: Availability / fail-open risk? (REDUCED)
+- Fixes a real regression: `kars dev` / `kars memory` / the demo previously
+  produced CRs that admission rejected. No fail-open — invalid scopes are still
+  rejected (now with a clear client-side message before the API call).
+
+## Verification
+- CLI: `tsc --noEmit` + oxlint clean; 851 vitest pass incl. new tests asserting
+  a colon scope is rejected and the valid charset (`session_1-a.b@c/d`) is
+  accepted, and the generated/default scopes use `_`.
+- E2E + manual CRD-admission fixtures updated to `agent_<name>` so the Kind E2E
+  `KarsMemory apply` admits again.
+- Examples + docs (`demo.yaml`, `crd-reference.md`, `cli-reference.md`) updated
+  so copy-pasted commands aren't rejected by admission.
+
+## Verdict
+Accept. Completes the v0.1.19 scope-charset change consistently across CLI
+codegen, examples, docs, and tests; no security control weakened.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/examples/full-stack-demo/README.md
+++ b/examples/full-stack-demo/README.md
@@ -34,7 +34,7 @@ NAME                                                       AGE
 inferencepolicy.kars.azure.com/demo-agent-inference        30s
 
 NAME                                              SANDBOX      STORE                SCOPE                PHASE       AGE
-karsmemory.kars.azure.com/demo-agent-memory       demo-agent   memory-demo-agent    agent:demo-agent     Compiled    30s
+karsmemory.kars.azure.com/demo-agent-memory       demo-agent   memory-demo-agent    agent_demo-agent     Compiled    30s
 
 NAME                                              URL                            PRODUCTION   PHASE      AGE
 mcpserver.kars.azure.com/demo-agent-mcp           https://mcp.example.com/sse    false        Ready      30s

--- a/examples/full-stack-demo/demo.yaml
+++ b/examples/full-stack-demo/demo.yaml
@@ -53,7 +53,7 @@ spec:
 # ── 2. KarsMemory ──────────────────────────────────────────────────
 # Binds the agent to a Foundry memory store. The router uses this to
 # scope every memory_*  tool call so the agent can only read/write its
-# own memories. `scope: "agent:demo-agent"` is the default convention.
+# own memories. `scope: "agent_demo-agent"` is the default convention.
 apiVersion: kars.azure.com/v1alpha1
 kind: KarsMemory
 metadata:
@@ -68,7 +68,7 @@ spec:
   # see runtimes/openclaw/src/core/agt-tools/foundry.ts:634 (the
   # plugin hardcodes this name when calling memory_* tools).
   storeName: memory-demo-agent
-  scope: "agent:demo-agent"
+  scope: "agent_demo-agent"
   retentionDays: 30
   deleteOnSandboxDelete: true
   displayName: "Demo Agent Memory"

--- a/tests/e2e-manual/scenarios/crd_admission.sh
+++ b/tests/e2e-manual/scenarios/crd_admission.sh
@@ -251,7 +251,7 @@ spec:
   storeName: memory-min
   sandboxRef:
     name: nonexistent-sandbox
-  scope: agent:nonexistent-sandbox
+  scope: agent_nonexistent-sandbox
 "; then
     metric_finish "cm_admit" crd_admission admitKarsMemory
     log_pass "KarsMemory admitted"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -581,7 +581,7 @@ spec:
   storeName: e2e-store
   sandboxRef:
     name: e2e-test
-  scope: "agent:e2e-test"
+  scope: "agent_e2e-test"
 EOF
     if wait_for_resource configmap karsmemory-e2e-karsmemory-binding kars-system 45; then
         pass "KarsMemory → binding ConfigMap created"


### PR DESCRIPTION
## Why

The E2E "KarsMemory apply rejected" failure on main. v0.1.19 added a `KarsMemory.spec.scope` CEL charset rule (rejects colons, which the Foundry Memory Store 400s) but left colon-form scopes (`agent:<name>`) in CLI codegen, the example demo, docs, and the E2E fixture. So `kars dev --target local-k8s` and `cli/src/refs.ts` generate a CR that admission now rejects — a real v0.1.19 regression, not just a test issue.

## What

Move every generated/default/example scope to the underscore convention (`agent_<name>`), matching the router (`effective_scope`/`sanitize_scope`) and the OpenClaw/Hermes plugins:
- `cli/src/refs.ts`, `cli/src/commands/dev/local-k8s.ts` — generated scopes.
- `cli/src/commands/memory.ts` — client-side charset validation + help text (clear pre-apply error).
- `tests/e2e/run.sh`, `tests/e2e-manual/scenarios/crd_admission.sh` — fixtures.
- `examples/full-stack-demo/*`, `docs/api/crd-reference.md`, `docs/cli-reference.md` — copy-pasteable scopes.

## Tests
- CLI: `tsc` + oxlint clean; 851 vitest (new tests pin colon rejection + valid charset `session_1-a.b@c/d`).
- E2E (Kind) `KarsMemory apply` should admit again.

Fast-follow to v0.1.19; will cut **v0.1.20**.