### PR TITLE
fix(cli): accept canonical `langgraph` --runtime flag (keep `lang-graph` alias)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+### Fixed — `--runtime langgraph` accepted (canonical spelling)
+
+`kars add <name> --runtime langgraph` previously failed with
+`Unknown --runtime value: langgraph` because the CLI flag parser only
+accepted the hyphenated `lang-graph`, even though the `--runtime` help
+text, the docs (`cli-reference.md`, `runtimes.md`, `README.md`), the
+controller (`plan_langgraph`), the runtime images
+(`kars-runtime-langgraph`) and the Helm values all use the unhyphenated
+`langgraph`. `langgraph` is now the canonical CLI flag; `lang-graph`
+continues to work as a back-compat alias (accepted by `flagToKind`,
+but not surfaced in pickers or the "Valid values" error text). Fixes
+the `--runtime langgraph` example shown in the getting-started guide and
+launch materials. (`cli/src/runtime.ts`, `cli/src/commands/operator/dialogs/spawn.ts`)
+
 ### Upstream alignment — AGT mesh-identity hardening merged
 
 [microsoft/agent-governance-toolkit#2719](https://github.com/microsoft/agent-governance-toolkit/pull/2719)

--- a/cli/src/commands/operator/dialogs/spawn.ts
+++ b/cli/src/commands/operator/dialogs/spawn.ts
@@ -73,7 +73,7 @@ export function openSpawnDialog(ctx: SpawnDialogContext): void {
       "openclaw":                   "OpenClaw",
       "openai-agents":              "OpenAI Agents",
       "microsoft-agent-framework":  "Microsoft Agent Framework",
-      "lang-graph":                 "LangGraph",
+      "langgraph":                  "LangGraph",
       "anthropic":                  "Anthropic Claude SDK",
       "pydantic-ai":                "Pydantic AI",
       "hermes":                     "Hermes",

--- a/cli/src/runtime.test.ts
+++ b/cli/src/runtime.test.ts
@@ -27,9 +27,29 @@ describe("flagToKind", () => {
     expect(flagToKind("OPENAI-AGENTS")).toBe("OpenAIAgents");
   });
 
+  it("resolves LangGraph via the canonical `langgraph` flag", () => {
+    expect(flagToKind("langgraph")).toBe("LangGraph");
+    expect(flagToKind("LangGraph")).toBe("LangGraph");
+  });
+
+  it("accepts the legacy hyphenated `lang-graph` as a back-compat alias", () => {
+    // `lang-graph` was the original flag spelling; `langgraph` is now
+    // canonical (matches images/controller/docs/help text). The alias
+    // must keep resolving so existing scripts don't break.
+    expect(flagToKind("lang-graph")).toBe("LangGraph");
+    expect(flagToKind("LANG-GRAPH")).toBe("LangGraph");
+  });
+
   it("throws with a helpful error on unknown flags", () => {
     expect(() => flagToKind("autogen")).toThrow(/Unknown --runtime value: autogen/);
     expect(() => flagToKind("")).toThrow(/Unknown --runtime value/);
+  });
+
+  it("does not advertise the `lang-graph` alias in the canonical valid-values list", () => {
+    // The alias is accepted but must stay out of the error text and
+    // pickers — only the canonical `langgraph` should surface.
+    expect(() => flagToKind("autogen")).toThrow(/langgraph/);
+    expect(() => flagToKind("autogen")).not.toThrow(/lang-graph/);
   });
 });
 
@@ -213,7 +233,7 @@ describe("wiredRuntimeFlags", () => {
       "openclaw",
       "openai-agents",
       "microsoft-agent-framework",
-      "lang-graph",
+      "langgraph",
       "anthropic",
       "pydantic-ai",
       "hermes",

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -33,7 +33,7 @@ export type RuntimeFlag =
   | "openai-agents"
   | "microsoft-agent-framework"
   | "semantic-kernel"
-  | "lang-graph"
+  | "langgraph"
   | "anthropic"
   | "pydantic-ai"
   | "hermes"
@@ -44,7 +44,7 @@ const FLAG_TO_KIND: Record<RuntimeFlag, RuntimeKind> = {
   "openai-agents": "OpenAIAgents",
   "microsoft-agent-framework": "MicrosoftAgentFramework",
   "semantic-kernel": "SemanticKernel",
-  "lang-graph": "LangGraph",
+  "langgraph": "LangGraph",
   "anthropic": "Anthropic",
   "pydantic-ai": "PydanticAi",
   "hermes": "Hermes",
@@ -96,8 +96,24 @@ export function wiredRuntimeFlags(): RuntimeFlag[] {
   });
 }
 
+/**
+ * Back-compat aliases accepted by `flagToKind` but intentionally NOT
+ * listed in `FLAG_TO_KIND`, so they never leak into pickers
+ * (`wiredRuntimeFlags`), the reverse `KIND_TO_FLAG` map, or the
+ * canonical "Valid values" error text. `lang-graph` was the original
+ * hyphenated flag; `langgraph` is now canonical and matches the
+ * runtime images, controller (`plan_langgraph`), Helm values, docs,
+ * and the `--runtime` help text. Old scripts using `lang-graph` keep
+ * working.
+ */
+const FLAG_ALIASES: Record<string, RuntimeFlag> = {
+  "lang-graph": "langgraph",
+};
+
 export function flagToKind(flag: string): RuntimeKind {
-  const k = FLAG_TO_KIND[flag.toLowerCase() as RuntimeFlag];
+  const normalized = flag.toLowerCase();
+  const canonical = (FLAG_ALIASES[normalized] ?? normalized) as RuntimeFlag;
+  const k = FLAG_TO_KIND[canonical];
   if (!k) {
     throw new Error(
       `Unknown --runtime value: ${flag}. ` +

--- a/docs/security-audits/2026-08-25-langgraph-runtime-alias.md
+++ b/docs/security-audits/2026-08-25-langgraph-runtime-alias.md
@@ -1,0 +1,50 @@
+# Security Audit — canonical LangGraph runtime flag
+
+Date: 2026-08-25
+Scope: `cli/src/runtime.ts`, `cli/src/runtime.test.ts`,
+`cli/src/commands/operator/dialogs/spawn.ts`, `CHANGELOG.md`.
+Gated paths: `cli/src/commands/operator/dialogs/spawn.ts`.
+
+## Summary
+
+The CLI previously documented and displayed `langgraph` while its runtime
+parser accepted only `lang-graph`. This change makes `langgraph` the canonical
+flag and keeps `lang-graph` as an accepted compatibility alias for existing
+scripts. Runtime selection still resolves to the same `LangGraph` CRD enum and
+the same runtime image/controller plan.
+
+## T1: New capability / attack surface? (NO)
+
+- No runtime, image, endpoint, credential, Kubernetes permission, or network
+  path is added.
+- Both spellings resolve to the existing `LangGraph` runtime kind.
+- The legacy spelling remains accepted but is not advertised in new pickers or
+  error messages.
+
+## T2: Security-control change? (NEUTRAL)
+
+- Runtime wiring, sandbox isolation, policy selection, and credential handling
+  are unchanged.
+- Input normalization remains a closed map from known CLI strings to the
+  existing typed `RuntimeKind`; unknown values still fail.
+
+## T3: Availability / fail-open risk? (REDUCED)
+
+- Fixes a documented command that previously failed before deployment.
+- Existing automation using `--runtime lang-graph` continues to work.
+- No fallback or silent runtime substitution is introduced.
+
+## Verification
+
+- CLI typecheck, lint, build, and full unit tests.
+- Focused runtime tests cover canonical, case-insensitive, and legacy alias
+  parsing plus picker/error-message behavior.
+- `security-audit-required`, LOC, and copyright gates.
+
+## Verdict
+
+Accept. The change fixes an inconsistent public CLI spelling while preserving
+the existing alias and runtime behavior.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@microsoft.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem

`kars add <name> --runtime langgraph` fails today:

```
Unknown --runtime value: langgraph. Valid values: …, lang-graph, …
```

The CLI flag parser (`cli/src/runtime.ts`) only accepted the **hyphenated** `lang-graph`, but the unhyphenated `langgraph` is the canonical spelling used everywhere else:

- the CLI's own `--runtime` help text (`add.ts`) — so the tool contradicted itself
- docs: `docs/cli-reference.md`, `docs/runtimes.md`, `README.md`
- controller: `plan_langgraph`, `langgraph_default_image()`
- runtime images: `kars-runtime-langgraph`, dirs `runtimes/langgraph/`
- Helm values: `runtimes.langgraph.image`
- E2E tests: `--runtime langgraph`

`lang-graph` was an accidental island in just the CLI flag parser + operator picker. This also makes the `--runtime langgraph` example in the getting-started guide / launch materials work out of the box.

## Fix

- `langgraph` is now the **canonical** flag in `FLAG_TO_KIND` and the operator TUI picker.
- `lang-graph` keeps working via a dedicated `FLAG_ALIASES` map consulted by `flagToKind()` — but it is **not** surfaced in pickers (`wiredRuntimeFlags`), the reverse `KIND_TO_FLAG` map, or the "Valid values" error text. No breakage for existing scripts.

## Tests

- Canonical `langgraph` and legacy `lang-graph` (case-insensitive) both resolve to `LangGraph`.
- The alias is asserted **absent** from the canonical valid-values error text.
- Updated the `wiredRuntimeFlags()` expected-set test to `langgraph`.

## Verification (local)

- ✅ `tsc --noEmit` clean
- ✅ `npm test` — 933 passed / 2 skipped (28 runtime tests incl. 4 new)
- ✅ `npm run lint` — 0 errors

No release cut with this PR — folding into the next batched release.