### PR TITLE
fix(memory): send MCP Accept header from runtime thin clients (fixes memory end-to-end)

### DIFF
--- a/docs/security-audits/2026-06-27-foundry-memory-mcp-accept-header.md
+++ b/docs/security-audits/2026-06-27-foundry-memory-mcp-accept-header.md
@@ -1,0 +1,75 @@
+# Security Audit — Foundry memory MCP Accept header (fix runtime memory end-to-end)
+
+Date: 2026-06-27
+Scope: `runtimes/openclaw/src/core/router-client.ts`, `runtimes/hermes/src/kars_runtime_hermes/plugin/foundry.py`, `runtimes/hermes/src/kars_runtime_hermes/plugin/router_client.py`, `inference-router/src/routes/mcp.rs` (tests only), plus runtime tests.
+Gated paths: `runtimes/openclaw/src/core/router-client.ts`, `inference-router/src/routes/mcp.rs`.
+
+## Summary
+
+Persistent agent memory was broken end-to-end from OpenClaw and Hermes: the
+agent's `foundry_memory` tool returned **"Accept must include both
+application/json and text/event-stream"** whenever it tried to read/write.
+
+Root cause (traced through every layer): the memory tool is a thin client that
+posts a single JSON-RPC `tools/call` to the router's `/platform/mcp` endpoint.
+That endpoint is an **MCP Streamable-HTTP** server and, per spec, requires the
+POST `Accept` header to advertise **both** `application/json` and
+`text/event-stream` (`inference-router/src/mcp/pipeline.rs` →
+`validate_accept_header`); otherwise it returns HTTP 406 before any dispatch.
+The two hand-rolled thin clients I introduced in the v0.1.19 memory
+consolidation (`callPlatformTool` in OpenClaw, `_call_platform_tool` in Hermes)
+sent **no** `Accept` header, so every memory call 406'd. The unit tests mocked
+the transport, so they never exercised the real header negotiation.
+
+It is specifically these two clients: OpenClaw's other Foundry tools call the
+router proxy directly (no MCP negotiation), and the maf-python / openai-agents /
+langgraph / pydantic-ai runtimes use MCP clients that already send the header.
+
+**Fix:** both thin clients now send `Accept: application/json,
+text/event-stream` (mirroring the maf-python client). Hermes' `router_client.call`
+gained an optional `headers` parameter to carry it.
+
+## T1: New capability / attack surface? (NO)
+- No new endpoint, tool, route, privilege, or network path. One request header is
+  added to an existing in-pod loopback call (`127.0.0.1:8443/platform/mcp`). The
+  `inference-router` change is **test-only** (added `#[tokio::test]` cases inside
+  `#[cfg(test)]`). No production router behaviour changes.
+
+## T2: Security-control change? (NEUTRAL)
+- The router's Accept enforcement is unchanged and still in force (a new test
+  asserts the 406 still fires when the header is absent, so a future client
+  regression is caught). The client simply now satisfies the spec-required
+  negotiation. No auth/crypto/governance/isolation change — store/scope
+  resolution, IMDS token minting (audience `https://ai.azure.com`), and the
+  Foundry contract are all untouched and continue to live in the router.
+
+## T3: Availability / fail-open risk? (REDUCED)
+- Restores a completely-broken capability (memory) with no fail-open: malformed
+  requests still 406, upstream auth failures still surface as the router's
+  existing `AuthMisconfigured` CRD signal. Adding the header cannot make a
+  previously-rejected request succeed in any way other than the intended one.
+
+## Verification
+- **Client side (the bug):**
+  - OpenClaw `platform-mcp-accept.test.ts` — a REAL loopback HTTP server that
+    enforces the same Accept negotiation as the router: asserts the thin client
+    sends both media types and parses the JSON-RPC result; plus a sanity check
+    that the server 406s when the header is omitted.
+  - Hermes `test_router_client.py` (headers forwarded to httpx) +
+    `test_foundry_http_fetch.py` (the memory tool sends the Accept header).
+- **Server side (the contract):**
+  - `inference-router` `platform_foundry_memory_dispatches_to_upstream_with_accept`
+    — `/platform/mcp` + Accept → real `PlatformDispatcher` → wiremock upstream
+    receives `:update_memories` with the correct `items[]`/`scope`/`update_delay`
+    contract; and `platform_foundry_memory_without_accept_is_406`.
+- Suites: OpenClaw 125, Hermes 149 (1 pre-existing unrelated `kars_agt_mesh`
+  wheel skip), inference-router lib 951 — all green. `cargo clippy -D warnings`
+  + `cargo fmt --check` + `ruff` + `tsc` + `oxlint` clean.
+
+## Verdict
+Accept. Single-header correctness fix that restores agent memory end-to-end,
+covered on both sides of the client/server contract; no security control
+weakened (and the server-side enforcement is now regression-tested).
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/inference-router/src/routes/mcp.rs
+++ b/inference-router/src/routes/mcp.rs
@@ -658,6 +658,95 @@ mod tests {
         );
     }
 
+    /// END-TO-END server proof for the Foundry memory path: a `tools/call`
+    /// for `foundry.memory` sent to `/platform/mcp` WITH the required Accept
+    /// header must traverse the pipeline, reach the real `PlatformDispatcher`,
+    /// and hit the upstream Foundry `:update_memories` with the correct
+    /// contract body. Pairs with the OpenClaw/Hermes thin-client tests (which
+    /// prove the client sends that Accept header) to cover the full path the
+    /// runtime memory bug lived in.
+    #[tokio::test]
+    async fn platform_foundry_memory_dispatches_to_upstream_with_accept() {
+        use wiremock::matchers::{method as wm_method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .and(path_regex(r"^/memory_stores/.*:update_memories$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"status": "queued"})))
+            .mount(&upstream)
+            .await;
+
+        // Real platform dispatcher, pointed at the mock upstream.
+        let state = McpRouteState {
+            config: Arc::new(InitializeConfig::default()),
+            minter: Arc::new(FixedMinter("platform-session-001")),
+            tools: Arc::new(crate::mcp::PlatformDispatcher::with_base_url(
+                upstream.uri(),
+            )),
+        };
+        let app = platform_mcp_route().with_state(state);
+
+        let req_body = json!({
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": {
+                "name": "foundry.memory",
+                "arguments": { "operation": "update", "text": "likes dark roast" }
+            }
+        });
+        let req = platform_post_body(
+            req_body.to_string().as_bytes(),
+            Some("application/json, text/event-stream"),
+        );
+        let (status, _, text) = body_text(app.oneshot(req).await.unwrap()).await;
+        assert_eq!(status, StatusCode::OK);
+        let v: Value = serde_json::from_str(&text).unwrap();
+        assert!(v["error"].is_null(), "no JSON-RPC envelope error: {v}");
+        assert_eq!(
+            v["result"]["isError"], false,
+            "memory update should succeed: {v}"
+        );
+
+        // The dispatcher actually called the upstream with the real contract.
+        let reqs = upstream.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1, "exactly one upstream memory call");
+        let body: Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert!(
+            body.get("messages").is_none(),
+            "must use items[], not legacy messages: {body}"
+        );
+        assert_eq!(body["update_delay"], json!(0));
+        assert_eq!(
+            body["items"][0]["content"][0]["text"],
+            json!("likes dark roast")
+        );
+        let scope = body["scope"].as_str().unwrap();
+        assert!(
+            !scope.is_empty() && !scope.contains(':'),
+            "valid scope: {scope}"
+        );
+    }
+
+    /// The same call WITHOUT the Accept header is rejected 406 — i.e. the
+    /// exact failure the runtime hit ("Accept must include both
+    /// application/json and text/event-stream"). Guards against a regression
+    /// where the server stops enforcing (which would mask a broken client).
+    #[tokio::test]
+    async fn platform_foundry_memory_without_accept_is_406() {
+        let req_body = json!({
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": { "name": "foundry.memory", "arguments": { "operation": "search" } }
+        });
+        let req = platform_post_body(req_body.to_string().as_bytes(), None);
+        let (status, _, text) = body_text(platform_app().oneshot(req).await.unwrap()).await;
+        assert_eq!(status, StatusCode::NOT_ACCEPTABLE);
+        assert!(text.contains("Accept must include both"), "got: {text}");
+    }
+
     // ----------------------------------------------------------------
     // protected_mcp_route — OAuth 2.1 wiring tests
     // ----------------------------------------------------------------

--- a/runtimes/hermes/src/kars_runtime_hermes/plugin/foundry.py
+++ b/runtimes/hermes/src/kars_runtime_hermes/plugin/foundry.py
@@ -62,7 +62,17 @@ def _call_platform_tool(name: str, arguments: dict[str, Any]) -> str:
         "params": {"name": name, "arguments": arguments},
     }
     try:
-        resp = router_client.call("POST", "/platform/mcp", json=rpc)
+        resp = router_client.call(
+            "POST",
+            "/platform/mcp",
+            json=rpc,
+            # The router's /platform/mcp is an MCP Streamable-HTTP endpoint and
+            # REQUIRES the Accept header to advertise both JSON and SSE, else it
+            # replies 406 "Accept must include both application/json and
+            # text/event-stream". Mirrors the maf-python / openai-agents
+            # runtimes' MCP client.
+            headers={"Accept": "application/json, text/event-stream"},
+        )
     except Exception as exc:  # noqa: BLE001
         return json.dumps({"error": f"{name} request failed: {exc}"})
     if resp.status_code >= 400:

--- a/runtimes/hermes/src/kars_runtime_hermes/plugin/router_client.py
+++ b/runtimes/hermes/src/kars_runtime_hermes/plugin/router_client.py
@@ -67,14 +67,25 @@ def _client() -> httpx.Client:
     )
 
 
-def call(method: str, path: str, *, json: Any | None = None, params: dict | None = None) -> httpx.Response:
+def call(
+    method: str,
+    path: str,
+    *,
+    json: Any | None = None,
+    params: dict | None = None,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
     """Call the router. Path is a leading-slash absolute path under base URL.
 
     Returns the raw httpx.Response so callers can branch on .status_code
     (some kars endpoints intentionally return 4xx as part of normal flow,
     e.g. /sandbox/{name}/status returns 404 while a sub-agent is booting).
+
+    ``headers`` are merged onto (and override) the per-process defaults — used
+    e.g. to send the MCP ``Accept: application/json, text/event-stream`` header
+    required by the router's ``/platform/mcp`` Streamable-HTTP endpoint.
     """
-    return _client().request(method, path, json=json, params=params)
+    return _client().request(method, path, json=json, params=params, headers=headers)
 
 
 def call_json(method: str, path: str, *, json: Any | None = None, params: dict | None = None) -> dict[str, Any]:

--- a/runtimes/hermes/tests/test_foundry_http_fetch.py
+++ b/runtimes/hermes/tests/test_foundry_http_fetch.py
@@ -237,3 +237,28 @@ def test_http_fetch_register_wires_tool() -> None:
     ctx = _FakeCtx()
     http_fetch.register(ctx)
     assert "http_fetch" in ctx.tools
+
+
+# ── foundry_memory — MCP Accept negotiation (regression) ───────────
+
+
+def test_foundry_memory_sends_mcp_accept_header() -> None:
+    """The router's /platform/mcp REQUIRES Accept: application/json +
+    text/event-stream, else it 406s. The thin client must send it —
+    this is the bug that broke memory end-to-end."""
+    captured: dict[str, Any] = {}
+
+    def fake_call(method: str, path: str, **kwargs: Any) -> httpx.Response:
+        captured["path"] = path
+        captured["headers"] = kwargs.get("headers")
+        return _mock_response(200, _rpc_ok('{"memories": []}'))
+
+    with mock.patch.object(foundry.router_client, "call", side_effect=fake_call):
+        foundry._foundry_memory({"operation": "search", "query": "x"})
+
+    assert captured["path"] == "/platform/mcp"
+    headers = captured["headers"]
+    assert headers is not None, "thin client must pass headers"
+    accept = headers.get("Accept", "")
+    assert "application/json" in accept
+    assert "text/event-stream" in accept

--- a/runtimes/hermes/tests/test_router_client.py
+++ b/runtimes/hermes/tests/test_router_client.py
@@ -1,0 +1,49 @@
+"""Unit tests for router_client.call header forwarding."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+from kars_runtime_hermes.plugin import router_client
+
+
+def test_call_forwards_headers_to_httpx() -> None:
+    """Per-call headers (e.g. the MCP Accept header) must reach the underlying
+    httpx request, merged onto the client defaults."""
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def request(self, method: str, path: str, **kwargs: Any) -> str:
+            captured["method"] = method
+            captured["path"] = path
+            captured["headers"] = kwargs.get("headers")
+            return "resp"
+
+    with mock.patch.object(router_client, "_client", return_value=_FakeClient()):
+        out = router_client.call(
+            "POST",
+            "/platform/mcp",
+            json={"x": 1},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+
+    assert out == "resp"
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/platform/mcp"
+    assert captured["headers"] == {"Accept": "application/json, text/event-stream"}
+
+
+def test_call_without_headers_passes_none() -> None:
+    """Backward-compat: omitting headers must not break existing callers."""
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def request(self, method: str, path: str, **kwargs: Any) -> str:
+            captured["headers"] = kwargs.get("headers")
+            return "resp"
+
+    with mock.patch.object(router_client, "_client", return_value=_FakeClient()):
+        router_client.call("GET", "/healthz")
+
+    assert captured["headers"] is None

--- a/runtimes/openclaw/src/core/router-client.ts
+++ b/runtimes/openclaw/src/core/router-client.ts
@@ -290,7 +290,15 @@ export async function callPlatformTool(
     params: { name, arguments: args },
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const resp: any = await routerCall("POST", "/platform/mcp", rpc, timeoutMs);
+  const resp: any = await routerCall("POST", "/platform/mcp", rpc, timeoutMs, {
+    // The router's /platform/mcp is an MCP Streamable-HTTP endpoint: it
+    // REQUIRES the Accept header to advertise both JSON and SSE, else it
+    // replies 406 "Accept must include both application/json and
+    // text/event-stream". (It actually returns application/json here, but the
+    // spec-mandated negotiation still applies.) Mirrors the maf-python /
+    // openai-agents runtimes.
+    Accept: "application/json, text/event-stream",
+  });
   if (resp && typeof resp === "object" && resp.error) {
     const reason =
       resp.error?.data?.reason || resp.error?.message || "unknown error";

--- a/runtimes/openclaw/src/platform-mcp-accept.test.ts
+++ b/runtimes/openclaw/src/platform-mcp-accept.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Regression test for the Foundry memory bug: the runtime calls the router's
+// MCP Streamable-HTTP endpoint `/platform/mcp`, which REQUIRES the Accept
+// header to advertise both `application/json` and `text/event-stream`. The
+// thin client must send it, else the router replies 406 "Accept must include
+// both application/json and text/event-stream" and memory is broken.
+//
+// This exercises `callPlatformTool` -> `routerCall` against a REAL loopback
+// HTTP server (no mocking of the transport), so it would have caught the
+// missing-header regression.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { callPlatformTool } from "./core/router-client.js";
+
+let server: Server | undefined;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = undefined;
+  }
+  delete process.env.KARS_ROUTER_URL;
+});
+
+/** Start a fake MCP server that enforces the same Accept negotiation the real
+ *  router does, captures the request, and returns a JSON-RPC tools/call
+ *  result. Resolves with the captured request once it's been hit. */
+function startFakeRouter(): Promise<{ port: number; captured: () => { accept?: string; body: any } }> {
+  let capturedAccept: string | undefined;
+  let capturedBody: any;
+  return new Promise((resolve) => {
+    server = createServer((req, res) => {
+      capturedAccept = req.headers["accept"];
+      let data = "";
+      req.on("data", (c) => (data += c));
+      req.on("end", () => {
+        capturedBody = JSON.parse(data || "{}");
+        const accept = (req.headers["accept"] || "") as string;
+        // Mirror the router pipeline: POST requires BOTH json + event-stream.
+        if (!(accept.includes("application/json") && accept.includes("text/event-stream"))) {
+          res.writeHead(406, { "content-type": "text/plain" });
+          res.end("Accept must include both application/json and text/event-stream");
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: capturedBody.id,
+          result: { content: [{ type: "text", text: '{"memories":[]}' }], isError: false },
+        }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server!.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ port, captured: () => ({ accept: capturedAccept, body: capturedBody }) });
+    });
+  });
+}
+
+describe("callPlatformTool — MCP Accept negotiation (foundry memory regression)", () => {
+  it("sends Accept: application/json + text/event-stream and parses the result", async () => {
+    const { port, captured } = await startFakeRouter();
+    process.env.KARS_ROUTER_URL = `http://127.0.0.1:${port}`;
+
+    const { text, isError } = await callPlatformTool("foundry.memory", {
+      operation: "search",
+      query: "coffee?",
+    });
+
+    const cap = captured();
+    expect(cap.accept).toBeDefined();
+    expect(cap.accept).toContain("application/json");
+    expect(cap.accept).toContain("text/event-stream");
+    // The JSON-RPC envelope was sent correctly.
+    expect(cap.body.method).toBe("tools/call");
+    expect(cap.body.params.name).toBe("foundry.memory");
+    expect(cap.body.params.arguments).toEqual({ operation: "search", query: "coffee?" });
+    // The router's text result is flattened back, not an error.
+    expect(isError).toBe(false);
+    expect(text).toBe('{"memories":[]}');
+  });
+
+  it("would surface the 406 as an error if the Accept header were missing", async () => {
+    // Sanity: prove the fake server actually rejects a missing Accept, so the
+    // positive test above is meaningful (not a no-op server).
+    const { port } = await startFakeRouter();
+    const res = await fetch(`http://127.0.0.1:${port}/platform/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" }, // no Accept
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "x", arguments: {} } }),
+    });
+    expect(res.status).toBe(406);
+    expect(await res.text()).toContain("Accept must include both");
+  });
+});


### PR DESCRIPTION
## Why

Agent memory was broken from **both** OpenClaw and Hermes — `foundry_memory` returned **"Accept must include both application/json and text/event-stream"** on every call (reported live after a cluster upgrade).

## Root cause (traced through every layer)

The memory tool is a thin client that posts a JSON-RPC `tools/call` to the router's `/platform/mcp` endpoint. That endpoint is **MCP Streamable-HTTP** and, per spec, requires the POST `Accept` header to advertise **both** `application/json` and `text/event-stream` (`inference-router/src/mcp/pipeline.rs::validate_accept_header`) — else it returns **HTTP 406 before any dispatch**.

The two thin clients I introduced in the v0.1.19 memory consolidation — OpenClaw `callPlatformTool`, Hermes `_call_platform_tool` — sent **no `Accept` header**. Their unit tests mocked the transport, so they never exercised the real negotiation. It's specifically these two: OpenClaw's other Foundry tools call the proxy directly, and maf-python / openai-agents / langgraph / pydantic-ai use MCP clients that already send the header.

This is purely the **client→router hop**. Store/scope resolution, the Foundry contract, IMDS auth, and RBAC were all correct — the call just never got past the 406.

## Fix

Both thin clients now send `Accept: application/json, text/event-stream` (mirroring the maf-python client). Hermes `router_client.call` gains an optional `headers` arg.

## Coverage — both sides of the contract

- **Client (the bug):** OpenClaw `platform-mcp-accept.test.ts` — a **real loopback HTTP server** that enforces the same Accept negotiation as the router; asserts the header is sent + the result parsed, and that the server 406s without it. Hermes `test_router_client.py` (headers forwarded to httpx) + `test_foundry_http_fetch.py` (memory tool sends Accept).
- **Server (the contract):** `inference-router` `platform_foundry_memory_dispatches_to_upstream_with_accept` — `/platform/mcp` + Accept → real `PlatformDispatcher` → wiremock upstream gets `:update_memories` with the correct `items[]`/`scope`/`update_delay` body; plus `platform_foundry_memory_without_accept_is_406`.

OpenClaw 125, Hermes 149, inference-router lib 951 — all green; clippy `-D warnings` + fmt + ruff + tsc + oxlint clean.

## Delivery

Ships in the `openclaw-sandbox` + `kars-runtime-hermes` images. After release, `kars upgrade` pulls them and restarts sandboxes → memory works. Will cut **v0.1.22**.