### PR TITLE
feat(helm): support existing Kubernetes clusters

### DIFF
--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -2,9 +2,9 @@ name: ci-gates
 
 on:
   pull_request:
-    branches: [main, 'public/pr*']
+    branches: [main, kars-bridge, 'public/pr*']
   push:
-    branches: [main]
+    branches: [main, kars-bridge]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -2,7 +2,7 @@ name: ci-gates
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'public/pr*']
   push:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,10 @@ jobs:
             --values deploy/helm/kars/values-generic.yaml >/tmp/kars-generic.yaml
           grep -q 'name: agentmesh-relay' /tmp/kars-generic.yaml
           grep -q 'name: agentmesh-registry' /tmp/kars-generic.yaml
+          helm template kars deploy/helm/kars --namespace kars-system \
+            --values deploy/helm/kars/values-existing-aks.yaml >/tmp/kars-existing-aks.yaml
+          grep -q 'REPLACE_ME.azurecr.io/kars-controller:latest' /tmp/kars-existing-aks.yaml
+          grep -q 'name: agentmesh-relay' /tmp/kars-existing-aks.yaml
 
   security-scan:
     name: Security Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       # of denying warnings (cargo's default warning bar is roughly
       # equivalent to RUSTSEC `high`).
       - name: npm audit (CLI dependencies)
-        run: npm audit --audit-level=high
+        run: npm audit --package-lock-only --audit-level=high
 
   runtime-openclaw-build:
     name: Runtime OpenClaw Build & Test
@@ -288,7 +288,10 @@ jobs:
       - run: npm run build
       - run: npm test
       - name: npm audit (Runtime OpenClaw dependencies)
-        run: npm audit --audit-level=high
+        # Audit the lockfile rather than the installed tree: @kars/mesh is a
+        # local file dependency, which the retiring quick-audit endpoint rejects
+        # as an "invalid package tree" even after a successful npm install.
+        run: npm audit --package-lock-only --audit-level=high
 
   mesh-plugin-build:
     name: Mesh Plugin Build & Test
@@ -307,7 +310,7 @@ jobs:
       - run: npm test
       - name: npm audit (Mesh Plugin dependencies)
         working-directory: mesh-plugin
-        run: npm audit --audit-level=high
+        run: npm audit --package-lock-only --audit-level=high
 
   python-sidecar:
     name: Python Lint & Test (AGT Sidecar)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,9 @@ jobs:
           helm template kars deploy/helm/kars --namespace kars-system \
             --values deploy/helm/kars/values-local-dev.yaml >/dev/null
           helm template kars deploy/helm/kars --namespace kars-system \
-            --values deploy/helm/kars/values-generic.yaml >/dev/null
+            --values deploy/helm/kars/values-generic.yaml >/tmp/kars-generic.yaml
+          grep -q 'name: agentmesh-relay' /tmp/kars-generic.yaml
+          grep -q 'name: agentmesh-registry' /tmp/kars-generic.yaml
 
   security-scan:
     name: Security Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,7 +411,7 @@ jobs:
           grep -q 'name: agentmesh-registry' /tmp/kars-generic.yaml
           helm template kars deploy/helm/kars --namespace kars-system \
             --values deploy/helm/kars/values-existing-aks.yaml >/tmp/kars-existing-aks.yaml
-          grep -q 'REPLACE_ME.azurecr.io/kars-controller:latest' /tmp/kars-existing-aks.yaml
+          grep -q 'ghcr.io/azure/kars-controller:latest' /tmp/kars-existing-aks.yaml
           grep -q 'name: agentmesh-relay' /tmp/kars-existing-aks.yaml
 
   security-scan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       # of denying warnings (cargo's default warning bar is roughly
       # equivalent to RUSTSEC `high`).
       - name: npm audit (CLI dependencies)
-        run: npm audit --package-lock-only --audit-level=high
+        run: node ../ci/npm-audit-bulk.mjs package-lock.json
 
   runtime-openclaw-build:
     name: Runtime OpenClaw Build & Test
@@ -288,10 +288,7 @@ jobs:
       - run: npm run build
       - run: npm test
       - name: npm audit (Runtime OpenClaw dependencies)
-        # Audit the lockfile rather than the installed tree: @kars/mesh is a
-        # local file dependency, which the retiring quick-audit endpoint rejects
-        # as an "invalid package tree" even after a successful npm install.
-        run: npm audit --package-lock-only --audit-level=high
+        run: node ../../ci/npm-audit-bulk.mjs package-lock.json
 
   mesh-plugin-build:
     name: Mesh Plugin Build & Test
@@ -310,7 +307,7 @@ jobs:
       - run: npm test
       - name: npm audit (Mesh Plugin dependencies)
         working-directory: mesh-plugin
-        run: npm audit --package-lock-only --audit-level=high
+        run: node ../ci/npm-audit-bulk.mjs package-lock.json
 
   python-sidecar:
     name: Python Lint & Test (AGT Sidecar)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       - run: helm lint deploy/helm/kars
+      - name: Render installation profiles
+        run: |
+          helm template kars deploy/helm/kars --namespace kars-system >/dev/null
+          helm template kars deploy/helm/kars --namespace kars-system \
+            --values deploy/helm/kars/values-local-dev.yaml >/dev/null
+          helm template kars deploy/helm/kars --namespace kars-system \
+            --values deploy/helm/kars/values-generic.yaml >/dev/null
 
   security-scan:
     name: Security Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, 'public/pr*']
   workflow_call:      # allow reuse from release.yml
   workflow_dispatch:  # manual trigger
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, kars-bridge]
   pull_request:
-    branches: [main, dev, 'public/pr*']
+    branches: [main, dev, kars-bridge, 'public/pr*']
   workflow_call:      # allow reuse from release.yml
   workflow_dispatch:  # manual trigger
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, kars-bridge]
   pull_request:
-    branches: [main, dev, 'public/pr*']
+    branches: [main, dev, kars-bridge, 'public/pr*']
   schedule:
     - cron: "30 5 * * 1"  # Monday 05:30 UTC
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, 'public/pr*']
   schedule:
     - cron: "30 5 * * 1"  # Monday 05:30 UTC
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'public/pr*']
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main, 'public/pr*']
+    branches: [main, kars-bridge, 'public/pr*']
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'public/pr*']
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -2,9 +2,9 @@ name: Secret Scanning
 
 on:
   push:
-    branches: [main]
+    branches: [main, kars-bridge]
   pull_request:
-    branches: [main, 'public/pr*']
+    branches: [main, kars-bridge, 'public/pr*']
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -185,8 +185,32 @@ On first launch you pick an inference provider — **GitHub Copilot** is easiest
 (one device-code login, no Azure account). The CLI on npm is **build-provenance
 attested** (SLSA) — verify with `npm audit signatures` after install.
 
-When you're ready for a managed cluster, `kars up` provisions AKS (see
-[Getting started → Deploy to AKS](docs/getting-started.md#step-2--deploy-to-aks)).
+When you're ready for a managed cluster, either let `kars up` provision the
+complete Azure stack, or install the Helm chart into infrastructure you already
+operate. See [Deploy to AKS](docs/getting-started.md#step-2--deploy-to-aks) and
+[Install with Helm](docs/how-to/helm-installation.md).
+
+For an existing AKS cluster:
+
+```bash
+helm upgrade --install kars deploy/helm/kars \
+  --namespace kars-system \
+  --create-namespace \
+  --values my-aks-values.yaml
+
+kars config adopt-aks \
+  --subscription <subscription-id> \
+  --region <region> \
+  --resource-group <resource-group> \
+  --cluster <aks-name> \
+  --acr-login-server <registry>.azurecr.io \
+  --context <kube-context>
+```
+
+Helm installs the Kars CRDs and controller. The adoption command verifies the
+installation and records its existing Azure metadata for `kars upgrade`,
+`push`, mesh lifecycle, and advanced `add` flows; it does not provision or
+change infrastructure.
 
 <details>
 <summary>Other ways to install</summary>

--- a/ci/npm-audit-bulk.mjs
+++ b/ci/npm-audit-bulk.mjs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { readFile } from "node:fs/promises";
+
+const lockPath = process.argv[2] ?? "package-lock.json";
+const lock = JSON.parse(await readFile(lockPath, "utf8"));
+const versions = new Map();
+
+for (const [path, metadata] of Object.entries(lock.packages ?? {})) {
+  if (!path || metadata.link || typeof metadata.version !== "string") continue;
+  const marker = "node_modules/";
+  const index = path.lastIndexOf(marker);
+  if (index < 0) continue;
+  const parts = path.slice(index + marker.length).split("/");
+  const name = parts[0]?.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+  if (!name) continue;
+  if (!versions.has(name)) versions.set(name, new Set());
+  versions.get(name).add(metadata.version);
+}
+
+const payload = Object.fromEntries(
+  [...versions.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, packageVersions]) => [name, [...packageVersions].sort()]),
+);
+
+const endpoint = "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk";
+let response;
+let lastError;
+for (let attempt = 1; attempt <= 4; attempt += 1) {
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (error) {
+    lastError = error;
+    if (attempt < 4) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 5_000));
+      continue;
+    }
+  }
+  if (!response) continue;
+  if (response.ok || (response.status !== 429 && response.status < 500)) break;
+  if (attempt < 4) await new Promise((resolve) => setTimeout(resolve, attempt * 5_000));
+}
+
+if (!response) {
+  throw new Error("npm bulk advisory request failed after four transport attempts", {
+    cause: lastError,
+  });
+}
+if (!response?.ok) {
+  const body = await response?.text();
+  throw new Error(
+    `npm bulk advisory request failed (${response?.status ?? "no response"}): ${body?.slice(0, 500) ?? ""}`,
+  );
+}
+
+const result = await response.json();
+const advisories = Object.values(result).flatMap((entries) =>
+  Array.isArray(entries) ? entries : [],
+);
+const blocking = advisories.filter((advisory) =>
+  advisory.severity === "high" || advisory.severity === "critical",
+);
+
+for (const advisory of advisories) {
+  console.log(
+    `${advisory.severity ?? "unknown"}: ${advisory.name ?? "package"} — ${advisory.title ?? advisory.url ?? "advisory"}`,
+  );
+}
+console.log(
+  `npm bulk audit: ${Object.keys(payload).length} packages, ${advisories.length} advisories, ${blocking.length} blocking`,
+);
+
+if (blocking.length > 0) process.exitCode = 1;

--- a/ci/npm-audit-bulk.mjs
+++ b/ci/npm-audit-bulk.mjs
@@ -89,7 +89,7 @@ for (const [name, entries] of Object.entries(result)) {
   }
   for (const advisory of entries) {
     if (!isRecord(advisory) ||
-        advisory.name !== name ||
+        (Object.hasOwn(advisory, "name") && advisory.name !== name) ||
         !Number.isSafeInteger(advisory.id) || advisory.id <= 0 ||
         !severities.has(advisory.severity) ||
         !isNonemptyString(advisory.title) ||
@@ -97,7 +97,9 @@ for (const [name, entries] of Object.entries(result)) {
         !isNonemptyString(advisory.vulnerable_versions)) {
       throw new Error(`Invalid npm advisory entry for package: ${name}`);
     }
-    advisories.push(advisory);
+    // npm's bulk fixtures identify the package by the map key, without a
+    // redundant name field (npm/metavuln-calculator normalizes it likewise).
+    advisories.push({ ...advisory, name });
   }
 }
 const blocking = advisories.filter((advisory) =>

--- a/ci/npm-audit-bulk.mjs
+++ b/ci/npm-audit-bulk.mjs
@@ -5,18 +5,36 @@ import { readFile } from "node:fs/promises";
 
 const lockPath = process.argv[2] ?? "package-lock.json";
 const lock = JSON.parse(await readFile(lockPath, "utf8"));
+const isRecord = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+const isNonemptyString = (value) =>
+  typeof value === "string" && value.trim().length > 0;
+if (!isRecord(lock) || ![2, 3].includes(lock.lockfileVersion) || !isRecord(lock.packages)) {
+  throw new Error("npm audit requires a version 2 or 3 lockfile with a packages map");
+}
 const versions = new Map();
 
-for (const [path, metadata] of Object.entries(lock.packages ?? {})) {
-  if (!path || metadata.link || typeof metadata.version !== "string") continue;
+for (const [path, metadata] of Object.entries(lock.packages)) {
+  if (!isRecord(metadata)) throw new Error(`Invalid lockfile entry: ${path}`);
+  if (!path || metadata.link === true) continue;
   const marker = "node_modules/";
   const index = path.lastIndexOf(marker);
   if (index < 0) continue;
+  if (!isNonemptyString(metadata.version)) {
+    throw new Error(`Missing package version in lockfile: ${path}`);
+  }
   const parts = path.slice(index + marker.length).split("/");
-  const name = parts[0]?.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
-  if (!name) continue;
+  // npm aliases retain the registry package name in metadata.name.
+  const name = metadata.name ??
+    (parts[0]?.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]);
+  if (typeof name !== "string" || !/^(?:@[^/@\s]+\/)?[^/@\s]+$/.test(name)) {
+    throw new Error(`Invalid package name in lockfile: ${path}`);
+  }
   if (!versions.has(name)) versions.set(name, new Set());
   versions.get(name).add(metadata.version);
+}
+if (versions.size === 0) {
+  throw new Error("Lockfile contains no auditable package versions");
 }
 
 const payload = Object.fromEntries(
@@ -27,7 +45,6 @@ const payload = Object.fromEntries(
 
 const endpoint = "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk";
 let response;
-let lastError;
 for (let attempt = 1; attempt <= 4; attempt += 1) {
   try {
     response = await fetch(endpoint, {
@@ -40,40 +57,56 @@ for (let attempt = 1; attempt <= 4; attempt += 1) {
       signal: AbortSignal.timeout(60_000),
     });
   } catch (error) {
-    lastError = error;
-    if (attempt < 4) {
-      await new Promise((resolve) => setTimeout(resolve, attempt * 5_000));
-      continue;
+    if (attempt === 4) {
+      throw new Error("npm bulk advisory request failed after four attempts", { cause: error });
     }
+    console.error(`npm audit transport failure (${attempt}/4): ${error.message}`);
+    await new Promise((resolve) => setTimeout(resolve, attempt * 5_000));
+    continue;
   }
-  if (!response) continue;
   if (response.ok || (response.status !== 429 && response.status < 500)) break;
-  if (attempt < 4) await new Promise((resolve) => setTimeout(resolve, attempt * 5_000));
+  if (attempt < 4) {
+    console.error(`npm audit HTTP ${response.status} (${attempt}/4); retrying`);
+    await response.body?.cancel();
+    await new Promise((resolve) => setTimeout(resolve, attempt * 5_000));
+  }
 }
 
-if (!response) {
-  throw new Error("npm bulk advisory request failed after four transport attempts", {
-    cause: lastError,
-  });
-}
-if (!response?.ok) {
-  const body = await response?.text();
+if (!response.ok) {
+  const body = await response.text();
   throw new Error(
-    `npm bulk advisory request failed (${response?.status ?? "no response"}): ${body?.slice(0, 500) ?? ""}`,
+    `npm bulk advisory request failed (${response.status}): ${body.slice(0, 500)}`,
   );
 }
 
 const result = await response.json();
-const advisories = Object.values(result).flatMap((entries) =>
-  Array.isArray(entries) ? entries : [],
-);
+if (!isRecord(result)) throw new Error("Invalid npm advisory response: expected a package map");
+const severities = new Set(["info", "low", "moderate", "high", "critical"]);
+const advisories = [];
+for (const [name, entries] of Object.entries(result)) {
+  if (!versions.has(name) || !Array.isArray(entries)) {
+    throw new Error(`Invalid npm advisory response for package: ${name}`);
+  }
+  for (const advisory of entries) {
+    if (!isRecord(advisory) ||
+        advisory.name !== name ||
+        !Number.isSafeInteger(advisory.id) || advisory.id <= 0 ||
+        !severities.has(advisory.severity) ||
+        !isNonemptyString(advisory.title) ||
+        !isNonemptyString(advisory.url) ||
+        !isNonemptyString(advisory.vulnerable_versions)) {
+      throw new Error(`Invalid npm advisory entry for package: ${name}`);
+    }
+    advisories.push(advisory);
+  }
+}
 const blocking = advisories.filter((advisory) =>
   advisory.severity === "high" || advisory.severity === "critical",
 );
 
 for (const advisory of advisories) {
   console.log(
-    `${advisory.severity ?? "unknown"}: ${advisory.name ?? "package"} — ${advisory.title ?? advisory.url ?? "advisory"}`,
+    `${advisory.severity}: ${advisory.name} - ${advisory.title} (${advisory.url})`,
   );
 }
 console.log(

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -22,8 +22,9 @@ import inquirer from "inquirer";
 import { existsSync, unlinkSync, writeFileSync, chmodSync, mkdirSync, readFileSync } from "fs";
 
 import {
-  loadConfig, saveSecrets, resetFirstRunFlag,
+  loadConfig, saveContext, saveSecrets, resetFirstRunFlag,
   CONFIG_DIR, CONFIG_FILE, CREDENTIALS_FILE, SECRETS_FILE,
+  type DeploymentContext,
   validateGithubModelsConfig,
 } from "../config.js";
 import {
@@ -38,6 +39,7 @@ export function configCommand(): Command {
 
   cmd.addCommand(showCmd());
   cmd.addCommand(modelCmd());
+  cmd.addCommand(adoptAksCmd());
   cmd.addCommand(resetCmd());
 
   return cmd;
@@ -81,6 +83,101 @@ function showCmd(): Command {
         }
         console.log();
       }
+    });
+}
+
+export function buildAdoptedAksContext(input: {
+  subscription: string;
+  region: string;
+  resourceGroup: string;
+  cluster: string;
+  acrLoginServer: string;
+  wiClientId?: string;
+  identityName?: string;
+  identityResourceGroup?: string;
+  oidcIssuerUrl?: string;
+  foundryEndpoint?: string;
+  foundryProjectEndpoint?: string;
+  keyVaultName?: string;
+}): DeploymentContext {
+  const acrLoginServer = input.acrLoginServer.trim().replace(/^https?:\/\//, "").replace(/\/+$/, "");
+  if (!acrLoginServer.endsWith(".azurecr.io")) {
+    throw new Error("--acr-login-server must be an Azure Container Registry host (*.azurecr.io)");
+  }
+  return {
+    subscription: input.subscription.trim(),
+    region: input.region.trim(),
+    resourceGroup: input.resourceGroup.trim(),
+    aksCluster: input.cluster.trim(),
+    acrLoginServer,
+    acrName: acrLoginServer.slice(0, -".azurecr.io".length),
+    wiClientId: input.wiClientId?.trim() || undefined,
+    identityName: input.identityName?.trim() || undefined,
+    identityResourceGroup: input.identityResourceGroup?.trim() || input.resourceGroup.trim(),
+    oidcIssuerUrl: input.oidcIssuerUrl?.trim() || undefined,
+    foundryEndpoint: input.foundryEndpoint?.trim() || undefined,
+    foundryProjectEndpoint: input.foundryProjectEndpoint?.trim() || undefined,
+    keyVaultName: input.keyVaultName?.trim() || undefined,
+    registryMode: "local",
+    phase: "complete",
+  };
+}
+
+function adoptAksCmd(): Command {
+  return new Command("adopt-aks")
+    .description("Register an existing Helm-installed AKS cluster with this CLI")
+    .requiredOption("--subscription <id>", "Azure subscription ID")
+    .requiredOption("--region <region>", "AKS region")
+    .requiredOption("--resource-group <name>", "AKS resource group")
+    .requiredOption("--cluster <name>", "AKS cluster name")
+    .requiredOption("--acr-login-server <host>", "ACR login server, e.g. contoso.azurecr.io")
+    .option("--context <name>", "Kubernetes context (defaults to current context)")
+    .option("--wi-client-id <id>", "Kars controller Workload Identity client ID")
+    .option("--identity-name <name>", "Kars managed identity name")
+    .option("--identity-resource-group <name>", "Managed identity resource group")
+    .option("--oidc-issuer-url <url>", "AKS OIDC issuer URL")
+    .option("--foundry-endpoint <url>", "Foundry/Azure OpenAI endpoint")
+    .option("--foundry-project-endpoint <url>", "Foundry project endpoint")
+    .option("--key-vault-name <name>", "Key Vault name")
+    .action(async (options) => {
+      const { execa } = await import("execa");
+      const kubectlContext = options.context ? ["--context", options.context] : [];
+      await execa(
+        "kubectl",
+        [
+          ...kubectlContext,
+          "get",
+          "crd",
+          "karssandboxes.kars.azure.com",
+          "--output",
+          "name",
+        ],
+        { stdio: "pipe" },
+      );
+      const helmContext = options.context ? ["--kube-context", options.context] : [];
+      await execa("helm", [...helmContext, "status", "kars", "--namespace", "kars-system"], {
+        stdio: "pipe",
+      });
+
+      const context = buildAdoptedAksContext({
+        subscription: options.subscription,
+        region: options.region,
+        resourceGroup: options.resourceGroup,
+        cluster: options.cluster,
+        acrLoginServer: options.acrLoginServer,
+        wiClientId: options.wiClientId,
+        identityName: options.identityName,
+        identityResourceGroup: options.identityResourceGroup,
+        oidcIssuerUrl: options.oidcIssuerUrl,
+        foundryEndpoint: options.foundryEndpoint,
+        foundryProjectEndpoint: options.foundryProjectEndpoint,
+        keyVaultName: options.keyVaultName,
+      });
+      saveContext(context);
+      console.log(chalk.green("\n  ✔ Existing AKS installation registered with the Kars CLI."));
+      console.log(chalk.dim(`    Cluster: ${context.aksCluster} (${context.resourceGroup})`));
+      console.log(chalk.dim(`    ACR:     ${context.acrLoginServer}`));
+      console.log(chalk.dim(`    Context: ~/.kars/context.json\n`));
     });
 }
 

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -91,7 +91,7 @@ export function buildAdoptedAksContext(input: {
   region: string;
   resourceGroup: string;
   cluster: string;
-  acrLoginServer: string;
+  acrLoginServer?: string;
   wiClientId?: string;
   identityName?: string;
   identityResourceGroup?: string;
@@ -100,8 +100,11 @@ export function buildAdoptedAksContext(input: {
   foundryProjectEndpoint?: string;
   keyVaultName?: string;
 }): DeploymentContext {
-  const acrLoginServer = input.acrLoginServer.trim().replace(/^https?:\/\//, "").replace(/\/+$/, "");
-  if (!acrLoginServer.endsWith(".azurecr.io")) {
+  const acrLoginServer = input.acrLoginServer
+    ?.trim()
+    .replace(/^https?:\/\//, "")
+    .replace(/\/+$/, "");
+  if (acrLoginServer && !acrLoginServer.endsWith(".azurecr.io")) {
     throw new Error("--acr-login-server must be an Azure Container Registry host (*.azurecr.io)");
   }
   return {
@@ -109,8 +112,8 @@ export function buildAdoptedAksContext(input: {
     region: input.region.trim(),
     resourceGroup: input.resourceGroup.trim(),
     aksCluster: input.cluster.trim(),
-    acrLoginServer,
-    acrName: acrLoginServer.slice(0, -".azurecr.io".length),
+    acrLoginServer: acrLoginServer || undefined,
+    acrName: acrLoginServer?.slice(0, -".azurecr.io".length),
     wiClientId: input.wiClientId?.trim() || undefined,
     identityName: input.identityName?.trim() || undefined,
     identityResourceGroup: input.identityResourceGroup?.trim() || input.resourceGroup.trim(),
@@ -130,7 +133,7 @@ function adoptAksCmd(): Command {
     .requiredOption("--region <region>", "AKS region")
     .requiredOption("--resource-group <name>", "AKS resource group")
     .requiredOption("--cluster <name>", "AKS cluster name")
-    .requiredOption("--acr-login-server <host>", "ACR login server, e.g. contoso.azurecr.io")
+    .option("--acr-login-server <host>", "Optional ACR mirror used by kars push/upgrade")
     .option("--context <name>", "Kubernetes context (defaults to current context)")
     .option("--wi-client-id <id>", "Kars controller Workload Identity client ID")
     .option("--identity-name <name>", "Kars managed identity name")
@@ -176,7 +179,7 @@ function adoptAksCmd(): Command {
       saveContext(context);
       console.log(chalk.green("\n  ✔ Existing AKS installation registered with the Kars CLI."));
       console.log(chalk.dim(`    Cluster: ${context.aksCluster} (${context.resourceGroup})`));
-      console.log(chalk.dim(`    ACR:     ${context.acrLoginServer}`));
+      console.log(chalk.dim(`    Images:  ${context.acrLoginServer ?? "public ghcr.io/azure"}`));
       console.log(chalk.dim(`    Context: ~/.kars/context.json\n`));
     });
 }

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -19,6 +19,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import inquirer from "inquirer";
+import { verifyAdoptedTarget } from "../lib/deployment-target.js";
 import { existsSync, unlinkSync, writeFileSync, chmodSync, mkdirSync, readFileSync } from "fs";
 
 import {
@@ -144,24 +145,6 @@ function adoptAksCmd(): Command {
     .option("--key-vault-name <name>", "Key Vault name")
     .action(async (options) => {
       const { execa } = await import("execa");
-      const kubectlContext = options.context ? ["--context", options.context] : [];
-      await execa(
-        "kubectl",
-        [
-          ...kubectlContext,
-          "get",
-          "crd",
-          "karssandboxes.kars.azure.com",
-          "--output",
-          "name",
-        ],
-        { stdio: "pipe" },
-      );
-      const helmContext = options.context ? ["--kube-context", options.context] : [];
-      await execa("helm", [...helmContext, "status", "kars", "--namespace", "kars-system"], {
-        stdio: "pipe",
-      });
-
       const context = buildAdoptedAksContext({
         subscription: options.subscription,
         region: options.region,
@@ -176,6 +159,9 @@ function adoptAksCmd(): Command {
         foundryProjectEndpoint: options.foundryProjectEndpoint,
         keyVaultName: options.keyVaultName,
       });
+      const scoped = await verifyAdoptedTarget(execa, context, options.context);
+      await scoped("kubectl", ["get", "crd", "karssandboxes.kars.azure.com", "--output", "name"], { stdio: "pipe" });
+      await scoped("helm", ["status", "kars", "--namespace", "kars-system"], { stdio: "pipe" });
       saveContext(context);
       console.log(chalk.green("\n  ✔ Existing AKS installation registered with the Kars CLI."));
       console.log(chalk.dim(`    Cluster: ${context.aksCluster} (${context.resourceGroup})`));

--- a/cli/src/commands/push-apply.test.ts
+++ b/cli/src/commands/push-apply.test.ts
@@ -1,0 +1,274 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, vi } from "vitest";
+import { applyPushedImages } from "./push-apply.js";
+import { controllerEnv, RUNTIME_IMAGE_TARGETS, type PushedImage } from "../lib/image-targets.js";
+import type { Execute } from "../lib/deployment-target.js";
+import type { DeploymentRecord } from "../lib/core-image-apply.js";
+import { releaseImagePlan } from "../lib/release.js";
+import { planSandboxImages } from "../lib/sandbox-image-apply.js";
+
+const digest = `sha256:${"a".repeat(64)}`;
+const pushed = (name: string): PushedImage => ({
+  name, image: `mirror.azurecr.io/${name === "sandbox" ? "openclaw-sandbox" : name === "router" ? "kars-inference-router"
+    : name === "relay" || name === "registry" ? `agentmesh-${name}-agt`
+    : RUNTIME_IMAGE_TARGETS.find(item => item.name === name)?.repo ?? `kars-${name}`}:latest`,
+});
+const reference = (name: string) => `${pushed(name).image}@${digest}`;
+const helmMetadata = () => ({
+  labels: { "app.kubernetes.io/managed-by": "Helm" },
+  annotations: { "meta.helm.sh/release-name": "kars", "meta.helm.sh/release-namespace": "kars-system" },
+});
+const healthy = () => ({ observedGeneration: 1, updatedReplicas: 1, readyReplicas: 1, conditions: [{ type: "Available", status: "True" }] });
+
+function setPath(object: Record<string, unknown>, key: string, value: string) {
+  const parts = key.split(".");
+  let target = object;
+  for (const part of parts.slice(0, -1)) target = (target[part] ??= {}) as Record<string, unknown>;
+  target[parts.at(-1)!] = value;
+}
+function getPath(object: Record<string, unknown>, path: string): string {
+  return path.split(".").reduce<unknown>((current, key) => (current as Record<string, unknown>)[key], object) as string;
+}
+
+function fixture(options: { legacyCore?: boolean; mesh?: "absent" | "helm" | "external"; fail?: string; mismatch?: boolean } = {}) {
+  const values: Record<string, unknown> = {
+    controller: { image: { repository: "ghcr.io/azure/kars-controller", tag: "v1.0.0", pullPolicy: "IfNotPresent" } },
+    inferenceRouter: { image: { repository: "ghcr.io/azure/kars-inference-router", tag: "v1.0.0" } },
+    sandbox: { image: { repository: "ghcr.io/azure/openclaw-sandbox", tag: "v1.0.0" } },
+    azure: { workloadIdentity: { clientId: "customer-wi" }, keyVaultCsi: { keyVaultName: "customer-vault" } },
+    agentMesh: { enabled: options.mesh === "helm" },
+  };
+  for (const runtime of RUNTIME_IMAGE_TARGETS) setPath(values, runtime.valueKey, `ghcr.io/azure/${runtime.repo}:v1.0.0`);
+  const controller: DeploymentRecord = {
+    metadata: { name: "kars-controller", namespace: "kars-system", resourceVersion: "1", generation: 1, ...(options.legacyCore ? {} : helmMetadata()) },
+    spec: { replicas: 1, template: { spec: { containers: [{
+      name: "controller", image: "ghcr.io/azure/kars-controller:v1.0.0", imagePullPolicy: "IfNotPresent",
+      env: [
+        { name: "SANDBOX_IMAGE", value: "ghcr.io/azure/openclaw-sandbox:v1.0.0" },
+        { name: "INFERENCE_ROUTER_IMAGE", value: "ghcr.io/azure/kars-inference-router:v1.0.0" },
+        ...RUNTIME_IMAGE_TARGETS.map(item => ({ name: item.env, value: getPath(values, item.valueKey) })),
+        { name: "CUSTOMER_SETTING", value: "retain-me" },
+      ],
+    }] } } }, status: healthy(),
+  };
+  const crs: Array<{ metadata: { name: string; namespace: string }; spec: { runtime: Record<string, unknown> } }> = [];
+  const sandboxes: DeploymentRecord[] = [];
+  const meshResources = options.mesh && options.mesh !== "absent" ? ["registry", "relay"].flatMap(component => {
+    const metadata = options.mesh === "helm" ? helmMetadata() : {
+      labels: { "app.kubernetes.io/managed-by": "platform-controller" }, annotations: {},
+    };
+    return [
+      { kind: "Deployment", metadata: { name: options.mesh === "external" ? `platform-${component}` : component, namespace: "agentmesh", generation: 1, ...metadata },
+        spec: { replicas: 1, template: { metadata: { labels: { app: `platform-${component}` } },
+          spec: { containers: [{ name: component, image: `old.example/${component}:old` }] } } }, status: healthy() },
+      { kind: "Service", metadata: { name: `agentmesh-${component}`, ...metadata }, spec: { selector: { app: `platform-${component}` } } },
+    ];
+  }) : [];
+  function addSandbox(name: string, kind: string, variant: string, config: Record<string, unknown> = {}) {
+    const cr = { metadata: { name, namespace: "kars-system" }, spec: { runtime: { kind, [variant]: config } } };
+    crs.push(cr);
+    const runtime = RUNTIME_IMAGE_TARGETS.find(item => item.kind === kind && (!item.language || (config.language ?? "python") === item.language));
+    const agentImage = typeof config.image === "string" ? config.image
+      : kind === "OpenClaw" ? "ghcr.io/azure/openclaw-sandbox:v1.0.0" : `ghcr.io/azure/${runtime?.repo}:v1.0.0`;
+    const deployment: DeploymentRecord = {
+      metadata: { name, namespace: `kars-${name}`, generation: 1, labels: { "kars.azure.com/sandbox": name, "kars.azure.com/parent-namespace": "kars-system" } },
+      spec: { replicas: 1, template: { spec: {
+        containers: [{ name: kind === "OpenClaw" ? "openclaw" : "agent", image: agentImage },
+          { name: "inference-router", image: "ghcr.io/azure/kars-inference-router:v1.0.0" }],
+        initContainers: [{ name: "egress-guard", image: "ghcr.io/azure/openclaw-sandbox:v1.0.0" }],
+      } } }, status: healthy(),
+    };
+    sandboxes.push(deployment);
+    return { cr, deployment };
+  }
+  function materialize(name: string) {
+    if (options.mismatch) return;
+    const cr = crs.find(item => item.metadata.name === name)!;
+    const deployment = sandboxes.find(item => item.metadata.name === name)!;
+    const vars = controller.spec.template.spec.containers[0].env!;
+    const image = (key: string) => vars.find(item => item.name === key)!.value!;
+    deployment.spec.template.spec.containers.find(item => item.name === "inference-router")!.image = image("INFERENCE_ROUTER_IMAGE");
+    deployment.spec.template.spec.initContainers![0].image = image("SANDBOX_IMAGE");
+    const kind = cr.spec.runtime.kind;
+    const target = RUNTIME_IMAGE_TARGETS.find(item => item.kind === kind
+      && (!item.language || ((cr.spec.runtime[item.variant] as { language?: string })?.language ?? "python") === item.language));
+    const config = cr.spec.runtime[kind === "OpenClaw" ? "openclaw" : target?.variant ?? "byo"] as { image?: string };
+    deployment.spec.template.spec.containers[0].image = config?.image ?? image(kind === "OpenClaw" ? "SANDBOX_IMAGE" : target!.env);
+  }
+  const execute = vi.fn(async (bin: string, args: readonly string[]) => {
+    if (options.fail && (args[0] === options.fail || args.includes(options.fail))) throw new Error(`failed ${options.fail}`);
+    if (bin === "az") return { stdout: digest };
+    if (bin === "helm" && args[0] === "list") return { stdout: JSON.stringify([{ name: "kars", chart: "kars-0.1.0" }]) };
+    if (bin === "helm" && args[0] === "get") return { stdout: JSON.stringify(values) };
+    if (bin === "helm" && args[0] === "upgrade") {
+      for (const arg of args.filter(arg => arg.includes("="))) {
+        const at = arg.indexOf("=");
+        setPath(values, arg.slice(0, at), arg.slice(at + 1));
+      }
+      const c = controller.spec.template.spec.containers[0];
+      if (!options.mismatch) c.image = `${getPath(values, "controller.image.repository")}:${getPath(values, "controller.image.tag")}`;
+      for (const name of ["router", "sandbox", ...RUNTIME_IMAGE_TARGETS.map(item => item.name)]) {
+        const target = RUNTIME_IMAGE_TARGETS.find(item => item.name === name);
+        const key = name === "router" ? "inferenceRouter" : name;
+        c.env!.find(item => item.name === controllerEnv(name))!.value = target ? getPath(values, target.valueKey)
+          : `${getPath(values, `${key}.image.repository`)}:${getPath(values, `${key}.image.tag`)}`;
+      }
+      for (const resource of meshResources.filter(item => options.mesh === "helm" && item.kind === "Deployment")) {
+        const component = resource.metadata.name;
+        const prefix = `agentMesh.${component}.image`;
+        resource.spec.template!.spec.containers[0].image = `${getPath(values, `${prefix}.repository`)}:${getPath(values, `${prefix}.tag`)}`;
+      }
+    }
+    if (bin === "kubectl" && args[0] === "patch") {
+      const ops = JSON.parse(args[args.indexOf("-p") + 1]) as Array<{ op: string; path: string; value: unknown }>;
+      for (const op of ops.filter(item => item.op !== "test")) {
+        const c = controller.spec.template.spec.containers[0];
+        if (op.path.endsWith("/env")) c.env = op.value as typeof c.env;
+        if (op.path.endsWith("/image")) c.image = op.value as string;
+        if (op.path.endsWith("/imagePullPolicy")) c.imagePullPolicy = op.value as string;
+      }
+    }
+    if (bin === "kubectl" && args[0] === "annotate") materialize(args[2]);
+    if (bin === "kubectl" && args[0] === "get") {
+      if (args[1] === "deployment,service") return { stdout: JSON.stringify({ items: meshResources }) };
+      if (args[1] === "deployments") return { stdout: JSON.stringify({ items: sandboxes }) };
+      if (args[1] === "karssandboxes") return { stdout: JSON.stringify({ items: crs }) };
+      if (args[1] === "karssandbox") return { stdout: JSON.stringify(crs.find(cr => cr.metadata.name === args[2])) };
+      if (args[1] === "deployment") return { stdout: JSON.stringify(args[2] === "kars-controller" ? controller
+        : sandboxes.find(item => item.metadata.name === args[2]) ?? meshResources.find(item => item.kind === "Deployment" && item.metadata.name === args[2])) };
+    }
+    return { stdout: "" };
+  }) as unknown as Execute;
+  const calls = () => vi.mocked(execute).mock.calls as unknown as Array<[string, string[]]>;
+  return { execute, values, controller, addSandbox, calls, meshResources };
+}
+
+describe("selected core push artifacts", () => {
+  it("moves a GHCR/pinned Helm controller to its pushed ACR digest without resetting customer values", async () => {
+    const f = fixture();
+    await applyPushedImages(f.execute, [pushed("controller")], "chart");
+    expect(f.controller.spec.template.spec.containers[0].image).toBe(reference("controller"));
+    expect(getPath(f.values, "azure.workloadIdentity.clientId")).toBe("customer-wi");
+    expect(getPath(f.values, "azure.keyVaultCsi.keyVaultName")).toBe("customer-vault");
+    expect(getPath(f.values, "inferenceRouter.image.tag")).toBe("v1.0.0");
+    expect(f.calls().filter(([bin, args]) => bin === "helm" && args[0] === "upgrade")).toHaveLength(1);
+  });
+
+  it("updates unmanaged controller image/env through version-guarded patches, without Helm", async () => {
+    const f = fixture({ legacyCore: true });
+    const agent = f.addSandbox("agent", "OpenClaw", "openclaw");
+    await applyPushedImages(f.execute, [pushed("controller"), pushed("router")], "chart");
+    expect(f.calls().some(([bin]) => bin === "helm")).toBe(false);
+    expect(f.controller.spec.template.spec.containers[0].image).toBe(reference("controller"));
+    expect(agent.deployment.spec.template.spec.containers[1].image).toBe(reference("router"));
+    expect(f.controller.spec.template.spec.containers[0].env).toContainEqual({ name: "CUSTOMER_SETTING", value: "retain-me" });
+    expect(f.calls().find(([, args]) => args[0] === "patch")?.[1].at(-1)).toContain("/metadata/resourceVersion");
+  });
+
+  it.each(["router", "sandbox"])("applies %s defaults and eligible workloads but preserves explicit agent pins", async name => {
+    const f = fixture();
+    const normal = f.addSandbox("normal", "OpenClaw", "openclaw");
+    const custom = f.addSandbox("custom", "OpenClaw", "openclaw", { image: "customer.example/custom:v9" });
+    const spec = JSON.stringify(custom.cr.spec);
+    await applyPushedImages(f.execute, [pushed(name)], "chart");
+    const index = name === "router" ? 1 : 0;
+    expect(normal.deployment.spec.template.spec.containers[index].image).toBe(reference(name));
+    expect(custom.deployment.spec.template.spec.containers[0].image).toBe("customer.example/custom:v9");
+    expect(JSON.stringify(custom.cr.spec)).toBe(spec);
+    if (name === "sandbox") expect(custom.deployment.spec.template.spec.initContainers![0].image).toBe(reference(name));
+    expect(f.calls().some(([, args]) => args[0] === "patch" && args.includes("karssandbox"))).toBe(false);
+  });
+
+  it.each(RUNTIME_IMAGE_TARGETS)("applies complete runtime mapping $name and leaves other runtimes untouched", async runtime => {
+    const f = fixture();
+    const selected = f.addSandbox("selected", runtime.kind, runtime.variant, runtime.language ? { language: runtime.language } : {});
+    const other = f.addSandbox("other", "OpenClaw", "openclaw");
+    const custom = f.addSandbox("custom", runtime.kind, runtime.variant, { image: "customer.example/runtime:v7", ...(runtime.language ? { language: runtime.language } : {}) });
+    await applyPushedImages(f.execute, [pushed(runtime.name)], "chart");
+    expect(getPath(f.values, runtime.valueKey)).toBe(reference(runtime.name));
+    expect(selected.deployment.spec.template.spec.containers[0].image).toBe(reference(runtime.name));
+    expect(other.deployment.spec.template.spec.containers[0].image).toBe("ghcr.io/azure/openclaw-sandbox:v1.0.0");
+    expect(custom.deployment.spec.template.spec.containers[0].image).toBe("customer.example/runtime:v7");
+    expect(releaseImagePlan("v1.2.3").some(item => item.target === `${runtime.repo}:latest`)).toBe(true);
+  });
+
+  it("combines core and owned mesh in one Helm upgrade", async () => {
+    const f = fixture({ mesh: "helm" });
+    await applyPushedImages(f.execute, [pushed("controller"), pushed("relay"), pushed("registry")], "chart");
+    const updates = f.calls().filter(([bin, args]) => bin === "helm" && args[0] === "upgrade");
+    expect(updates).toHaveLength(1);
+    expect(updates[0][1]).toContain(`agentMesh.relay.image.tag=latest@${digest}`);
+    expect(updates[0][1]).toContain(`controller.image.tag=latest@${digest}`);
+    expect(updates[0][1]).not.toContain("--take-ownership");
+  });
+
+  it("leaves external mesh untouched during a core-only apply", async () => {
+    const f = fixture({ mesh: "external" });
+    const before = JSON.stringify(f.meshResources);
+    await applyPushedImages(f.execute, [pushed("controller")], "chart");
+    expect(JSON.stringify(f.meshResources)).toBe(before);
+    expect(f.calls().some(([, args]) => args[0] === "rollout" && args.includes("agentmesh"))).toBe(false);
+    expect(f.calls().some(([, args]) => args[0] === "get" && args[1] === "deployment" && args.includes("agentmesh"))).toBe(false);
+  });
+
+  it("refuses explicit or default-all external mesh updates before any mutation", async () => {
+    for (const images of [[pushed("relay")], [pushed("controller"), pushed("relay"), pushed("registry")]]) {
+      const f = fixture({ mesh: "external" });
+      await expect(applyPushedImages(f.execute, images, "chart")).rejects.toThrow("External");
+      expect(f.calls().some(([, args]) => ["upgrade", "patch", "set", "annotate", "rollout"].includes(args[0]))).toBe(false);
+    }
+  });
+
+  it("rejects a build-only apply and reports a mixed build-only target as not deployed", async () => {
+    const f = fixture();
+    await expect(applyPushedImages(f.execute, [pushed("sandbox-base")], "chart")).rejects.toThrow("build-only");
+    expect(f.calls()).toHaveLength(0);
+    const result = await applyPushedImages(f.execute, [pushed("controller"), pushed("sandbox-base")], "chart");
+    expect(result.buildOnly).toEqual(["sandbox-base"]);
+    expect(result.applied).toEqual(["controller"]);
+  });
+
+  it("propagates a failed owning-config update", async () => {
+    const f = fixture({ fail: "upgrade" });
+    await expect(applyPushedImages(f.execute, [pushed("controller")], "chart")).rejects.toThrow("failed upgrade");
+    expect(f.calls().some(([, args]) => args[0] === "rollout")).toBe(false);
+  });
+
+  it("does not report applied when Helm accepts values but leaves the controller on old bits", async () => {
+    const f = fixture({ mismatch: true });
+    await expect(applyPushedImages(f.execute, [pushed("controller")], "chart")).rejects.toThrow("selected artifact");
+  });
+
+  it("fails before configuration mutations when the pushed digest cannot be resolved", async () => {
+    const f = fixture({ fail: "repository" });
+    await expect(applyPushedImages(f.execute, [pushed("controller")], "chart")).rejects.toThrow("failed repository");
+    expect(f.calls().some(([, args]) => ["upgrade", "patch", "annotate", "rollout"].includes(args[0]))).toBe(false);
+  });
+
+  it("distinguishes LangGraph TypeScript from Python for runtime-only application", async () => {
+    const f = fixture();
+    const python = f.addSandbox("python", "LangGraph", "langGraph", { language: "python" });
+    const typescript = f.addSandbox("typescript", "LangGraph", "langGraph", { language: "typescript" });
+    const oldPython = python.deployment.spec.template.spec.containers[0].image;
+    await applyPushedImages(f.execute, [pushed("runtime-langgraph-ts")], "chart");
+    expect(python.deployment.spec.template.spec.containers[0].image).toBe(oldPython);
+    expect(typescript.deployment.spec.template.spec.containers[0].image).toBe(reference("runtime-langgraph-ts"));
+  });
+
+  it("rejects actual workload mismatch even if restart/status commands succeed", async () => {
+    const f = fixture({ mismatch: true });
+    f.addSandbox("agent", "Hermes", "hermes");
+    await expect(applyPushedImages(f.execute, [pushed("runtime-hermes")], "chart")).rejects.toThrow("did not converge");
+  });
+
+  it("does not reset BYO pins or touch overlay workloads", () => {
+    const f = fixture();
+    const byo = f.addSandbox("byo", "BYO", "byo", { image: "customer.example/byo:v1" });
+    const plan = planSandboxImages(byo.cr, byo.deployment, [pushed("sandbox")]);
+    expect(plan.expected.every(item => item.init)).toBe(true);
+    const overlay = { ...byo.cr, spec: { ...byo.cr.spec, upstreamCompatibility: { sigsAgentSandbox: "overlay" } } };
+    expect(planSandboxImages(overlay, byo.deployment, [pushed("router")]).expected).toEqual([]);
+  });
+});

--- a/cli/src/commands/push-apply.ts
+++ b/cli/src/commands/push-apply.ts
@@ -2,25 +2,84 @@
 // Licensed under the MIT License.
 
 import type { Execute } from "../lib/deployment-target.js";
-import { restartController, restartSandboxes } from "../lib/deployment-rollout.js";
-import { applyMeshImages, inspectMeshInstallation, type MeshImages, type MeshInstallation } from "../lib/mesh-release.js";
+import { restartController } from "../lib/deployment-rollout.js";
+import {
+  assertMeshReleaseConsistency, inspectMeshInstallation, meshImageValueArgs,
+  recheckMeshOwnership, restartMesh, updateLegacyMeshImages, verifyMeshHealth,
+  type MeshImages, type MeshInstallation,
+} from "../lib/mesh-release.js";
+import { coreImageValues, imageValueArgs, PUSH_COMPONENTS, resolvePushedArtifacts, type PushedImage } from "../lib/image-targets.js";
+import { inspectCoreInstallation, recheckCoreOwnership, requireHealthyDeployment, updateLegacyCore, verifyCoreConfiguration } from "../lib/core-image-apply.js";
+import { inspectSandboxPlans, refreshSandboxImages } from "../lib/sandbox-image-apply.js";
 
+export interface PushApplyResult {
+  applied: string[];
+  buildOnly: string[];
+  updatedSandboxes: number;
+  preservedOverrides: number;
+}
+
+/** Update owning defaults, prove their selected artifact references, then ask
+ * the controller to reconcile eligible CRs without altering explicit pins. */
 export async function applyPushedImages(
   execute: Execute,
-  images: Array<{ name: string; image: string }>,
+  images: PushedImage[],
   chart: string,
   installation?: MeshInstallation,
-): Promise<void> {
+): Promise<PushApplyResult> {
+  if (images.some(item => !PUSH_COMPONENTS.includes(item.name))) throw new Error("Unknown pushed component; no apply plan exists");
+  const buildOnly = images.filter(item => item.name === "sandbox-base").map(item => item.name);
+  const deployable = images.filter(item => item.name !== "sandbox-base");
+  if (!deployable.length) throw new Error("sandbox-base is build-only; no deployment was applied");
+  const isMesh = (item: PushedImage) => item.name === "relay" || item.name === "registry";
+  const selectedCore = deployable.filter(item => !isMesh(item));
+  const selectedMesh = deployable.some(isMesh);
+  const core = selectedCore.length ? await inspectCoreInstallation(execute) : undefined;
+  const mesh = selectedMesh || core?.kind === "helm"
+    ? installation ?? await inspectMeshInstallation(execute) : undefined;
+  if (selectedMesh && (!mesh || mesh.kind === "external" || mesh.kind === "absent")) {
+    throw new Error("External or absent AgentMesh cannot be updated; choose explicit core targets instead.");
+  }
+  if (core?.kind === "helm" && mesh) assertMeshReleaseConsistency(mesh, core.values);
+  const artifacts = await resolvePushedArtifacts(execute, deployable);
+  const coreImages = artifacts.filter(item => !isMesh(item));
   const meshImages: MeshImages = {};
-  for (const image of images) {
-    if (image.name === "relay" || image.name === "registry") meshImages[image.name] = image.image;
+  for (const item of artifacts) if (item.name === "relay" || item.name === "registry") meshImages[item.name] = item.image;
+  const plans = await inspectSandboxPlans(execute, coreImages);
+  if (core) await recheckCoreOwnership(execute, core);
+  if (mesh && (selectedMesh || core?.kind === "helm")) await recheckMeshOwnership(execute, mesh);
+
+  const helmPlans = new Map<string, { release: string; namespace: string; args: string[] }>();
+  function addHelm(release: string, namespace: string, args: string[]) {
+    const key = `${namespace}/${release}`;
+    const plan = helmPlans.get(key) ?? { release, namespace, args: [] };
+    plan.args.push(...args);
+    helmPlans.set(key, plan);
   }
-  if (Object.keys(meshImages).length) {
-    const mesh = installation ?? await inspectMeshInstallation(execute);
-    await applyMeshImages(execute, mesh, meshImages, chart);
+  if (core?.kind === "helm") addHelm(core.release, core.releaseNamespace, imageValueArgs(coreImageValues(coreImages)));
+  if (selectedMesh && mesh?.kind === "helm") addHelm(mesh.release, mesh.releaseNamespace, meshImageValueArgs(meshImages));
+  if (helmPlans.size > 1) throw new Error("Selected components have different Helm owners; update one explicit target at a time.");
+
+  if (selectedMesh && mesh?.kind === "legacy") {
+    await updateLegacyMeshImages(execute, mesh, meshImages);
+    await restartMesh(execute, mesh, Object.keys(meshImages) as Array<"registry" | "relay">);
+    await verifyMeshHealth(execute, mesh, meshImages);
   }
-  // Preserve the existing controller refresh for non-mesh builds; a mesh-only
-  // push does not need to interrupt the unrelated controller or sandboxes.
-  if (images.some(image => image.name !== "relay" && image.name !== "registry")) await restartController(execute);
-  if (images.some(image => image.name === "sandbox" || image.name === "router")) await restartSandboxes(execute);
+  for (const plan of helmPlans.values()) {
+    await execute("helm", ["upgrade", plan.release, chart, "--namespace", plan.namespace,
+      "--reuse-values", ...plan.args, "--atomic", "--wait", "--timeout", "8m"], { stdio: "pipe" });
+  }
+  if (selectedMesh && mesh?.kind === "helm") {
+    await restartMesh(execute, mesh, Object.keys(meshImages) as Array<"registry" | "relay">);
+    await verifyMeshHealth(execute, mesh, meshImages);
+  }
+  if (core?.kind === "legacy") await updateLegacyCore(execute, core, coreImages);
+  if (core) {
+    await verifyCoreConfiguration(execute, core, coreImages);
+    await restartController(execute);
+    requireHealthyDeployment(await verifyCoreConfiguration(execute, core, coreImages));
+  }
+  const updatedSandboxes = await refreshSandboxImages(execute, plans);
+  return { applied: artifacts.map(item => item.name), buildOnly, updatedSandboxes,
+    preservedOverrides: plans.filter(plan => plan.pinned).length };
 }

--- a/cli/src/commands/push-apply.ts
+++ b/cli/src/commands/push-apply.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Execute } from "../lib/deployment-target.js";
+import { restartController, restartSandboxes } from "../lib/deployment-rollout.js";
+import { applyMeshImages, inspectMeshInstallation, type MeshImages, type MeshInstallation } from "../lib/mesh-release.js";
+
+export async function applyPushedImages(
+  execute: Execute,
+  images: Array<{ name: string; image: string }>,
+  chart: string,
+  installation?: MeshInstallation,
+): Promise<void> {
+  const meshImages: MeshImages = {};
+  for (const image of images) {
+    if (image.name === "relay" || image.name === "registry") meshImages[image.name] = image.image;
+  }
+  if (Object.keys(meshImages).length) {
+    const mesh = installation ?? await inspectMeshInstallation(execute);
+    await applyMeshImages(execute, mesh, meshImages, chart);
+  }
+  // Preserve the existing controller refresh for non-mesh builds; a mesh-only
+  // push does not need to interrupt the unrelated controller or sandboxes.
+  if (images.some(image => image.name !== "relay" && image.name !== "registry")) await restartController(execute);
+  if (images.some(image => image.name === "sandbox" || image.name === "router")) await restartSandboxes(execute);
+}

--- a/cli/src/commands/push.ts
+++ b/cli/src/commands/push.ts
@@ -8,6 +8,9 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import { loadContext } from "../config.js";
+import { preparePushTarget } from "../lib/deployment-target.js";
+import { inspectMeshInstallation } from "../lib/mesh-release.js";
+import { applyPushedImages } from "./push-apply.js";
 import { stageRustBinaries } from "../lib/stage-rust-bin.js";
 import { stageMeshPlugin } from "../lib/stage-mesh-plugin.js";
 import { ensureAgtRepo, ensureAgtWheels } from "../lib/agt-bootstrap.js";
@@ -20,6 +23,7 @@ export function pushCommand(): Command {
   cmd
     .description("Build and push images to ACR (uses cached context from last deploy)")
     .option("--acr <name>", "ACR name (default: from last deploy)")
+    .option("--subscription <id>", "Azure subscription (must match saved deployment when present)")
     .option("--only <image>", "Build only one image: controller, router, sandbox, sandbox-base, relay, registry")
     .option("--include-base", "Include sandbox-base in a full push (skipped by default — rebuild only when upgrading OpenClaw/Python/Go)")
     .option("--apply", "Restart deployments after push so pods pick up new images")
@@ -38,7 +42,7 @@ export function pushCommand(): Command {
       "Path to a locally-packed @microsoft/agent-governance-sdk .tgz to install in the sandbox image (auto-discovered from $KARS_AGT_REPO/agent-governance-typescript otherwise).",
     )
     .action(async (options) => {
-      const { execa } = await import("execa");
+      const { execa: rawExeca } = await import("execa");
       const blue = chalk.hex("#0078D4");
 
       if (options.meshProvider && options.meshProvider !== "agt") {
@@ -66,6 +70,12 @@ export function pushCommand(): Command {
         process.exit(1);
       }
 
+      const ctx = loadContext();
+      const execa = await preparePushTarget(rawExeca, ctx, options);
+      const updatesMesh = !options.only || options.only === "relay" || options.only === "registry";
+      const mesh = options.apply && updatesMesh ? await inspectMeshInstallation(execa) : undefined;
+      if (mesh?.kind === "absent") throw new Error("AgentMesh is not installed; install it before pushing mesh updates");
+
       let agtRepo: string;
       const agtDockerfileRel = "agent-governance-python/agent-mesh/docker/Dockerfile";
       // Auto-clone the pinned AGT fork (vendor/agt/pin.json) when no
@@ -92,7 +102,6 @@ export function pushCommand(): Command {
       }
 
       // Resolve ACR from context or flag
-      const ctx = loadContext();
       const acrName = options.acr || ctx?.acrName;
       const acrLoginServer = acrName ? `${acrName}.azurecr.io` : null;
 
@@ -383,112 +392,15 @@ export function pushCommand(): Command {
 
       // Rollout restart if --apply
       if (options.apply) {
-        const ns = "kars-system";
-
-        // The AGT manifest is the only mesh stack now; on --apply we ensure
-        // it's installed and the helm mesh.provider=agt value is set so
-        // future controller restarts and sandbox spawns carry the AGT env.
-        if (!options.only || options.only === "relay" || options.only === "registry") {
-          const meshSpin = ora("Applying AGT mesh manifest (deploy/agentmesh-agt.yaml)...").start();
-          try {
-            const agtManifest = path.join(repoRoot, "deploy/agentmesh-agt.yaml");
-            if (!fs.existsSync(agtManifest)) {
-              throw new Error(`AGT manifest missing: ${agtManifest}`);
-            }
-            await execa("kubectl", ["apply", "-f", agtManifest], { stdio: "pipe" });
-            meshSpin.succeed("AGT mesh manifest applied");
-          } catch (e: any) {
-            meshSpin.fail(`Mesh manifest apply failed: ${e.message?.split("\n")[0]}`);
-          }
-
-          const helmSpin = ora("Setting helm mesh.provider=agt...").start();
-          try {
-            await execa("helm", [
-              "upgrade", "kars", path.join(repoRoot, "deploy/helm/kars"),
-              "--namespace", ns,
-              "--reuse-values",
-              "--set", "mesh.provider=agt",
-            ], { stdio: "pipe" });
-            helmSpin.succeed("helm mesh.provider=agt");
-          } catch (e: any) {
-            helmSpin.fail(`helm upgrade failed: ${e.message?.split("\n")[0]} (apply manually: helm upgrade kars deploy/helm/kars --reuse-values --set mesh.provider=agt)`);
-          }
-        }
-
-        // Restart controller (manages all sandbox pods)
-        const spin = ora("Restarting deployments...").start();
+        const spin = ora("Applying pushed images to their owning deployments...").start();
         try {
-          await execa("kubectl", ["rollout", "restart", "deployment", "kars-controller", "-n", ns], { stdio: "pipe" });
-          spin.text = "Restarted kars-controller";
-
-          // If sandbox/router image changed, roll the sandbox Deployments.
-          // We use `kubectl rollout restart deploy -A -l kars.azure.com/component=sandbox`
-          // — annotation-bump that triggers a real rolling restart. The
-          // previous `delete pods --grace-period=10` approach was racy:
-          // the deletion fired BEFORE ACR/kubelet finished propagating
-          // the new `:latest` digest, so the recreated pod sometimes
-          // grabbed the OLD digest from a node-cache and the new push
-          // silently became "the next latest" with no one to re-pull.
-          // Rollout restart is the K8s-native fix that the deployment
-          // controller waits on (new pod must be Ready before old goes).
-          const sandboxImages = ["sandbox", "router"];
-          if (!options.only || sandboxImages.includes(options.only)) {
-            const { stdout: nsLines } = await execa("kubectl", [
-              "get", "namespaces", "-o", "name",
-            ], { stdio: "pipe" });
-            const perAgentNs = nsLines
-              .split("\n")
-              .map(l => l.replace("namespace/", "").trim())
-              .filter(n => n.startsWith("kars-") && n !== "kars-system");
-            if (perAgentNs.length > 0) {
-              spin.text = `Rolling out new image to ${perAgentNs.length} sandbox(es)...`;
-              // Per-namespace rollout restart of every Deployment labeled
-              // as a sandbox. Runs in parallel; each waits for the
-              // Deployment controller to bring up a Ready replica with
-              // the new pulled image before the old one terminates.
-              await Promise.all(perAgentNs.map(async nsName => {
-                try {
-                  const { stdout: deps } = await execa("kubectl", [
-                    "get", "deploy", "-n", nsName,
-                    "-l", "kars.azure.com/component=sandbox",
-                    "-o", "name",
-                  ], { stdio: "pipe" });
-                  const names = deps.split("\n").map(s => s.trim()).filter(Boolean);
-                  for (const dep of names) {
-                    await execa("kubectl", [
-                      "rollout", "restart", dep, "-n", nsName,
-                    ], { stdio: "pipe" }).catch(() => {});
-                  }
-                } catch { /* skip namespace */ }
-              }));
-              spin.text = `Waiting for ${perAgentNs.length} sandbox rollout(s) to complete...`;
-              // Wait for the rollouts to finish so the user can trust
-              // that on success their pods ARE running the new image.
-              await Promise.all(perAgentNs.map(async nsName => {
-                try {
-                  const { stdout: deps } = await execa("kubectl", [
-                    "get", "deploy", "-n", nsName,
-                    "-l", "kars.azure.com/component=sandbox",
-                    "-o", "name",
-                  ], { stdio: "pipe" });
-                  for (const dep of deps.split("\n").map(s => s.trim()).filter(Boolean)) {
-                    await execa("kubectl", [
-                      "rollout", "status", dep, "-n", nsName, "--timeout=120s",
-                    ], { stdio: "pipe" }).catch(() => {});
-                  }
-                } catch { /* skip */ }
-              }));
-            }
-          }
-
-          // If relay/registry changed, restart agentmesh
-          if (!options.only || options.only === "relay" || options.only === "registry") {
-            await execa("kubectl", ["rollout", "restart", "deployment", "-n", "agentmesh"], { stdio: "pipe" }).catch(() => {});
-          }
-
-          spin.succeed("Deployments restarted — pods will pull new images");
+          await applyPushedImages(execa, targets.map(image => ({
+            name: image.name, image: `${acrLoginServer}/${image.tag}`,
+          })), path.join(repoRoot, "deploy/helm/kars"), mesh);
+          spin.succeed("Selected deployments updated and rollouts verified");
         } catch (e: any) {
-          spin.fail(`Rollout restart failed: ${e.message?.split("\n")[0]}`);
+          spin.fail(`Image apply failed: ${e.message?.split("\n")[0]}`);
+          throw e;
         }
       } else if (ctx?.aksCluster) {
         console.log(chalk.dim(`  To apply: kars push --apply`));

--- a/cli/src/commands/push.ts
+++ b/cli/src/commands/push.ts
@@ -11,6 +11,7 @@ import { loadContext } from "../config.js";
 import { preparePushTarget } from "../lib/deployment-target.js";
 import { inspectMeshInstallation } from "../lib/mesh-release.js";
 import { applyPushedImages } from "./push-apply.js";
+import { dockerPushDigest, PUSH_COMPONENTS, RUNTIME_IMAGE_TARGETS } from "../lib/image-targets.js";
 import { stageRustBinaries } from "../lib/stage-rust-bin.js";
 import { stageMeshPlugin } from "../lib/stage-mesh-plugin.js";
 import { ensureAgtRepo, ensureAgtWheels } from "../lib/agt-bootstrap.js";
@@ -24,9 +25,9 @@ export function pushCommand(): Command {
     .description("Build and push images to ACR (uses cached context from last deploy)")
     .option("--acr <name>", "ACR name (default: from last deploy)")
     .option("--subscription <id>", "Azure subscription (must match saved deployment when present)")
-    .option("--only <image>", "Build only one image: controller, router, sandbox, sandbox-base, relay, registry")
+    .option("--only <image>", "Build one image: controller, router, sandbox, sandbox-base, relay, registry, or runtime-*")
     .option("--include-base", "Include sandbox-base in a full push (skipped by default — rebuild only when upgrading OpenClaw/Python/Go)")
-    .option("--apply", "Restart deployments after push so pods pick up new images")
+    .option("--apply", "Apply selected image configuration and verify the resulting rollouts")
     .option(
       "-m, --mesh-provider <provider>",
       "Mesh stack to build. Only 'agt' is supported (Microsoft AGT, in-memory). " +
@@ -55,6 +56,10 @@ export function pushCommand(): Command {
         process.exit(1);
       }
       const meshProvider = "agt" as const;
+      if (options.only && !PUSH_COMPONENTS.includes(options.only)) throw new Error(`Unknown image component: ${options.only}`);
+      if (options.apply && options.only === "sandbox-base") {
+        throw new Error("sandbox-base is build-only; omit --apply and rebuild a deployable sandbox image.");
+      }
 
       // Resolve AGT repo path — required to (re)build relay/registry images
       // Find repo root (look for deploy/helm directory). Done up-front
@@ -75,6 +80,9 @@ export function pushCommand(): Command {
       const updatesMesh = !options.only || options.only === "relay" || options.only === "registry";
       const mesh = options.apply && updatesMesh ? await inspectMeshInstallation(execa) : undefined;
       if (mesh?.kind === "absent") throw new Error("AgentMesh is not installed; install it before pushing mesh updates");
+      if (mesh?.kind === "external") {
+        throw new Error("External AgentMesh will not be changed. Select an explicit core --only target (controller, router, sandbox, or runtime-*).");
+      }
 
       let agtRepo: string;
       const agtDockerfileRel = "agent-governance-python/agent-mesh/docker/Dockerfile";
@@ -248,27 +256,11 @@ export function pushCommand(): Command {
         { name: "sandbox", tag: "openclaw-sandbox:latest", dockerfile: "sandbox-images/openclaw/Dockerfile",
           buildArgs: sandboxBuildArgs },
         ...meshImages,
-        // Multi-runtime adapter images — must match controller defaults in
-        // `controller/src/reconciler/runtime.rs` (DEFAULT_*_IMAGE constants).
-        { name: "runtime-openai-agents", tag: "kars-runtime-openai-agents:latest",
-          dockerfile: "sandbox-images/openai-agents/Dockerfile" },
-        { name: "runtime-maf-python", tag: "kars-runtime-maf-python:latest",
-          dockerfile: "sandbox-images/maf-python/Dockerfile" },
-        { name: "runtime-anthropic", tag: "kars-runtime-anthropic:latest",
-          dockerfile: "sandbox-images/anthropic/Dockerfile" },
-        { name: "runtime-langgraph", tag: "kars-runtime-langgraph:latest",
-          dockerfile: "sandbox-images/langgraph/Dockerfile" },
-        { name: "runtime-langgraph-ts", tag: "kars-runtime-langgraph-ts:latest",
-          dockerfile: "sandbox-images/langgraph-ts/Dockerfile" },
-        { name: "runtime-pydantic-ai", tag: "kars-runtime-pydantic-ai:latest",
-          dockerfile: "sandbox-images/pydantic-ai/Dockerfile" },
-        // Hermes runtime — ships the kars plugin (governance hook,
-        // kars_spawn family, Foundry tool wrappers) + the real Python
-        // AGT MeshClient (kars-agt-mesh). Controller default tag is
-        // `kars-runtime-hermes:latest` from reconciler/runtime.rs
-        // DEFAULT_HERMES_IMAGE.
-        { name: "runtime-hermes", tag: "kars-runtime-hermes:latest",
-          dockerfile: "sandbox-images/hermes/Dockerfile" },
+        // Shared with release imports, upgrade values, and push application.
+        ...RUNTIME_IMAGE_TARGETS.map(runtime => ({
+          name: runtime.name, tag: `${runtime.repo}:latest`,
+          dockerfile: `sandbox-images/${runtime.name.slice("runtime-".length)}/Dockerfile`,
+        })),
       ];
 
       // Sandbox images whose Dockerfile `COPY runtimes/wheels/` and
@@ -312,6 +304,7 @@ export function pushCommand(): Command {
       }
 
       let failures = 0;
+      const pushedArtifacts = new Map<string, string>();
       for (const img of targets) {
         const spin = ora(`Building ${img.tag}...`).start();
         try {
@@ -368,7 +361,12 @@ export function pushCommand(): Command {
           for (let attempt = 1; attempt <= 3; attempt++) {
             try {
               if (attempt > 1) await execa("az", ["acr", "login", "--name", acrName], { stdio: "pipe" });
-              await execa("docker", ["push", `${acrLoginServer}/${img.tag}`], { stdio: "pipe" });
+              const pushed = await execa("docker", ["push", `${acrLoginServer}/${img.tag}`], { stdio: "pipe" });
+              if (options.apply && img.name !== "sandbox-base") {
+                const digest = dockerPushDigest(`${pushed.stdout}\n${pushed.stderr}`);
+                if (!digest) throw new Error(`Docker did not provide an unambiguous pushed digest for ${img.name}; refusing to apply a mutable tag`);
+                pushedArtifacts.set(img.name, `${acrLoginServer}/${img.tag}@${digest}`);
+              }
               break;
             } catch (e: any) {
               if (attempt === 3) throw e;
@@ -394,10 +392,12 @@ export function pushCommand(): Command {
       if (options.apply) {
         const spin = ora("Applying pushed images to their owning deployments...").start();
         try {
-          await applyPushedImages(execa, targets.map(image => ({
-            name: image.name, image: `${acrLoginServer}/${image.tag}`,
+          const applied = await applyPushedImages(execa, targets.map(image => ({
+            name: image.name, image: pushedArtifacts.get(image.name) ?? `${acrLoginServer}/${image.tag}`,
           })), path.join(repoRoot, "deploy/helm/kars"), mesh);
-          spin.succeed("Selected deployments updated and rollouts verified");
+          spin.succeed(`Selected image configuration applied; ${applied.updatedSandboxes} eligible sandbox deployment(s) verified`);
+          if (applied.preservedOverrides) console.log(chalk.dim(`  Preserved ${applied.preservedOverrides} explicit sandbox/overlay image override(s).`));
+          if (applied.buildOnly.length) console.log(chalk.dim(`  Build-only (not deployed): ${applied.buildOnly.join(", ")}.`));
         } catch (e: any) {
           spin.fail(`Image apply failed: ${e.message?.split("\n")[0]}`);
           throw e;

--- a/cli/src/commands/target-resolution.test.ts
+++ b/cli/src/commands/target-resolution.test.ts
@@ -27,6 +27,30 @@ import { upgradeCommand } from "./upgrade.js";
 afterEach(() => { vi.restoreAllMocks(); vi.clearAllMocks(); });
 
 describe("real command handlers stop before mutations on target failure", () => {
+  it("rejects sandbox-base --apply before even requesting credentials or build preparation", async () => {
+    await expect(pushCommand().parseAsync(["--only", "sandbox-base", "--apply"], { from: "user" })).rejects.toThrow("build-only");
+    expect(mocked.execute).not.toHaveBeenCalled();
+    expect(mocked.ensureAgtRepo).not.toHaveBeenCalled();
+  });
+
+  it("default all-image push refuses an external mesh before image builds or ACR mutations", async () => {
+    mocked.execute.mockImplementation(async (bin: string, args: string[]) => {
+      if (bin === "az" && args[1] === "show") return { stdout: JSON.stringify({
+        id: "/subscriptions/sub-b/resourceGroups/shared-rg/providers/Microsoft.ContainerService/managedClusters/shared-aks",
+        fqdn: "cluster-b.example.test",
+      }) };
+      if (bin === "kubectl" && args[0] === "config") return { stdout: "https://cluster-b.example.test" };
+      if (bin === "kubectl" && args[1] === "deployment,service") return { stdout: JSON.stringify({ items: [
+        { kind: "Service", metadata: { name: "agentmesh-registry", ownerReferences: [{ name: "platform" }] } },
+        { kind: "Service", metadata: { name: "agentmesh-relay", ownerReferences: [{ name: "platform" }] } },
+      ] }) };
+      return { stdout: "" };
+    });
+    await expect(pushCommand().parseAsync(["--apply"], { from: "user" })).rejects.toThrow("External AgentMesh");
+    expect(mocked.ensureAgtRepo).not.toHaveBeenCalled();
+    expect(mocked.execute.mock.calls.some(([bin, args]) => bin === "docker" || (args as string[]).includes("acr"))).toBe(false);
+  });
+
   for (const command of ["push", "upgrade"] as const) {
     it(`${command} rejects Azure identity A instead of mutating adopted B or the ambient cluster`, async () => {
       mocked.execute.mockResolvedValue({ stdout: JSON.stringify({

--- a/cli/src/commands/target-resolution.test.ts
+++ b/cli/src/commands/target-resolution.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  execute: vi.fn(),
+  ensureAgtRepo: vi.fn(),
+  context: {
+    subscription: "sub-b", resourceGroup: "shared-rg", aksCluster: "shared-aks",
+    acrName: "mirror", acrLoginServer: "mirror.azurecr.io",
+  },
+}));
+
+vi.mock("execa", () => ({ execa: mocked.execute }));
+vi.mock("../config.js", async importOriginal => ({
+  ...await importOriginal<typeof import("../config.js")>(),
+  loadContext: () => mocked.context,
+}));
+vi.mock("../lib/agt-bootstrap.js", () => ({
+  ensureAgtRepo: mocked.ensureAgtRepo, ensureAgtWheels: vi.fn(),
+}));
+
+import { pushCommand } from "./push.js";
+import { upgradeCommand } from "./upgrade.js";
+
+afterEach(() => { vi.restoreAllMocks(); vi.clearAllMocks(); });
+
+describe("real command handlers stop before mutations on target failure", () => {
+  for (const command of ["push", "upgrade"] as const) {
+    it(`${command} rejects Azure identity A instead of mutating adopted B or the ambient cluster`, async () => {
+      mocked.execute.mockResolvedValue({ stdout: JSON.stringify({
+        id: "/subscriptions/sub-a/resourceGroups/shared-rg/providers/Microsoft.ContainerService/managedClusters/shared-aks",
+        fqdn: "cluster-a.example.test",
+      }) });
+      vi.spyOn(process, "exit").mockImplementation(code => { throw new Error(`exit:${code}`); });
+      const invocation = command === "push"
+        ? pushCommand().parseAsync(["--only", "relay", "--apply"], { from: "user" })
+        : upgradeCommand().parseAsync(["--yes", "--to", "v1.2.3"], { from: "user" });
+      await expect(invocation).rejects.toThrow(command === "push" ? "does not match" : "exit:1");
+      expect(mocked.execute).toHaveBeenCalledTimes(1);
+      const [bin, args] = mocked.execute.mock.calls[0] as [string, string[]];
+      expect(bin).toBe("az");
+      expect(args.slice(0, 2)).toEqual(["aks", "show"]);
+      expect(args[args.indexOf("--subscription") + 1]).toBe("sub-b");
+      expect(mocked.ensureAgtRepo).not.toHaveBeenCalled();
+    });
+
+    it(`${command} rejects Kubernetes context A before ACR, Helm, Docker or rollout mutations`, async () => {
+      mocked.execute.mockImplementation(async (bin: string, args: string[]) => {
+        if (bin === "az" && args[1] === "show") return { stdout: JSON.stringify({
+          id: "/subscriptions/sub-b/resourceGroups/shared-rg/providers/Microsoft.ContainerService/managedClusters/shared-aks",
+          fqdn: "cluster-b.example.test",
+        }) };
+        if (bin === "kubectl") return { stdout: "https://cluster-a.example.test" };
+        return { stdout: "" };
+      });
+      vi.spyOn(process, "exit").mockImplementation(code => { throw new Error(`exit:${code}`); });
+      const invocation = command === "push"
+        ? pushCommand().parseAsync(["--only", "relay", "--apply"], { from: "user" })
+        : upgradeCommand().parseAsync(["--yes", "--to", "v1.2.3"], { from: "user" });
+      await expect(invocation).rejects.toThrow(command === "push" ? "does not point" : "exit:1");
+      for (const [bin, args] of mocked.execute.mock.calls as Array<[string, string[]]>) {
+        expect(["helm", "docker"].includes(bin)).toBe(false);
+        expect(args.some(arg => ["acr", "rollout", "apply", "set"].includes(arg))).toBe(false);
+      }
+      expect(mocked.ensureAgtRepo).not.toHaveBeenCalled();
+    });
+  }
+});

--- a/cli/src/commands/upgrade-compat.test.ts
+++ b/cli/src/commands/upgrade-compat.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "vitest";
+import { buildAdoptedAksContext } from "./config.js";
+import { buildHelmUpgradeArgs, buildUpgradeContext, preflightFieldManagerConflicts } from "./upgrade.js";
+import type { MeshInstallation } from "../lib/mesh-release.js";
+
+const adopted = () => buildAdoptedAksContext({
+  subscription: "sub-b", region: "region", resourceGroup: "shared-rg",
+  cluster: "shared-aks", acrLoginServer: "mirror.azurecr.io",
+});
+
+describe("real adopted-context to upgrade compatibility", () => {
+  it("retains subscription B and does not clear unprovided identity or Key Vault", () => {
+    const context = buildUpgradeContext(adopted());
+    expect(context.subscription).toBe("sub-b");
+    const args = buildHelmUpgradeArgs(context, "chart", "v1.2.3");
+    expect(args).toContain("--reuse-values");
+    expect(args.some(arg => arg.startsWith("azure.workloadIdentity.clientId="))).toBe(false);
+    expect(args.some(arg => arg.startsWith("azure.keyVaultCsi.keyVaultName="))).toBe(false);
+  });
+
+  it.each([undefined, null, "", " "])("preserves release settings when saved optional values are %s", value => {
+    const context = buildUpgradeContext({ ...adopted(), wiClientId: value as string | undefined, keyVaultName: value as string | undefined });
+    const args = buildHelmUpgradeArgs(context, "chart");
+    expect(args.some(arg => arg.startsWith("azure.workloadIdentity.clientId="))).toBe(false);
+    expect(args.some(arg => arg.startsWith("azure.keyVaultCsi.keyVaultName="))).toBe(false);
+  });
+
+  it("applies intentional nonempty adopted identity values", () => {
+    const context = buildAdoptedAksContext({
+      ...adopted(), subscription: "sub-b", region: "region", resourceGroup: "shared-rg",
+      cluster: "shared-aks", wiClientId: "new-client", keyVaultName: "selected-vault",
+    });
+    const args = buildHelmUpgradeArgs(buildUpgradeContext(context), "chart");
+    expect(args).toContain("azure.workloadIdentity.clientId=new-client");
+    expect(args).toContain("azure.keyVaultCsi.keyVaultName=selected-vault");
+  });
+
+  it("updates Helm-owned mesh to the actual imported repositories and selected tag", () => {
+    const mesh: MeshInstallation = {
+      kind: "helm", namespace: "agentmesh", deployments: [], release: "kars",
+      releaseNamespace: "kars-system", values: { agentMesh: { enabled: true } },
+    };
+    const args = buildHelmUpgradeArgs(buildUpgradeContext(adopted()), "chart", "v1.2.3", { mesh });
+    for (const component of ["registry", "relay"]) {
+      expect(args).toContain(`agentMesh.${component}.image.repository=mirror.azurecr.io/agentmesh-${component}-agt`);
+      expect(args).toContain(`agentMesh.${component}.image.tag=v1.2.3`);
+    }
+    expect(args).not.toContain("--take-ownership");
+    expect(args).not.toContain("--force-recreate");
+  });
+
+  it("does not enable or adopt external mesh through an upgrade image override", () => {
+    const args = buildHelmUpgradeArgs(buildUpgradeContext(adopted()), "chart", "v1.2.3", {
+      mesh: { kind: "legacy", namespace: "agentmesh", deployments: [] },
+    });
+    expect(args.some(arg => arg.startsWith("agentMesh."))).toBe(false);
+  });
+
+  it("preflights the same owned mesh artifact values as the real upgrade", async () => {
+    let argv: readonly string[] = [];
+    const execute = (async (_bin: string, args: readonly string[]) => {
+      argv = args;
+      return { stdout: "" };
+    }) as unknown as typeof import("execa").execa;
+    const mesh: MeshInstallation = {
+      kind: "helm", namespace: "agentmesh", deployments: [], release: "kars",
+      releaseNamespace: "kars-system", values: { agentMesh: { enabled: true } },
+    };
+    await preflightFieldManagerConflicts(execute, buildUpgradeContext(adopted()), "chart", "v1.2.3", { mesh });
+    expect(argv).toContain("--dry-run=server");
+    expect(argv).toContain("agentMesh.relay.image.repository=mirror.azurecr.io/agentmesh-relay-agt");
+    expect(argv).toContain("agentMesh.relay.image.tag=v1.2.3");
+  });
+});

--- a/cli/src/commands/upgrade.test.ts
+++ b/cli/src/commands/upgrade.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect } from "vitest";
+import type { MeshInstallation } from "../lib/mesh-release.js";
 import {
   isFoundryProjectHost,
   resolveTargetVersion,
@@ -12,6 +13,14 @@ import {
   parseHelmFieldConflicts,
   suggestConflictRemediation,
 } from "./upgrade.js";
+
+const legacyMesh: MeshInstallation = {
+  kind: "legacy", namespace: "agentmesh",
+  deployments: [
+    { component: "registry", name: "registry", container: "registry", image: "example/registry:latest" },
+    { component: "relay", name: "relay", container: "relay", image: "example/relay:latest" },
+  ],
+};
 
 describe("isFoundryProjectHost", () => {
   it("accepts a real Foundry project endpoint", () => {
@@ -290,36 +299,37 @@ describe("detectCurrentVersion — honest, un-spoofable version detection", () =
 describe("rolloutRestartAll — refreshes every workload, mesh first", () => {
   it("restarts agentmesh relay+registry, the controller, and every sandbox", async () => {
     const calls: string[][] = [];
-    const execa = fakeExeca(() => "", calls);
-    await rolloutRestartAll(execa);
+    const execa = fakeExeca((_bin, args) => args[0] === "get" && args[1] === "deployments"
+      ? JSON.stringify({ items: [{ metadata: { name: "agent", namespace: "kars-agent" } }] }) : "", calls);
+    await rolloutRestartAll(execa, legacyMesh);
     const restarts = calls
       .filter((c) => c[0] === "kubectl" && c[1] === "rollout" && c[2] === "restart")
       .map((c) => c.join(" "));
     // mesh relay + registry by name (narrow, not --all)
-    expect(restarts.some((c) => c.includes("deployment/agentmesh-relay") && c.includes("-n agentmesh"))).toBe(true);
-    expect(restarts.some((c) => c.includes("deployment/agentmesh-registry") && c.includes("-n agentmesh"))).toBe(true);
+    expect(restarts.some((c) => c.includes("deployment/relay") && c.includes("-n agentmesh"))).toBe(true);
+    expect(restarts.some((c) => c.includes("deployment/registry") && c.includes("-n agentmesh"))).toBe(true);
     expect(restarts.some((c) => c.includes("--all"))).toBe(false);
     // controller + sandboxes
-    expect(restarts.some((c) => c.includes("-n kars-system") && c.includes("app.kubernetes.io/name=kars"))).toBe(true);
-    expect(restarts.some((c) => c.includes("-A") && c.includes("kars.azure.com/component=sandbox"))).toBe(true);
+    expect(restarts.some((c) => c.includes("-n kars-system") && c.includes("deployment/kars-controller"))).toBe(true);
+    expect(restarts.some((c) => c.includes("-n kars-agent") && c.includes("deployment/agent"))).toBe(true);
   });
 
   it("restarts the mesh BEFORE the controller (so deps come up against new mesh)", async () => {
     const calls: string[][] = [];
-    await rolloutRestartAll(fakeExeca(() => "", calls));
+    await rolloutRestartAll(fakeExeca((_bin, args) => args[0] === "get" ? '{"items":[]}' : "", calls), legacyMesh);
     const order = calls
       .filter((c) => c[0] === "kubectl" && c[1] === "rollout" && c[2] === "restart")
       .map((c) => c.join(" "));
-    const meshIdx = order.findIndex((c) => c.includes("agentmesh-relay"));
-    const ctrlIdx = order.findIndex((c) => c.includes("app.kubernetes.io/name=kars"));
+    const meshIdx = order.findIndex((c) => c.includes("deployment/relay"));
+    const ctrlIdx = order.findIndex((c) => c.includes("deployment/kars-controller"));
     expect(meshIdx).toBeGreaterThanOrEqual(0);
     expect(ctrlIdx).toBeGreaterThan(meshIdx);
   });
 
-  it("never throws even if every kubectl call fails (best-effort)", async () => {
+  it("propagates restart failures instead of reporting a success-shaped outcome", async () => {
     const calls: string[][] = [];
     const execa = fakeExeca(() => "THROW", calls);
-    await expect(rolloutRestartAll(execa)).resolves.toBeUndefined();
+    await expect(rolloutRestartAll(execa, legacyMesh)).rejects.toThrow("command failed");
   });
 });
 
@@ -327,6 +337,11 @@ describe("verifyHealth — strong enough to gate success", () => {
   const route = (ctrlAvail: string, podReasons: Record<string, string>) =>
     (bin: string, args: string[]): string | undefined => {
       if (bin === "kubectl" && args.includes("deployment") && args.includes("kars-controller")) return ctrlAvail;
+      if (bin === "kubectl" && args[0] === "get" && args[1] === "deployment") return JSON.stringify({
+        metadata: { generation: 1 },
+        spec: { replicas: 1 },
+        status: { observedGeneration: 1, readyReplicas: 1, updatedReplicas: 1, conditions: [{ type: "Available", status: "True" }] },
+      });
       if (bin === "kubectl" && args.includes("pods")) {
         const ns = args[args.indexOf("-n") + 1];
         return podReasons[ns] ?? "";
@@ -335,30 +350,31 @@ describe("verifyHealth — strong enough to gate success", () => {
     };
 
   it("healthy when controller Available and no bad pods", async () => {
-    const r = await verifyHealth(fakeExeca(route("True", {}), []));
+    const r = await verifyHealth(fakeExeca(route("True", {}), []), legacyMesh);
     expect(r.healthy).toBe(true);
   });
 
   it("unhealthy when the controller is not Available", async () => {
-    const r = await verifyHealth(fakeExeca(route("False", {}), []));
+    const r = await verifyHealth(fakeExeca(route("False", {}), []), legacyMesh);
     expect(r.healthy).toBe(false);
     expect(r.reason).toMatch(/controller/i);
   });
 
   it("unhealthy on ImagePullBackOff (the bad-image symptom)", async () => {
-    const r = await verifyHealth(fakeExeca(route("True", { "kars-system": "ImagePullBackOff " }), []));
+    const r = await verifyHealth(fakeExeca(route("True", { "kars-system": "ImagePullBackOff " }), []), legacyMesh);
     expect(r.healthy).toBe(false);
     expect(r.reason).toMatch(/ImagePullBackOff/);
   });
 
   it("unhealthy on CrashLoopBackOff in the agentmesh namespace", async () => {
-    const r = await verifyHealth(fakeExeca(route("True", { agentmesh: "CrashLoopBackOff " }), []));
+    const r = await verifyHealth(fakeExeca(route("True", { agentmesh: "CrashLoopBackOff " }), []), legacyMesh);
     expect(r.healthy).toBe(false);
     expect(r.reason).toMatch(/CrashLoopBackOff/);
   });
 
   it("unhealthy (not a false-positive) when the controller probe errors", async () => {
-    const r = await verifyHealth(fakeExeca(() => "THROW", []));
+    const r = await verifyHealth(fakeExeca(() => "THROW", []), legacyMesh);
     expect(r.healthy).toBe(false);
   });
+
 });

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -27,6 +27,7 @@ import chalk from "chalk";
 import { Stepper, banner, section, kvLine } from "../stepper.js";
 import { loadContext, type DeploymentContext } from "../config.js";
 import { requireBundledAsset } from "../lib/repo-assets.js";
+import { RUNTIME_IMAGE_TARGETS } from "../lib/image-targets.js";
 import { connectDeploymentTarget } from "../lib/deployment-target.js";
 import { restartController, restartSandboxes } from "../lib/deployment-rollout.js";
 import {
@@ -127,15 +128,6 @@ export function buildUpgradeContext(ctx: DeploymentContext): UpgradeContext {
  *  upgrade path enumerates the multi-runtime adapter images, so adding a
  *  runtime (e.g. langgraph-ts) is a one-line change that stays in sync with
  *  the import plan + the `kars up` install. */
-const RUNTIME_IMAGE_VALUES: ReadonlyArray<readonly [valueKey: string, repo: string]> = [
-  ["runtimes.openaiAgents.image", "kars-runtime-openai-agents"],
-  ["runtimes.mafPython.image", "kars-runtime-maf-python"],
-  ["runtimes.anthropic.image", "kars-runtime-anthropic"],
-  ["runtimes.langgraph.image", "kars-runtime-langgraph"],
-  ["runtimes.langgraphTs.image", "kars-runtime-langgraph-ts"],
-  ["runtimes.pydanticAi.image", "kars-runtime-pydantic-ai"],
-  ["runtimes.hermes.image", "kars-runtime-hermes"],
-];
 
 /** Build the `helm upgrade` args.
  *
@@ -186,7 +178,7 @@ export function buildHelmUpgradeArgs(
   // when the operator opted out of importing them — then we leave whatever the
   // prior install set (via --reuse-values) untouched.
   if (!opts.skipRuntimeImages) {
-    for (const [valueKey, repo] of RUNTIME_IMAGE_VALUES) {
+    for (const { valueKey, repo } of RUNTIME_IMAGE_TARGETS) {
       args.push("--set", `${valueKey}=${ctx.acrLoginServer}/${repo}:${tag}`);
     }
   }
@@ -435,6 +427,7 @@ Examples:
         const mesh = await inspectMeshInstallation(execa);
         const values = mesh.kind === "helm" ? mesh.values : await readReleaseValues(execa);
         assertMeshReleaseConsistency(mesh, values);
+        if (mesh.kind === "external") stepper.detail("info", "External AgentMesh is not part of this upgrade and will remain untouched.");
 
         // ── Pre-flight: cluster must be able to run the upgrade ────────
         // Fail fast on a degraded/stopped cluster (e.g. all nodes NotReady)
@@ -497,7 +490,9 @@ Examples:
         stepper.done(`Target release: ${target}`);
 
         // ── Dry-run: print plan + exit ────────────────────────────────
-        const images = releaseImagePlan(target, { includeRuntimes: !options.skipRuntimeImages });
+        const images = releaseImagePlan(target, { includeRuntimes: !options.skipRuntimeImages })
+          .filter(image => !["external", "absent"].includes(mesh.kind)
+            || !/^agentmesh-(relay|registry)-agt:/.test(image.target));
         if (options.dryRun) {
           stepper.stop();
           await printChangelog(current, target);
@@ -613,7 +608,7 @@ Examples:
         // Helm-managed pods; this also refreshes the standalone AgentMesh
         // relay/registry (not Helm-managed) and is a harmless belt-and-braces
         // for the Helm-managed ones.
-        stepper.step("Rolling AgentMesh, controller, router, and sandboxes to the new images...");
+        stepper.step("Rolling Kars-managed workloads to the new images...");
         if (mesh.kind === "legacy") {
           await updateLegacyMeshImages(execa, mesh, releaseMeshImages(ctx.acrLoginServer, target));
         }
@@ -634,7 +629,7 @@ Examples:
           ));
           process.exit(1);
         }
-        stepper.done("Cluster healthy on the new release");
+        stepper.done("Kars-managed workloads healthy on the new release");
 
         // ── Step 7: Reconcile Foundry Memory Store access ─────────────
         // Memory persistence depends on the Foundry PROJECT managed

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -25,8 +25,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { Stepper, banner, section, kvLine } from "../stepper.js";
-import { loadContext } from "../config.js";
+import { loadContext, type DeploymentContext } from "../config.js";
 import { requireBundledAsset } from "../lib/repo-assets.js";
+import { connectDeploymentTarget } from "../lib/deployment-target.js";
+import { restartController, restartSandboxes } from "../lib/deployment-rollout.js";
+import {
+  assertMeshReleaseConsistency, inspectMeshInstallation, meshImageValueArgs,
+  readReleaseValues, recheckMeshOwnership, releaseMeshImages, restartMesh, updateLegacyMeshImages,
+  verifyMeshHealth, type MeshInstallation,
+} from "../lib/mesh-release.js";
 import {
   releaseImagePlan,
   compareVersions,
@@ -39,8 +46,7 @@ import {
 } from "../lib/release.js";
 
 const NS = "kars-system";
-/** Namespace holding the standalone AgentMesh relay + registry Deployments
- *  (applied from `deploy/agentmesh-agt.yaml`, NOT part of the Helm chart). */
+/** Namespace shared by supported Helm-owned and legacy AgentMesh installations. */
 const MESH_NS = "agentmesh";
 
 /**
@@ -90,7 +96,8 @@ export function isFoundryProjectHost(ep: string): boolean {
   }
 }
 
-interface UpgradeContext {
+export interface UpgradeContext {
+  subscription?: string;
   acrLoginServer: string;
   aksCluster: string;
   resourceGroup: string;
@@ -98,6 +105,22 @@ interface UpgradeContext {
   keyVaultName?: string;
   foundryEndpoint?: string;
   foundryProjectEndpoint?: string;
+}
+
+export function buildUpgradeContext(ctx: DeploymentContext): UpgradeContext {
+  if (!ctx.acrLoginServer || !ctx.aksCluster || !ctx.resourceGroup) {
+    throw new Error("Deployment context requires its ACR, AKS cluster and resource group");
+  }
+  return {
+    subscription: ctx.subscription,
+    acrLoginServer: ctx.acrLoginServer,
+    aksCluster: ctx.aksCluster,
+    resourceGroup: ctx.resourceGroup,
+    wiClientId: ctx.wiClientId,
+    keyVaultName: ctx.keyVaultName,
+    foundryEndpoint: ctx.foundryEndpoint,
+    foundryProjectEndpoint: ctx.foundryProjectEndpoint,
+  };
 }
 
 /** Chart `runtimes.*` value keys → ACR repo names. The single place the
@@ -136,7 +159,7 @@ export function buildHelmUpgradeArgs(
   ctx: UpgradeContext,
   helmPath: string,
   target?: string,
-  opts: { skipRuntimeImages?: boolean; forceConflicts?: boolean; dryRunServer?: boolean } = {},
+  opts: { skipRuntimeImages?: boolean; forceConflicts?: boolean; dryRunServer?: boolean; mesh?: MeshInstallation } = {},
 ): string[] {
   const tag = target && target.length > 0 ? target : "latest";
   const args = [
@@ -150,9 +173,14 @@ export function buildHelmUpgradeArgs(
     "--set", `inferenceRouter.image.tag=${tag}`,
     "--set", `sandbox.image.repository=${ctx.acrLoginServer}/openclaw-sandbox`,
     "--set", `sandbox.image.tag=${tag}`,
-    "--set", `azure.workloadIdentity.clientId=${ctx.wiClientId || ""}`,
-    "--set", `azure.keyVaultCsi.keyVaultName=${ctx.keyVaultName || ""}`,
   ];
+  // Optional adoption fields are not clear operations. --reuse-values retains
+  // the verified release's identity and Key Vault when the cache omits them.
+  if (ctx.wiClientId?.trim()) args.push("--set", `azure.workloadIdentity.clientId=${ctx.wiClientId}`);
+  if (ctx.keyVaultName?.trim()) args.push("--set", `azure.keyVaultCsi.keyVaultName=${ctx.keyVaultName}`);
+  if (opts.mesh?.kind === "helm") {
+    args.push(...meshImageValueArgs(releaseMeshImages(ctx.acrLoginServer, tag)));
+  }
   // Pin every runtime adapter image explicitly (don't rely on --reuse-values,
   // which can't materialise a value an older install never set). Skipped only
   // when the operator opted out of importing them — then we leave whatever the
@@ -313,17 +341,17 @@ function reportFieldManagerConflicts(conflicts: FieldManagerConflict[]): void {
 /** Server-side dry-run pre-flight: detect field-manager conflicts WITHOUT
  *  changing anything. Returns the parsed conflicts (empty if the dry-run
  *  succeeds). A dry-run that fails for any *other* reason is reported as
- *  `otherError` and is non-fatal: the real upgrade runs next and surfaces the
- *  authoritative error rather than blocking on a flaky pre-flight. */
-async function preflightFieldManagerConflicts(
+ *  `otherError`; the caller stops rather than applying an unverified plan. */
+export async function preflightFieldManagerConflicts(
   execa: Execa,
   ctx: UpgradeContext,
   helmPath: string,
   target: string,
-  opts: { skipRuntimeImages?: boolean },
+  opts: { skipRuntimeImages?: boolean; mesh?: MeshInstallation },
 ): Promise<{ conflicts: FieldManagerConflict[]; otherError?: string }> {
   const args = buildHelmUpgradeArgs(ctx, helmPath, target, {
     skipRuntimeImages: opts.skipRuntimeImages,
+    mesh: opts.mesh,
     dryRunServer: true,
   });
   try {
@@ -368,7 +396,7 @@ Examples:
   kars upgrade --rollback          # Revert to the previous Helm revision
 `)
     .action(async (options) => {
-      const { execa } = await import("execa");
+      const { execa: rawExeca } = await import("execa");
 
       // ── Load + validate cached context ──────────────────────────────
       const ctxRaw = loadContext();
@@ -379,15 +407,7 @@ Examples:
         ));
         process.exit(1);
       }
-      const ctx: UpgradeContext = {
-        acrLoginServer: ctxRaw.acrLoginServer,
-        aksCluster: ctxRaw.aksCluster,
-        resourceGroup: ctxRaw.resourceGroup,
-        wiClientId: ctxRaw.wiClientId,
-        keyVaultName: ctxRaw.keyVaultName,
-        foundryEndpoint: ctxRaw.foundryEndpoint,
-        foundryProjectEndpoint: ctxRaw.foundryProjectEndpoint,
-      };
+      const ctx = buildUpgradeContext(ctxRaw);
       const acrName = ctx.acrLoginServer.replace(/\.azurecr\.io$/, "");
 
       banner("kars · Upgrade", "Move an existing cluster to a published release");
@@ -397,15 +417,13 @@ Examples:
       try {
         // ── Step 1: Connect to the cluster ────────────────────────────
         stepper.step(`Connecting to AKS '${ctx.aksCluster}'...`);
-        await execa("az", [
-          "aks", "get-credentials",
-          "--name", ctx.aksCluster, "--resource-group", ctx.resourceGroup,
-          "--overwrite-existing", "--output", "none",
-        ], { stdio: "pipe" });
+        const connected = await connectDeploymentTarget(rawExeca, ctx);
+        const execa = connected.execute;
+        ctx.subscription = connected.subscription;
         // Sanity: the Helm release must exist to upgrade/rollback.
         const { stdout: relJson } = await execa("helm", [
           "list", "-n", NS, "-o", "json",
-        ], { stdio: "pipe" }).catch(() => ({ stdout: "[]" }));
+        ], { stdio: "pipe" });
         const releases = JSON.parse(relJson || "[]") as Array<{ name: string; revision: string; app_version?: string }>;
         const karsRel = releases.find((r) => r.name === "kars");
         if (!karsRel) {
@@ -414,6 +432,9 @@ Examples:
           process.exit(1);
         }
         stepper.done(`Connected — kars release at revision ${karsRel.revision}`);
+        const mesh = await inspectMeshInstallation(execa);
+        const values = mesh.kind === "helm" ? mesh.values : await readReleaseValues(execa);
+        assertMeshReleaseConsistency(mesh, values);
 
         // ── Pre-flight: cluster must be able to run the upgrade ────────
         // Fail fast on a degraded/stopped cluster (e.g. all nodes NotReady)
@@ -440,13 +461,14 @@ Examples:
           stepper.done("Helm release rolled back");
 
           stepper.step("Restarting workloads...");
-          await rolloutRestartAll(execa);
+          const rollbackMesh = await inspectMeshInstallation(execa);
+          await rolloutRestartAll(execa, rollbackMesh);
           stepper.done("Workloads restarted");
 
           stepper.step("Verifying cluster health...");
-          const rbHealth = await verifyHealth(execa);
+          const rbHealth = await verifyHealth(execa, rollbackMesh);
           if (rbHealth.healthy) stepper.done("Cluster healthy after rollback");
-          else stepper.warn(`Rollback applied but the cluster isn't fully healthy yet: ${rbHealth.reason} — check \`kars status\``);
+          else throw new Error(`Rollback applied but cluster health failed: ${rbHealth.reason}`);
           stepper.summary();
           process.exit(0);
         }
@@ -552,6 +574,7 @@ Examples:
         // ── Step 4: Atomic Helm upgrade ───────────────────────────────
         stepper.step("Upgrading controller + CRDs (atomic Helm upgrade)...");
         const helmPath = requireBundledAsset("deploy/helm/kars");
+        await recheckMeshOwnership(execa, mesh);
 
         // Pre-flight: a server-side dry-run detects fields owned by another
         // field manager (e.g. a manual `kubectl set env`). Helm v4 applies
@@ -561,6 +584,7 @@ Examples:
         // silently overwriting a field a live operator may legitimately own.
         const pf = await preflightFieldManagerConflicts(execa, ctx, helmPath, target, {
           skipRuntimeImages: options.skipRuntimeImages,
+          mesh,
         });
         if (pf.conflicts.length > 0 && !options.forceConflicts) {
           stepper.fail("Field-manager conflict — upgrade stopped before any change");
@@ -574,12 +598,13 @@ Examples:
         if (pf.otherError) {
           // Non-conflict dry-run failure: don't block — the real upgrade below
           // surfaces the authoritative error (and its --atomic rolls back).
-          stepper.detail("info", "Pre-flight dry-run inconclusive — proceeding (real upgrade will report any error)");
+          throw new Error(`Helm pre-flight failed: ${pf.otherError}`);
         }
 
         await execa("helm", buildHelmUpgradeArgs(ctx, helmPath, target, {
           skipRuntimeImages: options.skipRuntimeImages,
           forceConflicts: options.forceConflicts,
+          mesh,
         }), { stdio: "pipe" });
         stepper.done("Helm upgrade applied (auto-rollback on failure via --atomic)");
 
@@ -589,12 +614,16 @@ Examples:
         // relay/registry (not Helm-managed) and is a harmless belt-and-braces
         // for the Helm-managed ones.
         stepper.step("Rolling AgentMesh, controller, router, and sandboxes to the new images...");
-        await rolloutRestartAll(execa);
+        if (mesh.kind === "legacy") {
+          await updateLegacyMeshImages(execa, mesh, releaseMeshImages(ctx.acrLoginServer, target));
+        }
+        await rolloutRestartAll(execa, mesh);
         stepper.done("Workloads restarted");
 
         // ── Step 6: Verify health (gates success) ─────────────────────
         stepper.step("Verifying cluster health...");
-        const health = await verifyHealth(execa);
+        const health = await verifyHealth(execa, mesh);
+        await verifyMeshHealth(execa, mesh, releaseMeshImages(ctx.acrLoginServer, target));
         if (!health.healthy) {
           stepper.fail("Cluster is not healthy after the upgrade");
           console.error(chalk.red(`\n  ${health.reason}\n`));
@@ -623,8 +652,8 @@ Examples:
             for (const n of mem.notes) stepper.detail("info", n);
             if (mem.granted) stepper.done("Foundry Memory Store access reconciled");
             else stepper.warn("Foundry Memory Store needs manual RBAC — see the notes above");
-          } catch {
-            stepper.warn("Could not reconcile Foundry Memory Store access (non-fatal) — run `kars up` to retry");
+          } catch (error) {
+            throw new Error("Foundry Memory Store reconciliation failed", { cause: error });
           }
         } else {
           stepper.done("No Foundry project bound — Memory Store reconcile skipped");
@@ -752,29 +781,13 @@ async function acrImport(execa: Execa, acrName: string, src: string, target: str
   ], { stdio: "pipe" }).then(() => true).catch(() => false);
 }
 
-/** Rolling-restart every kars workload so the new images are pulled.
- *
- *  Order matters: the AgentMesh relay + registry are restarted (and waited on)
- *  FIRST, so the controller + sandboxes that connect to the mesh come up
- *  against the already-upgraded mesh rather than briefly attaching to the old
- *  one and getting disconnected. The mesh deployments are standalone (in the
- *  `agentmesh` namespace, applied from a manifest, NOT Helm-managed), so
- *  nothing else refreshes them. We target the two known deployments by name
- *  rather than `--all` to keep the blast radius off anything else that might
- *  share the namespace. All best-effort — a missing deployment/namespace is a
- *  no-op, never a hard failure. */
-export async function rolloutRestartAll(execa: Execa): Promise<void> {
-  // 1. AgentMesh relay + registry first, then wait for them.
-  for (const dep of ["agentmesh-relay", "agentmesh-registry"]) {
-    await execa("kubectl", ["rollout", "restart", `deployment/${dep}`, "-n", MESH_NS], { stdio: "pipe" }).catch(() => {});
-    await execa("kubectl", ["rollout", "status", `deployment/${dep}`, "-n", MESH_NS, "--timeout=180s"], { stdio: "pipe" }).catch(() => {});
-  }
-  // 2. Controller (the inference-router runs as a sidecar inside each sandbox).
-  await execa("kubectl", ["rollout", "restart", "deployment", "-n", NS, "-l", "app.kubernetes.io/name=kars"], { stdio: "pipe" }).catch(() => {});
-  // 3. Sandboxes (per-component label, across namespaces).
-  await execa("kubectl", ["rollout", "restart", "deployment", "-A", "-l", "kars.azure.com/component=sandbox"], { stdio: "pipe" }).catch(() => {});
-  // 4. Wait for the controller to settle.
-  await execa("kubectl", ["rollout", "status", "deployment", "-n", NS, "kars-controller", "--timeout=300s"], { stdio: "pipe" }).catch(() => {});
+/** Restart actual mesh workloads first and wait for every changed deployment.
+ * A failed inventory, restart, or rollout is an upgrade failure. */
+export async function rolloutRestartAll(execa: Execa, installation?: MeshInstallation): Promise<void> {
+  const mesh = installation ?? await inspectMeshInstallation(execa);
+  await restartMesh(execa, mesh);
+  await restartController(execa);
+  await restartSandboxes(execa);
 }
 
 /** Structured health verdict for a post-upgrade / post-rollback check. */
@@ -789,7 +802,7 @@ export interface HealthResult {
  *  ImagePullBackOff / ErrImagePull / CrashLoopBackOff (the exact symptoms a bad
  *  `:version` image produces). Best-effort kubectl; any probe error degrades to
  *  a clear, non-healthy reason rather than a false "healthy". */
-export async function verifyHealth(execa: Execa): Promise<HealthResult> {
+export async function verifyHealth(execa: Execa, installation?: MeshInstallation): Promise<HealthResult> {
   const { stdout: ctrl } = await execa("kubectl", [
     "get", "deployment", "kars-controller", "-n", NS,
     "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
@@ -797,16 +810,21 @@ export async function verifyHealth(execa: Execa): Promise<HealthResult> {
   if (ctrl.trim() !== "True") {
     return { healthy: false, reason: "kars-controller Deployment is not Available." };
   }
-  // Scan for image-pull / crash-loop across the control-plane + mesh namespaces.
-  for (const ns of [NS, MESH_NS]) {
-    const { stdout } = await execa("kubectl", [
-      "get", "pods", "-n", ns,
-      "-o", "jsonpath={range .items[*]}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{end}",
-    ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
-    const bad = ["ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff"].find((r) => stdout.includes(r));
-    if (bad) {
-      return { healthy: false, reason: `One or more pods in '${ns}' are in ${bad} (likely a bad image).` };
+  try {
+    const mesh = installation ?? await inspectMeshInstallation(execa);
+    await verifyMeshHealth(execa, mesh);
+    for (const ns of mesh.deployments.length ? [NS, MESH_NS] : [NS]) {
+      const { stdout } = await execa("kubectl", [
+        "get", "pods", "-n", ns,
+        "-o", "jsonpath={range .items[*]}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{end}",
+      ], { stdio: "pipe" });
+      const bad = ["ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff"].find((r) => stdout.includes(r));
+      if (bad) {
+        return { healthy: false, reason: `One or more pods in '${ns}' are in ${bad} (likely a bad image).` };
+      }
     }
+  } catch (error) {
+    return { healthy: false, reason: error instanceof Error ? error.message : String(error) };
   }
   return { healthy: true, reason: "" };
 }
@@ -978,13 +996,11 @@ export async function assertClusterUpgradeable(
   const { stdout } = await execa("kubectl", [
     "get", "nodes",
     "-o", "jsonpath={range .items[*]}{.metadata.name}{\"|\"}{range .status.conditions[?(@.type=='Ready')]}{.status}{end}{\"\\n\"}{end}",
-  ], { stdio: "pipe" }).catch(() => ({ stdout: "" }));
+  ], { stdio: "pipe" });
 
   const lines = stdout.split("\n").map((l) => l.trim()).filter(Boolean);
   if (lines.length === 0) {
-    // Couldn't read nodes — don't hard-block on an unexpected API shape; the
-    // later `helm --wait` still guards correctness.
-    return { ok: true, reason: "", hints: [] };
+    return { ok: false, reason: "No cluster nodes were returned; upgrade stopped before image imports or cluster updates.", hints: [] };
   }
   const total = lines.length;
   const ready = lines.filter((l) => l.endsWith("|True")).length;

--- a/cli/src/config.test.ts
+++ b/cli/src/config.test.ts
@@ -263,6 +263,20 @@ describe("saveContext", () => {
         acrLoginServer: "ghcr.io/example",
       })).toThrow("*.azurecr.io");
     });
+
+    it("supports public GHCR installs without an ACR mirror", () => {
+      expect(buildAdoptedAksContext({
+        subscription: "sub-123",
+        region: "eastus2",
+        resourceGroup: "rg-existing",
+        cluster: "aks-existing",
+      })).toMatchObject({
+        aksCluster: "aks-existing",
+        acrLoginServer: undefined,
+        acrName: undefined,
+        phase: "complete",
+      });
+    });
   });
 
   it("sets restrictive file permissions (0o600)", () => {

--- a/cli/src/config.test.ts
+++ b/cli/src/config.test.ts
@@ -20,6 +20,7 @@ import {
   loadSecrets, saveSecrets, setSecret, deleteSecret, resolveSecret,
   listSecretVariants, KNOWN_SECRETS,
 } from "./config.js";
+import { buildAdoptedAksContext } from "./commands/config.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "fs";
 
 const mockExistsSync = vi.mocked(existsSync);
@@ -231,6 +232,37 @@ describe("saveContext", () => {
     expect(written.subscription).toBe("sub-123");
     expect(written.region).toBe("eastus2");
     expect(written.savedAt).toBeDefined();
+  });
+
+  describe("buildAdoptedAksContext", () => {
+    it("creates the deployment context required by upgrade and push", () => {
+      expect(buildAdoptedAksContext({
+        subscription: "sub-123",
+        region: "eastus2",
+        resourceGroup: "rg-existing",
+        cluster: "aks-existing",
+        acrLoginServer: "https://contoso.azurecr.io/",
+      })).toMatchObject({
+        subscription: "sub-123",
+        region: "eastus2",
+        resourceGroup: "rg-existing",
+        aksCluster: "aks-existing",
+        acrLoginServer: "contoso.azurecr.io",
+        acrName: "contoso",
+        registryMode: "local",
+        phase: "complete",
+      });
+    });
+
+    it("rejects non-ACR registries", () => {
+      expect(() => buildAdoptedAksContext({
+        subscription: "sub-123",
+        region: "eastus2",
+        resourceGroup: "rg-existing",
+        cluster: "aks-existing",
+        acrLoginServer: "ghcr.io/example",
+      })).toThrow("*.azurecr.io");
+    });
   });
 
   it("sets restrictive file permissions (0o600)", () => {

--- a/cli/src/lib/azure-subscription.ts
+++ b/cli/src/lib/azure-subscription.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Shared subscription pinning from the deployment-safety implementation (#531).
+export function pinAzureSubscription(args: readonly string[], subscriptionId: string): string[] {
+  const pinnedId = subscriptionId.trim();
+  if (!pinnedId) throw new Error("Azure subscription ID must not be empty");
+  const result = [...args];
+  const indexes = result.flatMap((arg, index) =>
+    arg === "--subscription" || arg.startsWith("--subscription=") ? [index] : []);
+  if (indexes.length === 0) return [...result, "--subscription", pinnedId];
+  if (indexes.length > 1) throw new Error("Azure command contains duplicate --subscription options");
+  const index = indexes[0];
+  const explicit = result[index] === "--subscription"
+    ? result[index + 1] : result[index].slice("--subscription=".length);
+  if (!explicit) throw new Error("--subscription requires a subscription ID");
+  if (explicit !== pinnedId) {
+    throw new Error(`Azure command is scoped to subscription '${explicit}', not the deployment subscription '${pinnedId}'`);
+  }
+  return result;
+}
+
+export function createSubscriptionPinnedExeca(
+  execute: typeof import("execa").execa,
+  subscriptionId: string,
+): typeof import("execa").execa {
+  return ((file: string, args?: readonly string[], options?: unknown) =>
+    execute(file, file === "az" ? pinAzureSubscription(args ?? [], subscriptionId) : args, options as never)
+  ) as unknown as typeof import("execa").execa;
+}

--- a/cli/src/lib/core-image-apply.ts
+++ b/cli/src/lib/core-image-apply.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Execute } from "./deployment-target.js";
+import { controllerEnv, coreImageValues, type PushedImage } from "./image-targets.js";
+import { readReleaseValues } from "./mesh-release.js";
+
+export interface DeploymentRecord {
+  metadata: { name: string; namespace: string; resourceVersion?: string; generation?: number; labels?: Record<string, string>; annotations?: Record<string, string>; ownerReferences?: unknown[] };
+  spec: { replicas?: number; template: { metadata?: { labels?: Record<string, string> }; spec: {
+    containers: Array<{ name: string; image: string; imagePullPolicy?: string; env?: Array<{ name: string; value?: string; valueFrom?: unknown }> }>;
+    initContainers?: Array<{ name: string; image: string; imagePullPolicy?: string }>;
+  } } };
+  status?: { observedGeneration?: number; readyReplicas?: number; updatedReplicas?: number; conditions?: Array<{ type: string; status: string }> };
+}
+export type CoreInstallation = { kind: "legacy"; deployment: DeploymentRecord; container: string }
+  | { kind: "helm"; deployment: DeploymentRecord; container: string; release: string; releaseNamespace: string; values: Record<string, unknown> };
+
+export async function readDeployment(execute: Execute, name: string, namespace: string): Promise<DeploymentRecord> {
+  const { stdout } = await execute("kubectl", ["get", "deployment", name, "-n", namespace, "-o", "json"], { stdio: "pipe" });
+  const deployment = JSON.parse(String(stdout)) as DeploymentRecord;
+  if (deployment?.metadata?.name !== name || !Array.isArray(deployment.spec?.template?.spec?.containers)) {
+    throw new Error(`Invalid deployment evidence for ${namespace}/${name}`);
+  }
+  return deployment;
+}
+
+export async function inspectCoreInstallation(execute: Execute): Promise<CoreInstallation> {
+  const deployment = await readDeployment(execute, "kars-controller", "kars-system");
+  const containers = deployment.spec.template.spec.containers;
+  const container = containers.find(item => item.name === "controller" || item.name === "kars-controller")
+    ?? (containers.length === 1 ? containers[0] : undefined);
+  if (!container) throw new Error("Cannot identify the Kars controller container");
+  const metadata = deployment.metadata;
+  if (metadata.ownerReferences?.length) throw new Error("Kars controller has an external Kubernetes owner");
+  const release = metadata.annotations?.["meta.helm.sh/release-name"];
+  const releaseNamespace = metadata.annotations?.["meta.helm.sh/release-namespace"];
+  const manager = metadata.labels?.["app.kubernetes.io/managed-by"];
+  if (!release && !releaseNamespace && !manager) return { kind: "legacy", deployment, container: container.name };
+  if (!release || !releaseNamespace || manager !== "Helm") throw new Error("Kars controller ownership is ambiguous");
+  const { stdout } = await execute("helm", ["list", "-n", releaseNamespace, "-o", "json"], { stdio: "pipe" });
+  const releases: unknown = JSON.parse(String(stdout));
+  if (!Array.isArray(releases) || !releases.some(item => item?.name === release
+    && typeof item.chart === "string" && item.chart.startsWith("kars-"))) throw new Error("Controller is not owned by a verified Kars release");
+  return { kind: "helm", deployment, container: container.name, release, releaseNamespace,
+    values: await readReleaseValues(execute, release, releaseNamespace) };
+}
+
+export async function recheckCoreOwnership(execute: Execute, core: CoreInstallation): Promise<void> {
+  const current = await inspectCoreInstallation(execute);
+  if (current.kind !== core.kind || current.container !== core.container
+    || (core.kind === "helm" && (current.kind !== "helm" || current.release !== core.release || current.releaseNamespace !== core.releaseNamespace))) {
+    throw new Error("Controller ownership changed during image preparation");
+  }
+}
+
+export async function updateLegacyCore(execute: Execute, core: CoreInstallation, images: PushedImage[]): Promise<void> {
+  if (core.kind !== "legacy") throw new Error("Direct controller updates require unmanaged ownership");
+  const verified = await inspectCoreInstallation(execute);
+  if (verified.kind !== "legacy") throw new Error("Controller ownership changed before its legacy update");
+  const current = verified.deployment;
+  if (!current.metadata.resourceVersion) throw new Error("Controller version is missing; refusing an unguarded update");
+  const index = current.spec.template.spec.containers.findIndex(item => item.name === core.container);
+  if (index < 0) throw new Error("Controller container changed");
+  const container = current.spec.template.spec.containers[index];
+  const env = [...(container.env ?? [])];
+  const operations: unknown[] = [{ op: "test", path: "/metadata/resourceVersion", value: current.metadata.resourceVersion }];
+  for (const item of images) {
+    if (item.name === "controller") {
+      operations.push({ op: "add", path: `/spec/template/spec/containers/${index}/image`, value: item.image },
+        { op: "add", path: `/spec/template/spec/containers/${index}/imagePullPolicy`, value: "Always" });
+    }
+    const name = controllerEnv(item.name);
+    if (name) {
+      if (env.filter(value => value.name === name).length > 1) throw new Error(`Ambiguous controller environment ${name}`);
+      const entry = env.findIndex(value => value.name === name);
+      if (entry < 0) env.push({ name, value: item.image });
+      else env[entry] = { name, value: item.image };
+    }
+  }
+  if (images.some(item => controllerEnv(item.name))) operations.push({ op: "add", path: `/spec/template/spec/containers/${index}/env`, value: env });
+  await execute("kubectl", ["patch", "deployment/kars-controller", "-n", "kars-system", "--type=json", "-p", JSON.stringify(operations)], { stdio: "pipe" });
+}
+
+export function valueAt(values: Record<string, unknown>, path: string): unknown {
+  return path.split(".").reduce<unknown>((value, key) =>
+    value && typeof value === "object" ? (value as Record<string, unknown>)[key] : undefined, values);
+}
+
+export async function verifyCoreConfiguration(execute: Execute, core: CoreInstallation, images: PushedImage[]): Promise<DeploymentRecord> {
+  if (core.kind === "helm") {
+    const values = await readReleaseValues(execute, core.release, core.releaseNamespace);
+    for (const [key, value] of Object.entries(coreImageValues(images))) {
+      if (valueAt(values, key) !== value) throw new Error(`Helm did not retain selected image configuration '${key}'`);
+    }
+  }
+  const deployment = await readDeployment(execute, "kars-controller", "kars-system");
+  const container = deployment.spec.template.spec.containers.find(item => item.name === core.container);
+  if (!container) throw new Error("Controller container missing after update");
+  for (const item of images) {
+    if (item.name === "controller" && container.image !== item.image) throw new Error("Controller is not configured with the selected artifact");
+    const envName = controllerEnv(item.name);
+    if (envName) {
+      const entries = container.env?.filter(entry => entry.name === envName) ?? [];
+      if (entries.length !== 1 || entries[0].value !== item.image) throw new Error(`Controller default '${envName}' does not match the selected artifact`);
+    }
+  }
+  return deployment;
+}
+
+export function requireHealthyDeployment(deployment: DeploymentRecord): void {
+  const desired = deployment.spec.replicas ?? 1;
+  if (desired < 1 || (deployment.status?.updatedReplicas ?? 0) < desired
+    || (deployment.status?.readyReplicas ?? 0) < desired
+    || (deployment.status?.observedGeneration ?? -1) < (deployment.metadata.generation ?? 0)
+    || !deployment.status?.conditions?.some(condition => condition.type === "Available" && condition.status === "True")) {
+    throw new Error(`Deployment ${deployment.metadata.namespace}/${deployment.metadata.name} is not healthy on its selected configuration`);
+  }
+}

--- a/cli/src/lib/deployment-rollout.ts
+++ b/cli/src/lib/deployment-rollout.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Execute } from "./deployment-target.js";
+
+export async function restartController(execute: Execute): Promise<void> {
+  await execute("kubectl", ["rollout", "restart", "deployment/kars-controller", "-n", "kars-system"], { stdio: "pipe" });
+  await execute("kubectl", ["rollout", "status", "deployment/kars-controller", "-n", "kars-system", "--timeout=300s"], { stdio: "pipe" });
+}
+
+export async function restartSandboxes(execute: Execute): Promise<void> {
+  const { stdout } = await execute("kubectl", [
+    "get", "deployments", "-A", "-l", "kars.azure.com/component=sandbox", "-o", "json",
+  ], { stdio: "pipe" });
+  const list = JSON.parse(String(stdout)) as { items?: Array<{ metadata?: { name?: string; namespace?: string } }> };
+  if (!Array.isArray(list.items)) throw new Error("Sandbox deployment inventory returned invalid JSON");
+  for (const deployment of list.items) {
+    const { name, namespace } = deployment.metadata ?? {};
+    if (!name || !namespace) throw new Error("Sandbox deployment inventory omitted its name or namespace");
+    await execute("kubectl", ["rollout", "restart", `deployment/${name}`, "-n", namespace], { stdio: "pipe" });
+    await execute("kubectl", ["rollout", "status", `deployment/${name}`, "-n", namespace, "--timeout=300s"], { stdio: "pipe" });
+  }
+}

--- a/cli/src/lib/deployment-target.test.ts
+++ b/cli/src/lib/deployment-target.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, vi } from "vitest";
+import { pinAzureSubscription, createSubscriptionPinnedExeca } from "./azure-subscription.js";
+import {
+  connectDeploymentTarget, createDeploymentExecutor, preparePushTarget,
+  resolveDeploymentSubscription, verifyAdoptedTarget, type Execute,
+} from "./deployment-target.js";
+
+const context = { subscription: "sub-b", resourceGroup: "shared-rg", aksCluster: "shared-aks" };
+const identity = {
+  id: "/subscriptions/sub-b/resourceGroups/shared-rg/providers/Microsoft.ContainerService/managedClusters/shared-aks",
+  fqdn: "cluster-b.example.test",
+};
+
+function executor(route: (bin: string, args: string[]) => string) {
+  return vi.fn(async (bin: string, args: readonly string[]) => ({ stdout: route(bin, [...args]) })) as unknown as Execute;
+}
+
+function recorded(execute: Execute): Array<[string, string[]]> {
+  return vi.mocked(execute).mock.calls as unknown as Array<[string, string[]]>;
+}
+
+function connectedRoute(bin: string, args: string[]): string {
+  if (bin === "az" && args[0] === "aks" && args[1] === "show") return JSON.stringify(identity);
+  if (bin === "kubectl" && args.includes("view")) return "https://cluster-b.example.test";
+  if (bin === "kubectl" && args.includes("current-context")) return "adopted";
+  return "";
+}
+
+describe("deployment subscription pinning (shared #531 pattern)", () => {
+  it("does not use ambient account A when the cache selected B", async () => {
+    const raw = executor(() => "");
+    expect(await resolveDeploymentSubscription(raw, context)).toBe("sub-b");
+    expect(raw).not.toHaveBeenCalled();
+    await createSubscriptionPinnedExeca(raw, "sub-b")("az", ["acr", "login", "--name", "mirror"]);
+    expect(raw).toHaveBeenCalledWith("az", ["acr", "login", "--name", "mirror", "--subscription", "sub-b"], undefined);
+  });
+
+  it("retains matching pins and rejects duplicate or conflicting explicit pins", () => {
+    expect(pinAzureSubscription(["aks", "show", "--subscription=sub-b"], "sub-b"))
+      .toEqual(["aks", "show", "--subscription=sub-b"]);
+    expect(() => pinAzureSubscription(["aks", "show", "--subscription", "sub-a"], "sub-b")).toThrow("not the deployment");
+    expect(() => pinAzureSubscription(["aks", "show", "--subscription", "sub-b", "--subscription=sub-b"], "sub-b")).toThrow("duplicate");
+    expect(() => pinAzureSubscription(["aks", "show", "--subscription"], "sub-b")).toThrow("requires");
+  });
+
+  it.each(["ResourceNotFound", "ResourceGroupNotFound", "ManagedClusterNotFound", "ParentResourceNotFound"])(
+    "legacy discovery skips only explicit %s results", async code => {
+      const raw = executor((_bin, args) => {
+        if (args[0] === "account") return JSON.stringify(["sub-a", "sub-b"]);
+        if (args[args.indexOf("--subscription") + 1] === "sub-a") throw new Error(`(${code}) absent`);
+        return JSON.stringify({ name: "shared-aks", resourceGroup: "shared-rg" });
+      });
+      expect(await resolveDeploymentSubscription(raw, { ...context, subscription: undefined })).toBe("sub-b");
+      expect(recorded(raw).slice(1).every(([, args]) => args.includes("--subscription"))).toBe(true);
+    },
+  );
+
+  it("rejects ambiguous legacy cluster names instead of choosing the ambient subscription", async () => {
+    const raw = executor((_bin, args) => args[0] === "account"
+      ? JSON.stringify(["sub-a", "sub-b"])
+      : JSON.stringify({ name: "shared-aks", resourceGroup: "shared-rg" }));
+    await expect(resolveDeploymentSubscription(raw, { ...context, subscription: undefined })).rejects.toThrow("multiple");
+    expect(recorded(raw).every(([, args]) => args[1] === "list" || args[1] === "show")).toBe(true);
+  });
+
+  it.each(["(AuthorizationFailed) denied", "timed out"])("propagates %s rather than treating it as absence", async message => {
+    const raw = executor((_bin, args) => {
+      if (args[0] === "account") return JSON.stringify(["sub-a", "sub-b"]);
+      throw new Error(message);
+    });
+    await expect(resolveDeploymentSubscription(raw, { ...context, subscription: undefined })).rejects.toThrow(message);
+    expect(raw).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["garbage", "{}", "[null]"])("rejects malformed legacy discovery: %s", async response => {
+    await expect(resolveDeploymentSubscription(executor(() => response), { ...context, subscription: undefined })).rejects.toThrow();
+  });
+});
+
+describe("verified Kubernetes target", () => {
+  it("pins credential retrieval, Azure mutation, Helm and kubectl to adopted B", async () => {
+    const raw = executor(connectedRoute);
+    const target = await connectDeploymentTarget(raw, context);
+    await target.execute("az", ["acr", "import", "--name", "mirror", "--source", "ghcr.io/azure/example:latest"]);
+    await target.execute("az", ["role", "assignment", "create", "--role", "reader"]);
+    await target.execute("helm", ["upgrade", "kars", "chart"]);
+    await target.execute("kubectl", ["rollout", "restart", "deployment/relay"]);
+    const calls = recorded(raw);
+    for (const [bin, argv] of calls) {
+      const args = argv as string[];
+      if (bin === "az") expect(args[args.indexOf("--subscription") + 1]).toBe("sub-b");
+      if (bin === "helm") expect(args[args.indexOf("--kube-context") + 1]).toBe(target.kubeContext);
+      if (bin === "kubectl") expect(args[args.indexOf("--context") + 1]).toBe(target.kubeContext);
+    }
+    expect(calls.some(([, args]) => args?.[0] === "account" && args?.[1] === "set")).toBe(false);
+  });
+
+  it("rejects Azure identity A before retrieving credentials or mutating anything", async () => {
+    const raw = executor(() => JSON.stringify({ ...identity, id: identity.id.replace("sub-b", "sub-a") }));
+    await expect(connectDeploymentTarget(raw, context)).rejects.toThrow("does not match");
+    expect(raw).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects kubeconfig A before any Helm, ACR, or rollout mutation", async () => {
+    const raw = executor((bin, args) => bin === "kubectl" ? "https://cluster-a.example.test" : connectedRoute(bin, args));
+    await expect(connectDeploymentTarget(raw, context)).rejects.toThrow("does not point");
+    expect(recorded(raw).some(([bin, args]) => bin === "helm" || args.includes("import") || args.includes("rollout"))).toBe(false);
+  });
+
+  it("rejects conflicting Kubernetes selections before subprocess execution", () => {
+    const raw = executor(() => "");
+    const pinned = createDeploymentExecutor(raw, "sub-b", "verified");
+    expect(() => pinned("kubectl", ["apply", "--context", "wrong"])).toThrow("different");
+    expect(() => pinned("helm", ["upgrade", "--kube-context=wrong"])).toThrow("different");
+    expect(raw).not.toHaveBeenCalled();
+  });
+
+  it("adoption verifies the existing context without rewriting kubeconfig", async () => {
+    const raw = executor(connectedRoute);
+    const scoped = await verifyAdoptedTarget(raw, context, "existing-b");
+    await scoped("helm", ["status", "kars"]);
+    expect(recorded(raw).some(([, args]) => args.includes("get-credentials"))).toBe(false);
+    expect(recorded(raw).at(-1)?.[1]).toEqual(["status", "kars", "--kube-context", "existing-b"]);
+  });
+
+  it("push without apply scopes ACR login but does not require Kubernetes", async () => {
+    const raw = executor(() => "");
+    const scoped = await preparePushTarget(raw, { subscription: "sub-b" }, {});
+    await scoped("az", ["acr", "login", "--name", "mirror"]);
+    expect(raw).toHaveBeenCalledTimes(1);
+    expect(recorded(raw)[0][1]).toContain("sub-b");
+  });
+
+  it("push rejects explicit A against adopted B before any operation", async () => {
+    const raw = executor(() => "");
+    await expect(preparePushTarget(raw, context, { apply: true, subscription: "sub-a" })).rejects.toThrow("differs");
+    expect(raw).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/lib/deployment-target.ts
+++ b/cli/src/lib/deployment-target.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { DeploymentContext } from "../config.js";
+import { createSubscriptionPinnedExeca } from "./azure-subscription.js";
+
+export type Execute = typeof import("execa").execa;
+type ClusterContext = Pick<DeploymentContext, "subscription" | "resourceGroup" | "aksCluster">;
+
+function isAksNotFound(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const detail = error as Record<string, unknown>;
+  const text = ["stderr", "stdout", "shortMessage", "message"]
+    .map(key => detail[key]).filter(value => typeof value === "string").join("\n");
+  return /\((?:ResourceNotFound|ResourceGroupNotFound|ManagedClusterNotFound|ParentResourceNotFound)\)/i.test(text)
+    || /["']code["']\s*:\s*["'](?:ResourceNotFound|ResourceGroupNotFound|ManagedClusterNotFound|ParentResourceNotFound)["']/i.test(text);
+}
+
+/** #531 compatibility rule: a legacy RG/AKS pair must resolve in exactly one
+ * enabled subscription. Authorization, transport and malformed-response errors
+ * are never interpreted as absence. */
+export async function resolveDeploymentSubscription(execute: Execute, ctx: ClusterContext): Promise<string> {
+  const cached = ctx.subscription?.trim();
+  if (cached) return cached;
+  if (!ctx.resourceGroup || !ctx.aksCluster) {
+    throw new Error("Deployment context lacks a subscription and an AKS identity; specify --subscription or adopt the intended cluster.");
+  }
+  const { stdout } = await execute("az", [
+    "account", "list", "--query", "[?state=='Enabled'].id", "--output", "json",
+  ], { stdio: "pipe", timeout: 15000 });
+  const candidates: unknown = JSON.parse(String(stdout));
+  if (!Array.isArray(candidates) || candidates.some(value => typeof value !== "string" || !value.trim())) {
+    throw new Error("Azure returned an invalid enabled subscription list");
+  }
+  const matches = new Set<string>();
+  for (const subscription of new Set(candidates.map(value => (value as string).trim()))) {
+    let output: string;
+    try {
+      const result = await execute("az", [
+        "aks", "show", "--resource-group", ctx.resourceGroup, "--name", ctx.aksCluster,
+        "--query", "{name:name,resourceGroup:resourceGroup}", "--output", "json", "--subscription", subscription,
+      ], { stdio: "pipe", timeout: 30000 });
+      output = String(result.stdout);
+    } catch (error) {
+      if (isAksNotFound(error)) continue;
+      throw error;
+    }
+    const cluster: unknown = JSON.parse(output);
+    if (!cluster || typeof cluster !== "object"
+      || typeof (cluster as Record<string, unknown>).name !== "string"
+      || typeof (cluster as Record<string, unknown>).resourceGroup !== "string") {
+      throw new Error(`Looking up cached AKS cluster in '${subscription}' returned an invalid cluster`);
+    }
+    const fields = cluster as { name: string; resourceGroup: string };
+    if (fields.name.toLowerCase() === ctx.aksCluster.toLowerCase()
+      && fields.resourceGroup.toLowerCase() === ctx.resourceGroup.toLowerCase()) matches.add(subscription);
+  }
+  if (matches.size === 1) return [...matches][0];
+  throw new Error(matches.size
+    ? "Cached AKS cluster exists in multiple enabled Azure subscriptions; adopt the intended subscription before updating."
+    : "No enabled Azure subscription contains the cached AKS cluster; update stopped before making changes.");
+}
+
+function pinOption(args: readonly string[], option: string, value: string): string[] {
+  const indexes = args.flatMap((arg, index) => arg === option || arg.startsWith(`${option}=`) ? [index] : []);
+  if (!indexes.length) return [...args, option, value];
+  const index = indexes[0];
+  const selected = args[index] === option ? args[index + 1] : args[index].slice(option.length + 1);
+  if (indexes.length !== 1 || selected !== value) throw new Error(`Command targets a different ${option}; deployment target is '${value}'`);
+  return [...args];
+}
+
+export function createDeploymentExecutor(execute: Execute, subscription: string, kubeContext: string): Execute {
+  const azure = createSubscriptionPinnedExeca(execute, subscription);
+  return ((file: string, args: readonly string[] = [], options?: unknown) =>
+    azure(file, file === "kubectl" ? pinOption(args, "--context", kubeContext)
+      : file === "helm" ? pinOption(args, "--kube-context", kubeContext) : args, options as never)
+  ) as unknown as Execute;
+}
+
+async function clusterIdentity(execute: Execute, ctx: ClusterContext, subscription: string): Promise<string[]> {
+  if (!ctx.resourceGroup?.trim() || !ctx.aksCluster?.trim()) throw new Error("Deployment context is missing resource group or AKS cluster");
+  const { stdout } = await createSubscriptionPinnedExeca(execute, subscription)("az", [
+    "aks", "show", "--resource-group", ctx.resourceGroup, "--name", ctx.aksCluster,
+    "--query", "{id:id,name:name,resourceGroup:resourceGroup,fqdn:fqdn,privateFqdn:privateFqdn}",
+    "--output", "json",
+  ], { stdio: "pipe", timeout: 30000 });
+  const cluster = JSON.parse(String(stdout)) as Record<string, unknown>;
+  const expectedId = `/subscriptions/${subscription}/resourceGroups/${ctx.resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${ctx.aksCluster}`;
+  if (typeof cluster?.id !== "string" || cluster.id.toLowerCase() !== expectedId.toLowerCase()) {
+    throw new Error("Azure AKS identity does not match the adopted subscription/resource group/cluster; no updates were made.");
+  }
+  const hosts = [cluster.fqdn, cluster.privateFqdn]
+    .filter((value): value is string => typeof value === "string" && !!value.trim())
+    .map(value => value.trim().toLowerCase());
+  if (!hosts.length) throw new Error("Azure AKS lookup returned no API-server hostname; cannot verify Kubernetes target.");
+  return hosts;
+}
+
+async function verifyKubeTarget(execute: Execute, hosts: string[]): Promise<void> {
+  const { stdout } = await execute("kubectl", [
+    "config", "view", "--minify", "--output", "jsonpath={.clusters[0].cluster.server}",
+  ], { stdio: "pipe", timeout: 15000 });
+  const server = new URL(String(stdout).trim());
+  if (server.protocol !== "https:" || server.username || server.password
+    || (server.port && server.port !== "443") || server.pathname !== "/" || server.search || server.hash
+    || !hosts.includes(server.hostname.toLowerCase())) {
+    throw new Error("Selected Kubernetes context does not point to the adopted AKS API server; no updates were made.");
+  }
+}
+
+export async function connectDeploymentTarget(execute: Execute, ctx: ClusterContext): Promise<{
+  execute: Execute; subscription: string; kubeContext: string;
+}> {
+  const subscription = await resolveDeploymentSubscription(execute, ctx);
+  const hosts = await clusterIdentity(execute, ctx, subscription);
+  const kubeContext = ["kars", subscription, ctx.resourceGroup!, ctx.aksCluster!].map(encodeURIComponent).join("/");
+  const azure = createSubscriptionPinnedExeca(execute, subscription);
+  await azure("az", [
+    "aks", "get-credentials", "--name", ctx.aksCluster!, "--resource-group", ctx.resourceGroup!,
+    "--context", kubeContext, "--overwrite-existing", "--output", "none",
+  ], { stdio: "pipe", timeout: 30000 });
+  const scoped = createDeploymentExecutor(execute, subscription, kubeContext);
+  await verifyKubeTarget(scoped, hosts);
+  return { execute: scoped, subscription, kubeContext };
+}
+
+/** Adoption only inspects the existing Kubernetes context; it never replaces it. */
+export async function verifyAdoptedTarget(execute: Execute, ctx: ClusterContext, requestedContext?: string): Promise<Execute> {
+  const subscription = await resolveDeploymentSubscription(execute, ctx);
+  const hosts = await clusterIdentity(execute, ctx, subscription);
+  const kubeContext = requestedContext?.trim()
+    || String((await execute("kubectl", ["config", "current-context"], { stdio: "pipe" })).stdout).trim();
+  if (!kubeContext) throw new Error("No Kubernetes context selected for AKS adoption");
+  const scoped = createDeploymentExecutor(execute, subscription, kubeContext);
+  await verifyKubeTarget(scoped, hosts);
+  return scoped;
+}
+
+export async function preparePushTarget(execute: Execute, ctx: DeploymentContext | null, options: {
+  apply?: boolean; subscription?: string;
+}): Promise<Execute> {
+  if (options.subscription && ctx?.subscription && options.subscription.trim() !== ctx.subscription.trim()) {
+    throw new Error("--subscription differs from the saved deployment subscription; adopt the intended deployment first.");
+  }
+  const target = { ...ctx, subscription: options.subscription || ctx?.subscription };
+  if (options.apply) return (await connectDeploymentTarget(execute, target)).execute;
+  return createSubscriptionPinnedExeca(execute, await resolveDeploymentSubscription(execute, target));
+}

--- a/cli/src/lib/external-mesh.test.ts
+++ b/cli/src/lib/external-mesh.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, vi } from "vitest";
+import type { Execute } from "./deployment-target.js";
+import { assertMeshReleaseConsistency, inspectMeshInstallation } from "./mesh-release.js";
+import { rolloutRestartAll, verifyHealth } from "../commands/upgrade.js";
+import { applyPushedImages } from "../commands/push-apply.js";
+
+function externalResources(owner: "none" | "controller" | "helm") {
+  const ownership = owner === "helm" ? {
+    labels: { "app.kubernetes.io/managed-by": "Helm" },
+    annotations: { "meta.helm.sh/release-name": "platform-mesh", "meta.helm.sh/release-namespace": "platform-system" },
+  } : owner === "controller" ? { ownerReferences: [{ kind: "PlatformMesh", name: "shared", controller: true }] } : {};
+  return ["registry", "relay"].flatMap(component => [
+    { kind: "Service", metadata: { name: `agentmesh-${component}`, ...ownership }, spec: { selector: { app: `platform-${component}` } } },
+    { kind: "Deployment", metadata: { name: `platform-${component}`, ...ownership },
+      spec: { template: { metadata: { labels: { app: `platform-${component}` } }, spec: { containers: [{ name: "platform", image: "external.example/mesh:custom" }] } } } },
+  ]);
+}
+
+describe("external mesh is not part of a disabled-Helm-mesh core operation", () => {
+  it.each(["none", "controller", "helm"] as const)("classifies standard Services with %s-owned custom deployments without probing their owner", async owner => {
+    const resources = externalResources(owner);
+    const calls: Array<[string, readonly string[]]> = [];
+    const execute = (async (bin: string, args: readonly string[]) => {
+      calls.push([bin, args]);
+      if (bin === "helm") throw new Error("External Helm owner must not be queried");
+      if (args[1] === "deployment,service") return { stdout: JSON.stringify({ items: resources }) };
+      if (args[0] === "get" && args[1] === "deployments") return { stdout: '{"items":[]}' };
+      if (args[0] === "get" && args[1] === "deployment" && args[2] === "kars-controller") return { stdout: "True" };
+      return { stdout: "" };
+    }) as unknown as Execute;
+    const mesh = await inspectMeshInstallation(execute);
+    expect(mesh.kind).toBe("external");
+    expect(mesh.deployments).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(() => assertMeshReleaseConsistency(mesh, { agentMesh: { enabled: false } })).not.toThrow();
+    expect(() => assertMeshReleaseConsistency(mesh, { agentMesh: { enabled: true } })).toThrow();
+    calls.length = 0;
+    // The same restart/health path is used after a core upgrade and rollback.
+    await rolloutRestartAll(execute, mesh);
+    expect((await verifyHealth(execute, mesh)).healthy).toBe(true);
+    expect(calls.some(([, args]) => args.includes("agentmesh") || args.some(arg => arg.includes("platform-")))).toBe(false);
+    calls.length = 0;
+    await expect(applyPushedImages(execute, [{ name: "relay", image: "mirror.azurecr.io/relay:latest" }], "chart", mesh))
+      .rejects.toThrow("External");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("still blocks mixed ownership when some resources claim the Kars release", async () => {
+    const resources = externalResources("helm");
+    resources[0].metadata.annotations = {
+      "meta.helm.sh/release-name": "kars", "meta.helm.sh/release-namespace": "kars-system",
+    };
+    const execute = vi.fn().mockResolvedValue({ stdout: JSON.stringify({ items: resources }) }) as unknown as Execute;
+    await expect(inspectMeshInstallation(execute)).rejects.toThrow("mixed");
+  });
+
+  it("does not treat unmarked external workloads as managed merely because their names match", async () => {
+    const resources = externalResources("none");
+    for (const item of resources) {
+      if (item.kind === "Deployment") item.metadata.name = item.metadata.name.replace("platform-", "");
+    }
+    const execute = vi.fn().mockResolvedValue({ stdout: JSON.stringify({ items: resources }) }) as unknown as Execute;
+    const mesh = await inspectMeshInstallation(execute);
+    expect(mesh.kind).toBe("external");
+    expect(() => assertMeshReleaseConsistency(mesh, { agentMesh: { enabled: false } })).not.toThrow();
+    await expect(applyPushedImages(execute, [{ name: "relay", image: "mirror.azurecr.io/relay:latest" }], "chart", mesh))
+      .rejects.toThrow("External");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cli/src/lib/image-targets.test.ts
+++ b/cli/src/lib/image-targets.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { parseAllDocuments } from "yaml";
+import { describe, expect, it } from "vitest";
+import { coreImageValues, dockerPushDigest, imageValueArgs, RUNTIME_IMAGE_TARGETS, splitImage } from "./image-targets.js";
+import { meshImageValueArgs } from "./mesh-release.js";
+
+const digest = `sha256:${"b".repeat(64)}`;
+const helmAvailable = spawnSync("helm", ["version", "--short"], { stdio: "pipe" }).status === 0;
+
+describe("immutable pushed artifact configuration", () => {
+  it("binds application to Docker's pushed manifest instead of a later concurrent latest tag", () => {
+    expect(dockerPushDigest(`latest: digest: ${digest} size: 1234`)).toBe(digest);
+    expect(dockerPushDigest("Pushed successfully without digest evidence")).toBeUndefined();
+    expect(dockerPushDigest(`digest: ${digest}\ndigest: sha256:${"c".repeat(64)}`)).toBeUndefined();
+  });
+
+  it("retains latest while binding it to a valid digest", () => {
+    expect(splitImage(`mirror.azurecr.io/agent:latest@${digest}`)).toEqual({
+      repository: "mirror.azurecr.io/agent", tag: `latest@${digest}`,
+    });
+    expect(() => splitImage("mirror.azurecr.io/agent:latest@sha256:invalid")).toThrow();
+    expect(() => splitImage("mirror.azurecr.io/agent:latest,other=value")).toThrow();
+  });
+
+  it.skipIf(!helmAvailable)("renders every selected core/runtime/mesh artifact through the actual chart", () => {
+    const chart = fileURLToPath(new URL("../../../deploy/helm/kars", import.meta.url));
+    const images = [
+      { name: "controller", image: `mirror.azurecr.io/kars-controller:latest@${digest}` },
+      { name: "router", image: `mirror.azurecr.io/kars-inference-router:latest@${digest}` },
+      { name: "sandbox", image: `mirror.azurecr.io/openclaw-sandbox:latest@${digest}` },
+      ...RUNTIME_IMAGE_TARGETS.map(runtime => ({ name: runtime.name, image: `mirror.azurecr.io/${runtime.repo}:latest@${digest}` })),
+    ];
+    const mesh = { registry: `mirror.azurecr.io/agentmesh-registry-agt:latest@${digest}`,
+      relay: `mirror.azurecr.io/agentmesh-relay-agt:latest@${digest}` };
+    const rendered = execFileSync("helm", ["template", "kars", chart, "--namespace", "kars-system",
+      "--set", "agentMesh.enabled=true", ...imageValueArgs(coreImageValues(images)), ...meshImageValueArgs(mesh)], { encoding: "utf8" });
+    const resources = parseAllDocuments(rendered).map(document => document.toJSON()) as Array<{
+      kind: string; metadata: { name: string };
+      spec?: { template?: { spec?: { containers?: Array<{ image: string; env?: Array<{ name: string; value?: string }> }> } } };
+    }>;
+    const controller = resources.find(item => item.kind === "Deployment" && item.metadata.name === "kars-controller")!
+      .spec!.template!.spec!.containers![0];
+    expect(controller.image).toBe(images[0].image);
+    expect(controller.env).toContainEqual(expect.objectContaining({ name: "INFERENCE_ROUTER_IMAGE", value: images[1].image }));
+    expect(controller.env).toContainEqual(expect.objectContaining({ name: "SANDBOX_IMAGE", value: images[2].image }));
+    for (const runtime of RUNTIME_IMAGE_TARGETS) {
+      expect(controller.env).toContainEqual(expect.objectContaining({
+        name: runtime.env, value: images.find(item => item.name === runtime.name)!.image,
+      }));
+    }
+    for (const name of ["registry", "relay"] as const) {
+      expect(resources.find(item => item.kind === "Deployment" && item.metadata.name === name)!
+        .spec!.template!.spec!.containers![0].image).toBe(mesh[name]);
+    }
+  });
+});

--- a/cli/src/lib/image-targets.ts
+++ b/cli/src/lib/image-targets.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { RuntimeKind } from "../runtime.js";
+import type { Execute } from "./deployment-target.js";
+
+/** The complete runtime image mapping formerly embedded in upgrade.ts, paired
+ * with the existing controller environment and RuntimeSpec variant names. */
+export const RUNTIME_IMAGE_TARGETS: ReadonlyArray<{
+  name: string; repo: string; valueKey: string; env: string;
+  kind: RuntimeKind; variant: string; language?: string;
+}> = [
+  { name: "runtime-openai-agents", repo: "kars-runtime-openai-agents", valueKey: "runtimes.openaiAgents.image", env: "OPENAI_AGENTS_RUNTIME_IMAGE", kind: "OpenAIAgents", variant: "openaiAgents" },
+  { name: "runtime-maf-python", repo: "kars-runtime-maf-python", valueKey: "runtimes.mafPython.image", env: "MAF_RUNTIME_IMAGE", kind: "MicrosoftAgentFramework", variant: "microsoftAgentFramework", language: "python" },
+  { name: "runtime-anthropic", repo: "kars-runtime-anthropic", valueKey: "runtimes.anthropic.image", env: "ANTHROPIC_RUNTIME_IMAGE", kind: "Anthropic", variant: "anthropic" },
+  { name: "runtime-langgraph", repo: "kars-runtime-langgraph", valueKey: "runtimes.langgraph.image", env: "LANGGRAPH_RUNTIME_IMAGE", kind: "LangGraph", variant: "langGraph", language: "python" },
+  { name: "runtime-langgraph-ts", repo: "kars-runtime-langgraph-ts", valueKey: "runtimes.langgraphTs.image", env: "LANGGRAPH_TS_RUNTIME_IMAGE", kind: "LangGraph", variant: "langGraph", language: "typescript" },
+  { name: "runtime-pydantic-ai", repo: "kars-runtime-pydantic-ai", valueKey: "runtimes.pydanticAi.image", env: "PYDANTIC_AI_RUNTIME_IMAGE", kind: "PydanticAi", variant: "pydanticAi" },
+  { name: "runtime-hermes", repo: "kars-runtime-hermes", valueKey: "runtimes.hermes.image", env: "HERMES_RUNTIME_IMAGE", kind: "Hermes", variant: "hermes" },
+];
+
+export interface PushedImage { name: string; image: string }
+export const PUSH_COMPONENTS = ["controller", "router", "sandbox", "sandbox-base", "relay", "registry", ...RUNTIME_IMAGE_TARGETS.map(item => item.name)];
+
+export function splitImage(image: string): { repository: string; tag: string } {
+  const withoutDigest = image.split("@")[0];
+  const index = withoutDigest.lastIndexOf(":");
+  if (index <= withoutDigest.lastIndexOf("/") || index === withoutDigest.length - 1
+    || /[\s,=]/.test(image) || (image.includes("@") && !/@sha256:[a-f0-9]{64}$/.test(image))) {
+    throw new Error(`A valid repository:tag artifact is required: ${image}`);
+  }
+  return { repository: image.slice(0, index), tag: image.slice(index + 1) };
+}
+
+export function runtimeTarget(name: string) {
+  return RUNTIME_IMAGE_TARGETS.find(item => item.name === name);
+}
+
+export function dockerPushDigest(output: string): string | undefined {
+  const digests = new Set([...output.matchAll(/\bdigest:\s*(sha256:[a-f0-9]{64})\b/g)].map(match => match[1]));
+  return digests.size === 1 ? [...digests][0] : undefined;
+}
+
+export function controllerEnv(name: string): string | undefined {
+  return name === "router" ? "INFERENCE_ROUTER_IMAGE"
+    : name === "sandbox" ? "SANDBOX_IMAGE" : runtimeTarget(name)?.env;
+}
+
+export function coreImageValues(images: PushedImage[]): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const { name, image } of images) {
+    const runtime = runtimeTarget(name);
+    if (runtime) values[runtime.valueKey] = image;
+    else if (["controller", "router", "sandbox"].includes(name)) {
+      const prefix = name === "router" ? "inferenceRouter" : name;
+      const { repository, tag } = splitImage(image);
+      values[`${prefix}.image.repository`] = repository;
+      values[`${prefix}.image.tag`] = tag;
+      values[`${prefix}.image.pullPolicy`] = "Always";
+    }
+  }
+  return values;
+}
+
+export function imageValueArgs(values: Record<string, string>): string[] {
+  return Object.entries(values).flatMap(([key, value]) => ["--set-string", `${key}=${value}`]);
+}
+
+/** Preserve the selected tag for readability, but bind it to the pushed ACR
+ * manifest. Even an older IfNotPresent workload cannot reuse stale :latest. */
+export async function resolvePushedArtifacts(execute: Execute, images: PushedImage[]): Promise<PushedImage[]> {
+  const resolved: PushedImage[] = [];
+  for (const item of images) {
+    splitImage(item.image);
+    if (item.image.includes("@")) { resolved.push(item); continue; }
+    const slash = item.image.indexOf("/");
+    const host = item.image.slice(0, slash);
+    if (!/^[a-z0-9]+\.azurecr\.io$/i.test(host)) throw new Error("Pushed artifacts must identify their target ACR");
+    const { stdout } = await execute("az", [
+      "acr", "repository", "show", "--name", host.slice(0, -".azurecr.io".length),
+      "--image", item.image.slice(slash + 1), "--query", "digest", "--output", "tsv",
+    ], { stdio: "pipe" });
+    const digest = String(stdout).trim();
+    if (!/^sha256:[a-f0-9]{64}$/.test(digest)) throw new Error(`Could not verify the pushed artifact digest for ${item.name}`);
+    resolved.push({ ...item, image: `${item.image}@${digest}` });
+  }
+  return resolved;
+}

--- a/cli/src/lib/kube-bootstrap.test.ts
+++ b/cli/src/lib/kube-bootstrap.test.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "vitest";
+import { explicitContextArg } from "./kube-bootstrap.js";
+
+describe("explicitContextArg", () => {
+  it("reads a separate --context value", () => {
+    expect(explicitContextArg(["node", "kars", "operator", "--context", "aks-prod"]))
+      .toBe("aks-prod");
+  });
+
+  it("reads an inline --context value", () => {
+    expect(explicitContextArg(["node", "kars", "operator", "--context=aks-prod"]))
+      .toBe("aks-prod");
+  });
+
+  it("rejects missing or empty values", () => {
+    expect(explicitContextArg(["node", "kars", "operator"])).toBeUndefined();
+    expect(explicitContextArg(["node", "kars", "operator", "--context"])).toBeUndefined();
+    expect(explicitContextArg(["node", "kars", "operator", "--context="])).toBeUndefined();
+  });
+});

--- a/cli/src/lib/kube-bootstrap.ts
+++ b/cli/src/lib/kube-bootstrap.ts
@@ -37,6 +37,13 @@ import * as path from "node:path";
 
 const HELP_FLAGS = new Set(["--help", "-h", "--version", "-V"]);
 
+export function explicitContextArg(argv: string[]): string | undefined {
+  const inline = argv.find((arg) => arg.startsWith("--context="));
+  if (inline) return inline.slice("--context=".length).trim() || undefined;
+  const index = argv.indexOf("--context");
+  return index >= 0 ? argv[index + 1]?.trim() || undefined : undefined;
+}
+
 // Commands that talk to an EXISTING cluster and therefore need a
 // kubeconfig context resolved up front. Everything not in this set
 // is allowed to run with no kubeconfig at all — most notably:
@@ -63,6 +70,10 @@ export async function bootstrapKubeContext(argv: string[]): Promise<void> {
   const cmd = (argv[2] ?? "").split("=", 1)[0];
   if (!cmd || cmd.startsWith("-") || !KUBE_COMMANDS.has(cmd)) return;
   if (process.env.KUBECONFIG) return;
+  // Commands that expose --context pass it to every kubectl call themselves.
+  // Treat that explicit user choice as sufficient even when kubeconfig has no
+  // global current-context.
+  if (explicitContextArg(argv)) return;
 
   try {
     await execa("which", ["kubectl"], { stdio: "pipe" });
@@ -120,4 +131,3 @@ function writeOverlay(ctx: string): void {
     try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
   });
 }
-

--- a/cli/src/lib/mesh-release.test.ts
+++ b/cli/src/lib/mesh-release.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, vi } from "vitest";
+import type { Execute } from "./deployment-target.js";
+import {
+  applyMeshImages, assertMeshReleaseConsistency, helmMeshEnabled,
+  inspectMeshInstallation, meshImageValueArgs, verifyMeshHealth,
+} from "./mesh-release.js";
+import { applyPushedImages } from "../commands/push-apply.js";
+
+function fixture(owned: boolean) {
+  const metadata = (name: string) => ({
+    name, generation: 1, ownerReferences: [] as Array<{ controller: boolean }>,
+    labels: owned ? { "app.kubernetes.io/managed-by": "Helm" } : {},
+    annotations: owned ? { "meta.helm.sh/release-name": "kars", "meta.helm.sh/release-namespace": "kars-system" } : {},
+  });
+  return ["registry", "relay"].flatMap(component => [
+    {
+      kind: "Deployment", metadata: metadata(component),
+      spec: { replicas: 1, selector: { matchLabels: { app: `agentmesh-${component}` } },
+        template: { spec: { containers: [{ name: component, image: `old.example/${component}:old` }] } } },
+      status: { observedGeneration: 1, readyReplicas: 1, updatedReplicas: 1, conditions: [{ type: "Available", status: "True" }] },
+    },
+    { kind: "Service", metadata: metadata(`agentmesh-${component}`), spec: { selector: { app: `agentmesh-${component}` } } },
+  ]);
+}
+
+function recorded(execute: Execute): Array<[string, string[]]> {
+  return vi.mocked(execute).mock.calls as unknown as Array<[string, string[]]>;
+}
+
+function mockInstallation(owned: boolean, fail?: (bin: string, args: readonly string[]) => void) {
+  const resources = fixture(owned);
+  const execute = vi.fn(async (bin: string, args: readonly string[]) => {
+    fail?.(bin, args);
+    if (bin === "kubectl" && args[1] === "deployment,service") return { stdout: JSON.stringify({ items: resources }) };
+    if (bin === "helm" && args[0] === "list") return { stdout: JSON.stringify([{ name: "kars", chart: "kars-0.1.0" }]) };
+    if (bin === "helm" && args[0] === "get") return { stdout: JSON.stringify({ agentMesh: { enabled: true } }) };
+    if (bin === "helm" && args[0] === "upgrade") {
+      for (const component of ["registry", "relay"]) {
+        const repository = args.find(arg => arg.startsWith(`agentMesh.${component}.image.repository=`))?.split("=")[1];
+        const tag = args.find(arg => arg.startsWith(`agentMesh.${component}.image.tag=`))?.split("=")[1];
+        if (repository && tag) {
+          resources.find(item => item.kind === "Deployment" && item.metadata.name === component)!
+            .spec.template!.spec.containers[0].image = `${repository}:${tag}`;
+        }
+      }
+    }
+    if (bin === "kubectl" && args[0] === "set") {
+      const name = args[2].replace("deployment/", "");
+      resources.find(item => item.kind === "Deployment" && item.metadata.name === name)!
+        .spec.template!.spec.containers[0].image = args[3].slice(args[3].indexOf("=") + 1);
+    }
+    if (bin === "kubectl" && args[0] === "get" && args[1] === "deployment") {
+      return { stdout: JSON.stringify(resources.find(item => item.kind === "Deployment" && item.metadata.name === args[2])) };
+    }
+    return { stdout: "" };
+  }) as unknown as Execute;
+  return { execute, resources };
+}
+
+describe("AgentMesh ownership and image application", () => {
+  it("uses the owning Helm release for push --only relay --apply, never applies a legacy selector", async () => {
+    const { execute, resources } = mockInstallation(true);
+    const selectors = resources.map(item => JSON.stringify(item.spec.selector));
+    await applyPushedImages(execute, [{ name: "relay", image: "mirror.azurecr.io/agentmesh-relay-agt:latest" }], "chart");
+    const calls = recorded(execute);
+    const upgrade = calls.find(([bin, args]) => bin === "helm" && args?.[0] === "upgrade");
+    expect(upgrade?.[1]).toEqual(expect.arrayContaining([
+      "kars", "chart", "--namespace", "kars-system", "--reuse-values",
+      "agentMesh.relay.image.repository=mirror.azurecr.io/agentmesh-relay-agt",
+      "agentMesh.relay.image.tag=latest", "--atomic",
+    ]));
+    expect(calls.some(([bin, args]) => bin === "kubectl" && (args?.[0] === "apply" || args?.[0] === "set"))).toBe(false);
+    expect(calls.some(([, args]) => args?.some(arg => ["--take-ownership", "--force", "--force-recreate", "--force-conflicts"].includes(arg)))).toBe(false);
+    expect(calls.some(([, args]) => args?.includes("deployment/relay"))).toBe(true);
+    expect(calls.some(([, args]) => args?.includes("deployment/agentmesh-relay"))).toBe(false);
+    expect(calls.some(([, args]) => args?.includes("deployment/kars-controller"))).toBe(false);
+    expect(resources.map(item => JSON.stringify(item.spec.selector))).toEqual(selectors);
+  });
+
+  it("updates legacy mesh directly without requiring Helm or replacing Services", async () => {
+    const { execute, resources } = mockInstallation(false, bin => { if (bin === "helm") throw new Error("Helm is not installed"); });
+    const mesh = await inspectMeshInstallation(execute);
+    expect(mesh.kind).toBe("legacy");
+    await applyMeshImages(execute, mesh, { relay: "mirror.azurecr.io/agentmesh-relay-agt:latest" }, "chart");
+    expect(recorded(execute).some(([bin]) => bin === "helm")).toBe(false);
+    expect(recorded(execute).some(([, args]) => args[0] === "apply")).toBe(false);
+    expect(recorded(execute).some(([, args]) => args.includes("relay=mirror.azurecr.io/agentmesh-relay-agt:latest"))).toBe(true);
+    expect(resources.find(item => item.kind === "Service" && item.metadata.name === "agentmesh-relay")?.spec.selector)
+      .toEqual({ app: "agentmesh-relay" });
+  });
+
+  it.each(["upgrade", "status"])("propagates failed Helm apply/rollout step %s", async step => {
+    const { execute } = mockInstallation(true, (bin, args) => {
+      if ((step === "upgrade" && bin === "helm" && args[0] === step)
+        || (step === "status" && bin === "kubectl" && args[0] === "rollout" && args[1] === step)) throw new Error(`failed ${step}`);
+    });
+    await expect(applyPushedImages(execute, [{ name: "relay", image: "mirror.azurecr.io/relay:latest" }], "chart"))
+      .rejects.toThrow(`failed ${step}`);
+  });
+
+  it("propagates a failed legacy image update", async () => {
+    const { execute } = mockInstallation(false, (_bin, args) => { if (args[0] === "set") throw new Error("set image denied"); });
+    await expect(applyPushedImages(execute, [{ name: "relay", image: "mirror.azurecr.io/relay:latest" }], "chart"))
+      .rejects.toThrow("set image denied");
+    expect(recorded(execute).some(([, args]) => args[0] === "rollout")).toBe(false);
+  });
+
+  it("rejects inventory failures before any mutation", async () => {
+    const execute = vi.fn().mockRejectedValue(new Error("inventory denied")) as unknown as Execute;
+    await expect(applyPushedImages(execute, [{ name: "relay", image: "mirror.azurecr.io/relay:latest" }], "chart"))
+      .rejects.toThrow("inventory denied");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects partial/mixed ownership instead of adopting a Service or deployment", async () => {
+    const { execute, resources } = mockInstallation(true);
+    resources[1].metadata.annotations = {};
+    resources[1].metadata.labels = {};
+    await expect(inspectMeshInstallation(execute)).rejects.toThrow("mixed or incomplete");
+    expect(recorded(execute).some(([bin]) => bin === "helm")).toBe(false);
+  });
+
+  it("rejects ownership by another controller", async () => {
+    const { execute, resources } = mockInstallation(false);
+    for (const resource of resources) resource.metadata.labels = { "app.kubernetes.io/managed-by": "another-controller" };
+    await expect(inspectMeshInstallation(execute)).rejects.toThrow("ownership");
+  });
+
+  it("does not classify Kubernetes-owned resources as unmanaged", async () => {
+    const { execute, resources } = mockInstallation(false);
+    resources[0].metadata.ownerReferences = [{ controller: true }];
+    await expect(inspectMeshInstallation(execute)).rejects.toThrow("another Kubernetes owner");
+    expect(recorded(execute).some(([, args]) => args[0] === "set" || args[0] === "upgrade")).toBe(false);
+  });
+
+  it("rejects an ownership change during image-build preparation", async () => {
+    const { execute, resources } = mockInstallation(false);
+    const original = await inspectMeshInstallation(execute);
+    for (const resource of resources) {
+      resource.metadata.labels = { "app.kubernetes.io/managed-by": "Helm" };
+      resource.metadata.annotations = { "meta.helm.sh/release-name": "kars", "meta.helm.sh/release-namespace": "kars-system" };
+    }
+    await expect(applyMeshImages(execute, original, { relay: "mirror.azurecr.io/relay:latest" }, "chart"))
+      .rejects.toThrow("ownership changed");
+    expect(recorded(execute).some(([, args]) => args[0] === "set" || args[0] === "upgrade" || args[0] === "apply")).toBe(false);
+  });
+
+  it("does not report an old/unavailable owned deployment as healthy", async () => {
+    const { execute, resources } = mockInstallation(true);
+    const mesh = await inspectMeshInstallation(execute);
+    resources[0].status!.readyReplicas = 0;
+    await expect(verifyMeshHealth(execute, mesh)).rejects.toThrow("healthy rollout");
+  });
+
+  it("requires actual image evidence, not just Available=True", async () => {
+    const { execute } = mockInstallation(true);
+    const mesh = await inspectMeshInstallation(execute);
+    await expect(verifyMeshHealth(execute, mesh, { relay: "mirror.azurecr.io/relay:new" })).rejects.toThrow("selected image");
+  });
+
+  it("preserves absent maps but rejects values that imply ownership adoption", () => {
+    expect(helmMeshEnabled({})).toBe(false);
+    expect(helmMeshEnabled({ agentMesh: null })).toBe(false);
+    expect(helmMeshEnabled({ agentMesh: { enabled: false } })).toBe(false);
+    expect(() => helmMeshEnabled({ agentMesh: { enabled: "false" } })).toThrow("boolean");
+    expect(() => assertMeshReleaseConsistency({ kind: "legacy", namespace: "agentmesh", deployments: [] },
+      { agentMesh: { enabled: true } })).toThrow("ownership");
+    expect(meshImageValueArgs({ registry: "mirror.azurecr.io/agentmesh-registry-agt:v1.2.3" }))
+      .toContain("agentMesh.registry.image.tag=v1.2.3");
+  });
+});

--- a/cli/src/lib/mesh-release.test.ts
+++ b/cli/src/lib/mesh-release.test.ts
@@ -10,16 +10,19 @@ import {
 import { applyPushedImages } from "../commands/push-apply.js";
 
 function fixture(owned: boolean) {
+  const labels: Record<string, string> = owned
+    ? { "app.kubernetes.io/managed-by": "Helm" }
+    : { "kars.azure.com/mesh-provider": "agt" };
   const metadata = (name: string) => ({
     name, generation: 1, ownerReferences: [] as Array<{ controller: boolean }>,
-    labels: owned ? { "app.kubernetes.io/managed-by": "Helm" } : {},
+    labels: { ...labels },
     annotations: owned ? { "meta.helm.sh/release-name": "kars", "meta.helm.sh/release-namespace": "kars-system" } : {},
   });
   return ["registry", "relay"].flatMap(component => [
     {
       kind: "Deployment", metadata: metadata(component),
       spec: { replicas: 1, selector: { matchLabels: { app: `agentmesh-${component}` } },
-        template: { spec: { containers: [{ name: component, image: `old.example/${component}:old` }] } } },
+        template: { metadata: { labels: { app: `agentmesh-${component}` } }, spec: { containers: [{ name: component, image: `old.example/${component}:old` }] } } },
       status: { observedGeneration: 1, readyReplicas: 1, updatedReplicas: 1, conditions: [{ type: "Available", status: "True" }] },
     },
     { kind: "Service", metadata: metadata(`agentmesh-${component}`), spec: { selector: { app: `agentmesh-${component}` } } },
@@ -34,6 +37,7 @@ function mockInstallation(owned: boolean, fail?: (bin: string, args: readonly st
   const resources = fixture(owned);
   const execute = vi.fn(async (bin: string, args: readonly string[]) => {
     fail?.(bin, args);
+    if (bin === "az") return { stdout: `sha256:${"a".repeat(64)}` };
     if (bin === "kubectl" && args[1] === "deployment,service") return { stdout: JSON.stringify({ items: resources }) };
     if (bin === "helm" && args[0] === "list") return { stdout: JSON.stringify([{ name: "kars", chart: "kars-0.1.0" }]) };
     if (bin === "helm" && args[0] === "get") return { stdout: JSON.stringify({ agentMesh: { enabled: true } }) };
@@ -70,7 +74,7 @@ describe("AgentMesh ownership and image application", () => {
     expect(upgrade?.[1]).toEqual(expect.arrayContaining([
       "kars", "chart", "--namespace", "kars-system", "--reuse-values",
       "agentMesh.relay.image.repository=mirror.azurecr.io/agentmesh-relay-agt",
-      "agentMesh.relay.image.tag=latest", "--atomic",
+      `agentMesh.relay.image.tag=latest@sha256:${"a".repeat(64)}`, "--atomic",
     ]));
     expect(calls.some(([bin, args]) => bin === "kubectl" && (args?.[0] === "apply" || args?.[0] === "set"))).toBe(false);
     expect(calls.some(([, args]) => args?.some(arg => ["--take-ownership", "--force", "--force-recreate", "--force-conflicts"].includes(arg)))).toBe(false);
@@ -123,16 +127,16 @@ describe("AgentMesh ownership and image application", () => {
     expect(recorded(execute).some(([bin]) => bin === "helm")).toBe(false);
   });
 
-  it("rejects ownership by another controller", async () => {
+  it("classifies another controller's installation as external", async () => {
     const { execute, resources } = mockInstallation(false);
     for (const resource of resources) resource.metadata.labels = { "app.kubernetes.io/managed-by": "another-controller" };
-    await expect(inspectMeshInstallation(execute)).rejects.toThrow("ownership");
+    expect((await inspectMeshInstallation(execute)).kind).toBe("external");
   });
 
-  it("does not classify Kubernetes-owned resources as unmanaged", async () => {
+  it("classifies Kubernetes-owned resources as external rather than unmanaged", async () => {
     const { execute, resources } = mockInstallation(false);
     resources[0].metadata.ownerReferences = [{ controller: true }];
-    await expect(inspectMeshInstallation(execute)).rejects.toThrow("another Kubernetes owner");
+    expect((await inspectMeshInstallation(execute)).kind).toBe("external");
     expect(recorded(execute).some(([, args]) => args[0] === "set" || args[0] === "upgrade")).toBe(false);
   });
 

--- a/cli/src/lib/mesh-release.ts
+++ b/cli/src/lib/mesh-release.ts
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 import type { Execute } from "./deployment-target.js";
+import { splitImage } from "./image-targets.js";
 
 export const MESH_NAMESPACE = "agentmesh";
 export type MeshComponent = "registry" | "relay";
 export type MeshImages = Partial<Record<MeshComponent, string>>;
 interface MeshDeployment { component: MeshComponent; name: string; container: string; image: string }
 export type MeshInstallation = {
-  kind: "absent" | "legacy";
+  kind: "absent" | "legacy" | "external";
   namespace: string;
   deployments: MeshDeployment[];
 } | {
@@ -23,7 +24,7 @@ export type MeshInstallation = {
 interface Resource {
   kind?: string;
   metadata?: { name?: string; annotations?: Record<string, string>; labels?: Record<string, string>; generation?: number; ownerReferences?: unknown[] };
-  spec?: { replicas?: number; template?: { spec?: { containers?: Array<{ name?: string; image?: string }> } } };
+  spec?: { replicas?: number; selector?: Record<string, string>; template?: { metadata?: { labels?: Record<string, string> }; spec?: { containers?: Array<{ name?: string; image?: string }> } } };
   status?: { observedGeneration?: number; readyReplicas?: number; updatedReplicas?: number; conditions?: Array<{ type?: string; status?: string }> };
 }
 
@@ -72,23 +73,58 @@ export async function inspectMeshInstallation(execute: Execute): Promise<MeshIns
   }
   const list = parseObject(raw, "AgentMesh inventory");
   if (!Array.isArray(list.items)) throw new Error("AgentMesh inventory has no items array");
-  const resources = (list.items as Resource[]).filter(resource => componentOf(resource));
+  const items = list.items as Resource[];
+  if (items.some(item => !item || typeof item !== "object")) throw new Error("Invalid AgentMesh resource inventory");
+  const services = items.filter(item => item.kind === "Service" && componentOf(item));
+  const resources = items.filter(resource => componentOf(resource) || (
+    resource.kind === "Deployment" && services.some(service => {
+      const selector = service.spec?.selector;
+      return selector && Object.keys(selector).length > 0
+        && Object.entries(selector).every(([key, value]) => resource.spec?.template?.metadata?.labels?.[key] === value);
+    })
+  ));
   if (!resources.length) return { kind: "absent", namespace: MESH_NAMESPACE, deployments: [] };
-  if (resources.some(resource => resource.metadata?.ownerReferences?.length)) {
-    throw new Error("AgentMesh resources have another Kubernetes owner; refusing an unmanaged update.");
+  const external = (): MeshInstallation => ({ kind: "external", namespace: MESH_NAMESPACE, deployments: [] });
+  const claimsKars = resources.some(resource =>
+    resource.metadata?.annotations?.["meta.helm.sh/release-name"] === "kars"
+      && (!resource.metadata.annotations["meta.helm.sh/release-namespace"]
+        || resource.metadata.annotations["meta.helm.sh/release-namespace"] === "kars-system"));
+  const foreignOwnership = resources.some(resource => resource.metadata?.ownerReferences?.length
+    || (!!resource.metadata?.labels?.["app.kubernetes.io/managed-by"]
+      && resource.metadata.labels["app.kubernetes.io/managed-by"] !== "Helm")
+    || (!!resource.metadata?.annotations?.["meta.helm.sh/release-name"]
+      && (resource.metadata.annotations["meta.helm.sh/release-name"] !== "kars"
+        || resource.metadata.annotations["meta.helm.sh/release-namespace"] !== "kars-system")));
+  if (foreignOwnership) {
+    if (claimsKars) throw new Error("AgentMesh has mixed Kars/external ownership; refusing adoption.");
+    return external();
   }
+  if (!claimsKars && resources.some(resource => resource.metadata?.labels?.["app.kubernetes.io/managed-by"] === "Helm")) {
+    return external();
+  }
+  if (!claimsKars && resources.some(resource => resource.kind === "Deployment" && !componentOf(resource))) return external();
   const deployments: MeshDeployment[] = [];
   for (const component of ["registry", "relay"] as const) {
     const matching = resources.filter(resource => componentOf(resource) === component);
     const workload = matching.filter(resource => resource.kind === "Deployment");
     const services = matching.filter(resource => resource.kind === "Service");
     if (workload.length !== 1 || services.length !== 1) {
-      throw new Error(`AgentMesh ${component} has incomplete or ambiguous deployment/service ownership; refusing to adopt or replace selectors.`);
+      if (!claimsKars) return external();
+      throw new Error(`AgentMesh ${component} has incomplete or ambiguous Kars deployment/service ownership; refusing selector adoption.`);
+    }
+    if (!claimsKars) {
+      const selector = services[0].spec?.selector;
+      const labels = workload[0].spec?.template?.metadata?.labels;
+      if (!selector || !Object.keys(selector).length
+        || !Object.entries(selector).every(([key, value]) => labels?.[key] === value)) return external();
     }
     const containers = workload[0].spec?.template?.spec?.containers ?? [];
     const container = containers.find(item => item.name === component || item.name === `agentmesh-${component}`)
       ?? (containers.length === 1 ? containers[0] : undefined);
-    if (!container?.name || !container.image) throw new Error(`Cannot identify AgentMesh ${component} container`);
+    if (!container?.name || !container.image) {
+      if (!claimsKars) return external();
+      throw new Error(`Cannot identify AgentMesh ${component} container`);
+    }
     deployments.push({ component, name: workload[0].metadata!.name!, container: container.name, image: container.image });
   }
   const owners = resources.map(resource => ({
@@ -97,6 +133,10 @@ export async function inspectMeshInstallation(execute: Execute): Promise<MeshIns
     manager: resource.metadata?.labels?.["app.kubernetes.io/managed-by"],
   }));
   if (owners.every(owner => !owner.release && !owner.namespace && !owner.manager)) {
+    // Canonical names alone are not a management grant. The standalone Kars
+    // manifest explicitly marks both workloads as its AGT installation.
+    if (!resources.filter(resource => resource.kind === "Deployment").every(resource =>
+      resource.metadata?.labels?.["kars.azure.com/mesh-provider"] === "agt")) return external();
     return { kind: "legacy", namespace: MESH_NAMESPACE, deployments };
   }
   const owner = owners[0];
@@ -142,12 +182,9 @@ export function meshImageValueArgs(images: MeshImages): string[] {
   for (const component of ["registry", "relay"] as const) {
     const image = images[component];
     if (!image) continue;
-    const colon = image.lastIndexOf(":");
-    if (image.includes("@") || colon <= image.lastIndexOf("/") || colon === image.length - 1) {
-      throw new Error(`AgentMesh ${component} requires the actual repository:tag artifact`);
-    }
-    args.push("--set-string", `agentMesh.${component}.image.repository=${image.slice(0, colon)}`,
-      "--set-string", `agentMesh.${component}.image.tag=${image.slice(colon + 1)}`);
+    const { repository, tag } = splitImage(image);
+    args.push("--set-string", `agentMesh.${component}.image.repository=${repository}`,
+      "--set-string", `agentMesh.${component}.image.tag=${tag}`);
   }
   return args;
 }
@@ -157,6 +194,7 @@ export function releaseMeshImages(registry: string, tag: string): MeshImages {
 }
 
 export async function restartMesh(execute: Execute, mesh: MeshInstallation, components?: MeshComponent[]): Promise<void> {
+  if (mesh.kind === "external" || mesh.kind === "absent") return;
   for (const deployment of mesh.deployments.filter(item => !components || components.includes(item.component))) {
     await execute("kubectl", ["rollout", "restart", `deployment/${deployment.name}`, "-n", mesh.namespace], { stdio: "pipe" });
     await execute("kubectl", ["rollout", "status", `deployment/${deployment.name}`, "-n", mesh.namespace, "--timeout=180s"], { stdio: "pipe" });
@@ -164,6 +202,7 @@ export async function restartMesh(execute: Execute, mesh: MeshInstallation, comp
 }
 
 export async function verifyMeshHealth(execute: Execute, mesh: MeshInstallation, expected: MeshImages = {}): Promise<void> {
+  if (mesh.kind === "external" || mesh.kind === "absent") return;
   for (const deployment of mesh.deployments) {
     const { stdout } = await execute("kubectl", ["get", "deployment", deployment.name, "-n", mesh.namespace, "-o", "json"], { stdio: "pipe" });
     const resource = parseObject(String(stdout), `AgentMesh ${deployment.name}`) as Resource;
@@ -193,6 +232,7 @@ export async function updateLegacyMeshImages(execute: Execute, mesh: MeshInstall
 
 export async function applyMeshImages(execute: Execute, mesh: MeshInstallation, images: MeshImages, chart: string): Promise<void> {
   if (mesh.kind === "absent") throw new Error("AgentMesh is not installed; install it explicitly before pushing mesh updates");
+  if (mesh.kind === "external") throw new Error("External AgentMesh is not managed by Kars; explicit mesh updates are refused.");
   await recheckMeshOwnership(execute, mesh);
   if (mesh.kind === "helm") {
     await execute("helm", ["upgrade", mesh.release, chart, "--namespace", mesh.releaseNamespace,

--- a/cli/src/lib/mesh-release.ts
+++ b/cli/src/lib/mesh-release.ts
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Execute } from "./deployment-target.js";
+
+export const MESH_NAMESPACE = "agentmesh";
+export type MeshComponent = "registry" | "relay";
+export type MeshImages = Partial<Record<MeshComponent, string>>;
+interface MeshDeployment { component: MeshComponent; name: string; container: string; image: string }
+export type MeshInstallation = {
+  kind: "absent" | "legacy";
+  namespace: string;
+  deployments: MeshDeployment[];
+} | {
+  kind: "helm";
+  namespace: string;
+  deployments: MeshDeployment[];
+  release: string;
+  releaseNamespace: string;
+  values: Record<string, unknown>;
+};
+
+interface Resource {
+  kind?: string;
+  metadata?: { name?: string; annotations?: Record<string, string>; labels?: Record<string, string>; generation?: number; ownerReferences?: unknown[] };
+  spec?: { replicas?: number; template?: { spec?: { containers?: Array<{ name?: string; image?: string }> } } };
+  status?: { observedGeneration?: number; readyReplicas?: number; updatedReplicas?: number; conditions?: Array<{ type?: string; status?: string }> };
+}
+
+function parseObject(raw: string, label: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(`${label} returned an invalid object`);
+  return parsed as Record<string, unknown>;
+}
+
+export async function readReleaseValues(execute: Execute, release = "kars", namespace = "kars-system"): Promise<Record<string, unknown>> {
+  const { stdout } = await execute("helm", ["get", "values", release, "-n", namespace, "--all", "-o", "json"], { stdio: "pipe" });
+  return String(stdout).trim() === "null" ? {} : parseObject(String(stdout), "Helm values");
+}
+
+export function helmMeshEnabled(values: Record<string, unknown>): boolean {
+  if (values.agentMesh == null) return false;
+  if (typeof values.agentMesh !== "object" || Array.isArray(values.agentMesh)) throw new Error("agentMesh values must be a map");
+  const mesh = values.agentMesh as Record<string, unknown>;
+  if (mesh.enabled != null && typeof mesh.enabled !== "boolean") throw new Error("agentMesh.enabled must be boolean");
+  return mesh.enabled === true;
+}
+
+function componentOf(resource: Resource): MeshComponent | undefined {
+  const name = resource.metadata?.name;
+  for (const component of ["registry", "relay"] as const) {
+    if (resource.kind === "Deployment" && (name === component || name === `agentmesh-${component}`)) return component;
+    if (resource.kind === "Service" && name === `agentmesh-${component}`) return component;
+  }
+  return undefined;
+}
+
+/** Inspect Kubernetes ownership first. Existing unmanaged installations do not
+ * require a Helm binary or a Helm release merely to refresh their images. */
+export async function inspectMeshInstallation(execute: Execute): Promise<MeshInstallation> {
+  let raw: string;
+  try {
+    raw = String((await execute("kubectl", [
+      "get", "deployment,service", "-n", MESH_NAMESPACE, "-o", "json",
+    ], { stdio: "pipe" })).stdout);
+  } catch (error) {
+    const text = `${(error as { stderr?: string }).stderr ?? ""}\n${String(error)}`;
+    if (/\(NotFound\).*namespaces?\s+"agentmesh"\s+not found/.test(text)) {
+      return { kind: "absent", namespace: MESH_NAMESPACE, deployments: [] };
+    }
+    throw error;
+  }
+  const list = parseObject(raw, "AgentMesh inventory");
+  if (!Array.isArray(list.items)) throw new Error("AgentMesh inventory has no items array");
+  const resources = (list.items as Resource[]).filter(resource => componentOf(resource));
+  if (!resources.length) return { kind: "absent", namespace: MESH_NAMESPACE, deployments: [] };
+  if (resources.some(resource => resource.metadata?.ownerReferences?.length)) {
+    throw new Error("AgentMesh resources have another Kubernetes owner; refusing an unmanaged update.");
+  }
+  const deployments: MeshDeployment[] = [];
+  for (const component of ["registry", "relay"] as const) {
+    const matching = resources.filter(resource => componentOf(resource) === component);
+    const workload = matching.filter(resource => resource.kind === "Deployment");
+    const services = matching.filter(resource => resource.kind === "Service");
+    if (workload.length !== 1 || services.length !== 1) {
+      throw new Error(`AgentMesh ${component} has incomplete or ambiguous deployment/service ownership; refusing to adopt or replace selectors.`);
+    }
+    const containers = workload[0].spec?.template?.spec?.containers ?? [];
+    const container = containers.find(item => item.name === component || item.name === `agentmesh-${component}`)
+      ?? (containers.length === 1 ? containers[0] : undefined);
+    if (!container?.name || !container.image) throw new Error(`Cannot identify AgentMesh ${component} container`);
+    deployments.push({ component, name: workload[0].metadata!.name!, container: container.name, image: container.image });
+  }
+  const owners = resources.map(resource => ({
+    release: resource.metadata?.annotations?.["meta.helm.sh/release-name"],
+    namespace: resource.metadata?.annotations?.["meta.helm.sh/release-namespace"],
+    manager: resource.metadata?.labels?.["app.kubernetes.io/managed-by"],
+  }));
+  if (owners.every(owner => !owner.release && !owner.namespace && !owner.manager)) {
+    return { kind: "legacy", namespace: MESH_NAMESPACE, deployments };
+  }
+  const owner = owners[0];
+  if (!owner.release || !owner.namespace || owners.some(item =>
+    item.release !== owner.release || item.namespace !== owner.namespace || item.manager !== "Helm")) {
+    throw new Error("AgentMesh has mixed or incomplete Helm ownership; refusing selector adoption.");
+  }
+  const { stdout } = await execute("helm", ["list", "-n", owner.namespace, "-o", "json"], { stdio: "pipe" });
+  const releases: unknown = JSON.parse(String(stdout));
+  if (!Array.isArray(releases) || !releases.some(item =>
+    item?.name === owner.release && typeof item.chart === "string" && item.chart.startsWith("kars-"))) {
+    throw new Error("AgentMesh is not owned by a verified Kars Helm release");
+  }
+  const values = await readReleaseValues(execute, owner.release, owner.namespace);
+  if (!helmMeshEnabled(values)) throw new Error("AgentMesh Helm ownership conflicts with agentMesh.enabled; refusing an unsafe update");
+  const namespace = (values.agentMesh as Record<string, unknown>).namespace;
+  if (namespace != null && namespace !== MESH_NAMESPACE) throw new Error("Only the agentmesh namespace is supported");
+  return { kind: "helm", namespace: MESH_NAMESPACE, deployments, release: owner.release, releaseNamespace: owner.namespace, values };
+}
+
+export function assertMeshReleaseConsistency(mesh: MeshInstallation, values: Record<string, unknown>): void {
+  const enabled = helmMeshEnabled(values);
+  if (enabled !== (mesh.kind === "helm")
+    || (mesh.kind === "helm" && (mesh.release !== "kars" || mesh.releaseNamespace !== "kars-system"))) {
+    throw new Error("Kars Helm mesh values do not match actual deployment ownership; refusing automatic adoption or ownership changes.");
+  }
+}
+
+export async function recheckMeshOwnership(execute: Execute, expected: MeshInstallation): Promise<void> {
+  const current = await inspectMeshInstallation(execute);
+  const identity = (mesh: MeshInstallation) => JSON.stringify({
+    kind: mesh.kind, namespace: mesh.namespace,
+    release: mesh.kind === "helm" ? [mesh.releaseNamespace, mesh.release] : null,
+    deployments: mesh.deployments.map(({ name, container }) => [name, container]),
+  });
+  if (identity(current) !== identity(expected)) {
+    throw new Error("AgentMesh ownership changed during preparation; update stopped before modifying its resources.");
+  }
+}
+
+export function meshImageValueArgs(images: MeshImages): string[] {
+  const args: string[] = [];
+  for (const component of ["registry", "relay"] as const) {
+    const image = images[component];
+    if (!image) continue;
+    const colon = image.lastIndexOf(":");
+    if (image.includes("@") || colon <= image.lastIndexOf("/") || colon === image.length - 1) {
+      throw new Error(`AgentMesh ${component} requires the actual repository:tag artifact`);
+    }
+    args.push("--set-string", `agentMesh.${component}.image.repository=${image.slice(0, colon)}`,
+      "--set-string", `agentMesh.${component}.image.tag=${image.slice(colon + 1)}`);
+  }
+  return args;
+}
+
+export function releaseMeshImages(registry: string, tag: string): MeshImages {
+  return { registry: `${registry}/agentmesh-registry-agt:${tag}`, relay: `${registry}/agentmesh-relay-agt:${tag}` };
+}
+
+export async function restartMesh(execute: Execute, mesh: MeshInstallation, components?: MeshComponent[]): Promise<void> {
+  for (const deployment of mesh.deployments.filter(item => !components || components.includes(item.component))) {
+    await execute("kubectl", ["rollout", "restart", `deployment/${deployment.name}`, "-n", mesh.namespace], { stdio: "pipe" });
+    await execute("kubectl", ["rollout", "status", `deployment/${deployment.name}`, "-n", mesh.namespace, "--timeout=180s"], { stdio: "pipe" });
+  }
+}
+
+export async function verifyMeshHealth(execute: Execute, mesh: MeshInstallation, expected: MeshImages = {}): Promise<void> {
+  for (const deployment of mesh.deployments) {
+    const { stdout } = await execute("kubectl", ["get", "deployment", deployment.name, "-n", mesh.namespace, "-o", "json"], { stdio: "pipe" });
+    const resource = parseObject(String(stdout), `AgentMesh ${deployment.name}`) as Resource;
+    const replicas = resource.spec?.replicas ?? 1;
+    if (replicas < 1 || (resource.status?.readyReplicas ?? 0) < replicas
+      || (resource.status?.updatedReplicas ?? 0) < replicas
+      || (resource.status?.observedGeneration ?? -1) < (resource.metadata?.generation ?? 0)
+      || !resource.status?.conditions?.some(condition => condition.type === "Available" && condition.status === "True")) {
+      throw new Error(`AgentMesh deployment '${deployment.name}' has not completed a healthy rollout`);
+    }
+    const image = resource.spec?.template?.spec?.containers?.find(item => item.name === deployment.container)?.image;
+    if (expected[deployment.component] && image !== expected[deployment.component]) {
+      throw new Error(`AgentMesh ${deployment.name} is not running the selected image artifact`);
+    }
+  }
+}
+
+export async function updateLegacyMeshImages(execute: Execute, mesh: MeshInstallation, images: MeshImages): Promise<void> {
+  if (mesh.kind !== "legacy") throw new Error("Direct image updates require an existing unmanaged AgentMesh installation");
+  for (const deployment of mesh.deployments) {
+    if (images[deployment.component]) {
+      await execute("kubectl", ["set", "image", `deployment/${deployment.name}`,
+        `${deployment.container}=${images[deployment.component]}`, "-n", mesh.namespace], { stdio: "pipe" });
+    }
+  }
+}
+
+export async function applyMeshImages(execute: Execute, mesh: MeshInstallation, images: MeshImages, chart: string): Promise<void> {
+  if (mesh.kind === "absent") throw new Error("AgentMesh is not installed; install it explicitly before pushing mesh updates");
+  await recheckMeshOwnership(execute, mesh);
+  if (mesh.kind === "helm") {
+    await execute("helm", ["upgrade", mesh.release, chart, "--namespace", mesh.releaseNamespace,
+      "--reuse-values", ...meshImageValueArgs(images), "--atomic", "--wait", "--timeout", "8m"], { stdio: "pipe" });
+  } else {
+    await updateLegacyMeshImages(execute, mesh, images);
+  }
+  const components = (["registry", "relay"] as const).filter(component => images[component]);
+  await restartMesh(execute, mesh, [...components]);
+  await verifyMeshHealth(execute, mesh, images);
+}

--- a/cli/src/lib/release.ts
+++ b/cli/src/lib/release.ts
@@ -5,6 +5,8 @@
 // `kars dev --release`, and `kars upgrade`: the canonical GHCR image plan,
 // semantic-version comparison, and latest-release discovery.
 
+import { RUNTIME_IMAGE_TARGETS } from "./image-targets.js";
+
 export const RELEASE_GHCR = "ghcr.io/azure";
 
 export interface ReleaseImage {
@@ -37,11 +39,7 @@ export function releaseImagePlan(
     { src: `${G}/kars-agentmesh-registry:${version}`, target: "agentmesh-registry-agt:latest", required: true },
   ];
   if (opts.includeRuntimes !== false) {
-    for (const rt of [
-      "kars-runtime-openai-agents", "kars-runtime-maf-python", "kars-runtime-anthropic",
-      "kars-runtime-langgraph", "kars-runtime-langgraph-ts", "kars-runtime-pydantic-ai",
-      "kars-runtime-hermes",
-    ]) {
+    for (const { repo: rt } of RUNTIME_IMAGE_TARGETS) {
       images.push({ src: `${G}/${rt}:${version}`, target: `${rt}:latest`, required: false });
     }
   }

--- a/cli/src/lib/repo-assets.test.ts
+++ b/cli/src/lib/repo-assets.test.ts
@@ -31,6 +31,7 @@ const REQUIRED_RELEASE_ASSETS = [
   "deploy/helm/kars",
   "deploy/helm/kars/values-local-dev.yaml",
   "deploy/helm/kars/values-generic.yaml",
+  "deploy/helm/kars/values-existing-aks.yaml",
   "deploy/agentmesh-agt.yaml",
   // aks (kars up --release)
   "deploy/bicep/main.bicep",

--- a/cli/src/lib/repo-assets.test.ts
+++ b/cli/src/lib/repo-assets.test.ts
@@ -30,6 +30,7 @@ const REQUIRED_RELEASE_ASSETS = [
   // local-k8s (kars dev --release --target local-k8s)
   "deploy/helm/kars",
   "deploy/helm/kars/values-local-dev.yaml",
+  "deploy/helm/kars/values-generic.yaml",
   "deploy/agentmesh-agt.yaml",
   // aks (kars up --release)
   "deploy/bicep/main.bicep",

--- a/cli/src/lib/sandbox-image-apply.ts
+++ b/cli/src/lib/sandbox-image-apply.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { agentContainerName, runtimeKindFromCr } from "../runtime.js";
+import type { Execute } from "./deployment-target.js";
+import { runtimeTarget, type PushedImage } from "./image-targets.js";
+import { readDeployment, requireHealthyDeployment, type DeploymentRecord } from "./core-image-apply.js";
+
+interface SandboxRecord {
+  metadata: { name: string; namespace: string };
+  spec?: {
+    runtime?: Record<string, unknown> & { kind?: string };
+    openclaw?: { image?: string };
+    upstreamCompatibility?: { sigsAgentSandbox?: string };
+    suspended?: boolean;
+  };
+}
+export interface SandboxImagePlan {
+  cr: SandboxRecord;
+  deployment: DeploymentRecord;
+  expected: Array<{ container: string; init: boolean; image: string }>;
+  pinned: boolean;
+}
+
+export function planSandboxImages(cr: SandboxRecord, deployment: DeploymentRecord, images: PushedImage[]): SandboxImagePlan {
+  const expected: SandboxImagePlan["expected"] = [];
+  let pinned = false;
+  if (cr.spec?.upstreamCompatibility?.sigsAgentSandbox === "overlay") return { cr, deployment, expected, pinned: true };
+  const kind = runtimeKindFromCr(cr);
+  for (const item of images) {
+    if (item.name === "router") expected.push({ container: "inference-router", init: false, image: item.image });
+    if (item.name === "sandbox") {
+      if (deployment.spec.template.spec.initContainers?.some(container => container.name === "egress-guard")) {
+        expected.push({ container: "egress-guard", init: true, image: item.image });
+      }
+      if (kind === "OpenClaw") {
+        const config = cr.spec?.runtime?.openclaw as { image?: unknown } | undefined;
+        if (config?.image != null || cr.spec?.openclaw?.image != null) pinned = true;
+        else expected.push({ container: agentContainerName(kind), init: false, image: item.image });
+      }
+    }
+    const runtime = runtimeTarget(item.name);
+    if (runtime && runtime.kind === kind) {
+      const config = cr.spec?.runtime?.[runtime.variant] as { image?: unknown; language?: string } | undefined;
+      if (runtime.language && (config?.language ?? "python") !== runtime.language) continue;
+      if (config?.image != null) pinned = true;
+      else expected.push({ container: agentContainerName(kind), init: false, image: item.image });
+    }
+  }
+  for (const item of expected) {
+    const containers = item.init ? deployment.spec.template.spec.initContainers : deployment.spec.template.spec.containers;
+    if (!containers?.some(container => container.name === item.container)) throw new Error(`Eligible workload lacks '${item.container}'`);
+  }
+  return { cr, deployment, expected, pinned };
+}
+
+export async function inspectSandboxPlans(execute: Execute, images: PushedImage[]): Promise<SandboxImagePlan[]> {
+  if (!images.some(item => item.name === "router" || item.name === "sandbox" || runtimeTarget(item.name))) return [];
+  const [deployments, sandboxes] = await Promise.all([
+    execute("kubectl", ["get", "deployments", "-A", "-l", "kars.azure.com/component=sandbox", "-o", "json"], { stdio: "pipe" }),
+    execute("kubectl", ["get", "karssandboxes", "-A", "-o", "json"], { stdio: "pipe" }),
+  ]);
+  const list = JSON.parse(String(deployments.stdout)) as { items?: DeploymentRecord[] };
+  const crs = JSON.parse(String(sandboxes.stdout)) as { items?: SandboxRecord[] };
+  if (!Array.isArray(list.items) || !Array.isArray(crs.items)) throw new Error("Cannot verify sandbox image overrides");
+  return list.items.map(deployment => {
+    const labels = deployment.metadata?.labels ?? {};
+    const name = labels["kars.azure.com/sandbox"] || deployment.metadata?.name;
+    const namespace = labels["kars.azure.com/parent-namespace"];
+    const candidates = crs.items!.filter(cr => cr.metadata?.name === name && (!namespace || cr.metadata.namespace === namespace));
+    if (candidates.length !== 1 || !deployment.metadata.namespace) throw new Error(`Cannot identify the owning CR for sandbox deployment ${name}`);
+    return planSandboxImages(candidates[0], deployment, images);
+  });
+}
+
+/** Let the controller materialize its new defaults from each unmodified CR.
+ * Only metadata is touched, never a customer's explicit spec image pin. */
+export async function refreshSandboxImages(execute: Execute, plans: SandboxImagePlan[]): Promise<number> {
+  let updated = 0;
+  for (const plan of plans.filter(item => item.expected.length > 0)) {
+    const { cr, deployment } = plan;
+    // Re-read authority before triggering reconciliation; a concurrently added
+    // custom pin must be preserved, not patched back to a new default.
+    const { stdout } = await execute("kubectl", ["get", "karssandbox", cr.metadata.name, "-n", cr.metadata.namespace, "-o", "json"], { stdio: "pipe" });
+    const current = JSON.parse(String(stdout)) as SandboxRecord;
+    if (JSON.stringify(current.spec) !== JSON.stringify(cr.spec)) throw new Error(`Sandbox ${cr.metadata.name} changed during image preparation; retry with its current overrides`);
+    await execute("kubectl", ["annotate", "karssandbox", cr.metadata.name, "-n", cr.metadata.namespace,
+      `kars.azure.com/image-refresh=${Date.now()}`, "--overwrite"], { stdio: "pipe" });
+    for (const item of plan.expected) {
+      const containers = item.init ? "initContainers" : "containers";
+      await execute("kubectl", ["wait", `deployment/${deployment.metadata.name}`, "-n", deployment.metadata.namespace,
+        `--for=jsonpath={.spec.template.spec.${containers}[?(@.name=="${item.container}")].image}=${item.image}`,
+        "--timeout=180s"], { stdio: "pipe" });
+    }
+    if ((deployment.spec.replicas ?? 1) > 0) {
+      await execute("kubectl", ["rollout", "restart", `deployment/${deployment.metadata.name}`, "-n", deployment.metadata.namespace], { stdio: "pipe" });
+      await execute("kubectl", ["rollout", "status", `deployment/${deployment.metadata.name}`, "-n", deployment.metadata.namespace, "--timeout=300s"], { stdio: "pipe" });
+    }
+    const actual = await readDeployment(execute, deployment.metadata.name, deployment.metadata.namespace);
+    for (const item of plan.expected) {
+      const containers = item.init ? actual.spec.template.spec.initContainers : actual.spec.template.spec.containers;
+      if (containers?.find(container => container.name === item.container)?.image !== item.image) {
+        throw new Error(`Sandbox ${cr.metadata.name}/${item.container} did not converge to the selected artifact`);
+      }
+    }
+    if ((deployment.spec.replicas ?? 1) > 0) requireHealthyDeployment(actual);
+    updated++;
+  }
+  return updated;
+}

--- a/cli/src/testing/helm-installation.test.ts
+++ b/cli/src/testing/helm-installation.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse, parseAllDocuments, stringify } from "yaml";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const chart = join(root, "deploy/helm/kars");
+const temporaryDirectories: string[] = [];
+
+interface Container {
+  name?: string;
+  image?: string;
+  env?: Array<{ name: string; value?: string }>;
+  command?: string[];
+}
+
+interface Manifest {
+  kind: string;
+  metadata?: { name?: string; labels?: Record<string, string> };
+  spec?: {
+    replicas?: number;
+    strategy?: { type?: string };
+    selector?: Record<string, unknown>;
+    template?: {
+      metadata?: { labels?: Record<string, string> };
+      spec?: { containers?: Container[]; initContainers?: Container[] };
+    };
+  };
+}
+
+function documents(text: string): Manifest[] {
+  return parseAllDocuments(text).map((document) => {
+    if (document.errors.length) throw document.errors[0];
+    return document.toJSON();
+  }).filter(Boolean);
+}
+
+function render(path = chart, args: string[] = []): Manifest[] {
+  return documents(execFileSync(
+    "helm", ["template", "kars", path, "--namespace", "kars-system", ...args],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 30_000 },
+  ));
+}
+
+function resource(resources: Manifest[], kind: string, name: string): Manifest {
+  const found = resources.find((item) => item.kind === kind && item.metadata?.name === name);
+  if (!found) throw new Error(`Missing ${kind}/${name}`);
+  return found;
+}
+
+function reusedValuesChart(enableMesh = false): string {
+  const directory = mkdtempSync(join(tmpdir(), "kars-reused-values-"));
+  temporaryDirectories.push(directory);
+  const copied = join(directory, "chart");
+  cpSync(chart, copied, { recursive: true });
+  const savedValues = parse(readFileSync(join(chart, "values.yaml"), "utf8"));
+  // --reuse-values replaces the new chart defaults with the saved old map.
+  // These two fields did not exist before the generic-installation feature.
+  delete savedValues.agentMesh;
+  delete savedValues.sandbox.nodeSelector;
+  savedValues.controller.replicas = 3;
+  savedValues.azure.workloadIdentity.clientId = "existing-customer-identity";
+  savedValues.sandbox.image.repository = "registry.customer.example/existing-agent";
+  if (enableMesh) savedValues.agentMesh = { enabled: true };
+  writeFileSync(join(copied, "values.yaml"), stringify(savedValues));
+  return copied;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("existing Helm installation compatibility", () => {
+  it("preserves saved customer values and the legacy selector when new maps are absent", () => {
+    const manifests = render(reusedValuesChart());
+    expect(manifests.some((item) => item.metadata?.name === "agentmesh-registry")).toBe(false);
+    const controller = resource(manifests, "Deployment", "kars-controller");
+    expect(controller.spec?.replicas).toBe(3);
+    const env = controller.spec?.template?.spec?.containers?.[0]?.env;
+    expect(env).toContainEqual({ name: "KARS_SANDBOX_NODE_SELECTOR_JSON", value: "{}" });
+    expect(env).toContainEqual({ name: "AZURE_WI_CLIENT_ID", value: "existing-customer-identity" });
+    expect(env).toContainEqual({
+      name: "SANDBOX_IMAGE", value: "registry.customer.example/existing-agent:latest",
+    });
+  });
+
+  it("can enable the new mesh using reused values without missing nested defaults", () => {
+    const manifests = render(reusedValuesChart(true));
+    for (const component of ["registry", "relay"]) {
+      const deployment = resource(manifests, "Deployment", component);
+      expect(deployment.spec?.replicas).toBe(1);
+      expect(deployment.spec?.template?.spec?.containers?.[0]?.image)
+        .toBe(`ghcr.io/azure/kars-agentmesh-${component}:latest`);
+    }
+  });
+
+  it("treats removed/null new configuration as the compatible disabled/default state", () => {
+    const manifests = render(chart, ["--set", "agentMesh=null,sandbox.nodeSelector=null"]);
+    expect(manifests.some((item) => item.metadata?.name === "agentmesh-registry")).toBe(false);
+    expect(resource(manifests, "Deployment", "kars-controller").spec?.template?.spec?.containers?.[0]?.env)
+      .toContainEqual({ name: "KARS_SANDBOX_NODE_SELECTOR_JSON", value: "{}" });
+  });
+
+  it("uses deployment and service selectors compatible with the standalone AGT manifest", () => {
+    const legacy = documents(readFileSync(join(root, "deploy/agentmesh-agt.yaml"), "utf8"));
+    const manifests = render(chart, ["--set", "agentMesh.enabled=true"]);
+    for (const component of ["registry", "relay"]) {
+      const deployment = resource(manifests, "Deployment", component);
+      expect(deployment.spec?.selector).toEqual(resource(legacy, "Deployment", component).spec?.selector);
+      expect(deployment.spec?.template?.metadata?.labels?.app).toBe(`agentmesh-${component}`);
+      expect(deployment.spec?.template?.metadata?.labels?.["app.kubernetes.io/name"])
+        .toBe(`agentmesh-${component}`);
+      expect(deployment.spec?.strategy?.type).toBe("Recreate");
+      const service = `agentmesh-${component}`;
+      expect(resource(manifests, "Service", service).spec?.selector)
+        .toEqual(resource(legacy, "Service", service).spec?.selector);
+    }
+  });
+
+  it("allows explicit maintenance scale-down without replacing zero with the default", () => {
+    const manifests = render(chart, [
+      "--set", "agentMesh.enabled=true,agentMesh.registry.replicas=0,agentMesh.relay.replicas=0",
+    ]);
+    expect(resource(manifests, "Deployment", "registry").spec?.replicas).toBe(0);
+    expect(resource(manifests, "Deployment", "relay").spec?.replicas).toBe(0);
+  });
+
+  it.each([
+    ["agentMesh.namespace=mesh-custom", /agentMesh.namespace must be agentmesh/],
+    ["agentMesh.registry.replicas=2", /replica counts must be 0 or 1/],
+    ["agentMesh.relay.replicas=2", /replica counts must be 0 or 1/],
+    ["agentMesh.registry.replicas=-1", /replica counts must be 0 or 1/],
+  ])("rejects unsupported mesh configuration: %s", (setting, message) => {
+    expect(() => render(chart, ["--set", `agentMesh.enabled=true,${setting}`])).toThrow(message);
+  });
+
+  it.each(["values-generic.yaml", "values-existing-aks.yaml"])(
+    "%s keeps the profile needed by existing/default enhanced sandbox CRs",
+    (profile) => {
+      const manifests = render(chart, ["--values", join(chart, profile)]);
+      const installer = resource(manifests, "DaemonSet", "kars-seccomp-installer");
+      const command = installer.spec?.template?.spec?.initContainers?.[0]?.command?.join("\n");
+      expect(command).toContain("/host/seccomp/profiles/kars-strict.json");
+      expect(command).not.toContain("/host/seccomp/profiles/RuntimeDefault.json");
+    },
+  );
+});

--- a/cli/src/testing/publication-guardrails.test.ts
+++ b/cli/src/testing/publication-guardrails.test.ts
@@ -101,6 +101,16 @@ describe("npm audit gate", () => {
     expect(result.stdout).toContain("1 blocking");
   });
 
+  it.each(["info", "low", "moderate", "high", "critical"])(
+    "handles standard npm bulk %s records whose package name is only in the map key",
+    (severity) => {
+      const result = audit([{ body: { example: [{ ...advisory, name: undefined, severity }] } }]);
+      expect(result.status).toBe(["high", "critical"].includes(severity) ? 1 : 0);
+      expect(result.stdout).toContain(`${severity}: example`);
+      expect(result.stderr).not.toContain("Invalid npm advisory");
+    },
+  );
+
   it.each(["info", "low", "moderate"])("reports nonblocking %s advisories", (severity) => {
     const result = audit([{ body: { example: [{ ...advisory, severity }] } }]);
     expect(result.status).toBe(0);
@@ -112,6 +122,7 @@ describe("npm audit gate", () => {
     { example: advisory }, { example: [null] },
     { example: [{ ...advisory, severity: "unknown" }] },
     { example: [{ ...advisory, name: "another-package" }] },
+    { example: [{ ...advisory, name: null }] },
     { example: [{ ...advisory, id: undefined }] },
     { example: [{ ...advisory, vulnerable_versions: "" }] },
     { unknown: [] },

--- a/cli/src/testing/publication-guardrails.test.ts
+++ b/cli/src/testing/publication-guardrails.test.ts
@@ -208,8 +208,32 @@ describe("stacked publication gates", () => {
     (name) => {
       const workflow = parse(readFileSync(join(root, `.github/workflows/${name}.yml`), "utf8"));
       expect(workflow.on.pull_request.branches).toContain("main");
+      expect(workflow.on.pull_request.branches).toContain("kars-bridge");
       expect(workflow.on.pull_request.branches).toContain("public/pr*");
       expect(workflow.on.pull_request_target).toBeUndefined();
+    },
+  );
+
+  it.each(["ci", "ci-gates", "codeql", "secret-scanning"])(
+    "%s checks the combined integration head after a staged merge",
+    (name) => {
+      const workflow = parse(readFileSync(join(root, `.github/workflows/${name}.yml`), "utf8"));
+      expect(workflow.on.push.branches).toContain("kars-bridge");
+    },
+  );
+
+  it.each(["image-cache-publish", "image-sign-sbom", "release", "release-internal", "release-public-interim"])(
+    "%s cannot automatically publish from an integration-branch push",
+    (name) => {
+      const workflow = parse(readFileSync(join(root, `.github/workflows/${name}.yml`), "utf8"));
+      const push = workflow.on.push;
+      if (push) {
+        expect(Array.isArray(push.branches) || Array.isArray(push.tags)).toBe(true);
+        expect(push.branches ?? []).not.toContain("kars-bridge");
+        expect(push.branches ?? []).not.toContain("*");
+        expect(push.branches ?? []).not.toContain("**");
+      }
+      expect(workflow.on.workflow_run).toBeUndefined();
     },
   );
 

--- a/cli/src/testing/publication-guardrails.test.ts
+++ b/cli/src/testing/publication-guardrails.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const auditScript = join(root, "ci/npm-audit-bulk.mjs");
+const temporaryDirectories: string[] = [];
+const advisory = {
+  id: 1234,
+  name: "example",
+  severity: "high",
+  title: "Advisory fixture",
+  url: "https://github.com/advisories/GHSA-example",
+  vulnerable_versions: "<2.0.0",
+};
+const lockfile = {
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "fixture" },
+    "node_modules/example": { version: "1.0.0" },
+  },
+};
+
+// Exercise the real CLI entry point with an isolated registry, without network access.
+const runner = `
+  import { pathToFileURL } from "node:url";
+  const steps = JSON.parse(process.env.AUDIT_STEPS);
+  let calls = 0;
+  globalThis.setTimeout = (callback) => { callback(); return 0; };
+  globalThis.fetch = async (url, options) => {
+    if (url !== "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk") {
+      throw new Error("unexpected registry");
+    }
+    console.log("PAYLOAD:" + options.body);
+    const step = steps[Math.min(calls++, steps.length - 1)];
+    if (step.transportError) throw new TypeError("registry unreachable");
+    return new Response(step.raw ?? JSON.stringify(step.body), {
+      status: step.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  process.on("exit", () => console.log("CALLS:" + calls));
+  process.argv = [process.execPath, process.env.AUDIT_SCRIPT, process.env.AUDIT_LOCK];
+  await import(pathToFileURL(process.env.AUDIT_SCRIPT).href);
+`;
+
+function audit(steps: object[], lock: unknown = lockfile) {
+  const directory = mkdtempSync(join(tmpdir(), "kars-audit-test-"));
+  temporaryDirectories.push(directory);
+  const lockPath = join(directory, "package-lock.json");
+  writeFileSync(lockPath, JSON.stringify(lock));
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", runner], {
+    encoding: "utf8",
+    timeout: 10_000,
+    env: {
+      ...process.env,
+      AUDIT_SCRIPT: auditScript,
+      AUDIT_LOCK: lockPath,
+      AUDIT_STEPS: JSON.stringify(steps),
+    },
+  });
+  if (result.error) throw result.error;
+  expect(result.signal).toBeNull();
+  return result;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("npm audit gate", () => {
+  it.each(["cli", "mesh-plugin", "runtimes/openclaw"])("audits the complete %s lockfile", (project) => {
+    const lock = JSON.parse(readFileSync(join(root, project, "package-lock.json"), "utf8"));
+    const result = audit([{ body: {} }], lock);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("CALLS:1");
+    const line = result.stdout.split("\n").find((entry) => entry.startsWith("PAYLOAD:"));
+    expect(line).toBeDefined();
+    expect(Object.keys(JSON.parse(line!.slice("PAYLOAD:".length))).length).toBeGreaterThan(0);
+  });
+
+  it("accepts a valid empty advisory map after auditing packages", () => {
+    const result = audit([{ body: {} }]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('PAYLOAD:{"example":["1.0.0"]}');
+    expect(result.stdout).toContain("1 packages, 0 advisories, 0 blocking");
+  });
+
+  it.each(["high", "critical"])("blocks %s advisories", (severity) => {
+    const result = audit([{ body: { example: [{ ...advisory, severity }] } }]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("1 blocking");
+  });
+
+  it.each(["info", "low", "moderate"])("reports nonblocking %s advisories", (severity) => {
+    const result = audit([{ body: { example: [{ ...advisory, severity }] } }]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`${severity}: example`);
+  });
+
+  it.each([
+    null, [], "error", { error: "service unavailable" },
+    { example: advisory }, { example: [null] },
+    { example: [{ ...advisory, severity: "unknown" }] },
+    { example: [{ ...advisory, name: "another-package" }] },
+    { example: [{ ...advisory, id: undefined }] },
+    { example: [{ ...advisory, vulnerable_versions: "" }] },
+    { unknown: [] },
+  ])("rejects malformed success responses: %j", (body) => {
+    const result = audit([{ body }]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Invalid npm advisory");
+    expect(result.stdout).not.toContain("0 blocking");
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(audit([{ raw: "<html>unavailable</html>" }]).status).not.toBe(0);
+  });
+
+  it.each([
+    { transportError: true }, { status: 429 }, { status: 503 },
+  ])("retries transient errors before processing the result: %j", (failure) => {
+    const result = audit([failure, { body: { example: [advisory] } }]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("CALLS:2");
+    expect(result.stdout).toContain("1 blocking");
+  });
+
+  it("recovers from a transient error with a valid empty map", () => {
+    const result = audit([{ status: 503 }, { body: {} }]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("CALLS:2");
+  });
+
+  it.each([{ transportError: true }, { status: 503 }])("fails after four retries: %j", (step) => {
+    const result = audit([step]);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain("CALLS:4");
+    expect(result.stdout).not.toContain("0 blocking");
+  });
+
+  it("reports the final transport error rather than an earlier HTTP response", () => {
+    const result = audit([{ status: 503 }, { transportError: true }]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("failed after four attempts");
+    expect(result.stdout).toContain("CALLS:4");
+  });
+
+  it("does not retry a non-transient HTTP error", () => {
+    const result = audit([{ status: 400 }]);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain("CALLS:1");
+  });
+
+  it.each([
+    null, {}, { lockfileVersion: 1, dependencies: {} },
+    { lockfileVersion: 3, packages: [] },
+    { lockfileVersion: 3, packages: {} },
+    { lockfileVersion: 3, packages: { "node_modules/example": {} } },
+  ])("refuses an incomplete audit payload: %j", (lock) => {
+    const result = audit([{ body: {} }], lock);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain("CALLS:0");
+  });
+
+  it("uses real names for aliases and deduplicates nested and scoped versions", () => {
+    const result = audit([{ body: {} }], {
+      lockfileVersion: 2,
+      packages: {
+        "": {},
+        "node_modules/alias": { name: "example", version: "1.0.0" },
+        "node_modules/example": { version: "1.0.0" },
+        "node_modules/parent/node_modules/example": { version: "1.1.0" },
+        "node_modules/@scope/name": { version: "2.0.0" },
+        "node_modules/linked": { link: true, resolved: "../linked" },
+      },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('"example":["1.0.0","1.1.0"]');
+    expect(result.stdout).toContain('"@scope/name":["2.0.0"]');
+    expect(result.stdout).not.toContain('"linked"');
+  });
+});
+
+describe("stacked publication gates", () => {
+  it.each(["ci", "ci-gates", "codeql", "dependency-review", "secret-scanning"])(
+    "%s retains main and covers publication PR bases without privileged PR execution",
+    (name) => {
+      const workflow = parse(readFileSync(join(root, `.github/workflows/${name}.yml`), "utf8"));
+      expect(workflow.on.pull_request.branches).toContain("main");
+      expect(workflow.on.pull_request.branches).toContain("public/pr*");
+      expect(workflow.on.pull_request_target).toBeUndefined();
+    },
+  );
+
+  it("keeps all three npm audits mandatory", () => {
+    const workflow = parse(readFileSync(join(root, ".github/workflows/ci.yml"), "utf8"));
+    for (const jobName of ["cli-build", "runtime-openclaw-build", "mesh-plugin-build"]) {
+      const job = workflow.jobs[jobName];
+      expect(job["continue-on-error"]).not.toBe(true);
+      const steps = job.steps.filter((step: { run?: string }) => step.run?.includes("npm-audit-bulk.mjs"));
+      expect(steps).toHaveLength(1);
+      expect(steps[0]["continue-on-error"]).not.toBe(true);
+      expect(steps[0].if).toBeUndefined();
+      expect(steps[0].run).toMatch(/^node (?:\.\.\/){1,2}ci\/npm-audit-bulk\.mjs package-lock\.json$/);
+    }
+  });
+});

--- a/controller/src/reconciler/mod.rs
+++ b/controller/src/reconciler/mod.rs
@@ -44,13 +44,25 @@ use mcp_egress::mcp_egress_rule;
 mod pod_spec;
 pub(crate) use pod_spec::{
     build_egress_guard_command, build_pod_security_context, isolation_scheduling,
+    sandbox_node_selector_from,
 };
+
+fn sandbox_node_selector(default_pool: &str) -> Result<serde_json::Value, ReconcileError> {
+    sandbox_node_selector_from(
+        &std::env::var("KARS_SANDBOX_NODE_SELECTOR_JSON").unwrap_or_default(),
+        default_pool,
+    )
+    .map_err(ReconcileError::Configuration)
+}
+
 #[derive(Debug, thiserror::Error)]
 enum ReconcileError {
     #[error("Kubernetes API error: {0}")]
     Kube(#[from] kube::Error),
     #[error("JSON serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
+    #[error("Controller configuration error: {0}")]
+    Configuration(String),
 }
 
 /// Shared controller context.
@@ -1342,6 +1354,7 @@ async fn reconcile(sandbox: Arc<KarsSandbox>, ctx: Arc<Context>) -> Result<Actio
         let image = runtime_plan.image.clone();
 
         let (runtime_class, pool_label) = isolation_scheduling(&sandbox_config.isolation);
+        let node_selector = sandbox_node_selector(pool_label)?;
 
         let pull_policy = if ctx.dev_profile || !image.ends_with(":latest") {
             "IfNotPresent"
@@ -2119,9 +2132,7 @@ async fn reconcile(sandbox: Arc<KarsSandbox>, ctx: Arc<Context>) -> Result<Actio
                             "value": "true",
                             "effect": "NoSchedule"
                         }],
-                        "nodeSelector": {
-                            "kars.azure.com/pool": pool_label
-                        }
+                        "nodeSelector": node_selector
         });
 
         // Set runtimeClassName for Kata (confidential) isolation
@@ -3200,7 +3211,7 @@ fn error_requeue_duration(error: &ReconcileError) -> Duration {
         // Serde errors are deterministic — the same body will fail again.
         // Back off longer so we don't spam logs while a human fixes the
         // bad CR.
-        ReconcileError::SerdeJson(_) => 300,
+        ReconcileError::SerdeJson(_) | ReconcileError::Configuration(_) => 300,
     };
     crate::backoff::requeue_secs_with_jitter(base)
 }
@@ -3210,6 +3221,7 @@ fn error_policy(sandbox: Arc<KarsSandbox>, error: &ReconcileError, _ctx: Arc<Con
     let class = match error {
         ReconcileError::Kube(_) => "kube_api",
         ReconcileError::SerdeJson(_) => "serde",
+        ReconcileError::Configuration(_) => "configuration",
     };
     crate::metrics::record_reconcile_error("KarsSandbox", class);
     tracing::error!(

--- a/controller/src/reconciler/pod_spec.rs
+++ b/controller/src/reconciler/pod_spec.rs
@@ -61,6 +61,25 @@ pub(crate) fn isolation_scheduling(isolation: &str) -> (Option<&'static str>, &'
     }
 }
 
+pub(crate) fn sandbox_node_selector_from(
+    raw: &str,
+    default_pool: &str,
+) -> Result<serde_json::Value, String> {
+    if raw.trim().is_empty() || raw.trim() == "{}" {
+        return Ok(serde_json::json!({ "kars.azure.com/pool": default_pool }));
+    }
+    let selector: serde_json::Map<String, serde_json::Value> = serde_json::from_str(raw)
+        .map_err(|error| format!("KARS_SANDBOX_NODE_SELECTOR_JSON is invalid JSON: {error}"))?;
+    if selector.is_empty()
+        || selector
+            .iter()
+            .any(|(key, value)| key.trim().is_empty() || !value.is_string())
+    {
+        return Err("KARS_SANDBOX_NODE_SELECTOR_JSON must be a non-empty string map".into());
+    }
+    Ok(serde_json::Value::Object(selector))
+}
+
 /// Build the egress-guard init-container command.
 ///
 /// Standard sandboxes (every kind except SRE) get the full lockdown:

--- a/controller/src/reconciler/tests.rs
+++ b/controller/src/reconciler/tests.rs
@@ -97,6 +97,37 @@ fn isolation_scheduling_confidential() {
 }
 
 #[test]
+fn sandbox_node_selector_defaults_to_kars_pool() {
+    assert_eq!(
+        sandbox_node_selector_from("", "sandbox").expect("default selector"),
+        serde_json::json!({"kars.azure.com/pool": "sandbox"})
+    );
+}
+
+#[test]
+fn sandbox_node_selector_accepts_portable_labels() {
+    let selector = sandbox_node_selector_from(
+        r#"{"kubernetes.io/os":"linux","node.kubernetes.io/instance-type":"worker"}"#,
+        "sandbox",
+    )
+    .expect("configured selector");
+    assert_eq!(
+        selector,
+        serde_json::json!({
+            "kubernetes.io/os": "linux",
+            "node.kubernetes.io/instance-type": "worker"
+        })
+    );
+}
+
+#[test]
+fn sandbox_node_selector_rejects_non_string_values() {
+    let error = sandbox_node_selector_from(r#"{"kubernetes.io/os":true}"#, "sandbox")
+        .expect_err("selector values must be strings");
+    assert!(error.contains("non-empty string map"));
+}
+
+#[test]
 fn crd_defaults_are_secure() {
     let cfg = SandboxConfig::default();
     assert_eq!(cfg.isolation, "enhanced");

--- a/deploy/helm/kars/README.md
+++ b/deploy/helm/kars/README.md
@@ -59,3 +59,7 @@ For an existing AKS cluster, run `kars config adopt-aks` after Helm installation
 to write the local deployment context used by `kars upgrade`, `kars push`, and
 mesh lifecycle commands. Kubernetes-only commands already use the selected
 kube context directly.
+
+Start from `values-existing-aks.yaml`; it mirrors the Helm values written by
+`kars up` after provisioning and marks every customer-specific value with
+`REPLACE_ME`.

--- a/deploy/helm/kars/README.md
+++ b/deploy/helm/kars/README.md
@@ -62,6 +62,7 @@ kube context directly.
 
 Start from `values-existing-aks.yaml`; it mirrors the Helm values written by
 `kars up` after provisioning and marks every customer-specific value with
-`REPLACE_ME`. Import the referenced images into the selected ACR, grant the AKS
-kubelet identity `AcrPull`, and stamp `karsRelease` with the exact common
-release tag before installation.
+`REPLACE_ME`. It uses the fixed public GHCR repositories. When a private mirror
+is required, replace those repositories, import every image into the selected
+ACR, and grant the AKS kubelet identity `AcrPull`. Stamp `karsRelease` with the
+exact common release tag before installation.

--- a/deploy/helm/kars/README.md
+++ b/deploy/helm/kars/README.md
@@ -54,3 +54,8 @@ helm template kars deploy/helm/kars \
 The chart templates all Kars `CustomResourceDefinition` objects during Helm
 installation. CRDs added by later Kars versions are installed when that chart
 version is upgraded.
+
+For an existing AKS cluster, run `kars config adopt-aks` after Helm installation
+to write the local deployment context used by `kars upgrade`, `kars push`, and
+mesh lifecycle commands. Kubernetes-only commands already use the selected
+kube context directly.

--- a/deploy/helm/kars/README.md
+++ b/deploy/helm/kars/README.md
@@ -1,0 +1,50 @@
+# Kars Helm chart
+
+This chart installs the Kars CRDs, controller, RBAC, admission controls,
+policies, and optional operational components into an existing Kubernetes
+cluster. It does not provision the cluster, registry, inference backend, cloud
+identity, or AGT relay/registry.
+
+## Support status
+
+| Environment | Status |
+|---|---|
+| Local kind | Tested with `values-local-dev.yaml` |
+| AKS | Primary tested deployment |
+| EKS, GKE, and other Kubernetes | Chart-render tested with `values-generic.yaml`; runtime support depends on operator-provided integrations |
+
+## Existing non-AKS cluster
+
+The generic overlay disables Azure Workload Identity metadata and Azure-only
+chart settings, uses RuntimeDefault seccomp, and replaces the AKS-specific
+sandbox pool selector with the standard Linux node label.
+
+```bash
+helm upgrade --install kars deploy/helm/kars \
+  --namespace kars-system \
+  --create-namespace \
+  --values deploy/helm/kars/values-generic.yaml \
+  --values my-generic-values.yaml
+```
+
+`my-generic-values.yaml` must provide pullable images, an inference endpoint
+and router-side authentication, a reachable AGT relay/registry, and any
+environment-specific secret-store, policy, monitoring, ingress, and signing
+integrations. A NetworkPolicy-capable CNI is required.
+
+The overlay is opt-in and does not change existing AKS defaults.
+
+## Validate
+
+```bash
+helm lint deploy/helm/kars
+helm template kars deploy/helm/kars \
+  --namespace kars-system \
+  --values deploy/helm/kars/values-generic.yaml >/tmp/kars.yaml
+```
+
+Install the matching AGT stack separately before creating sandboxes:
+
+```bash
+kubectl apply -f deploy/agentmesh-agt.yaml
+```

--- a/deploy/helm/kars/README.md
+++ b/deploy/helm/kars/README.md
@@ -3,7 +3,8 @@
 This chart installs the Kars CRDs, controller, RBAC, admission controls,
 policies, and optional operational components into an existing Kubernetes
 cluster. It does not provision the cluster, registry, inference backend, cloud
-identity, or AGT relay/registry.
+identity, or inference credentials. The generic profile also deploys the
+Microsoft AGT AgentMesh relay and registry from the public Kars release images.
 
 ## Support status
 
@@ -28,11 +29,18 @@ helm upgrade --install kars deploy/helm/kars \
 ```
 
 `my-generic-values.yaml` must provide pullable images, an inference endpoint
-and router-side authentication, a reachable AGT relay/registry, and any
-environment-specific secret-store, policy, monitoring, ingress, and signing
-integrations. A NetworkPolicy-capable CNI is required.
+and router-side authentication, and any environment-specific secret-store,
+policy, monitoring, ingress, and signing integrations. A NetworkPolicy-capable
+CNI is required.
 
 The overlay is opt-in and does not change existing AKS defaults.
+
+To use an externally managed AgentMesh deployment instead, set:
+
+```yaml
+agentMesh:
+  enabled: false
+```
 
 ## Validate
 
@@ -43,8 +51,6 @@ helm template kars deploy/helm/kars \
   --values deploy/helm/kars/values-generic.yaml >/tmp/kars.yaml
 ```
 
-Install the matching AGT stack separately before creating sandboxes:
-
-```bash
-kubectl apply -f deploy/agentmesh-agt.yaml
-```
+The chart templates all Kars `CustomResourceDefinition` objects during Helm
+installation. CRDs added by later Kars versions are installed when that chart
+version is upgraded.

--- a/deploy/helm/kars/README.md
+++ b/deploy/helm/kars/README.md
@@ -62,4 +62,6 @@ kube context directly.
 
 Start from `values-existing-aks.yaml`; it mirrors the Helm values written by
 `kars up` after provisioning and marks every customer-specific value with
-`REPLACE_ME`.
+`REPLACE_ME`. Import the referenced images into the selected ACR, grant the AKS
+kubelet identity `AcrPull`, and stamp `karsRelease` with the exact common
+release tag before installation.

--- a/deploy/helm/kars/templates/agentmesh.yaml
+++ b/deploy/helm/kars/templates/agentmesh.yaml
@@ -1,0 +1,143 @@
+{{- if .Values.agentMesh.enabled }}
+{{- if .Values.agentMesh.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.agentMesh.namespace }}
+  labels:
+    app.kubernetes.io/name: agentmesh
+    app.kubernetes.io/part-of: kars
+    kars.azure.com/mesh-provider: agt
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: {{ .Values.agentMesh.namespace }}
+  labels:
+    app.kubernetes.io/name: agentmesh-registry
+    app.kubernetes.io/part-of: kars
+spec:
+  replicas: {{ .Values.agentMesh.registry.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentmesh-registry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agentmesh-registry
+        app.kubernetes.io/part-of: kars
+        kars.azure.com/mesh-provider: agt
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: registry
+          image: "{{ .Values.agentMesh.registry.image.repository }}:{{ .Values.agentMesh.registry.image.tag }}"
+          imagePullPolicy: {{ .Values.agentMesh.registry.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8082
+          env:
+            - { name: HOST, value: "0.0.0.0" }
+            - { name: PORT, value: "8082" }
+            - { name: LOG_LEVEL, value: "info" }
+          readinessProbe:
+            httpGet: { path: /health, port: http }
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentmesh-registry
+  namespace: {{ .Values.agentMesh.namespace }}
+spec:
+  selector:
+    app.kubernetes.io/name: agentmesh-registry
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: relay
+  namespace: {{ .Values.agentMesh.namespace }}
+  labels:
+    app.kubernetes.io/name: agentmesh-relay
+    app.kubernetes.io/part-of: kars
+spec:
+  replicas: {{ .Values.agentMesh.relay.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentmesh-relay
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agentmesh-relay
+        app.kubernetes.io/part-of: kars
+        kars.azure.com/mesh-provider: agt
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: relay
+          image: "{{ .Values.agentMesh.relay.image.repository }}:{{ .Values.agentMesh.relay.image.tag }}"
+          imagePullPolicy: {{ .Values.agentMesh.relay.image.pullPolicy }}
+          ports:
+            - name: websocket
+              containerPort: 8083
+          env:
+            - { name: HOST, value: "0.0.0.0" }
+            - { name: PORT, value: "8083" }
+            - { name: LOG_LEVEL, value: "info" }
+            - name: REGISTRY_URL
+              value: "http://agentmesh-registry.{{ .Values.agentMesh.namespace }}.svc.cluster.local:8080"
+            - { name: REQUIRE_REGISTRATION, value: "true" }
+          readinessProbe:
+            httpGet: { path: /health, port: websocket }
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: websocket }
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+          resources:
+            requests: { cpu: 100m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 128Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentmesh-relay
+  namespace: {{ .Values.agentMesh.namespace }}
+spec:
+  selector:
+    app.kubernetes.io/name: agentmesh-relay
+  ports:
+    - name: websocket
+      port: 8765
+      targetPort: websocket
+{{- end }}

--- a/deploy/helm/kars/templates/agentmesh.yaml
+++ b/deploy/helm/kars/templates/agentmesh.yaml
@@ -1,31 +1,55 @@
-{{- if .Values.agentMesh.enabled }}
-{{- if .Values.agentMesh.createNamespace }}
+{{- $mesh := .Values.agentMesh | default dict }}
+{{- if $mesh.enabled }}
+{{- $namespace := $mesh.namespace | default "agentmesh" }}
+{{- if ne $namespace "agentmesh" }}
+{{- fail "agentMesh.namespace must be agentmesh: current Kars endpoints and NetworkPolicies use this fixed namespace" }}
+{{- end }}
+{{- $registry := $mesh.registry | default dict }}
+{{- $relay := $mesh.relay | default dict }}
+{{- $registryImage := $registry.image | default dict }}
+{{- $relayImage := $relay.image | default dict }}
+{{- $registryReplicas := dig "replicas" 1 $registry }}
+{{- $relayReplicas := dig "replicas" 1 $relay }}
+{{- range $replicas := list $registryReplicas $relayReplicas }}
+{{- if not (has (toString $replicas) (list "0" "1")) }}
+{{- fail "AgentMesh replica counts must be 0 or 1: the shipped relay and registry do not share state across replicas" }}
+{{- end }}
+{{- end }}
+{{- $createNamespace := dig "createNamespace" true $mesh }}
+{{- if not (kindIs "bool" $createNamespace) }}
+{{- fail "agentMesh.createNamespace must be a boolean" }}
+{{- end }}
+{{- if $createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.agentMesh.namespace }}
+  name: {{ $namespace }}
   labels:
     app.kubernetes.io/name: agentmesh
     app.kubernetes.io/part-of: kars
     kars.azure.com/mesh-provider: agt
+    kars.azure.com/managed: "true"
 ---
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: registry
-  namespace: {{ .Values.agentMesh.namespace }}
+  namespace: {{ $namespace }}
   labels:
     app.kubernetes.io/name: agentmesh-registry
     app.kubernetes.io/part-of: kars
 spec:
-  replicas: {{ .Values.agentMesh.registry.replicas }}
+  replicas: {{ $registryReplicas }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
-      app.kubernetes.io/name: agentmesh-registry
+      app: agentmesh-registry
   template:
     metadata:
       labels:
+        app: agentmesh-registry
         app.kubernetes.io/name: agentmesh-registry
         app.kubernetes.io/part-of: kars
         kars.azure.com/mesh-provider: agt
@@ -38,8 +62,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: registry
-          image: "{{ .Values.agentMesh.registry.image.repository }}:{{ .Values.agentMesh.registry.image.tag }}"
-          imagePullPolicy: {{ .Values.agentMesh.registry.image.pullPolicy }}
+          image: {{ printf "%s:%s" ($registryImage.repository | default "ghcr.io/azure/kars-agentmesh-registry") ($registryImage.tag | default "latest") | quote }}
+          imagePullPolicy: {{ $registryImage.pullPolicy | default "Always" }}
           ports:
             - name: http
               containerPort: 8082
@@ -65,10 +89,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: agentmesh-registry
-  namespace: {{ .Values.agentMesh.namespace }}
+  namespace: {{ $namespace }}
 spec:
   selector:
-    app.kubernetes.io/name: agentmesh-registry
+    app: agentmesh-registry
   ports:
     - name: http
       port: 8080
@@ -78,18 +102,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: relay
-  namespace: {{ .Values.agentMesh.namespace }}
+  namespace: {{ $namespace }}
   labels:
     app.kubernetes.io/name: agentmesh-relay
     app.kubernetes.io/part-of: kars
 spec:
-  replicas: {{ .Values.agentMesh.relay.replicas }}
+  replicas: {{ $relayReplicas }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
-      app.kubernetes.io/name: agentmesh-relay
+      app: agentmesh-relay
   template:
     metadata:
       labels:
+        app: agentmesh-relay
         app.kubernetes.io/name: agentmesh-relay
         app.kubernetes.io/part-of: kars
         kars.azure.com/mesh-provider: agt
@@ -102,8 +129,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: relay
-          image: "{{ .Values.agentMesh.relay.image.repository }}:{{ .Values.agentMesh.relay.image.tag }}"
-          imagePullPolicy: {{ .Values.agentMesh.relay.image.pullPolicy }}
+          image: {{ printf "%s:%s" ($relayImage.repository | default "ghcr.io/azure/kars-agentmesh-relay") ($relayImage.tag | default "latest") | quote }}
+          imagePullPolicy: {{ $relayImage.pullPolicy | default "Always" }}
           ports:
             - name: websocket
               containerPort: 8083
@@ -112,7 +139,7 @@ spec:
             - { name: PORT, value: "8083" }
             - { name: LOG_LEVEL, value: "info" }
             - name: REGISTRY_URL
-              value: "http://agentmesh-registry.{{ .Values.agentMesh.namespace }}.svc.cluster.local:8080"
+              value: "http://agentmesh-registry.{{ $namespace }}.svc.cluster.local:8080"
             - { name: REQUIRE_REGISTRATION, value: "true" }
           readinessProbe:
             httpGet: { path: /health, port: websocket }
@@ -132,10 +159,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: agentmesh-relay
-  namespace: {{ .Values.agentMesh.namespace }}
+  namespace: {{ $namespace }}
 spec:
   selector:
-    app.kubernetes.io/name: agentmesh-relay
+    app: agentmesh-relay
   ports:
     - name: websocket
       port: 8765

--- a/deploy/helm/kars/templates/controller-deployment.yaml
+++ b/deploy/helm/kars/templates/controller-deployment.yaml
@@ -17,7 +17,9 @@ spec:
       labels:
         app.kubernetes.io/name: kars
         app.kubernetes.io/component: controller
+        {{- if .Values.azure.workloadIdentity.enabled }}
         azure.workload.identity/use: "true"
+        {{- end }}
     spec:
       serviceAccountName: kars-controller
       automountServiceAccountToken: true
@@ -47,6 +49,8 @@ spec:
                   fieldPath: metadata.name
             - name: AZURE_WI_CLIENT_ID
               value: {{ .Values.azure.workloadIdentity.clientId | quote }}
+            - name: KARS_SANDBOX_NODE_SELECTOR_JSON
+              value: {{ .Values.sandbox.nodeSelector | toJson | quote }}
             {{- if .Values.controller.byoStrict }}
             - name: BYO_STRICT_MODE
               value: "1"

--- a/deploy/helm/kars/templates/controller-deployment.yaml
+++ b/deploy/helm/kars/templates/controller-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: AZURE_WI_CLIENT_ID
               value: {{ .Values.azure.workloadIdentity.clientId | quote }}
             - name: KARS_SANDBOX_NODE_SELECTOR_JSON
-              value: {{ .Values.sandbox.nodeSelector | toJson | quote }}
+              value: {{ .Values.sandbox.nodeSelector | default dict | toJson | quote }}
             {{- if .Values.controller.byoStrict }}
             - name: BYO_STRICT_MODE
               value: "1"

--- a/deploy/helm/kars/templates/rbac.yaml
+++ b/deploy/helm/kars/templates/rbac.yaml
@@ -8,8 +8,10 @@ metadata:
   labels:
     app.kubernetes.io/name: kars
     app.kubernetes.io/component: controller
+  {{- if .Values.azure.workloadIdentity.enabled }}
   annotations:
     azure.workload.identity/client-id: {{ .Values.azure.workloadIdentity.clientId | quote }}
+  {{- end }}
 ---
 # Controller ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/kars/values-existing-aks.yaml
+++ b/deploy/helm/kars/values-existing-aks.yaml
@@ -1,0 +1,93 @@
+# Existing AKS installation template.
+#
+# Copy this file, replace every REPLACE_ME value, and install with:
+#   helm upgrade --install kars deploy/helm/kars \
+#     --namespace kars-system --create-namespace \
+#     --values my-aks-values.yaml
+#
+# This mirrors the Helm values emitted by `kars up` after Azure infrastructure
+# provisioning. It does not create or grant access to AKS, ACR, Foundry,
+# Key Vault, managed identities, federated credentials, or Azure RBAC.
+
+controller:
+  image:
+    repository: REPLACE_ME.azurecr.io/kars-controller
+    tag: "latest"
+    pullPolicy: Always
+
+inferenceRouter:
+  image:
+    repository: REPLACE_ME.azurecr.io/kars-inference-router
+    tag: "latest"
+    pullPolicy: Always
+  azure:
+    openai:
+      endpoint: https://REPLACE_ME.openai.azure.com
+
+sandbox:
+  image:
+    repository: REPLACE_ME.azurecr.io/openclaw-sandbox
+    tag: "latest"
+    pullPolicy: Always
+  # Portable baseline for an existing cluster. Replace with a dedicated
+  # agentpool selector and enhanced/confidential isolation when available.
+  isolation: standard
+  seccompProfile: RuntimeDefault
+  nodeSelector:
+    kubernetes.io/os: linux
+
+runtimes:
+  openaiAgents:
+    image: REPLACE_ME.azurecr.io/kars-runtime-openai-agents:latest
+  mafPython:
+    image: REPLACE_ME.azurecr.io/kars-runtime-maf-python:latest
+  anthropic:
+    image: REPLACE_ME.azurecr.io/kars-runtime-anthropic:latest
+  langgraph:
+    image: REPLACE_ME.azurecr.io/kars-runtime-langgraph:latest
+  langgraphTs:
+    image: REPLACE_ME.azurecr.io/kars-runtime-langgraph-ts:latest
+  pydanticAi:
+    image: REPLACE_ME.azurecr.io/kars-runtime-pydantic-ai:latest
+  hermes:
+    image: REPLACE_ME.azurecr.io/kars-runtime-hermes:latest
+
+foundry:
+  endpoint: https://REPLACE_ME.services.ai.azure.com
+  projectEndpoint: https://REPLACE_ME.services.ai.azure.com/api/projects/REPLACE_ME
+  deployments: '["REPLACE_ME-chat-deployment"]'
+  # AKS kubelet managed-identity client ID used for IMDS fallback.
+  imdsClientId: REPLACE_ME
+
+contentSafety:
+  endpoint: https://REPLACE_ME.cognitiveservices.azure.com
+
+azure:
+  workloadIdentity:
+    enabled: true
+    # Federated managed-identity client ID used by the Kars controller.
+    clientId: REPLACE_ME
+  keyVaultCsi:
+    enabled: true
+    keyVaultName: REPLACE_ME
+  policy:
+    enabled: true
+  entraAuth:
+    enabled: false
+
+fedcred:
+  subscriptionId: REPLACE_ME
+  identityName: REPLACE_ME
+  identityResourceGroup: REPLACE_ME
+  oidcIssuerUrl: https://REPLACE_ME.oic.prod-aks.azure.com/REPLACE_ME/
+
+mesh:
+  provider: agt
+
+# A manual Helm-only install owns AgentMesh. Set enabled=false only when an
+# existing external relay/registry already expose the standard Service names.
+agentMesh:
+  enabled: true
+
+# Stamp the installed Kars version used by `kars upgrade` discovery.
+karsRelease: latest

--- a/deploy/helm/kars/values-existing-aks.yaml
+++ b/deploy/helm/kars/values-existing-aks.yaml
@@ -89,5 +89,6 @@ mesh:
 agentMesh:
   enabled: true
 
-# Stamp the installed Kars version used by `kars upgrade` discovery.
-karsRelease: latest
+# Stamp the actual installed Kars release used by `kars upgrade` discovery,
+# for example v0.1.26. Do not use the literal value "latest".
+karsRelease: REPLACE_ME_KARS_VERSION

--- a/deploy/helm/kars/values-existing-aks.yaml
+++ b/deploy/helm/kars/values-existing-aks.yaml
@@ -5,19 +5,20 @@
 #     --namespace kars-system --create-namespace \
 #     --values my-aks-values.yaml
 #
-# This mirrors the Helm values emitted by `kars up` after Azure infrastructure
-# provisioning. It does not create or grant access to AKS, ACR, Foundry,
+# This mirrors the Helm configuration emitted by `kars up` after Azure
+# infrastructure provisioning, but pulls the fixed public Kars images directly
+# from GHCR. It does not create or grant access to AKS, ACR, Foundry,
 # Key Vault, managed identities, federated credentials, or Azure RBAC.
 
 controller:
   image:
-    repository: REPLACE_ME.azurecr.io/kars-controller
+    repository: ghcr.io/azure/kars-controller
     tag: "latest"
     pullPolicy: Always
 
 inferenceRouter:
   image:
-    repository: REPLACE_ME.azurecr.io/kars-inference-router
+    repository: ghcr.io/azure/kars-inference-router
     tag: "latest"
     pullPolicy: Always
   azure:
@@ -26,7 +27,7 @@ inferenceRouter:
 
 sandbox:
   image:
-    repository: REPLACE_ME.azurecr.io/openclaw-sandbox
+    repository: ghcr.io/azure/openclaw-sandbox
     tag: "latest"
     pullPolicy: Always
   # Portable baseline for an existing cluster. Replace with a dedicated
@@ -38,19 +39,19 @@ sandbox:
 
 runtimes:
   openaiAgents:
-    image: REPLACE_ME.azurecr.io/kars-runtime-openai-agents:latest
+    image: ghcr.io/azure/kars-runtime-openai-agents:latest
   mafPython:
-    image: REPLACE_ME.azurecr.io/kars-runtime-maf-python:latest
+    image: ghcr.io/azure/kars-runtime-maf-python:latest
   anthropic:
-    image: REPLACE_ME.azurecr.io/kars-runtime-anthropic:latest
+    image: ghcr.io/azure/kars-runtime-anthropic:latest
   langgraph:
-    image: REPLACE_ME.azurecr.io/kars-runtime-langgraph:latest
+    image: ghcr.io/azure/kars-runtime-langgraph:latest
   langgraphTs:
-    image: REPLACE_ME.azurecr.io/kars-runtime-langgraph-ts:latest
+    image: ghcr.io/azure/kars-runtime-langgraph-ts:latest
   pydanticAi:
-    image: REPLACE_ME.azurecr.io/kars-runtime-pydantic-ai:latest
+    image: ghcr.io/azure/kars-runtime-pydantic-ai:latest
   hermes:
-    image: REPLACE_ME.azurecr.io/kars-runtime-hermes:latest
+    image: ghcr.io/azure/kars-runtime-hermes:latest
 
 foundry:
   endpoint: https://REPLACE_ME.services.ai.azure.com

--- a/deploy/helm/kars/values-existing-aks.yaml
+++ b/deploy/helm/kars/values-existing-aks.yaml
@@ -30,10 +30,9 @@ sandbox:
     repository: ghcr.io/azure/openclaw-sandbox
     tag: "latest"
     pullPolicy: Always
-  # Portable baseline for an existing cluster. Replace with a dedicated
-  # agentpool selector and enhanced/confidential isolation when available.
-  isolation: standard
-  seccompProfile: RuntimeDefault
+  # Keep the profile used by existing/default enhanced sandbox CRs installed.
+  # Portable CRs select standard/RuntimeDefault explicitly.
+  seccompProfile: kars-strict
   nodeSelector:
     kubernetes.io/os: linux
 

--- a/deploy/helm/kars/values-generic.yaml
+++ b/deploy/helm/kars/values-generic.yaml
@@ -1,0 +1,45 @@
+# Generic Kubernetes overlay for an existing non-AKS cluster.
+#
+# Azure/AKS defaults remain authoritative in values.yaml. This opt-in overlay
+# removes Azure identity metadata and the AKS-specific sandbox pool selector.
+# Operators must provide registry access, an inference backend and credential,
+# and a compatible AGT relay/registry.
+
+controller:
+  image:
+    repository: ghcr.io/azure/kars-controller
+
+inferenceRouter:
+  image:
+    repository: ghcr.io/azure/kars-inference-router
+  azure:
+    contentSafety:
+      enabled: false
+    promptShields:
+      enabled: false
+
+sandbox:
+  image:
+    repository: ghcr.io/azure/openclaw-sandbox
+  isolation: standard
+  seccompProfile: RuntimeDefault
+  nodeSelector:
+    kubernetes.io/os: linux
+
+monitoring:
+  containerInsights: false
+
+azure:
+  workloadIdentity:
+    enabled: false
+    clientId: ""
+  keyVaultCsi:
+    enabled: false
+    keyVaultName: ""
+  policy:
+    enabled: false
+  entraAuth:
+    enabled: false
+
+signerPolicy:
+  enabled: false

--- a/deploy/helm/kars/values-generic.yaml
+++ b/deploy/helm/kars/values-generic.yaml
@@ -18,6 +18,9 @@ inferenceRouter:
     promptShields:
       enabled: false
 
+agentMesh:
+  enabled: true
+
 sandbox:
   image:
     repository: ghcr.io/azure/openclaw-sandbox

--- a/deploy/helm/kars/values-generic.yaml
+++ b/deploy/helm/kars/values-generic.yaml
@@ -24,8 +24,9 @@ agentMesh:
 sandbox:
   image:
     repository: ghcr.io/azure/openclaw-sandbox
-  isolation: standard
-  seccompProfile: RuntimeDefault
+  # Installer filename, not a sandbox CR default. Keep enhanced/default CRs
+  # runnable; portable CRs select standard/RuntimeDefault explicitly.
+  seccompProfile: kars-strict
   nodeSelector:
     kubernetes.io/os: linux
 

--- a/deploy/helm/kars/values.yaml
+++ b/deploy/helm/kars/values.yaml
@@ -51,6 +51,27 @@ inferenceRouter:
     promptShields:
       enabled: true
 
+# Microsoft AGT AgentMesh relay + registry.
+#
+# Disabled by default because existing `kars up` and `kars dev` flows deploy
+# AgentMesh separately. Enable this for a self-contained Helm installation.
+agentMesh:
+  enabled: false
+  namespace: agentmesh
+  createNamespace: true
+  registry:
+    replicas: 1
+    image:
+      repository: ghcr.io/azure/kars-agentmesh-registry
+      tag: "latest"
+      pullPolicy: Always
+  relay:
+    replicas: 1
+    image:
+      repository: ghcr.io/azure/kars-agentmesh-relay
+      tag: "latest"
+      pullPolicy: Always
+
 # Default sandbox configuration
 sandbox:
   image:

--- a/deploy/helm/kars/values.yaml
+++ b/deploy/helm/kars/values.yaml
@@ -67,6 +67,9 @@ sandbox:
   runAsNonRoot: true
   runAsUser: 1000
   runAsGroup: 1000
+  # Optional environment-specific node selector. Empty preserves the existing
+  # `kars.azure.com/pool=<isolation pool>` scheduling contract.
+  nodeSelector: {}
   writablePaths:
     - /sandbox
     - /tmp

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This is the documentation index. The top-level [`README`](../README.md) is a fas
 
 <a href="quickstart.md" class="btn-primary">Quickstart — 3 commands</a>
 <a href="getting-started.md#step-2--deploy-to-aks" class="btn-primary">Run it on AKS</a>
+<a href="how-to/helm-installation.md" class="btn-primary">Install on an existing cluster</a>
 <a href="architecture.md" class="btn-primary">Architecture</a>
 <a href="maturity.md" class="btn-primary">Feature status</a>
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Quickstart](quickstart.md)
 - [Getting started](getting-started.md)
+- [Install with Helm](how-to/helm-installation.md)
 - [CLI reference](cli-reference.md)
 - [Use cases](use-cases.md)
   - [Exec-brief walkthrough](use-cases/exec-brief-walkthrough.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1124,7 +1124,11 @@ kars credentials update my-agent --brave-api-key $KEY --no-restart
 
 ### `kars config`
 
-Inspects and edits the local CLI configuration at `~/.kars/config.json`. This is the file `kars dev` and `kars credentials` write to, holding your provider choice, endpoint, and default model. The command is a thin viewer + per-provider model picker — it doesn't touch secrets (use `kars credentials` for those) and it doesn't talk to your cluster (it's purely local).
+Inspects and edits local CLI state under `~/.kars/`. Provider/model
+subcommands remain local-only. `adopt-aks` is the explicit exception: it
+read-verifies an existing Kars Helm release and writes deployment metadata to
+`~/.kars/context.json` so Azure lifecycle commands can operate on a cluster
+that was not provisioned by `kars up`.
 
 **Usage:**
 ```
@@ -1136,6 +1140,7 @@ kars config <subcommand> [arguments]
 |---|---|
 | `show` | Print the effective local configuration (provider, endpoint, model). For `github-models`, also validates the saved model against the live catalog. |
 | `model [model-id]` | Pick or set the local default inference model. Provider-aware: presents the curated Copilot catalog for `github-copilot`, the live tool-capable catalog for `github-models`, or accepts a free-form deployment name for `foundry`. Omit the argument for an interactive picker. |
+| `adopt-aks` | Register an existing Helm-installed AKS cluster with the CLI. Verifies the Helm release and `KarsSandbox` CRD, then writes explicit subscription, region, resource-group, cluster, and ACR metadata without modifying infrastructure. |
 | `reset` | Clear the local configuration file (does not touch saved secrets). |
 
 **Examples:**
@@ -1151,9 +1156,22 @@ kars config model claude-opus-4.7
 
 # Set it directly (Foundry deployment name)
 kars config model gpt-4.1
+
+# Register a Kars Helm installation on existing AKS infrastructure
+kars config adopt-aks \
+  --subscription <subscription-id> \
+  --region eastus2 \
+  --resource-group <resource-group> \
+  --cluster <aks-name> \
+  --acr-login-server <registry>.azurecr.io \
+  --context <kube-context>
 ```
 
-**See also:** [`kars credentials`](#kars-credentials), [`kars model`](#kars-model) (per-sandbox).
+Kubernetes-facing commands such as `operator`, `list`, `connect`, and policy
+commands work directly from the selected kube context and do not require an
+adopted Azure context.
+
+**See also:** [`kars credentials`](#kars-credentials), [`kars model`](#kars-model) (per-sandbox), [Install with Helm](how-to/helm-installation.md).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -359,6 +359,9 @@ start with `values-generic.yaml`. See the
 [Helm installation guide](how-to/helm-installation.md).
 
 ```bash
+cp deploy/helm/kars/values-existing-aks.yaml my-aks-values.yaml
+# Replace every REPLACE_ME value.
+
 helm upgrade --install kars deploy/helm/kars \
   --namespace kars-system \
   --create-namespace \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -353,7 +353,10 @@ kars destroy --all                # everything, including the resource group
 
 ## Bring your own AKS / Foundry / ACR
 
-If you already have an AKS cluster and a Foundry project, you can install kars into them directly with the Helm chart:
+If you already have a Kubernetes cluster and inference backend, install Kars
+directly with the Helm chart. AKS uses the default values; non-AKS clusters
+start with `values-generic.yaml`. See the
+[Helm installation guide](how-to/helm-installation.md).
 
 ```bash
 helm install kars deploy/helm/kars \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -359,15 +359,38 @@ start with `values-generic.yaml`. See the
 [Helm installation guide](how-to/helm-installation.md).
 
 ```bash
-helm install kars deploy/helm/kars \
-  --namespace kars-system --create-namespace \
-  --set acr.loginServer=<youracr>.azurecr.io \
-  --set foundry.endpoint=https://<your>.openai.azure.com \
-  --set foundry.deploymentName=gpt-4.1 \
-  --set workloadIdentity.clientId=<federated-mi-client-id>
+helm upgrade --install kars deploy/helm/kars \
+  --namespace kars-system \
+  --create-namespace \
+  --values my-aks-values.yaml
 ```
 
-Then submit `KarsSandbox` resources directly with `kubectl apply` — see the [minimal example](api/crd-reference.md#minimal-example) for the smallest valid sandbox + `InferencePolicy` pair. The CLI is convenient but optional — every action it takes is a Helm value, a Kubernetes resource, or an `az` call you can perform yourself. See **[Operations / GitOps](operations/gitops.md)**.
+The override file supplies the existing ACR image repositories, Foundry
+endpoints/deployments, and `azure.workloadIdentity.clientId`. The default chart
+does not double-deploy AgentMesh because `kars up` manages it separately; for a
+Helm-owned mesh, set `agentMesh.enabled=true`.
+
+Register the existing infrastructure with the CLI when you want Azure lifecycle
+commands:
+
+```bash
+kars config adopt-aks \
+  --subscription <subscription-id> \
+  --region <region> \
+  --resource-group <resource-group> \
+  --cluster <aks-name> \
+  --acr-login-server <registry>.azurecr.io \
+  --context <kube-context>
+```
+
+The command verifies the Kars Helm release and CRD before writing local
+metadata; it does not mutate the cluster or Azure resources. `kars operator`,
+`list`, `connect`, and other Kubernetes-facing commands already work directly
+from the selected kube context.
+
+Then submit `KarsSandbox` resources directly with `kubectl apply` — see the
+[minimal example](api/crd-reference.md#minimal-example). The CLI remains
+optional. See **[Operations / GitOps](operations/gitops.md)**.
 
 ---
 

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -51,3 +51,25 @@ submitted directly with `kubectl apply`.
 
 All Kars CRDs are rendered by the chart and installed by Helm before the
 controller begins reconciling custom resources.
+
+## Register an existing AKS installation with the CLI
+
+Kubernetes-facing commands recognize any explicit/current kube context.
+Azure lifecycle commands also need the deployment metadata normally written by
+`kars up`. After a manual Helm installation, register that metadata without
+provisioning or changing infrastructure:
+
+```bash
+kars config adopt-aks \
+  --subscription <subscription-id> \
+  --region eastus2 \
+  --resource-group <aks-resource-group> \
+  --cluster <aks-cluster-name> \
+  --acr-login-server <registry>.azurecr.io \
+  --context <kubectl-context>
+```
+
+The command verifies the Kars Helm release and `KarsSandbox` CRD, then writes
+`~/.kars/context.json`. Optional Workload Identity, OIDC, Foundry, identity, and
+Key Vault flags enable the corresponding advanced `add`, mesh, and lifecycle
+flows.

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -36,15 +36,23 @@ externally.
 
 ## Existing AKS
 
-Use the default values as the AKS baseline and provide your registry, Foundry,
-Workload Identity, and environment settings in an override file:
+Copy the checked-in template that mirrors the values emitted by `kars up`:
 
 ```bash
+cp deploy/helm/kars/values-existing-aks.yaml my-aks-values.yaml
+# Replace every REPLACE_ME value.
+
 helm upgrade --install kars deploy/helm/kars \
   --namespace kars-system \
   --create-namespace \
   --values my-aks-values.yaml
 ```
+
+The template includes controller/router/sandbox and runtime images, Foundry
+account/project/deployment values, Content Safety, Workload Identity, Key
+Vault, kubelet IMDS identity, federated-credential metadata, AgentMesh, and the
+release stamp. The referenced Azure resources and role assignments must already
+exist.
 
 The CLI remains optional. After Helm installation, Kars resources can be
 submitted directly with `kubectl apply`.

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -54,6 +54,22 @@ Vault, kubelet IMDS identity, federated-credential metadata, AgentMesh, and the
 release stamp. The referenced Azure resources and role assignments must already
 exist.
 
+Before installation, import every image referenced by the template into the
+selected ACR and grant the AKS kubelet identity `AcrPull`. The public source
+images and exact names are listed in the release notes; use the same release
+tag for every component, then set `karsRelease` to that tag. Mixing tags can
+create controller/router/runtime protocol drift.
+
+The minimum Azure-side prerequisites are:
+
+- AKS with OIDC issuer and Workload Identity enabled;
+- ACR containing the Kars controller, router, sandbox, runtime, and any
+  privately mirrored AgentMesh images referenced by your values;
+- a federated controller managed identity and its client ID;
+- Foundry/Azure OpenAI data-plane access for the identities used by the router;
+- Key Vault/CSI permissions when `azure.keyVaultCsi.enabled=true`;
+- NetworkPolicy-capable networking and nodes matching `sandbox.nodeSelector`.
+
 The CLI remains optional. After Helm installation, Kars resources can be
 submitted directly with `kubectl apply`.
 

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -1,0 +1,48 @@
+# Install Kars with Helm
+
+Use the Helm chart when the Kubernetes cluster, registry, inference backend,
+identity, and AgentMesh services already exist.
+
+## Local kind
+
+```bash
+helm upgrade --install kars deploy/helm/kars \
+  --namespace kars-system \
+  --create-namespace \
+  --values deploy/helm/kars/values-local-dev.yaml
+```
+
+Load all referenced development images into kind before installation.
+
+## Existing non-AKS Kubernetes cluster
+
+Start with the generic overlay and layer environment-specific values on top:
+
+```bash
+helm upgrade --install kars deploy/helm/kars \
+  --namespace kars-system \
+  --create-namespace \
+  --values deploy/helm/kars/values-generic.yaml \
+  --values my-generic-values.yaml
+```
+
+The generic overlay leaves AKS defaults untouched. It disables Azure identity
+metadata, uses RuntimeDefault seccomp, and schedules sandboxes with the
+portable `kubernetes.io/os=linux` selector. Supply pullable images, inference
+authentication, AGT relay/registry endpoints, a NetworkPolicy-capable CNI, and
+any environment-specific integrations.
+
+## Existing AKS
+
+Use the default values as the AKS baseline and provide your registry, Foundry,
+Workload Identity, and environment settings in an override file:
+
+```bash
+helm upgrade --install kars deploy/helm/kars \
+  --namespace kars-system \
+  --create-namespace \
+  --values my-aks-values.yaml
+```
+
+The CLI remains optional. After Helm installation, Kars resources can be
+submitted directly with `kubectl apply`.

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -29,8 +29,10 @@ helm upgrade --install kars deploy/helm/kars \
 The generic overlay leaves AKS defaults untouched. It disables Azure identity
 metadata, uses RuntimeDefault seccomp, and schedules sandboxes with the
 portable `kubernetes.io/os=linux` selector. Supply pullable images, inference
-authentication, AGT relay/registry endpoints, a NetworkPolicy-capable CNI, and
-any environment-specific integrations.
+authentication, a NetworkPolicy-capable CNI, and any environment-specific
+integrations. The profile deploys the Microsoft AGT AgentMesh relay and
+registry; set `agentMesh.enabled=false` only when those services are managed
+externally.
 
 ## Existing AKS
 
@@ -46,3 +48,6 @@ helm upgrade --install kars deploy/helm/kars \
 
 The CLI remains optional. After Helm installation, Kars resources can be
 submitted directly with `kubectl apply`.
+
+All Kars CRDs are rendered by the chart and installed by Helm before the
+controller begins reconciling custom resources.

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -54,17 +54,17 @@ Vault, kubelet IMDS identity, federated-credential metadata, AgentMesh, and the
 release stamp. The referenced Azure resources and role assignments must already
 exist.
 
-Before installation, import every image referenced by the template into the
-selected ACR and grant the AKS kubelet identity `AcrPull`. The public source
-images and exact names are listed in the release notes; use the same release
-tag for every component, then set `karsRelease` to that tag. Mixing tags can
-create controller/router/runtime protocol drift.
+The template uses the fixed public `ghcr.io/azure/*` image repositories. To
+mirror images into a private ACR instead, replace the repository values, import
+every referenced image, and grant the AKS kubelet identity `AcrPull`. Keep one
+release tag across every component and set `karsRelease` to that tag; mixing
+tags can create controller/router/runtime protocol drift.
 
 The minimum Azure-side prerequisites are:
 
 - AKS with OIDC issuer and Workload Identity enabled;
-- ACR containing the Kars controller, router, sandbox, runtime, and any
-  privately mirrored AgentMesh images referenced by your values;
+- public GHCR access, or an ACR containing every privately mirrored image
+  referenced by your values;
 - a federated controller managed identity and its client ID;
 - Foundry/Azure OpenAI data-plane access for the identities used by the router;
 - Key Vault/CSI permissions when `azure.keyVaultCsi.enabled=true`;
@@ -89,11 +89,11 @@ kars config adopt-aks \
   --region eastus2 \
   --resource-group <aks-resource-group> \
   --cluster <aks-cluster-name> \
-  --acr-login-server <registry>.azurecr.io \
   --context <kubectl-context>
 ```
 
 The command verifies the Kars Helm release and `KarsSandbox` CRD, then writes
-`~/.kars/context.json`. Optional Workload Identity, OIDC, Foundry, identity, and
-Key Vault flags enable the corresponding advanced `add`, mesh, and lifecycle
-flows.
+`~/.kars/context.json`. Add `--acr-login-server <registry>.azurecr.io` when
+using a private mirror or when enabling `kars push` and the current ACR-based
+`kars upgrade` flow. Optional Workload Identity, OIDC, Foundry, identity, and
+Key Vault flags enable the corresponding advanced flows.

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -1,7 +1,8 @@
 # Install Kars with Helm
 
-Use the Helm chart when the Kubernetes cluster, registry, inference backend,
-identity, and AgentMesh services already exist.
+Use the Helm chart when the Kubernetes cluster, image access, inference backend,
+and required identity configuration already exist. The chart can manage
+AgentMesh or use an existing external deployment.
 
 ## Local kind
 
@@ -27,12 +28,41 @@ helm upgrade --install kars deploy/helm/kars \
 ```
 
 The generic overlay leaves AKS defaults untouched. It disables Azure identity
-metadata, uses RuntimeDefault seccomp, and schedules sandboxes with the
-portable `kubernetes.io/os=linux` selector. Supply pullable images, inference
+metadata and schedules sandboxes with the portable `kubernetes.io/os=linux`
+selector. It still installs `profiles/kars-strict.json` for existing/default
+enhanced sandbox CRs; Helm values do not change those CRD defaults. To use the
+portable standard/RuntimeDefault posture, declare it explicitly in each CR as
+shown below. Supply pullable images, inference
 authentication, a NetworkPolicy-capable CNI, and any environment-specific
 integrations. The profile deploys the Microsoft AGT AgentMesh relay and
 registry; set `agentMesh.enabled=false` only when those services are managed
 externally.
+
+The shipped AgentMesh implementation supports the fixed `agentmesh` namespace
+and one registry/relay replica each (zero is allowed for deliberate maintenance).
+Other namespaces or multiple replicas are rejected rather than accepted with
+broken routing or independent in-memory state. Updates use `Recreate`; expect
+clients to reconnect during a mesh upgrade.
+
+After creating a suitable `InferencePolicy` in `kars-system`, replace
+`existing-inference-policy` with its name and submit a portable sandbox:
+
+```yaml
+apiVersion: kars.azure.com/v1alpha1
+kind: KarsSandbox
+metadata:
+  name: portable-agent
+  namespace: kars-system
+spec:
+  runtime:
+    kind: OpenClaw
+    openclaw: {}
+  inferenceRef:
+    name: existing-inference-policy
+  sandbox:
+    isolation: standard
+    seccompProfile: RuntimeDefault
+```
 
 ## Existing AKS
 

--- a/docs/how-to/helm-installation.md
+++ b/docs/how-to/helm-installation.md
@@ -127,3 +127,14 @@ The command verifies the Kars Helm release and `KarsSandbox` CRD, then writes
 using a private mirror or when enabling `kars push` and the current ACR-based
 `kars upgrade` flow. Optional Workload Identity, OIDC, Foundry, identity, and
 Key Vault flags enable the corresponding advanced flows.
+
+`kars push --apply` updates the owning image configuration and verifies the
+pushed artifact, rather than merely restarting an old image. Explicit sandbox
+image pins are preserved. `sandbox-base` is a build dependency, not a deployable
+target; rebuild the sandbox image before applying it.
+
+Core upgrades leave external AgentMesh services untouched. Mesh image updates
+are limited to the owning Kars Helm release or the standalone Kars deployment
+marked `kars.azure.com/mesh-provider=agt`. Matching service/deployment names alone
+do not authorize an update. With external mesh, select an explicit core
+`kars push --only` target; the CLI will not adopt or replace external workloads.

--- a/docs/security-audits/2026-09-04-existing-aks-adoption.md
+++ b/docs/security-audits/2026-09-04-existing-aks-adoption.md
@@ -1,0 +1,43 @@
+# Security Audit — Existing AKS CLI adoption
+
+Date: 2026-09-04
+Scope: `cli/src/commands/config.ts`, `docs/how-to/helm-installation.md`.
+Gated paths: `cli/src/commands/config.ts`.
+
+## Summary
+
+Adds an explicit command that registers metadata for an existing,
+Helm-installed AKS cluster in the local Kars deployment context. The command
+does not create, update, or delete Azure or Kubernetes resources.
+
+## T1: New capability / attack surface? (YES)
+
+- Adds `kars config adopt-aks`.
+- Reads the selected cluster's Kars CRD and Helm release.
+- Writes `~/.kars/context.json`, which existing lifecycle commands already use.
+
+## T2: Security-control change? (NEUTRAL)
+
+- Cluster selection remains explicit through `--context` or the user's current
+  kube context.
+- The command verifies both the `KarsSandbox` CRD and `kars` Helm release before
+  persisting metadata.
+- Registry input is restricted to Azure Container Registry hosts.
+
+## T3: Availability / fail-open risk? (REDUCED)
+
+- Helm-installed clusters no longer require hand-written context files.
+- Missing cluster access, CRDs, or Helm ownership fail before context is saved.
+
+## Verification
+
+- CLI typecheck, focused tests, package build, LOC, and repository security
+  gates.
+
+## Verdict
+
+Accept. The command is read-only against infrastructure and makes existing
+cluster targeting explicit and auditable.
+
+Signed-off-by: Pal Lakatos-Toth <pallakatos@github.com>
+Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/tests/cncf-conformance/src/lib.rs
+++ b/tests/cncf-conformance/src/lib.rs
@@ -712,7 +712,7 @@ pub fn check_supply_chain_rows() -> Outcome {
     let required = [
         ("cargo-deny", "cargo deny check"),
         ("trivy", "aquasecurity/trivy-action"),
-        ("npm-audit", "npm audit --audit-level=high"),
+        ("npm-audit", "npm-audit-bulk.mjs"),
         ("cosign-verify", "cosign-verify"),
     ];
     let mut missing = Vec::new();


### PR DESCRIPTION
## Summary

- add an opt-in `values-generic.yaml` profile for existing non-AKS Kubernetes clusters
- deploy the published Microsoft AGT AgentMesh relay and registry for the generic Helm profile
- make sandbox node selection configurable while preserving the existing AKS pool selector by default
- emit Azure Workload Identity metadata only when the existing value is enabled
- add a checked-in existing-AKS values template and kars config adopt-aks for explicit local CLI registration
- honor explicit operator kube contexts without requiring a global current-context
- render default, local-kind, generic, and existing-AKS profiles in CI
- document Helm installation and CRD ownership without requiring the Kars CLI

## Images

The generic profile uses the image names produced by the public release workflow:

- `ghcr.io/azure/kars-controller:latest`
- `ghcr.io/azure/kars-inference-router:latest`
- `ghcr.io/azure/openclaw-sandbox:latest`
- `ghcr.io/azure/kars-agentmesh-relay:latest`
- `ghcr.io/azure/kars-agentmesh-registry:latest`

All five published manifests were verified directly.

## AgentMesh ownership

`agentMesh.enabled` defaults to `false` so existing `kars up` and `kars dev` flows continue managing AgentMesh separately without duplicate Helm ownership. `values-generic.yaml` enables it, producing the `agentmesh` namespace, relay/registry Deployments, and the stable `agentmesh-relay:8765` / `agentmesh-registry:8080` Services expected by Kars routers and runtimes. Operators with an external AgentMesh deployment can set `agentMesh.enabled=false`.

## CRDs

The chart renders and installs every Kars `CustomResourceDefinition` included in that chart version. The current public base renders 12 CRDs; later stacked API PRs add their CRD templates to the same Helm lifecycle.

## Backward compatibility

The default values remain AKS-first. `sandbox.nodeSelector` defaults to `{}`, which resolves to the existing `kars.azure.com/pool=<isolation pool>` selector. `azure.workloadIdentity.enabled` remains `true`, so existing AKS installs retain current identity metadata. AgentMesh remains disabled in default values because existing CLI flows already deploy it.

## Prior local qualification

- `cargo test --package kars-controller`: 860 passed
- phase taxonomy guard: passed
- CNCF conformance criteria: 17/17 passed, including the new AgentMesh Deployments
- `cargo clippy --all-targets --all-features -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- CLI release-asset tests and typecheck: passed
- Helm lint plus default/local-kind/generic rendering: passed
- all five GHCR image manifests verified
- LOC gate: passed

This is PR 1 of the ordered Kars-Bridge publicization stack and contains no Bridge orchestration, inference, or runtime API changes.

## Publication review contract

First foundation: review and merge into the protected kars-bridge integration branch, not directly into main.

- Kars remains independently usable; none of these core foundations requires Bridge.
- This is a scoped foundation, not a claim that the complete Bridge execution/engineering experience is publicly available.
- CI, CodeQL, dependency review, secret scanning, and all existing policy gates now run on publication PR bases as well as their existing protected branches. No gate is waived and no privileged pull_request_target trigger is introduced.
- The npm bulk audit gate rejects malformed lockfiles and advisory responses, preserves high/critical blocking, and fails after bounded retries. CLI regression coverage includes the three shipped lockfiles.
- The local results above describe earlier qualification, not a substitute for the latest commit's GitHub checks or approval. Latest-head qualification and independent foundation review are in progress.
- No customer/H100 deployment or merge is part of preparing this PR.


## Integration landing plan

The public integration branch `kars-bridge` starts at current main `7eb039e9`. Land the reviewed, fully qualified slices there in order: Azure/kars#543 -> Azure/kars#544 -> Azure/kars#545 -> Azure/kars#547, followed by the remaining bounded layers. Downstream PRs stay stacked for focused review until their parent lands, then retarget to the integration branch. Preserve merge ancestry; do not squash/restack away reviewed history by default.

The integration branch has required CI/security gates, up-to-date-base checks, independent approval and conversation resolution, with force pushes, deletion and admin bypass disabled. Its CI pushes must not automatically publish images or releases. Required genuine audit sign-offs are not waived.

Only after complete cross-layer review and qualification of standalone Kars, existing-customer CLI/install/upgrade behavior, and additive Bridge install/removal should a final integration-to-main promotion PR be merged. No partial runtime is being landed directly in main.
