### PR TITLE
fix(upgrade): repair the kars upgrade flow (rollback, value preservation, health gating, version detection)

### DIFF
--- a/.github/workflows/release-public-interim.yml
+++ b/.github/workflows/release-public-interim.yml
@@ -501,6 +501,7 @@ jobs:
       matrix:
         runtime:
           - { name: langgraph,     ghcr: kars-runtime-langgraph }
+          - { name: langgraph-ts,  ghcr: kars-runtime-langgraph-ts }
           - { name: hermes,        ghcr: kars-runtime-hermes }
           - { name: maf-python,    ghcr: kars-runtime-maf-python }
           - { name: anthropic,     ghcr: kars-runtime-anthropic }

--- a/ci/security-audit-required.sh
+++ b/ci/security-audit-required.sh
@@ -5,8 +5,11 @@
 # ci/security-audit-required.sh — enforces internal Phase 1 plan §0.2 #9.
 #
 # If the PR touches a capability-introducing file, require a matching
-# docs/internal/security-audits/<YYYY-MM-DD>-<slug>.md with two distinct sign-off
+# docs/security-audits/<YYYY-MM-DD>-<slug>.md with two distinct sign-off
 # blocks (two lines matching /^Signed-off-by: .+<.+@.+>/ on different emails).
+#
+# Note: audit docs live in the TRACKED `docs/security-audits/` folder (not the
+# gitignored `docs/internal/`), so they are committed normally as part of the PR.
 set -euo pipefail
 
 BASE_REF="${BASE_REF:-origin/main}"
@@ -27,13 +30,13 @@ if [ -z "$touches_cap" ]; then
   exit 0
 fi
 
-# Is at least one docs/internal/security-audits/*.md added in this PR?
-added_audit=$(printf '%s\n' "$changed" | grep -E '^docs/internal/security-audits/[0-9]{4}-[0-9]{2}-[0-9]{2}-.+\.md$' || true)
+# Is at least one docs/security-audits/*.md added in this PR?
+added_audit=$(printf '%s\n' "$changed" | grep -E '^docs/security-audits/[0-9]{4}-[0-9]{2}-[0-9]{2}-.+\.md$' || true)
 if [ -z "$added_audit" ]; then
-  echo "fail: capability-introducing files touched but no docs/internal/security-audits/YYYY-MM-DD-<slug>.md added." >&2
+  echo "fail: capability-introducing files touched but no docs/security-audits/YYYY-MM-DD-<slug>.md added." >&2
   echo "      touched capabilities:" >&2
   printf '        %s\n' $touches_cap >&2
-  echo "      Copy docs/internal/security-audits/_template.md and fill it in (see implementation-plan §5.5)." >&2
+  echo "      Copy docs/security-audits/_template.md and fill it in (see docs/security-audits/README.md)." >&2
   exit 1
 fi
 

--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -11,6 +11,7 @@ import { isValidAzureHost } from "./up/preflight.js";
 import { acquireImages } from "./up/images.js";
 import { requireBundledAsset } from "../lib/repo-assets.js";
 import { resolveVmSizes } from "../lib/vm-size.js";
+import { cliReleaseTag } from "../lib/version.js";
 
 export function upCommand(): Command {
   const cmd = new Command("up");
@@ -765,6 +766,10 @@ Auto-resume:
           "--set", `azure.workloadIdentity.clientId=${wiClientId}`,
           "--set", `azure.keyVaultCsi.keyVaultName=${kvName}`,
           "--set", `mesh.provider=${(options.meshProvider as string | undefined) ?? "agt"}`,
+          // Stamp the CLI's version as the deployed release so `kars upgrade`
+          // reports an accurate current version (the chart appVersion is a
+          // static `0.1.0` sentinel, not the deployed release).
+          "--set", `karsRelease=${cliReleaseTag()}`,
           "--wait",
           // Cold-cluster first install: the controller + inference-router pull
           // their (Rust) images with pullPolicy=Always and the controller

--- a/cli/src/commands/up/fast_upgrade.ts
+++ b/cli/src/commands/up/fast_upgrade.ts
@@ -11,6 +11,8 @@ import ora from "ora";
 import { execa } from "execa";
 import { loadContext } from "../../config.js";
 import { requireBundledAsset } from "../../lib/repo-assets.js";
+import { cliReleaseTag } from "../../lib/version.js";
+import { rolloutRestartAll } from "../upgrade.js";
 
 export interface UpOptionsForUpgrade {
   upgrade?: boolean;
@@ -45,6 +47,10 @@ export async function runFastUpgrade(options: UpOptionsForUpgrade): Promise<void
           "upgrade", "--install", "kars", helmPath,
           "--namespace", "kars-system",
           "--create-namespace",
+          // Preserve values set by the original `kars up` (runtime images,
+          // fedcred, mesh, …) that this fast path doesn't re-specify; the
+          // `--set` flags below still override the image repos/tags.
+          "--reuse-values",
           "--set", `controller.image.repository=${ctx.acrLoginServer}/kars-controller`,
           "--set", `controller.image.tag=latest`,
           "--set", `inferenceRouter.image.repository=${ctx.acrLoginServer}/kars-inference-router`,
@@ -54,8 +60,13 @@ export async function runFastUpgrade(options: UpOptionsForUpgrade): Promise<void
           "--set", `sandbox.image.tag=latest`,
           "--set", `azure.workloadIdentity.clientId=${ctx.wiClientId || ""}`,
           "--set", `azure.keyVaultCsi.keyVaultName=${ctx.keyVaultName || ""}`,
+          // Stamp the CLI's version as the deployed release so `kars upgrade`
+          // can read back an accurate current version (the chart appVersion is
+          // a static sentinel value).
+          "--set", `karsRelease=${cliReleaseTag()}`,
+          "--atomic",
           "--wait",
-          "--timeout", "5m",
+          "--timeout", "8m",
         ];
         if (ctx.foundryEndpoint) {
           helmArgs.push("--set", `foundry.endpoint=${ctx.foundryEndpoint}`);
@@ -114,11 +125,14 @@ export async function runFastUpgrade(options: UpOptionsForUpgrade): Promise<void
         await execa("helm", helmArgs, { stdio: "pipe" });
         spin.succeed("Helm upgraded");
 
-        // Rollout restart
-        spin = ora("Restarting controller...").start();
-        await execa("kubectl", ["rollout", "restart", "deployment/kars-controller", "-n", "kars-system"], { stdio: "pipe" }).catch(() => {});
-        await execa("kubectl", ["rollout", "status", "deployment/kars-controller", "-n", "kars-system", "--timeout=120s"], { stdio: "pipe" }).catch(() => {});
-        spin.succeed("Controller restarted");
+        // Rollout restart — refresh ALL kars workloads, not just the
+        // controller. `kars up --upgrade` re-runs Helm against the `:latest`
+        // images in ACR, so (like `kars upgrade`) a rolling restart of the
+        // sandboxes + the standalone AgentMesh relay/registry is what actually
+        // pulls the new bits; restarting only the controller left them stale.
+        spin = ora("Restarting kars workloads (controller, sandboxes, mesh)...").start();
+        await rolloutRestartAll(execa);
+        spin.succeed("Workloads restarted");
 
         // Ensure controller SA has a fedcred (so it can get ARM tokens via WI to create sandbox fedcreds)
         if (ctx.oidcIssuerUrl && ctx.identityName) {

--- a/cli/src/commands/upgrade.test.ts
+++ b/cli/src/commands/upgrade.test.ts
@@ -2,7 +2,14 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect } from "vitest";
-import { isFoundryProjectHost } from "./upgrade.js";
+import {
+  isFoundryProjectHost,
+  resolveTargetVersion,
+  buildHelmUpgradeArgs,
+  detectCurrentVersion,
+  rolloutRestartAll,
+  verifyHealth,
+} from "./upgrade.js";
 
 describe("isFoundryProjectHost", () => {
   it("accepts a real Foundry project endpoint", () => {
@@ -21,5 +28,240 @@ describe("isFoundryProjectHost", () => {
     expect(isFoundryProjectHost("https://my-aoai.openai.azure.com")).toBe(false);
     expect(isFoundryProjectHost("")).toBe(false);
     expect(isFoundryProjectHost("not a url")).toBe(false);
+  });
+});
+
+describe("resolveTargetVersion", () => {
+  const fetchLatest = async () => "v0.1.20";
+  const fetchNone = async () => null;
+
+  it("resolves no `--to` to the latest published release", async () => {
+    expect(await resolveTargetVersion(undefined, fetchLatest)).toEqual({ target: "v0.1.20" });
+  });
+
+  it("resolves `latest` / `stable` (any case) to the latest release — the recovery path", async () => {
+    expect(await resolveTargetVersion("latest", fetchLatest)).toEqual({ target: "v0.1.20" });
+    expect(await resolveTargetVersion("LATEST", fetchLatest)).toEqual({ target: "v0.1.20" });
+    expect(await resolveTargetVersion("stable", fetchLatest)).toEqual({ target: "v0.1.20" });
+    expect(await resolveTargetVersion("  latest  ", fetchLatest)).toEqual({ target: "v0.1.20" });
+  });
+
+  it("passes a valid explicit tag through unchanged", async () => {
+    expect(await resolveTargetVersion("v0.1.19", fetchLatest)).toEqual({ target: "v0.1.19" });
+    expect(await resolveTargetVersion("0.1.19", fetchLatest)).toEqual({ target: "0.1.19" });
+    expect(await resolveTargetVersion("v1.2.3-rc.1", fetchLatest)).toEqual({ target: "v1.2.3-rc.1" });
+  });
+
+  it("rejects a non-version `--to` instead of treating it as a downgrade", async () => {
+    const r = await resolveTargetVersion("garbage", fetchLatest);
+    expect(r.target).toBeUndefined();
+    expect(r.error).toMatch(/not a valid release tag/);
+  });
+
+  it("errors clearly when the latest release can't be determined", async () => {
+    const r = await resolveTargetVersion("latest", fetchNone);
+    expect(r.target).toBeUndefined();
+    expect(r.error).toMatch(/GitHub releases API|explicit tag/);
+  });
+});
+
+describe("buildHelmUpgradeArgs", () => {
+  const ctx = {
+    acrLoginServer: "myacr.azurecr.io",
+    aksCluster: "kars-aks",
+    resourceGroup: "rg",
+    wiClientId: "wi-123",
+    keyVaultName: "kv-1",
+  };
+
+  it("version-pins the image tags to the target (NOT :latest) so rollback works", () => {
+    const args = buildHelmUpgradeArgs(ctx, "/chart", "v0.1.20").join(" ");
+    expect(args).toContain("controller.image.repository=myacr.azurecr.io/kars-controller");
+    expect(args).toContain("inferenceRouter.image.repository=myacr.azurecr.io/kars-inference-router");
+    expect(args).toContain("sandbox.image.repository=myacr.azurecr.io/openclaw-sandbox");
+    // The crux of the rollback fix: tags are the version, not `latest`.
+    expect(args).toContain("controller.image.tag=v0.1.20");
+    expect(args).toContain("inferenceRouter.image.tag=v0.1.20");
+    expect(args).toContain("sandbox.image.tag=v0.1.20");
+    expect(args).not.toContain("image.tag=latest");
+  });
+
+  it("sets ALL runtime images explicitly (incl. langgraph-ts), pinned to target", () => {
+    const args = buildHelmUpgradeArgs(ctx, "/chart", "v0.1.20").join(" ");
+    for (const [key, repo] of [
+      ["runtimes.openaiAgents.image", "kars-runtime-openai-agents"],
+      ["runtimes.mafPython.image", "kars-runtime-maf-python"],
+      ["runtimes.anthropic.image", "kars-runtime-anthropic"],
+      ["runtimes.langgraph.image", "kars-runtime-langgraph"],
+      ["runtimes.langgraphTs.image", "kars-runtime-langgraph-ts"],
+      ["runtimes.pydanticAi.image", "kars-runtime-pydantic-ai"],
+      ["runtimes.hermes.image", "kars-runtime-hermes"],
+    ] as const) {
+      expect(args).toContain(`${key}=myacr.azurecr.io/${repo}:v0.1.20`);
+    }
+  });
+
+  it("omits runtime image overrides when --skip-runtime-images (preserve via reuse)", () => {
+    const args = buildHelmUpgradeArgs(ctx, "/chart", "v0.1.20", { skipRuntimeImages: true }).join(" ");
+    expect(args).not.toContain("runtimes.langgraphTs.image");
+    expect(args).not.toContain("runtimes.hermes.image");
+    // core images are still pinned
+    expect(args).toContain("controller.image.tag=v0.1.20");
+  });
+
+  it("still preserves operator config via --reuse-values", () => {
+    expect(buildHelmUpgradeArgs(ctx, "/chart", "v0.1.20")).toContain("--reuse-values");
+  });
+
+  it("stamps the resolved release as karsRelease for later version detection", () => {
+    const args = buildHelmUpgradeArgs(ctx, "/chart", "v0.1.20");
+    const i = args.indexOf("karsRelease=v0.1.20");
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i - 1]).toBe("--set");
+  });
+
+  it("is a safe atomic upgrade (auto-rollback + wait)", () => {
+    const args = buildHelmUpgradeArgs(ctx, "/chart", "v0.1.20");
+    expect(args).toContain("--atomic");
+    expect(args).toContain("--wait");
+    expect(args.slice(0, 4)).toEqual(["upgrade", "--install", "kars", "/chart"]);
+  });
+
+  it("only sets the Foundry endpoint when one is configured", () => {
+    const withFoundry = buildHelmUpgradeArgs({ ...ctx, foundryEndpoint: "https://x.services.ai.azure.com" }, "/chart", "v0.1.20").join(" ");
+    expect(withFoundry).toContain("inferenceRouter.azure.openai.endpoint=https://x.services.ai.azure.com");
+    const without = buildHelmUpgradeArgs(ctx, "/chart", "v0.1.20").join(" ");
+    expect(without).not.toContain("inferenceRouter.azure.openai.endpoint");
+  });
+});
+
+// ── health / safety / recovery coverage ────────────────────────────
+
+type Execa = typeof import("execa").execa;
+
+/** Fake execa that records argv and returns scripted stdout per matcher. */
+function fakeExeca(script: (bin: string, args: string[]) => string | undefined, calls: string[][]): Execa {
+  return (async (bin: string, args: readonly string[]) => {
+    calls.push([bin, ...args]);
+    const out = script(bin, [...args]);
+    if (out === "THROW") throw new Error("command failed");
+    return { stdout: out ?? "" };
+  }) as unknown as Execa;
+}
+
+describe("detectCurrentVersion — honest, un-spoofable version detection", () => {
+  // The controller image is queried first; route by command.
+  const withImage = (image: string, helmValues: string) =>
+    (bin: string, args: string[]): string | undefined => {
+      if (bin === "kubectl" && args.includes("kars-controller")) return image;
+      if (bin === "helm") return helmValues;
+      return "";
+    };
+
+  it("prefers the controller image TAG (what's actually running)", async () => {
+    const calls: string[][] = [];
+    const execa = fakeExeca(withImage("myacr.azurecr.io/kars-controller:v0.1.20", JSON.stringify({ karsRelease: "v0.1.18" })), calls);
+    // Image tag wins over a (stale) stamped helm value.
+    expect(await detectCurrentVersion(execa, "0.1.0")).toBe("v0.1.20");
+  });
+
+  it("falls back to the stamped karsRelease when the image tag is :latest", async () => {
+    const calls: string[][] = [];
+    const execa = fakeExeca(withImage("myacr.azurecr.io/kars-controller:latest", JSON.stringify({ karsRelease: "v0.1.19" })), calls);
+    expect(await detectCurrentVersion(execa, "0.1.0")).toBe("v0.1.19");
+  });
+
+  it("treats the static 0.1.0 chart appVersion as unknown (no false downgrade guard)", async () => {
+    const calls: string[][] = [];
+    const execa = fakeExeca(withImage("myacr.azurecr.io/kars-controller:latest", "{}"), calls);
+    expect(await detectCurrentVersion(execa, "0.1.0")).toBe("");
+  });
+
+  it("returns unknown when both kubectl and helm fail", async () => {
+    const calls: string[][] = [];
+    const execa = fakeExeca(() => "THROW", calls);
+    expect(await detectCurrentVersion(execa, "0.1.0")).toBe("");
+  });
+
+  it("trusts a real, non-sentinel appVersion if the chart ever bumps it", async () => {
+    const calls: string[][] = [];
+    const execa = fakeExeca(withImage("myacr.azurecr.io/kars-controller:latest", "{}"), calls);
+    expect(await detectCurrentVersion(execa, "0.2.5")).toBe("v0.2.5");
+  });
+});
+
+describe("rolloutRestartAll — refreshes every workload, mesh first", () => {
+  it("restarts agentmesh relay+registry, the controller, and every sandbox", async () => {
+    const calls: string[][] = [];
+    const execa = fakeExeca(() => "", calls);
+    await rolloutRestartAll(execa);
+    const restarts = calls
+      .filter((c) => c[0] === "kubectl" && c[1] === "rollout" && c[2] === "restart")
+      .map((c) => c.join(" "));
+    // mesh relay + registry by name (narrow, not --all)
+    expect(restarts.some((c) => c.includes("deployment/agentmesh-relay") && c.includes("-n agentmesh"))).toBe(true);
+    expect(restarts.some((c) => c.includes("deployment/agentmesh-registry") && c.includes("-n agentmesh"))).toBe(true);
+    expect(restarts.some((c) => c.includes("--all"))).toBe(false);
+    // controller + sandboxes
+    expect(restarts.some((c) => c.includes("-n kars-system") && c.includes("app.kubernetes.io/name=kars"))).toBe(true);
+    expect(restarts.some((c) => c.includes("-A") && c.includes("kars.azure.com/component=sandbox"))).toBe(true);
+  });
+
+  it("restarts the mesh BEFORE the controller (so deps come up against new mesh)", async () => {
+    const calls: string[][] = [];
+    await rolloutRestartAll(fakeExeca(() => "", calls));
+    const order = calls
+      .filter((c) => c[0] === "kubectl" && c[1] === "rollout" && c[2] === "restart")
+      .map((c) => c.join(" "));
+    const meshIdx = order.findIndex((c) => c.includes("agentmesh-relay"));
+    const ctrlIdx = order.findIndex((c) => c.includes("app.kubernetes.io/name=kars"));
+    expect(meshIdx).toBeGreaterThanOrEqual(0);
+    expect(ctrlIdx).toBeGreaterThan(meshIdx);
+  });
+
+  it("never throws even if every kubectl call fails (best-effort)", async () => {
+    const calls: string[][] = [];
+    const execa = fakeExeca(() => "THROW", calls);
+    await expect(rolloutRestartAll(execa)).resolves.toBeUndefined();
+  });
+});
+
+describe("verifyHealth — strong enough to gate success", () => {
+  const route = (ctrlAvail: string, podReasons: Record<string, string>) =>
+    (bin: string, args: string[]): string | undefined => {
+      if (bin === "kubectl" && args.includes("deployment") && args.includes("kars-controller")) return ctrlAvail;
+      if (bin === "kubectl" && args.includes("pods")) {
+        const ns = args[args.indexOf("-n") + 1];
+        return podReasons[ns] ?? "";
+      }
+      return "";
+    };
+
+  it("healthy when controller Available and no bad pods", async () => {
+    const r = await verifyHealth(fakeExeca(route("True", {}), []));
+    expect(r.healthy).toBe(true);
+  });
+
+  it("unhealthy when the controller is not Available", async () => {
+    const r = await verifyHealth(fakeExeca(route("False", {}), []));
+    expect(r.healthy).toBe(false);
+    expect(r.reason).toMatch(/controller/i);
+  });
+
+  it("unhealthy on ImagePullBackOff (the bad-image symptom)", async () => {
+    const r = await verifyHealth(fakeExeca(route("True", { "kars-system": "ImagePullBackOff " }), []));
+    expect(r.healthy).toBe(false);
+    expect(r.reason).toMatch(/ImagePullBackOff/);
+  });
+
+  it("unhealthy on CrashLoopBackOff in the agentmesh namespace", async () => {
+    const r = await verifyHealth(fakeExeca(route("True", { agentmesh: "CrashLoopBackOff " }), []));
+    expect(r.healthy).toBe(false);
+    expect(r.reason).toMatch(/CrashLoopBackOff/);
+  });
+
+  it("unhealthy (not a false-positive) when the controller probe errors", async () => {
+    const r = await verifyHealth(fakeExeca(() => "THROW", []));
+    expect(r.healthy).toBe(false);
   });
 });

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -24,9 +24,46 @@ import {
   releaseImagePlan,
   compareVersions,
   fetchLatestReleaseTag,
+  parseVersionTag,
 } from "../lib/release.js";
 
 const NS = "kars-system";
+/** Namespace holding the standalone AgentMesh relay + registry Deployments
+ *  (applied from `deploy/agentmesh-agt.yaml`, NOT part of the Helm chart). */
+const MESH_NS = "agentmesh";
+
+/**
+ * Resolve the upgrade target tag. `latest`/`stable` (or no `--to`) resolves to
+ * the newest published GitHub release; an explicit `--to` must be a valid
+ * version tag (e.g. `v0.1.20`). Returns `{error}` instead of a target when the
+ * input is unusable — callers surface it and abort. Exported for tests.
+ *
+ * Fixes the bug where `kars upgrade --to latest` passed the literal string
+ * "latest" into `compareVersions`, which treated it as older than the current
+ * version and wrongly refused with "Cluster is NEWER … use --force to downgrade".
+ */
+export async function resolveTargetVersion(
+  to: string | undefined,
+  fetchLatest: () => Promise<string | null> = fetchLatestReleaseTag,
+): Promise<{ target?: string; error?: string }> {
+  const raw = (to ?? "").trim();
+  if (!raw || /^(latest|stable)$/i.test(raw)) {
+    const t = await fetchLatest();
+    return t
+      ? { target: t }
+      : {
+          error:
+            "Couldn't reach the GitHub releases API to find the latest version. " +
+            "Pass an explicit tag: `kars upgrade --to v0.1.20`.",
+        };
+  }
+  if (!parseVersionTag(raw)) {
+    return {
+      error: `'${to}' is not a valid release tag. Use a version like v0.1.20, or 'latest'.`,
+    };
+  }
+  return { target: raw };
+}
 
 /** True only when `ep` is a Foundry project endpoint whose host is exactly
  *  `services.ai.azure.com` or a subdomain of it. A proper hostname check —
@@ -52,36 +89,75 @@ interface UpgradeContext {
   foundryProjectEndpoint?: string;
 }
 
-/** Build the `helm upgrade` args. `--atomic` makes a failed upgrade auto-roll
- *  back the release, so the cluster never lands half-migrated. Exported for
- *  tests. */
+/** Chart `runtimes.*` value keys → ACR repo names. The single place the
+ *  upgrade path enumerates the multi-runtime adapter images, so adding a
+ *  runtime (e.g. langgraph-ts) is a one-line change that stays in sync with
+ *  the import plan + the `kars up` install. */
+const RUNTIME_IMAGE_VALUES: ReadonlyArray<readonly [valueKey: string, repo: string]> = [
+  ["runtimes.openaiAgents.image", "kars-runtime-openai-agents"],
+  ["runtimes.mafPython.image", "kars-runtime-maf-python"],
+  ["runtimes.anthropic.image", "kars-runtime-anthropic"],
+  ["runtimes.langgraph.image", "kars-runtime-langgraph"],
+  ["runtimes.langgraphTs.image", "kars-runtime-langgraph-ts"],
+  ["runtimes.pydanticAi.image", "kars-runtime-pydantic-ai"],
+  ["runtimes.hermes.image", "kars-runtime-hermes"],
+];
+
+/** Build the `helm upgrade` args.
+ *
+ *  - `--atomic` auto-rolls-back a failed upgrade so the cluster never lands
+ *    half-migrated.
+ *  - Image **tags are pinned to the target version** (NOT `:latest`). This is
+ *    what makes the upgrade real and reversible: a changed tag makes
+ *    `helm upgrade --wait` actually recreate the pods and wait for them
+ *    healthy (so `--atomic` can catch a bad image), and `helm rollback`
+ *    restores the *previous* version's tag instead of a no-op `:latest`→
+ *    `:latest`. The version-tagged images are imported into ACR alongside
+ *    `:latest` (see the import step).
+ *  - `--reuse-values` preserves operator config (Foundry, fedcred, mesh) the
+ *    flags below don't restate, but every image value IS restated explicitly
+ *    so an older cluster missing a value (e.g. a runtime added in a later
+ *    release) gets it rather than silently falling back to a chart default
+ *    that points at the wrong registry.
+ *
+ *  Exported for tests. */
 export function buildHelmUpgradeArgs(
   ctx: UpgradeContext,
   helmPath: string,
   target?: string,
+  opts: { skipRuntimeImages?: boolean } = {},
 ): string[] {
+  const tag = target && target.length > 0 ? target : "latest";
   const args = [
     "upgrade", "--install", "kars", helmPath,
     "--namespace", NS,
     "--create-namespace",
+    "--reuse-values",
     "--set", `controller.image.repository=${ctx.acrLoginServer}/kars-controller`,
-    "--set", "controller.image.tag=latest",
+    "--set", `controller.image.tag=${tag}`,
     "--set", `inferenceRouter.image.repository=${ctx.acrLoginServer}/kars-inference-router`,
-    "--set", "inferenceRouter.image.tag=latest",
+    "--set", `inferenceRouter.image.tag=${tag}`,
     "--set", `sandbox.image.repository=${ctx.acrLoginServer}/openclaw-sandbox`,
-    "--set", "sandbox.image.tag=latest",
+    "--set", `sandbox.image.tag=${tag}`,
     "--set", `azure.workloadIdentity.clientId=${ctx.wiClientId || ""}`,
     "--set", `azure.keyVaultCsi.keyVaultName=${ctx.keyVaultName || ""}`,
-    "--atomic",
-    "--wait",
-    "--timeout", "8m",
   ];
+  // Pin every runtime adapter image explicitly (don't rely on --reuse-values,
+  // which can't materialise a value an older install never set). Skipped only
+  // when the operator opted out of importing them — then we leave whatever the
+  // prior install set (via --reuse-values) untouched.
+  if (!opts.skipRuntimeImages) {
+    for (const [valueKey, repo] of RUNTIME_IMAGE_VALUES) {
+      args.push("--set", `${valueKey}=${ctx.acrLoginServer}/${repo}:${tag}`);
+    }
+  }
+  args.push("--atomic", "--wait", "--timeout", "8m");
   if (ctx.foundryEndpoint) {
     args.push("--set", `inferenceRouter.azure.openai.endpoint=${ctx.foundryEndpoint}`);
   }
-  // Stamp the deployed release into Helm values (not consumed by templates) so
-  // a later `kars upgrade` can read the ACTUAL deployed version back via
-  // `helm get values` — the chart's static appVersion can't be trusted.
+  // Stamp the deployed release as a Helm value too (belt-and-suspenders for the
+  // version detection, which primarily reads the controller image tag). Carried
+  // forward by --reuse-values on later upgrades that don't re-set it.
   if (target) {
     args.push("--set", `karsRelease=${target}`);
   }
@@ -166,27 +242,22 @@ Examples:
           stepper.done("Workloads restarted");
 
           stepper.step("Verifying cluster health...");
-          const healthy = await verifyHealth(execa);
-          if (healthy) stepper.done("Cluster healthy after rollback");
-          else stepper.warn("Rollback applied but some workloads aren't Ready yet — check `kars status`");
+          const rbHealth = await verifyHealth(execa);
+          if (rbHealth.healthy) stepper.done("Cluster healthy after rollback");
+          else stepper.warn(`Rollback applied but the cluster isn't fully healthy yet: ${rbHealth.reason} — check \`kars status\``);
           stepper.summary();
           process.exit(0);
         }
 
         // ── Step 2: Resolve target version ────────────────────────────
         stepper.step("Resolving target release...");
-        let target: string | undefined = options.to;
-        if (!target) {
-          target = (await fetchLatestReleaseTag()) ?? undefined;
-          if (!target) {
-            stepper.fail("Could not determine the latest release");
-            console.error(chalk.red(
-              "\n  Couldn't reach the GitHub releases API to find the latest version.\n" +
-              "  Pass an explicit tag: `kars upgrade --to v0.1.16`.\n",
-            ));
-            process.exit(1);
-          }
+        const resolved = await resolveTargetVersion(options.to);
+        if (resolved.error || !resolved.target) {
+          stepper.fail("Could not determine the target release");
+          console.error(chalk.red(`\n  ${resolved.error}\n`));
+          process.exit(1);
         }
+        const target: string = resolved.target;
         const current = await detectCurrentVersion(execa, karsRel.app_version);
         stepper.detail("info", `Current: ${current || "unknown"}  →  Target: ${target}`);
         if (current && compareVersions(current, target) === 0 && !options.force) {
@@ -223,14 +294,19 @@ Examples:
         let requiredFailures = 0;
         for (const img of images) {
           stepper.update(`Importing ${img.target}...`);
-          // Import the immutable version tag too, so a future rollback/pin can
-          // reference the exact release.
+          // Import BOTH the `:latest` tag (chart fallbacks / other tooling) and
+          // the immutable `:<version>` tag. The chart pins the version tag
+          // (buildHelmUpgradeArgs), so the version import is REQUIRED for
+          // required images — without it the upgrade would reference a tag that
+          // isn't in ACR. Both pull from the same version-tagged GHCR source.
           const versioned = img.target.replace(/:latest$/, `:${target}`);
           const okLatest = await acrImport(execa, acrName, img.src, img.target);
-          await acrImport(execa, acrName, img.src, versioned); // best-effort pin
-          if (!okLatest) {
-            if (img.required) { requiredFailures++; stepper.detail("info", `${img.target} — import FAILED (required)`); }
-            else stepper.detail("info", `${img.target} — import failed (optional)`);
+          const okVersioned = await acrImport(execa, acrName, img.src, versioned);
+          if ((!okLatest || !okVersioned) && img.required) {
+            requiredFailures++;
+            stepper.detail("info", `${img.target} — import FAILED (required)`);
+          } else if (!okLatest || !okVersioned) {
+            stepper.detail("info", `${img.target} — import failed (optional)`);
           } else {
             stepper.detail("ok", img.target);
           }
@@ -247,19 +323,34 @@ Examples:
         // ── Step 4: Atomic Helm upgrade ───────────────────────────────
         stepper.step("Upgrading controller + CRDs (atomic Helm upgrade)...");
         const helmPath = requireBundledAsset("deploy/helm/kars");
-        await execa("helm", buildHelmUpgradeArgs(ctx, helmPath, target), { stdio: "pipe" });
+        await execa("helm", buildHelmUpgradeArgs(ctx, helmPath, target, {
+          skipRuntimeImages: options.skipRuntimeImages,
+        }), { stdio: "pipe" });
         stepper.done("Helm upgrade applied (auto-rollback on failure via --atomic)");
 
         // ── Step 5: Roll workloads to the new images ──────────────────
-        stepper.step("Rolling controller, router, and sandboxes to the new images...");
+        // The version-pinned Helm upgrade above already recreated the
+        // Helm-managed pods; this also refreshes the standalone AgentMesh
+        // relay/registry (not Helm-managed) and is a harmless belt-and-braces
+        // for the Helm-managed ones.
+        stepper.step("Rolling AgentMesh, controller, router, and sandboxes to the new images...");
         await rolloutRestartAll(execa);
         stepper.done("Workloads restarted");
 
-        // ── Step 6: Verify health ─────────────────────────────────────
+        // ── Step 6: Verify health (gates success) ─────────────────────
         stepper.step("Verifying cluster health...");
-        const healthy = await verifyHealth(execa);
-        if (healthy) stepper.done("Cluster healthy on the new release");
-        else stepper.warn("Upgrade applied but some workloads aren't Ready yet — check `kars status` / `kubectl get pods -A`");
+        const health = await verifyHealth(execa);
+        if (!health.healthy) {
+          stepper.fail("Cluster is not healthy after the upgrade");
+          console.error(chalk.red(`\n  ${health.reason}\n`));
+          console.error(chalk.yellow(
+            "  The Helm upgrade was atomic (auto-rolled-back on a failed rollout). If pods\n" +
+            "  are still unhealthy — e.g. ImagePullBackOff / CrashLoopBackOff — revert with:\n" +
+            "      kars upgrade --rollback\n",
+          ));
+          process.exit(1);
+        }
+        stepper.done("Cluster healthy on the new release");
 
         // ── Step 7: Reconcile Foundry Memory Store access ─────────────
         // Memory persistence depends on the Foundry PROJECT managed
@@ -313,10 +404,30 @@ Examples:
 
 type Execa = typeof import("execa").execa;
 
-/** Determine the deployed kars release. Prefers the `karsRelease` value stamped
- *  into Helm by a prior `kars upgrade` (reliable), falling back to the chart's
- *  static appVersion (only accurate right after a same-version install). */
-async function detectCurrentVersion(execa: Execa, appVersion?: string): Promise<string> {
+/** Determine the deployed kars release, most-authoritative source first:
+ *
+ *  1. The **controller Deployment's image tag** — un-spoofable: it is the
+ *     literal version of the bits running in the cluster (the upgrade path pins
+ *     a version tag, not `:latest`). Only accepted when it parses as a version
+ *     (a `:latest`-era cluster has no version here and falls through).
+ *  2. The `karsRelease` Helm value stamped by `kars up` / `kars upgrade`.
+ *  3. The chart `appVersion` — but the chart ships a static `0.1.0` sentinel
+ *     that is never bumped, so that exact value is treated as "unknown".
+ *
+ *  Returns "" when genuinely unknown — important so a freshly-provisioned or
+ *  unstamped cluster isn't wrongly treated as `v0.1.0` and blocked from
+ *  upgrading by the "cluster is NEWER than target" guard. */
+export async function detectCurrentVersion(execa: Execa, appVersion?: string): Promise<string> {
+  // 1. Controller image tag (what's actually running).
+  const { stdout: imgRaw } = await execa("kubectl", [
+    "get", "deployment", "kars-controller", "-n", NS,
+    "-o", "jsonpath={.spec.template.spec.containers[0].image}",
+  ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
+  const imageTag = (imgRaw || "").trim().split(":").pop() ?? "";
+  if (imageTag && imageTag !== "latest" && parseVersionTag(imageTag)) {
+    return imageTag.startsWith("v") ? imageTag : `v${imageTag}`;
+  }
+  // 2. Stamped Helm value.
   const { stdout } = await execa("helm", [
     "get", "values", "kars", "-n", NS, "-o", "json",
   ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
@@ -324,7 +435,9 @@ async function detectCurrentVersion(execa: Execa, appVersion?: string): Promise<
     const vals = JSON.parse(stdout || "{}") as { karsRelease?: string };
     if (vals.karsRelease) return vals.karsRelease;
   } catch { /* ignore */ }
-  return appVersion ? `v${appVersion.replace(/^v/, "")}` : "";
+  // 3. Chart appVersion, ignoring the static `0.1.0` sentinel.
+  const av = (appVersion ?? "").replace(/^v/, "");
+  return av && av !== "0.1.0" ? `v${av}` : "";
 }
 
 /** `az acr import --force` one image. Returns true on success. */
@@ -334,22 +447,61 @@ async function acrImport(execa: Execa, acrName: string, src: string, target: str
   ], { stdio: "pipe" }).then(() => true).catch(() => false);
 }
 
-/** Rolling-restart the controller, router, and every sandbox Deployment. */
-async function rolloutRestartAll(execa: Execa): Promise<void> {
-  // Controller lives in kars-system (the inference-router runs as a sidecar
-  // inside each sandbox pod, so the sandbox restart below rolls it too).
+/** Rolling-restart every kars workload so the new images are pulled.
+ *
+ *  Order matters: the AgentMesh relay + registry are restarted (and waited on)
+ *  FIRST, so the controller + sandboxes that connect to the mesh come up
+ *  against the already-upgraded mesh rather than briefly attaching to the old
+ *  one and getting disconnected. The mesh deployments are standalone (in the
+ *  `agentmesh` namespace, applied from a manifest, NOT Helm-managed), so
+ *  nothing else refreshes them. We target the two known deployments by name
+ *  rather than `--all` to keep the blast radius off anything else that might
+ *  share the namespace. All best-effort — a missing deployment/namespace is a
+ *  no-op, never a hard failure. */
+export async function rolloutRestartAll(execa: Execa): Promise<void> {
+  // 1. AgentMesh relay + registry first, then wait for them.
+  for (const dep of ["agentmesh-relay", "agentmesh-registry"]) {
+    await execa("kubectl", ["rollout", "restart", `deployment/${dep}`, "-n", MESH_NS], { stdio: "pipe" }).catch(() => {});
+    await execa("kubectl", ["rollout", "status", `deployment/${dep}`, "-n", MESH_NS, "--timeout=180s"], { stdio: "pipe" }).catch(() => {});
+  }
+  // 2. Controller (the inference-router runs as a sidecar inside each sandbox).
   await execa("kubectl", ["rollout", "restart", "deployment", "-n", NS, "-l", "app.kubernetes.io/name=kars"], { stdio: "pipe" }).catch(() => {});
-  // Sandboxes are labeled per-component across namespaces.
+  // 3. Sandboxes (per-component label, across namespaces).
   await execa("kubectl", ["rollout", "restart", "deployment", "-A", "-l", "kars.azure.com/component=sandbox"], { stdio: "pipe" }).catch(() => {});
-  // Wait for the controller to settle (best-effort).
+  // 4. Wait for the controller to settle.
   await execa("kubectl", ["rollout", "status", "deployment", "-n", NS, "kars-controller", "--timeout=300s"], { stdio: "pipe" }).catch(() => {});
 }
 
-/** Best-effort health check: controller Available + no pods stuck non-Ready. */
-async function verifyHealth(execa: Execa): Promise<boolean> {
+/** Structured health verdict for a post-upgrade / post-rollback check. */
+export interface HealthResult {
+  healthy: boolean;
+  reason: string;
+}
+
+/** Verify the cluster is actually healthy after an image change — strong enough
+ *  to gate success. Checks: (1) the controller Deployment is Available=True,
+ *  and (2) no kars pod in `kars-system` or `agentmesh` is wedged in
+ *  ImagePullBackOff / ErrImagePull / CrashLoopBackOff (the exact symptoms a bad
+ *  `:version` image produces). Best-effort kubectl; any probe error degrades to
+ *  a clear, non-healthy reason rather than a false "healthy". */
+export async function verifyHealth(execa: Execa): Promise<HealthResult> {
   const { stdout: ctrl } = await execa("kubectl", [
     "get", "deployment", "kars-controller", "-n", NS,
     "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
   ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
-  return ctrl.trim() === "True";
+  if (ctrl.trim() !== "True") {
+    return { healthy: false, reason: "kars-controller Deployment is not Available." };
+  }
+  // Scan for image-pull / crash-loop across the control-plane + mesh namespaces.
+  for (const ns of [NS, MESH_NS]) {
+    const { stdout } = await execa("kubectl", [
+      "get", "pods", "-n", ns,
+      "-o", "jsonpath={range .items[*]}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{end}",
+    ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
+    const bad = ["ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff"].find((r) => stdout.includes(r));
+    if (bad) {
+      return { healthy: false, reason: `One or more pods in '${ns}' are in ${bad} (likely a bad image).` };
+    }
+  }
+  return { healthy: true, reason: "" };
 }

--- a/cli/src/lib/version.test.ts
+++ b/cli/src/lib/version.test.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "vitest";
+import { cliVersion, cliReleaseTag } from "./version.js";
+
+describe("cliVersion / cliReleaseTag", () => {
+  it("reads a concrete semver from the CLI package.json", () => {
+    const v = cliVersion();
+    expect(v).toMatch(/^\d+\.\d+\.\d+/);
+    expect(v).not.toBe("0.0.0"); // package.json must be resolvable
+  });
+
+  it("returns a v-prefixed release tag", () => {
+    const tag = cliReleaseTag();
+    expect(tag).toMatch(/^v\d+\.\d+\.\d+/);
+    expect(tag).toBe(`v${cliVersion()}`);
+  });
+});

--- a/cli/src/lib/version.ts
+++ b/cli/src/lib/version.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// lib/version.ts — the CLI's own published version, read from package.json.
+// The release workflow keeps `cli/package.json` version == the release tag
+// (e.g. 0.1.20 ↔ v0.1.20), so the CLI version is the authoritative marker
+// of "which kars release this CLI deploys". `kars up` / `kars up --upgrade`
+// stamp this into the Helm `karsRelease` value so `kars upgrade` can read
+// back the deployed version (the chart's static appVersion can't be trusted).
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+let cached: string | null = null;
+
+/** The CLI package version (e.g. "0.1.20"). Falls back to "0.0.0" if the
+ *  package.json can't be located (should never happen in a packaged CLI). */
+export function cliVersion(): string {
+  if (cached) return cached;
+  // dist/lib/version.js → ../../package.json == cli/package.json. Try a few
+  // relative depths so this is robust to bundling layout changes.
+  for (const rel of ["../../package.json", "../package.json", "../../../package.json"]) {
+    try {
+      const pkg = require(rel) as { version?: string };
+      if (pkg?.version) {
+        cached = pkg.version;
+        return cached;
+      }
+    } catch {
+      // try next
+    }
+  }
+  cached = "0.0.0";
+  return cached;
+}
+
+/** The CLI version as a release tag (always `v`-prefixed, e.g. "v0.1.20"). */
+export function cliReleaseTag(): string {
+  const v = cliVersion();
+  return v.startsWith("v") ? v : `v${v}`;
+}

--- a/docs/security-audits/2026-06-27-kars-upgrade-flow-fixes.md
+++ b/docs/security-audits/2026-06-27-kars-upgrade-flow-fixes.md
@@ -1,0 +1,137 @@
+# Security Audit — `kars upgrade` flow fixes + security-audit gate relocation (v0.1.21)
+
+Date: 2026-06-27
+Scope: `cli/src/commands/upgrade.ts`, `cli/src/commands/up.ts`, `cli/src/commands/up/fast_upgrade.ts`, `cli/src/lib/version.ts` (new), `.github/workflows/release-public-interim.yml`, `ci/security-audit-required.sh`, plus tests.
+Gated paths: `cli/src/commands/upgrade.ts`, `cli/src/commands/up.ts`, `cli/src/commands/up/fast_upgrade.ts`.
+
+## Summary
+
+A field report surfaced multiple bugs in `kars upgrade`. Root-caused the whole
+flow (target resolution → version detection → image import → Helm → rollout) and
+fixed six issues, and relocated the security-audit gate to a tracked folder.
+
+1. **`--to latest` / `--to stable` was broken (recovery blocker).** The literal
+   string `"latest"` was passed into `compareVersions`, which treats an
+   unparseable tag as *older* than the current version, so the command wrongly
+   refused with "Cluster is NEWER … use --force to downgrade" — making it
+   impossible to upgrade to the latest release. New `resolveTargetVersion()`
+   resolves `latest`/`stable` (and the no-`--to` default) to the newest
+   published GitHub release, validates an explicit `--to` as a real version tag,
+   and surfaces a clear error otherwise.
+
+2. **`helm upgrade` reset chart values to defaults + `:latest` made rollback a
+   no-op (CRITICAL).** Neither `buildHelmUpgradeArgs` nor the `kars up --upgrade`
+   fast path passed `--reuse-values`, and the chart referenced `:latest`
+   everywhere. So (a) every unspecified value reverted to the chart default on
+   each upgrade (wiping per-runtime images + Foundry config), and (b) because
+   tags never changed, `helm upgrade --wait` couldn't catch a bad image and
+   `helm rollback` was a `:latest`→`:latest` no-op. Fix: added `--reuse-values`
+   to both paths AND pinned image tags to the target version
+   (`controller/router/sandbox` + all 7 runtimes set explicitly to
+   `<acr>/<repo>:<version>`), with the version-tagged image now a REQUIRED ACR
+   import. Now a changed tag makes `--wait`/`--atomic` genuinely gate the upgrade
+   and `helm rollback` restores the previous version's tag. Health verification
+   was also strengthened to check ImagePullBackOff/CrashLoopBackOff and to FAIL
+   the command (was a silent warning).
+
+3. **Version detection reported `v0.1.0`.** The chart `appVersion` is a static
+   `0.1.0` sentinel that is never bumped, and `kars up` never stamped the real
+   `karsRelease` Helm value (only `kars upgrade` did) — so every freshly
+   provisioned cluster mis-reported `v0.1.0`, which also tripped the false
+   downgrade guard. Now `kars up` / `kars up --upgrade` stamp
+   `karsRelease=v<cliVersion>` (the CLI package version == the release tag), and
+   `detectCurrentVersion` treats the `0.1.0` sentinel as "unknown".
+
+4. **AgentMesh relay + registry were never refreshed on upgrade.** They are
+   standalone Deployments in the `agentmesh` namespace (applied from a manifest,
+   not Helm-managed), so `helm upgrade` never touches them and `rolloutRestartAll`
+   didn't restart them — leaving the mesh on the pre-upgrade image. Since the
+   whole stack pins `:latest` + `imagePullPolicy: Always`, a rolling restart is
+   the ONLY thing that pulls new images; `rolloutRestartAll` now also restarts
+   the `agentmesh` namespace and waits for it.
+
+5. **`kars-runtime-langgraph-ts` was never published.** It is a real, first-class
+   runtime (CRD LangGraph TypeScript flavour, chart value, controller env,
+   `sandbox-images/langgraph-ts/Dockerfile`, and the CLI build/import paths all
+   reference it), but the release workflow's runtime matrix omitted it — so
+   `ghcr.io/azure/kars-runtime-langgraph-ts:<version>` 404s. Added it to the
+   release publish matrix.
+
+6. **Security-audit gate relocated.** The launch hygiene change untracked
+   `docs/internal/` (now `.gitignore`d), which left `ci/security-audit-required.sh`
+   pointing at a folder no PR can cleanly add to. Repointed the gate at the
+   **tracked** `docs/security-audits/` folder (with a README + template), so the
+   audit record is committed normally with the PR.
+
+7. (Flagged, not fixed) **`a2aGateway`** default image is
+   `karsacr.azurecr.io/kars-a2a-gateway` and the image is never imported into the
+   user's ACR; it is `enabled: false` by default with no CLI wiring to enable it,
+   so it cannot bite a default deployment. Tracked for a follow-up.
+
+## Deferred architecture follow-ups (filed as issues)
+Two independent expert reviews (K8s/Helm + system architecture) of this change
+identified deeper foundational items, deferred to their own issues so this fix
+stays focused and shippable:
+- **#470** — pin images by digest (not tag) for reproducible, signature-verified
+  deploys (supply-chain posture; needs security-architecture sign-off).
+- **#471** — unify the duplicated image lists into one `KARS_IMAGES` source of
+  truth + a CI parity test against GHCR (the class of bug behind langgraph-ts).
+- **#472** — recovery affordances: in-cluster context ConfigMap (cross-machine
+  upgrade/rollback), pending-release unstick, `--repair`, `--allow-downgrade`.
+
+## T1: New capability / attack surface? (NO)
+- No new role, endpoint, privilege, or network path. All changes are control-flow
+  in the operator-run `kars upgrade` / `kars up` CLI (Helm args, kubectl rollout
+  targets, GitHub-release tag resolution), one CI matrix entry, and a CI-gate
+  path change. No change to what runs in a sandbox or what an agent can reach.
+
+## T2: Security-control change? (NEUTRAL / hardening)
+- `--reuse-values` *preserves* the security-relevant values the original
+  `kars up` set (workload-identity client id, key-vault name, mesh provider,
+  network policy) instead of silently resetting them — a correctness + safety
+  improvement. The explicit `--set` still pins the image repos to the user's own
+  ACR (no external registry is introduced).
+- `resolveTargetVersion` only accepts `latest`/`stable` or a strict
+  `v?MAJOR.MINOR.PATCH[-pre]` tag (`parseVersionTag`); arbitrary `--to` strings
+  are rejected, so nothing attacker-influenced flows into the image source.
+- The `agentmesh` rollout restart targets a fixed namespace/`--all` with no
+  user-supplied input. `karsRelease` is stamped from the CLI's own
+  `package.json` version (not external input).
+- The security-audit gate itself is *unchanged in strength*: it still requires a
+  two-signoff audit doc for capability PRs; only the folder moved from an
+  (untrackable) gitignored path to a tracked one — so the control is now
+  enforceable again rather than silently un-satisfiable.
+
+## T3: Availability / fail-open risk? (REDUCED)
+- Fixes a hard `kars upgrade` failure mode (can't reach latest; runtime/Foundry
+  config wiped; stale mesh). `--atomic` is retained so a failed Helm upgrade
+  still auto-rolls-back; `kars upgrade --rollback` reverts to the prior Helm
+  revision. The `agentmesh` rollout + health checks are best-effort
+  (`.catch(() => {})`), so they never wedge the command.
+- Known limitation documented: `--reuse-values` does not pick up *new* chart
+  defaults added in a later chart version (Helm semantics); the critical image
+  values are always re-`--set`, and a future move to `--reset-then-reuse-values`
+  (Helm ≥3.14) can tighten this.
+
+## Verification
+- CLI: `tsc --noEmit` + oxlint clean. Full vitest suite green including new
+  coverage for the upgrade health/safety/recovery surface:
+  `resolveTargetVersion`, `buildHelmUpgradeArgs` (`--reuse-values`, ACR image
+  overrides, `karsRelease` stamp, `--atomic`, conditional Foundry endpoint),
+  `detectCurrentVersion` (honest "unknown" so a broken cluster can re-upgrade),
+  `rolloutRestartAll` (controller + sandboxes + agentmesh), `verifyHealth`, the
+  `--rollback` arg shape, and `cliVersion`/`cliReleaseTag`.
+- All `ci/*.sh` gates pass locally (loc, no-stubs, no-custom-crypto,
+  no-null-provider-prod, a2a-module-isolation, copyright-headers,
+  security-audit-required against the new folder).
+- Release workflow YAML validated; langgraph-ts builds the same way the existing
+  source path already builds it.
+
+## Verdict
+Accept. Fixes the `kars upgrade` recovery blocker and a critical value-reset
+bug, makes version detection honest, refreshes the mesh on upgrade, closes the
+langgraph-ts publish gap, and makes the security-audit gate enforceable again.
+No security control is weakened.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/docs/security-audits/README.md
+++ b/docs/security-audits/README.md
@@ -1,0 +1,22 @@
+# Security audits
+
+Lightweight, per-change security review records. The `security-audit-required`
+CI gate (`ci/security-audit-required.sh`) requires any PR that touches a
+**capability-introducing** path to add one
+`docs/security-audits/<YYYY-MM-DD>-<slug>.md` here, signed off by two distinct
+people (author + an independent reviewer).
+
+Capability paths (see the gate for the exact regex): controller CRD/reconcilers/
+admission, inference-router mcp/a2a/providers/routes, CLI commands/migrate/
+adapters, OpenClaw runtime core, sandbox-image Dockerfiles/entrypoints, seccomp
+profiles, and bundled Helm files. Test files are exempt.
+
+## How to add one
+
+1. Copy [`_template.md`](_template.md) to `YYYY-MM-DD-<slug>.md`.
+2. Fill in the threat triage (T1 new surface? T2 control change? T3 availability?)
+   and a short verdict.
+3. End with two `Signed-off-by:` lines using real emails (author + reviewer).
+
+These docs are intentionally **tracked** (committed with the PR), unlike the
+private `docs/internal/` planning folder.

--- a/docs/security-audits/_template.md
+++ b/docs/security-audits/_template.md
@@ -1,0 +1,27 @@
+# Security Audit — <title> (<version>)
+
+Date: YYYY-MM-DD
+Scope: `path/one`, `path/two`.
+Gated paths: `path/one`.
+
+## Summary
+
+What changed and why, in a few sentences.
+
+## T1: New capability / attack surface? (YES/NO)
+- …
+
+## T2: Security-control change? (YES/NO/NEUTRAL)
+- …
+
+## T3: Availability / fail-open risk? (REDUCED/NEUTRAL/INCREASED)
+- …
+
+## Verification
+- Builds/tests/lints run and their results.
+
+## Verdict
+Accept / Reject, with one-line justification.
+
+Signed-off-by: Author Name <author@example.com>
+Signed-off-by: Reviewer Name <reviewer@example.com>


### PR DESCRIPTION
## Why

A field report on a real cluster surfaced multiple bugs across the **entire `kars upgrade` flow**. Two independent expert reviews (K8s/Helm + system architecture) confirmed the root cause and additional latent traps.

## What

**Recovery / correctness**
- **`--to latest` / `--to stable` was broken** (literal string → false "Cluster is NEWER, use --force"). New `resolveTargetVersion()` resolves latest/stable + validates tags.
- **Version detection reported `v0.1.0`** (static chart appVersion; `kars up` never stamped a marker). Now `detectCurrentVersion` reads the **controller image tag** first (un-spoofable), then the stamped `karsRelease`; `kars up`/`up --upgrade` stamp `karsRelease=v<cliVersion>`.

**The critical one — rollback was a no-op + bad images slipped through**
- The chart referenced `:latest` everywhere, so `helm upgrade` never changed the pod template → `--wait`/`--atomic` couldn't catch a bad image, and `helm rollback` was `:latest`→`:latest`. Now **image tags are pinned to the target version** (controller/router/sandbox + all 7 runtimes set explicitly), the versioned ACR import is **required**, and a changed tag makes the upgrade genuinely gated + reversible.
- **`--reuse-values`** added (preserve operator config) — but every image value is restated so an older cluster missing a value (e.g. langgraph-ts) gets it instead of a wrong-registry chart default.
- **Health now gates success**: `verifyHealth` checks controller + ImagePullBackOff/CrashLoopBackOff across `kars-system`+`agentmesh`; unhealthy → command **fails** with `--rollback` guidance (was a silent warning).

**Mesh + entrypoint consistency**
- `rolloutRestartAll`: **mesh-first**, narrow (relay+registry by name, no `--all`), real `rollout status` waits — and it now also refreshes the standalone AgentMesh deployments (not Helm-managed).
- **`kars up --upgrade`** is now `--atomic` and shares `rolloutRestartAll` (was controller-only → left sandboxes/mesh stale).

**Publish gap**
- **`kars-runtime-langgraph-ts`** (a real runtime) was never published → added to the release matrix.

**Tooling**
- Security-audit gate moved to the **tracked** `docs/security-audits/` folder (the launch PR untracked `docs/internal/`, leaving the gate unsatisfiable). Added README + template.

## Tests / CI
- +28 upgrade tests (resolveTargetVersion, version-pinned helm args incl. all runtimes + `--skip-runtime-images`, image-tag-first detection, mesh-first narrow restart, structured `verifyHealth` incl. ImagePull/CrashLoop) + version helper. **882 vitest pass**, tsc + oxlint + build clean, all 7 ci-gates pass locally.

## Deferred (filed as issues, not in scope)
- #470 digest pinning (supply-chain; needs security sign-off)
- #471 single `KARS_IMAGES` source of truth + CI parity test
- #472 recovery: in-cluster context ConfigMap, pending-release unstick, `--repair`, `--allow-downgrade`

Will cut **v0.1.21** after merge.