### PR TITLE
chore(release): prepare v0.1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — `crd-well-oiled-machine`
 
+## [0.1.26] — 2026-08-25
+
+### Security and dependency maintenance
+
+- Restored the current CI/security baseline after advisory and toolchain drift:
+  patched Rust and npm dependencies, retained fail-hard audit gates, and
+  preserved customer-facing CLI, CRD, router API, and mesh contracts.
+- Fixed predictable shared-temporary-file races before generated manifests are
+  consumed by `kubectl` or `az`.
+- Upgraded and corrected Sigstore verification, explicitly selected JWT crypto
+  providers under workspace feature unification, and refreshed verified
+  build/release action pins.
+- Cleared the actionable Dependabot and serious CodeQL backlog; remaining
+  findings were either fixed or dispositioned with documented rationale.
+
+### Fixed
+
+- `kars add <name> --runtime langgraph` now accepts the canonical spelling.
+  The historical `lang-graph` spelling remains supported as a compatibility
+  alias for existing scripts.
+
 ### Fixed — `--runtime langgraph` accepted (canonical spelling)
 
 `kars add <name> --runtime langgraph` previously failed with

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kars-runtime/cli",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kars-runtime/cli",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Enterprise-grade runtime for running OpenClaw AI assistants safely on Azure",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.1.26

Patch release containing the merged maintenance work:

- dependency/security baseline restoration (#499)
- verified compatible dependency refresh (#500)
- canonical `langgraph` runtime flag with `lang-graph` compatibility alias (#483)
- real CodeQL temporary-file race remediation and security alert cleanup

## Release metadata

- `@kars-runtime/cli`: 0.1.25 → 0.1.26
- package lock root version updated
- CHANGELOG release section added

## Evidence

- current main passed complete CI after #483
- CLI typecheck, lint, build and 933 tests passed
- `npm pack --dry-run` produced `kars-runtime-cli-0.1.26.tgz`
- `v0.1.26` is unused on GitHub and npm

After merge, an annotated `v0.1.26` tag will trigger the signed public release pipeline. No cluster deployment is part of this PR.